### PR TITLE
Fix manageState in `snaps-simulator`

### DIFF
--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.3.1",
     "@metamask/auto-changelog": "^3.1.0",
-    "@metamask/browser-passworder": "^4.0.2",
+    "@metamask/browser-passworder": "^4.1.0",
     "@metamask/eslint-config": "^11.0.0",
     "@metamask/eslint-config-jest": "^11.0.0",
     "@metamask/eslint-config-nodejs": "^11.0.1",

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -38,6 +38,7 @@
     "@emotion/styled": "^11.10.8",
     "@ethersproject/units": "^5.7.0",
     "@metamask/base-controller": "^3.0.0",
+    "@metamask/browser-passworder": "^4.1.0",
     "@metamask/eth-json-rpc-middleware": "^11.0.0",
     "@metamask/key-tree": "^7.0.0",
     "@metamask/permission-controller": "^4.0.0",

--- a/packages/snaps-simulator/src/features/simulation/sagas.ts
+++ b/packages/snaps-simulator/src/features/simulation/sagas.ts
@@ -1,4 +1,5 @@
 import { ControllerMessenger } from '@metamask/base-controller';
+import { encrypt, decrypt } from '@metamask/browser-passworder';
 import { createFetchMiddleware } from '@metamask/eth-json-rpc-middleware';
 import { mnemonicPhraseToBytes } from '@metamask/key-tree/dist/utils';
 import {
@@ -77,6 +78,8 @@ export function* initSaga({ payload }: PayloadAction<string>) {
     ...buildSnapEndowmentSpecifications(Object.keys(ExcludedSnapEndowments)),
     ...buildSnapRestrictedMethodSpecifications([], {
       // TODO: Add all the hooks required
+      encrypt,
+      decrypt,
       getUnlockPromise: async () => Promise.resolve(true),
       getMnemonic: async () => mnemonicPhraseToBytes(srp),
       showDialog: async (...args: Parameters<typeof showDialog>) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3802,7 +3802,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/browser-passworder@npm:^4.0.2":
+"@metamask/browser-passworder@npm:^4.1.0":
   version: 4.1.0
   resolution: "@metamask/browser-passworder@npm:4.1.0"
   checksum: f1edb3b75594b8e8d075b3134c9ce6c73573160eb48184ef722b9d96a5763db1e2e9acb166fc5c66c7c82936e134a02a3fb4c0022ca9a948857a30181cb84d7e
@@ -4102,7 +4102,7 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": ^2.3.1
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/browser-passworder": ^4.0.2
+    "@metamask/browser-passworder": ^4.1.0
     "@metamask/eslint-config": ^11.0.0
     "@metamask/eslint-config-jest": ^11.0.0
     "@metamask/eslint-config-nodejs": ^11.0.1
@@ -4498,6 +4498,7 @@ __metadata:
     "@ethersproject/units": ^5.7.0
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.0.0
+    "@metamask/browser-passworder": ^4.1.0
     "@metamask/eslint-config": ^11.0.0
     "@metamask/eslint-config-browser": ^11.1.0
     "@metamask/eslint-config-jest": ^11.0.0


### PR DESCRIPTION
Fixes the manageState implementation in `snaps-simulator`. 

The implementation was broken since it now expects the hooks `encrypt` and `decrypt` to be available for client-specific encryption. This wasn't added in the hackathon version of `snaps-simulator`.