### PR TITLE
Rename repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # snaps
 
-Everything around [MetaMask Snaps](https://metamask.io/snaps/)
+Everything around [MetaMask Snaps](https://metamask.io/snaps/).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MetaMask Snaps
 
-Everything around [MetaMask Snaps](https://metamask.io/snaps/).
+Extend the functionality of MetaMask using [Snaps](https://metamask.io/snaps/).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# snaps-monorepo
+# snaps
 
-Monorepo for experimental snaps dependencies.
+Everything around [MetaMask Snaps](https://metamask.io/snaps/)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# snaps
+# MetaMask Snaps
 
 Everything around [MetaMask Snaps](https://metamask.io/snaps/).
 


### PR DESCRIPTION
Update the README to fit with the new repo name and remove the unnecessary `-monorepo` moniker.