### PR TITLE
[DO NOT MERGE] Add reproduction for `console` hardening issue

### DIFF
--- a/packages/snaps-execution-environments/lavamoat/browserify/console/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/console/policy.json
@@ -1,0 +1,9 @@
+{
+  "resources": {
+    "external:../snaps-utils/src/logging.ts": {
+      "globals": {
+        "console": true
+      }
+    }
+  }
+}

--- a/packages/snaps-execution-environments/scripts/build.js
+++ b/packages/snaps-execution-environments/scripts/build.js
@@ -32,6 +32,10 @@ const ENTRY_POINTS = {
     entryPoint: './src/webworker/pool/index.ts',
     html: true,
   },
+  console: {
+    entryPoint: './src/console.ts',
+    node: true,
+  },
 };
 
 const OUTPUT_PATH = './dist/browserify';

--- a/packages/snaps-execution-environments/src/console.ts
+++ b/packages/snaps-execution-environments/src/console.ts
@@ -1,0 +1,18 @@
+/* eslint-disable no-console, import/unambiguous */
+
+// Upon running this file, this `console.log` shows up as expected. However, the
+// second one does not. It seems that hardening `console._stdout` breaks it.
+console.log(1);
+
+// `harden(console)` does not harden non-enumerable properties. Potentially a
+// separate issue. In the endowment we were extracting all properties from
+// `console`, including `_stdout`, and trying to harden that. It seems to fail
+// with a couple of Node.js-specific properties, such as `_stdout` and
+// `_stderr`. This is a minimal reproduction of the issue.
+// @ts-expect-error - `_stdout` is Node-specific.
+harden(console._stdout);
+
+// This `console.log` does not show up. There appears to be an SES error in the
+// console, but since the error properties are non-enumerable, it does not show
+// the message or stack. I'm not sure how to get the error message out of SES.
+console.log(2);


### PR DESCRIPTION
This is just a reproduction for a potential issue with SES and/or LavaMoat.

The issue can be reproduced by running the following commands in the `packages/snaps-execution-environments` folder:

```bash
yarn build && node dist/browserify/console/bundle.js
```