### PR TITLE
Bump Chrome and Chromedriver to v114

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/node": "^17.0.36",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
-    "chromedriver": "^112.0.0",
+    "chromedriver": "^114.0.1",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",

--- a/scripts/install-chrome.sh
+++ b/scripts/install-chrome.sh
@@ -5,12 +5,12 @@ set -u
 set -o pipefail
 
 # To get the latest version, see <https://www.ubuntuupdates.org/ppa/google_chrome?dist=stable>
-CHROME_VERSION='112.0.5615.49-1'
+CHROME_VERSION='114.0.5735.106-1'
 CHROME_BINARY="google-chrome-stable_${CHROME_VERSION}_amd64.deb"
 CHROME_BINARY_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/${CHROME_BINARY}"
 
 # To retrieve this checksum, run the `wget` and `shasum` commands below
-CHROME_BINARY_SHA512SUM='eb80ebc1a44a00caee1b153879e4e980518611f5be532da62066cd8ec63df69d518eef9e2917a9c3b735382bb5807b03313fa66b28c823f87607e5d07dffc606'
+CHROME_BINARY_SHA512SUM='fb9c4cd882839f56013cca7535ca4b2e3779a3148654225515039d3d8ee0f21bdd1a0e1631918c4ec729041258b471a7b2acedb8027b5e55af1cc1c8cd642609'
 
 wget -O "${CHROME_BINARY}" -t 5 "${CHROME_BINARY_URL}"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9215,9 +9215,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromedriver@npm:^112.0.0":
-  version: 112.0.0
-  resolution: "chromedriver@npm:112.0.0"
+"chromedriver@npm:^114.0.1":
+  version: 114.0.1
+  resolution: "chromedriver@npm:114.0.1"
   dependencies:
     "@testim/chrome-version": ^1.1.3
     axios: ^1.2.1
@@ -9228,7 +9228,7 @@ __metadata:
     tcp-port-used: ^1.0.1
   bin:
     chromedriver: bin/chromedriver
-  checksum: 6cd254c50326ca1775adac54cac1dc1b96a32fd9af1dfb7c44e812c619286ec96c727f74adbbece50a1f3efd463b895f05aadbce95cec9e23525b8bdf379de7f
+  checksum: 568e3383db1e6c5c1918170e128a72946a58afba4fb303e8b8fa46290390955d7304045ad0e10066c29941e3092fcba1d9716a375c90b4fbac7bb22d260d09d8
   languageName: node
   linkType: hard
 
@@ -20639,7 +20639,7 @@ __metadata:
     "@types/node": ^17.0.36
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
-    chromedriver: ^112.0.0
+    chromedriver: ^114.0.1
     eslint: ^8.27.0
     eslint-config-prettier: ^8.5.0
     eslint-plugin-import: ^2.26.0


### PR DESCRIPTION
This bumps Chromedriver and the Chrome version used in CI to `v114`, which matches the latest stable Chrome version.