### PR TITLE
Bump `@metamask/utils` and `@metamask/snaps-registry`

### DIFF
--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -40,7 +40,7 @@
     "@babel/preset-typescript": "^7.20.12",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",
-    "@metamask/utils": "^5.0.0",
+    "@metamask/utils": "^6.0.0",
     "yargs": "^17.7.1"
   },
   "devDependencies": {

--- a/packages/examples/examples/bls-signer/snap.manifest.json
+++ b/packages/examples/examples/bls-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "ILArdHVquRmf8bcMzhKtI0MRHRrnD479SHBUxOcyTws=",
+    "shasum": "yOO0ebbLpLKQS+hVZqKpJFIrYwKddqL6awyXjp3hJno=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/ethers-js/snap.manifest.json
+++ b/packages/examples/examples/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "B5mBOjk5Mf9LkNHO93irlR4c7Erxi+09lDIvu96HisE=",
+    "shasum": "paoHBwquIo8DnyxvWKWCaNLyXuOKtj+Xf3sMMuD586c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/insights/package.json
+++ b/packages/examples/examples/insights/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@metamask/abi-utils": "^1.1.1",
     "@metamask/snaps-ui": "workspace:^",
-    "@metamask/utils": "^5.0.0"
+    "@metamask/utils": "^6.0.0"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.3.1",

--- a/packages/examples/examples/insights/snap.manifest.json
+++ b/packages/examples/examples/insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "gdxbPEbVpMPm6n5zz6HS2z83QDs0bdg6Vj6a736ErA4=",
+    "shasum": "7AjxrnYyneWXstL3EPDKwlwK62LbeaULp64G7yy7uaY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/signer/packages/bitcoin/package.json
+++ b/packages/examples/examples/signer/packages/bitcoin/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@metamask/key-tree": "^7.0.0",
     "@metamask/snaps-types": "workspace:^",
-    "@metamask/utils": "^5.0.0",
+    "@metamask/utils": "^6.0.0",
     "@noble/secp256k1": "^1.7.1",
     "buffer": "^6.0.3"
   },

