### PR TITLE
Run ESLint in parallel across packages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,5 +84,10 @@ module.exports = {
     },
   ],
 
-  ignorePatterns: ['!.prettierrc.js', '**/!.eslintrc.js', '**/dist*/'],
+  ignorePatterns: [
+    '!.prettierrc.js',
+    '**/!.eslintrc.js',
+    '**/dist*/',
+    'packages/',
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "setup": "yarn install",
     "postinstall": "simple-git-hooks",
-    "lint:eslint": "yarn workspaces foreach --exclude root --parallel --verbose run eslint . --cache --ext js,jsx,ts,tsx",
+    "lint:eslint": "yarn workspaces foreach --parallel --verbose run eslint . --cache --ext js,jsx,ts,tsx",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!**/CHANGELOG.md' '**/*.yml' '**/*.html'",
     "lint:changelogs": "yarn workspaces foreach --parallel --verbose run lint:changelog",
     "lint:tsconfig": "node scripts/verify-tsconfig.mjs",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "setup": "yarn install",
     "postinstall": "simple-git-hooks",
-    "lint:eslint": "yarn workspaces foreach --parallel --verbose run eslint . --cache --ext js,jsx,ts,tsx",
+    "lint:eslint": "yarn workspaces foreach --parallel --verbose run lint:eslint",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!**/CHANGELOG.md' '**/*.yml' '**/*.html'",
     "lint:changelogs": "yarn workspaces foreach --parallel --verbose run lint:changelog",
     "lint:tsconfig": "node scripts/verify-tsconfig.mjs",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "setup": "yarn install",
     "postinstall": "simple-git-hooks",
-    "lint:eslint": "eslint . --cache --ext js,jsx,ts,tsx",
+    "lint:eslint": "yarn workspaces foreach --exclude root --parallel --verbose run eslint . --cache --ext js,jsx,ts,tsx",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!**/CHANGELOG.md' '**/*.yml' '**/*.html'",
     "lint:changelogs": "yarn workspaces foreach --parallel --verbose run lint:changelog",
     "lint:tsconfig": "node scripts/verify-tsconfig.mjs",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -16,10 +16,6 @@
   ],
   "scripts": {
     "lint:changelog": "yarn auto-changelog validate",
-    "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '**/*.html' '!CHANGELOG.md' --ignore-path ../../.gitignore",
-    "lint": "yarn lint:eslint && yarn lint:misc --check",
-    "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "build": "yarn workspaces foreach --parallel --verbose run build",
     "build:post-tsc": "yarn build"
   },

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -20,7 +20,7 @@
     "lint": "yarn lint:eslint && yarn lint:constraints && yarn lint:misc --check && yarn lint:changelog",
     "lint:changelog": "auto-changelog validate",
     "lint:constraints": "yarn constraints",
-    "lint:eslint": "eslint . --cache --ext js,ts",
+    "lint:eslint": "eslint . --cache --ext js,ts,jsx,tsx",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:constraints --fix && yarn lint:misc --write && yarn lint:changelog",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' '**/*.html' '!.yarnrc.yml' --ignore-path .gitignore --no-error-on-unmatched-pattern",
     "prepack": "./scripts/prepack.sh",


### PR DESCRIPTION
Running ESlint in parallel across packages is quite a bit faster than running ESLint from the root exclusively.

First run is without parallelizing, second run is running in parallel. Caching disabled for both.
```
yarn lint:fix  223.57s user 11.81s system 157% cpu 2:28.99 total
yarn lint:fix  327.04s user 19.74s system 377% cpu 1:31.89 total
```