### PR TITLE
Fix response typing in `snaps-simulator`

### DIFF
--- a/packages/snaps-simulator/src/features/handlers/cronjobs/slice.ts
+++ b/packages/snaps-simulator/src/features/handlers/cronjobs/slice.ts
@@ -1,5 +1,5 @@
 import { HandlerType } from '@metamask/snaps-utils';
-import { JsonRpcRequest } from '@metamask/utils';
+import { JsonRpcRequest, JsonRpcResponse, Json } from '@metamask/utils';
 import { createSelector } from '@reduxjs/toolkit';
 
 import { createHandlerSlice } from '../slice';
@@ -9,7 +9,7 @@ type Request = {
   request?: JsonRpcRequest;
 };
 
-type Response = string;
+type Response = JsonRpcResponse<Json>;
 
 export const INITIAL_STATE = {
   request: {

--- a/packages/snaps-simulator/src/features/handlers/json-rpc/slice.ts
+++ b/packages/snaps-simulator/src/features/handlers/json-rpc/slice.ts
@@ -1,5 +1,5 @@
 import { HandlerType } from '@metamask/snaps-utils';
-import { JsonRpcRequest } from '@metamask/utils';
+import { Json, JsonRpcRequest, JsonRpcResponse } from '@metamask/utils';
 import { createSelector } from '@reduxjs/toolkit';
 
 import { createHandlerSlice } from '../slice';
@@ -9,7 +9,7 @@ type Request = {
   request?: JsonRpcRequest;
 };
 
-type Response = string;
+type Response = JsonRpcResponse<Json>;
 
 export const INITIAL_STATE = {
   request: {

--- a/packages/snaps-simulator/src/features/handlers/transactions/slice.ts
+++ b/packages/snaps-simulator/src/features/handlers/transactions/slice.ts
@@ -1,5 +1,5 @@
 import { HandlerType } from '@metamask/snaps-utils';
-import { JsonRpcRequest } from '@metamask/utils';
+import { JsonRpcRequest, JsonRpcResponse, Json } from '@metamask/utils';
 import { createSelector } from '@reduxjs/toolkit';
 
 import { createHandlerSlice } from '../slice';
@@ -12,7 +12,7 @@ type Request = {
   }>;
 };
 
-type Response = string;
+type Response = JsonRpcResponse<Json>;
 
 export const INITIAL_STATE = {
   request: {},


### PR DESCRIPTION
Fixes the types for the response slices in `snaps-simulator`. These were wrongly marked as string.