### PR TITLE
Properly tag prerelease versions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -71,8 +71,7 @@ jobs:
           key: ${{ github.sha }}
       - name: Get release tag
         id: get-release-tag
-        run: |
-          echo "tag=$(yarn get-release-tag)" >> "$GITHUB_OUTPUT"
+        run: echo "tag=$(yarn get-release-tag)" >> "$GITHUB_OUTPUT"
         shell: bash
       - run: npm config set ignore-scripts true
       - name: Publish ${{ steps.get-release-tag.outputs.tag }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -72,13 +72,7 @@ jobs:
       - name: Get release tag
         id: get-release-tag
         run: |
-          branch=${GITHUB_REF#refs/heads/}
-          if [ "$branch" = "main" ]
-          then
-            echo "tag=flask" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
-          fi
+          echo "tag=$(yarn get-release-tag)" >> "$GITHUB_OUTPUT"
         shell: bash
       - run: npm config set ignore-scripts true
       - name: Publish ${{ steps.get-release-tag.outputs.tag }}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "child-workspace-package-names-as-json": "ts-node scripts/child-workspace-package-names-as-json.ts",
     "prepare-preview-builds": "yarn workspaces foreach --parallel run prepare-manifest:preview",
     "publish-previews": "yarn workspaces foreach --parallel run publish:preview",
-    "install-chrome": "./scripts/install-chrome.sh"
+    "install-chrome": "./scripts/install-chrome.sh",
+    "get-release-tag": "ts-node --swc scripts/get-release-tag.ts"
   },
   "simple-git-hooks": {
     "pre-commit": "yarn lint-staged && yarn dedupe --check"
@@ -60,6 +61,7 @@
     "@metamask/eslint-config-jest": "^11.0.0",
     "@metamask/eslint-config-nodejs": "^11.0.1",
     "@metamask/eslint-config-typescript": "^11.0.0",
+    "@metamask/utils": "^6.0.0",
     "@types/jest": "^27.5.1",
     "@types/node": "^17.0.36",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
@@ -80,6 +82,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^4.1.2",
+    "semver": "^7.3.7",
     "simple-git-hooks": "^2.7.0",
     "ts-node": "^10.9.1",
     "typescript": "~4.8.4"

--- a/scripts/get-release-tag.ts
+++ b/scripts/get-release-tag.ts
@@ -1,0 +1,43 @@
+import { assert } from '@metamask/utils';
+import { prerelease } from 'semver';
+
+import packageJson from '../package.json';
+
+enum Tag {
+  Flask = 'flask',
+  Next = 'next',
+  Latest = 'latest',
+}
+
+/**
+ * Get the release tag from the current branch name and `package.json` version.
+ *
+ * - If the branch name is `main`, the tag is `flask`.
+ * - Otherwise, if the version is a prerelease, the tag is `next`.
+ * - Otherwise, the tag is `latest`.
+ *
+ * @returns The release tag.
+ */
+export function main(): Tag {
+  const branchName = process.env.GITHUB_REF_NAME;
+  const { version } = packageJson;
+
+  assert(branchName, 'GITHUB_REF_NAME must be set.');
+  assert(version, '`package.json` must have a version.');
+
+  // Currently, Flask releases are deployed from the `main` branch.
+  if (branchName === 'main') {
+    return Tag.Flask;
+  }
+
+  // Otherwise, we're on a stable branch, which may or may not be a prerelease.
+  const prereleaseTag = prerelease(version);
+  if (prereleaseTag) {
+    return Tag.Next;
+  }
+
+  return Tag.Latest;
+}
+
+// eslint-disable-next-line no-console
+console.log(main());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
   ],
   "compilerOptions": {
     "esModuleInterop": true,
-    "noEmit": true
+    "noEmit": true,
+    "resolveJsonModule": true
   },
   "files": [],
   "include": ["scripts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -20763,7 +20763,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^4.1.2
-    semver: ^7.5.1
+    semver: ^7.3.7
     simple-git-hooks: ^2.7.0
     ts-node: ^10.9.1
     typescript: ~4.8.4
@@ -20986,7 +20986,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.0, semver@npm:^7.5.1":
+"semver@npm:^7.0.0, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.0":
   version: 7.5.1
   resolution: "semver@npm:7.5.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -20742,6 +20742,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^11.0.0
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
+    "@metamask/utils": ^6.0.0
     "@types/jest": ^27.5.1
     "@types/node": ^17.0.36
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -20762,6 +20763,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^4.1.2
+    semver: ^7.5.1
     simple-git-hooks: ^2.7.0
     ts-node: ^10.9.1
     typescript: ~4.8.4
@@ -20984,7 +20986,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.0":
+"semver@npm:^7.0.0, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.0, semver@npm:^7.5.1":
   version: 7.5.1
   resolution: "semver@npm:7.5.1"
   dependencies:


### PR DESCRIPTION
This refactors the tag logic in CI for releases:

- If the branch is `main`, the release is tagged as `flask`.
- If the branch is not `main`:
   - If the version is a prerelease version (i.e., it includes something like `-prerelease.1` in the version), it is tagged as `next`.
   - Otherwise, it is tagged as `latest`.