### PR TITLE
Run LavaMoat policy generation in a separate job in CI

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -54,6 +54,30 @@ jobs:
           cache: yarn
       - run: yarn --immutable --immutable-cache
       - run: yarn build
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty at end of job"
+            exit 1
+          fi
+
+  policy:
+    name: Generate LavaMoat policy
+    runs-on: ubuntu-latest
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [16.x, 18.x]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+      - run: yarn --immutable --immutable-cache
       - name: Generate LavaMoat policy
         run: yarn workspace @metamask/snaps-execution-environments build:lavamoat:policy
       - name: Require clean working directory


### PR DESCRIPTION
This is a small change to the build step in CI. We now run LavaMoat policy generation in a separate job, as it does not any build files.