--- a/packages/examples/examples/signer/packages/bitcoin/snap.manifest.json
+++ b/packages/examples/examples/signer/packages/bitcoin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "XwPEcpD8onJRmkkanZBbefBxg4nrh7F62O4Jf0W8Mm4=",
+    "shasum": "FT9PQ+DixNKKD9gEiZXgpT7bSkfiUIrJxShvzK66+Ug=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/signer/packages/core/package.json
+++ b/packages/examples/examples/signer/packages/core/package.json
@@ -11,7 +11,7 @@
     "start": "mm-snap serve"
   },
   "dependencies": {
-    "@metamask/utils": "^5.0.0",
+    "@metamask/utils": "^6.0.0",
     "async-mutex": "^0.4.0"
   },
   "devDependencies": {

--- a/packages/examples/examples/signer/packages/core/snap.manifest.json
+++ b/packages/examples/examples/signer/packages/core/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "E5ubPfWPWRP+vosR5wld7wo/5n2a7Hm0ue8bjVzNYkk=",
+    "shasum": "p3f7LzTD3jd3USsISLcA2+vzkl0un8CdROV00FcUIfg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/signer/packages/ethereum/package.json
+++ b/packages/examples/examples/signer/packages/ethereum/package.json
@@ -14,7 +14,7 @@
     "@ethereumjs/tx": "^3.5.2",
     "@metamask/key-tree": "^7.0.0",
     "@metamask/snaps-types": "workspace:^",
-    "@metamask/utils": "^5.0.0",
+    "@metamask/utils": "^6.0.0",
     "buffer": "^6.0.3"
   },
   "devDependencies": {

--- a/packages/examples/examples/signer/packages/ethereum/snap.manifest.json
+++ b/packages/examples/examples/signer/packages/ethereum/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "uJMbRtXCLeKuPsCcMOHmOYeHZjO3avnXUksG480E8Jg=",
+    "shasum": "QhCXxDcLAq3WvphChbqXk7pLtdorlg7bqWHoPLiAxYQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/multichain-provider/package.json
+++ b/packages/multichain-provider/package.json
@@ -29,7 +29,7 @@
     "@metamask/providers": "^10.2.1",
     "@metamask/safe-event-emitter": "^3.0.0",
     "@metamask/snaps-utils": "workspace:^",
-    "@metamask/utils": "^5.0.0",
+    "@metamask/utils": "^6.0.0",
     "nanoid": "^3.1.31"
   },
   "devDependencies": {

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -32,7 +32,7 @@
     "@metamask/snaps-ui": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",
     "@metamask/types": "^1.1.0",
-    "@metamask/utils": "^5.0.0",
+    "@metamask/utils": "^6.0.0",
     "@noble/hashes": "^1.1.3",
     "eth-rpc-errors": "^4.0.3",
     "nanoid": "^3.1.31",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -47,7 +47,7 @@
     "@babel/preset-typescript": "^7.20.12",
     "@metamask/snaps-browserify-plugin": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",
-    "@metamask/utils": "^5.0.0",
+    "@metamask/utils": "^6.0.0",
     "babelify": "^10.0.0",
     "browserify": "^17.0.0",
     "chokidar": "^3.5.2",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -40,7 +40,7 @@
     "@metamask/post-message-stream": "^6.1.2",
     "@metamask/rpc-methods": "workspace:^",
     "@metamask/snaps-execution-environments": "workspace:^",
-    "@metamask/snaps-registry": "^1.2.0",
+    "@metamask/snaps-registry": "^1.2.1",
     "@metamask/snaps-utils": "workspace:^",
     "@metamask/utils": "^6.0.0",
     "@xstate/fsm": "^2.0.0",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -42,7 +42,7 @@
     "@metamask/snaps-execution-environments": "workspace:^",
     "@metamask/snaps-registry": "^1.2.0",
     "@metamask/snaps-utils": "workspace:^",
-    "@metamask/utils": "^5.0.0",
+    "@metamask/utils": "^6.0.0",
     "@xstate/fsm": "^2.0.0",
     "concat-stream": "^2.0.0",
     "cron-parser": "^4.5.0",

--- a/packages/snaps-execution-environments/lavamoat/browserify/iframe/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/iframe/policy.json
@@ -47,8 +47,20 @@
         "removeEventListener": true
       },
       "packages": {
-        "@metamask/post-message-stream>readable-stream": true,
-        "@metamask/utils": true
+        "@metamask/post-message-stream>@metamask/utils": true,
+        "@metamask/post-message-stream>readable-stream": true
+      }
+    },
+    "@metamask/post-message-stream>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "browserify>buffer": true,
+        "eslint>debug": true,
+        "superstruct": true,
+        "ts-jest>semver": true
       }
     },
     "@metamask/post-message-stream>readable-stream": {

--- a/packages/snaps-execution-environments/lavamoat/browserify/node-process/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/node-process/policy.json
@@ -69,9 +69,24 @@
         "removeEventListener": true
       },
       "packages": {
+        "@metamask/post-message-stream>@metamask/utils": true,
         "@metamask/post-message-stream>readable-stream": true,
-        "@metamask/utils": true,
         "worker_threads": true
+      }
+    },
+    "@metamask/post-message-stream>@metamask/utils": {
+      "builtin": {
+        "buffer.Buffer": true
+      },
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "buffer": true,
+        "eslint>debug": true,
+        "superstruct": true,
+        "ts-jest>semver": true
       }
     },
     "@metamask/post-message-stream>readable-stream": {

--- a/packages/snaps-execution-environments/lavamoat/browserify/node-thread/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/node-thread/policy.json
@@ -69,9 +69,24 @@
         "removeEventListener": true
       },
       "packages": {
+        "@metamask/post-message-stream>@metamask/utils": true,
         "@metamask/post-message-stream>readable-stream": true,
-        "@metamask/utils": true,
         "worker_threads": true
+      }
+    },
+    "@metamask/post-message-stream>@metamask/utils": {
+      "builtin": {
+        "buffer.Buffer": true
+      },
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "buffer": true,
+        "eslint>debug": true,
+        "superstruct": true,
+        "ts-jest>semver": true
       }
     },
     "@metamask/post-message-stream>readable-stream": {

--- a/packages/snaps-execution-environments/lavamoat/browserify/offscreen/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/offscreen/policy.json
@@ -12,8 +12,20 @@
         "removeEventListener": true
       },
       "packages": {
-        "@metamask/post-message-stream>readable-stream": true,
-        "@metamask/utils": true
+        "@metamask/post-message-stream>@metamask/utils": true,
+        "@metamask/post-message-stream>readable-stream": true
+      }
+    },
+    "@metamask/post-message-stream>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "browserify>buffer": true,
+        "eslint>debug": true,
+        "superstruct": true,
+        "ts-jest>semver": true
       }
     },
     "@metamask/post-message-stream>readable-stream": {

--- a/packages/snaps-execution-environments/lavamoat/browserify/worker-executor/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/worker-executor/policy.json
@@ -47,8 +47,20 @@
         "removeEventListener": true
       },
       "packages": {
-        "@metamask/post-message-stream>readable-stream": true,
-        "@metamask/utils": true
+        "@metamask/post-message-stream>@metamask/utils": true,
+        "@metamask/post-message-stream>readable-stream": true
+      }
+    },
+    "@metamask/post-message-stream>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "browserify>buffer": true,
+        "eslint>debug": true,
+        "superstruct": true,
+        "ts-jest>semver": true
       }
     },
     "@metamask/post-message-stream>readable-stream": {

--- a/packages/snaps-execution-environments/lavamoat/browserify/worker-pool/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/worker-pool/policy.json
@@ -12,8 +12,20 @@
         "removeEventListener": true
       },
       "packages": {
-        "@metamask/post-message-stream>readable-stream": true,
-        "@metamask/utils": true
+        "@metamask/post-message-stream>@metamask/utils": true,
+        "@metamask/post-message-stream>readable-stream": true
+      }
+    },
+    "@metamask/post-message-stream>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "browserify>buffer": true,
+        "eslint>debug": true,
+        "superstruct": true,
+        "ts-jest>semver": true
       }
     },
     "@metamask/post-message-stream>readable-stream": {

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -40,7 +40,7 @@
     "@metamask/providers": "^10.2.1",
     "@metamask/rpc-methods": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",
-    "@metamask/utils": "^5.0.0",
+    "@metamask/utils": "^6.0.0",
     "eth-rpc-errors": "^4.0.3",
     "json-rpc-engine": "^6.1.0",
     "nanoid": "^3.1.31",

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -44,7 +44,7 @@
     "@metamask/snaps-controllers": "workspace:^",
     "@metamask/snaps-ui": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",
-    "@metamask/utils": "^5.0.0",
+    "@metamask/utils": "^6.0.0",
     "@minoru/react-dnd-treeview": "^3.4.4",
     "@reduxjs/toolkit": "^1.9.5",
     "date-fns": "^2.30.0",

--- a/packages/snaps-types/package.json
+++ b/packages/snaps-types/package.json
@@ -30,7 +30,7 @@
     "@metamask/providers": "^10.2.1",
     "@metamask/rpc-methods": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",
-    "@metamask/utils": "^5.0.0"
+    "@metamask/utils": "^6.0.0"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.3.1",

--- a/packages/snaps-ui/package.json
+++ b/packages/snaps-ui/package.json
@@ -25,7 +25,7 @@
     "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
-    "@metamask/utils": "^5.0.0",
+    "@metamask/utils": "^6.0.0",
     "superstruct": "^1.0.3"
   },
   "devDependencies": {

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -59,7 +59,7 @@
     "@metamask/providers": "^10.2.1",
     "@metamask/snaps-registry": "^1.2.0",
     "@metamask/snaps-ui": "workspace:^",
-    "@metamask/utils": "^5.0.0",
+    "@metamask/utils": "^6.0.0",
     "@noble/hashes": "^1.1.3",
     "@scure/base": "^1.1.1",
     "cron-parser": "^4.5.0",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -57,7 +57,7 @@
     "@metamask/base-controller": "^3.0.0",
     "@metamask/permission-controller": "^4.0.0",
     "@metamask/providers": "^10.2.1",
-    "@metamask/snaps-registry": "^1.2.0",
+    "@metamask/snaps-registry": "^1.2.1",
     "@metamask/snaps-ui": "workspace:^",
     "@metamask/utils": "^6.0.0",
     "@noble/hashes": "^1.1.3",

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@metamask/snaps-utils": "workspace:^",
-    "@metamask/utils": "^5.0.0",
+    "@metamask/utils": "^6.0.0",
     "webpack-sources": "^3.2.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4288,7 +4288,7 @@ __metadata:
     "@metamask/post-message-stream": ^6.1.2
     "@metamask/rpc-methods": "workspace:^"
     "@metamask/snaps-execution-environments": "workspace:^"
-    "@metamask/snaps-registry": ^1.2.0
+    "@metamask/snaps-registry": ^1.2.1
     "@metamask/snaps-utils": "workspace:^"
     "@metamask/template-snap": ^0.7.0
     "@metamask/utils": ^6.0.0
@@ -4435,14 +4435,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/snaps-registry@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@metamask/snaps-registry@npm:1.2.0"
+"@metamask/snaps-registry@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@metamask/snaps-registry@npm:1.2.1"
   dependencies:
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.0.0
     "@noble/secp256k1": ^1.7.1
     superstruct: ^1.0.3
-  checksum: d0534680e713ca94e41cbb86f5f700aaf8c1f36b88fc1ed24b4669f11f8583b6d949f6724b8d9fd518a6210131af4ea7822e73ce34e64649dbe29a28850c6682
+  checksum: d2d5b743a8b55b6f685708b2b694534585329585c6d94819328e270fd77c68c0bede88b866821db9c22a667eca1f4961ed860d83b438cf009bd1c4df6e75b78a
   languageName: node
   linkType: hard
 
@@ -4666,7 +4666,7 @@ __metadata:
     "@metamask/permission-controller": ^4.0.0
     "@metamask/post-message-stream": ^6.1.2
     "@metamask/providers": ^10.2.1
-    "@metamask/snaps-registry": ^1.2.0
+    "@metamask/snaps-registry": ^1.2.1
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/utils": ^6.0.0
     "@noble/hashes": ^1.1.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -3845,7 +3845,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^11.0.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.0.0
     "@types/jest": ^27.5.1
     "@types/node": ^17.0.36
     "@types/rimraf": ^3.0.0
@@ -4003,7 +4003,7 @@ __metadata:
     "@metamask/providers": ^10.2.1
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/snaps-utils": "workspace:^"
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.0.0
     "@types/jest": ^27.5.1
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -4113,7 +4113,7 @@ __metadata:
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
     "@metamask/types": ^1.1.0
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.0.0
     "@noble/hashes": ^1.1.3
     "@types/node": ^17.0.36
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -4223,7 +4223,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^11.0.0
     "@metamask/snaps-browserify-plugin": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.0.0
     "@types/browserify": ^12.0.37
     "@types/is-url": ^1.2.28
     "@types/jest": ^27.5.1
@@ -4291,7 +4291,7 @@ __metadata:
     "@metamask/snaps-registry": ^1.2.0
     "@metamask/snaps-utils": "workspace:^"
     "@metamask/template-snap": ^0.7.0
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.0.0
     "@peculiar/webcrypto": ^1.3.3
     "@types/concat-stream": ^2.0.0
     "@types/gunzip-maybe": ^1.4.0
@@ -4376,7 +4376,7 @@ __metadata:
     "@metamask/providers": ^10.2.1
     "@metamask/rpc-methods": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.0.0
     "@types/express": ^4.17.17
     "@types/jest": ^27.5.1
     "@types/node": ^17.0.36
@@ -4506,7 +4506,7 @@ __metadata:
     "@metamask/snaps-controllers": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.0.0
     "@minoru/react-dnd-treeview": ^3.4.4
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.10
     "@redux-saga/is": ^1.1.3
@@ -4594,7 +4594,7 @@ __metadata:
     "@metamask/providers": ^10.2.1
     "@metamask/rpc-methods": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.0.0
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
     eslint: ^8.27.0
@@ -4623,7 +4623,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^11.0.0
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.0.0
     "@types/jest": ^27.5.1
     "@types/semver": ^7.3.10
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -4668,7 +4668,7 @@ __metadata:
     "@metamask/providers": ^10.2.1
     "@metamask/snaps-registry": ^1.2.0
     "@metamask/snaps-ui": "workspace:^"
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.0.0
     "@noble/hashes": ^1.1.3
     "@scure/base": ^1.1.1
     "@types/jest": ^27.5.1
@@ -4735,7 +4735,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
     "@metamask/snaps-utils": "workspace:^"
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.0.0
     "@types/jest": ^27.5.1
     "@types/webpack-sources": ^3.2.0
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -4797,6 +4797,19 @@ __metadata:
     semver: ^7.3.8
     superstruct: ^1.0.3
   checksum: eca82e42911b2840deb4f32f0f215c5ffd14d22d68afbbe92d3180e920e509e310777b15eab29def3448f3535b66596ceb4c23666ec846adacc8e1bb093ff882
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@metamask/utils@npm:6.0.0"
+  dependencies:
+    "@ethereumjs/tx": ^4.1.2
+    "@types/debug": ^4.1.7
+    debug: ^4.3.4
+    semver: ^7.3.8
+    superstruct: ^1.0.3
+  checksum: 502a75c82af729f813a08382e8ca5e3bfab7903a377b375e781ffcd5541e3a57b468a0daf02bb8e5c5bcb9051408f51c1ffb7a92b90bfd89946e7691c1117ca9
   languageName: node
   linkType: hard
 
@@ -21103,7 +21116,7 @@ __metadata:
     "@metamask/key-tree": ^7.0.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.0.0
     "@noble/secp256k1": ^1.7.1
     buffer: ^6.0.3
     through2: ^4.0.2
@@ -21117,7 +21130,7 @@ __metadata:
     "@metamask/key-tree": ^7.0.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.0.0
     async-mutex: ^0.4.0
   languageName: unknown
   linkType: soft
@@ -21130,7 +21143,7 @@ __metadata:
     "@metamask/key-tree": ^7.0.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.0.0
     buffer: ^6.0.3
     through2: ^4.0.2
   languageName: unknown
@@ -22399,7 +22412,7 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.0.0
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
     eslint: ^8.27.0


### PR DESCRIPTION
Bumps `@metamask/utils` to `6.0.0` and `@metamask/snaps-registry` to `1.2.1`