### PR TITLE
Add `sideEffects: false` to every package

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -119,3 +119,8 @@ gen_enforced_dependency(WorkspaceCwd, DependencyIdent, null, DependencyType) :-
   workspace_has_dependency(WorkspaceCwd, DependencyIdent, DependencyRange, 'dependencies'),
   workspace_has_dependency(WorkspaceCwd, DependencyIdent, DependencyRange, DependencyType),
   DependencyType == 'devDependencies'.
+
+% Dependencies may not have side effects.
+gen_enforced_field(WorkspaceCwd, 'sideEffects', 'false') :-
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "license": "ISC",
+  "sideEffects": false,
   "bin": "./dist/main.js",
   "files": [
     "dist/"

--- a/packages/multichain-provider/package.json
+++ b/packages/multichain-provider/package.json
@@ -5,6 +5,7 @@
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"
   },
+  "sideEffects": false,
   "main": "dist/index.js",
   "files": [
     "dist/"

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"
   },
+  "sideEffects": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -8,6 +8,7 @@
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"
   },
+  "sideEffects": false,
   "main": "dist/index.js",
   "files": [
     "dist/"

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "license": "ISC",
+  "sideEffects": false,
   "main": "dist/index.js",
   "bin": {
     "mm-snap": "./dist/main.js"

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"
   },
+  "sideEffects": false,
   "main": "dist/index.js",
   "browser": {
     "./dist/services": "./dist/services/browser.js"

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"
   },
+  "sideEffects": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -9,6 +9,7 @@
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"
   },
+  "sideEffects": false,
   "main": "dist/index.js",
   "files": [
     "dist/"

--- a/packages/snaps-types/package.json
+++ b/packages/snaps-types/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"
   },
+  "sideEffects": false,
   "main": "dist/index.d.ts",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/snaps-ui/package.json
+++ b/packages/snaps-ui/package.json
@@ -5,6 +5,7 @@
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"
   },
+  "sideEffects": false,
   "main": "dist/index.js",
   "files": [
     "dist/"

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -5,6 +5,7 @@
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"
   },
+  "sideEffects": false,
   "exports": {
     ".": {
       "browser": {

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -9,6 +9,7 @@
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"
   },
+  "sideEffects": false,
   "main": "dist/index.js",
   "files": [
     "dist/"


### PR DESCRIPTION
This allows tree shaking of packages by 3rd party bundlers (Webpack, Rollup, etc.)

https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free