### PR TITLE
Improve JSON parsing safety

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@metamask/eslint-config-jest": "^11.0.0",
     "@metamask/eslint-config-nodejs": "^11.0.1",
     "@metamask/eslint-config-typescript": "^11.0.0",
-    "@metamask/utils": "^6.0.0",
+    "@metamask/utils": "^6.0.1",
     "@types/jest": "^27.5.1",
     "@types/node": "^17.0.36",
     "@typescript-eslint/eslint-plugin": "^5.42.1",

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -42,7 +42,7 @@
     "@babel/preset-typescript": "^7.20.12",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",
-    "@metamask/utils": "^6.0.0",
+    "@metamask/utils": "^6.0.1",
     "yargs": "^17.7.1"
   },
   "devDependencies": {

--- a/packages/examples/examples/bls-signer/snap.manifest.json
+++ b/packages/examples/examples/bls-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "UbQZJ9Ut1cfJgJxt9ZdpTJeq6qKapeZktT/6/DeVXqg=",
+    "shasum": "4fuXpWUXFxzfRG6wd9wUkvMtV8JX7YJlPR0r0ecW91Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/ethers-js/snap.manifest.json
+++ b/packages/examples/examples/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "r0zZfgIGqBWbwzQCUI7EYqQbObRFt3ca4bAdsVrTtY4=",
+    "shasum": "X0oC6/2iSGMQjyb+v0luO+74uREqCGeE1M+/ZpDUxds=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/insights/package.json
+++ b/packages/examples/examples/insights/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@metamask/abi-utils": "^1.1.1",
     "@metamask/snaps-ui": "workspace:^",
-    "@metamask/utils": "^6.0.0"
+    "@metamask/utils": "^6.0.1"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.3.1",

--- a/packages/examples/examples/insights/snap.manifest.json
+++ b/packages/examples/examples/insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "61IKoCH2L7+Q6PQL1cTZ62ilZ8rDgZyIa5KnPNekCgE=",
+    "shasum": "ZkMdApjKKW9G+pA8v0EiiQS/FRxSGAhB2CJaoRm6LW4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/signer/packages/bitcoin/package.json
+++ b/packages/examples/examples/signer/packages/bitcoin/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@metamask/key-tree": "^7.0.0",
     "@metamask/snaps-types": "workspace:^",
-    "@metamask/utils": "^6.0.0",
+    "@metamask/utils": "^6.0.1",
     "@noble/secp256k1": "^1.7.1",
     "buffer": "^6.0.3"
   },

--- a/packages/examples/examples/signer/packages/bitcoin/snap.manifest.json
+++ b/packages/examples/examples/signer/packages/bitcoin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "V3dUNYpni1miT4PH1Y6ICD7Ox1m1rkuY56DWsP1kyR0=",
+    "shasum": "8CiQeuo6gFyZ/YhmLhH8etYC3GbBk/Rw6/8hKmWkauk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/signer/packages/core/package.json
+++ b/packages/examples/examples/signer/packages/core/package.json
@@ -15,7 +15,7 @@
     "lint:ci": "yarn lint"
   },
   "dependencies": {
-    "@metamask/utils": "^6.0.0",
+    "@metamask/utils": "^6.0.1",
     "async-mutex": "^0.4.0"
   },
   "devDependencies": {

--- a/packages/examples/examples/signer/packages/core/snap.manifest.json
+++ b/packages/examples/examples/signer/packages/core/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4RYywGcgs+SWD8/IBZuVGsCzI8TsqmNgFfkq02Wz6wE=",
+    "shasum": "5oLCuClHhG/hGG/F/AJceBy1xrPHAvKsB2DRGjgdydg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/signer/packages/ethereum/package.json
+++ b/packages/examples/examples/signer/packages/ethereum/package.json
@@ -18,7 +18,7 @@
     "@ethereumjs/tx": "^3.5.2",
     "@metamask/key-tree": "^7.0.0",
     "@metamask/snaps-types": "workspace:^",
-    "@metamask/utils": "^6.0.0",
+    "@metamask/utils": "^6.0.1",
     "buffer": "^6.0.3"
   },
   "devDependencies": {

--- a/packages/examples/examples/signer/packages/ethereum/snap.manifest.json
+++ b/packages/examples/examples/signer/packages/ethereum/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "sACAkdh6cGkVCyQ5sunL32lg+TTDjqakPqR/3VFZGOY=",
+    "shasum": "QQrrVVifstz9G8xkM3Goo6fB4vz/VFs+1+zGeuiL2zY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/multichain-provider/package.json
+++ b/packages/multichain-provider/package.json
@@ -31,7 +31,7 @@
     "@metamask/providers": "^11.0.0",
     "@metamask/safe-event-emitter": "^3.0.0",
     "@metamask/snaps-utils": "workspace:^",
-    "@metamask/utils": "^6.0.0",
+    "@metamask/utils": "^6.0.1",
     "nanoid": "^3.1.31"
   },
   "devDependencies": {

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -34,7 +34,7 @@
     "@metamask/snaps-ui": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",
     "@metamask/types": "^1.1.0",
-    "@metamask/utils": "^6.0.0",
+    "@metamask/utils": "^6.0.1",
     "@noble/hashes": "^1.1.3",
     "eth-rpc-errors": "^4.0.3",
     "nanoid": "^3.1.31",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-typescript": "^7.20.12",
     "@metamask/snaps-browserify-plugin": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",
-    "@metamask/utils": "^6.0.0",
+    "@metamask/utils": "^6.0.1",
     "babelify": "^10.0.0",
     "browserify": "^17.0.0",
     "chokidar": "^3.5.2",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -44,7 +44,7 @@
     "@metamask/snaps-execution-environments": "workspace:^",
     "@metamask/snaps-registry": "^1.2.1",
     "@metamask/snaps-utils": "workspace:^",
-    "@metamask/utils": "^6.0.0",
+    "@metamask/utils": "^6.0.1",
     "@xstate/fsm": "^2.0.0",
     "concat-stream": "^2.0.0",
     "cron-parser": "^4.5.0",

--- a/packages/snaps-controllers/src/snaps/location/http.ts
+++ b/packages/snaps-controllers/src/snaps/location/http.ts
@@ -5,8 +5,9 @@ import {
   NpmSnapFileNames,
   createSnapManifest,
   normalizeRelative,
+  parseJson,
 } from '@metamask/snaps-utils';
-import { assert, assertStruct, getSafeJson } from '@metamask/utils';
+import { assert, assertStruct } from '@metamask/utils';
 
 import { SnapLocation } from './location';
 
@@ -63,7 +64,7 @@ export class HttpLocation implements SnapLocation {
       );
     }
     const contents = await response.text();
-    const manifest = getSafeJson(JSON.parse(contents));
+    const manifest = parseJson(contents);
     const vfile = new VirtualFile<SnapManifest>({
       value: contents,
       result: createSnapManifest(manifest),

--- a/packages/snaps-controllers/src/snaps/location/http.ts
+++ b/packages/snaps-controllers/src/snaps/location/http.ts
@@ -6,7 +6,7 @@ import {
   createSnapManifest,
   normalizeRelative,
 } from '@metamask/snaps-utils';
-import { assert, assertStruct } from '@metamask/utils';
+import { assert, assertStruct, getSafeJson } from '@metamask/utils';
 
 import { SnapLocation } from './location';
 
@@ -63,7 +63,7 @@ export class HttpLocation implements SnapLocation {
       );
     }
     const contents = await response.text();
-    const manifest = JSON.parse(contents);
+    const manifest = getSafeJson(JSON.parse(contents));
     const vfile = new VirtualFile<SnapManifest>({
       value: contents,
       result: createSnapManifest(manifest),

--- a/packages/snaps-controllers/src/snaps/location/npm.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.ts
@@ -7,12 +7,12 @@ import {
   SnapManifest,
   VirtualFile,
   normalizeRelative,
+  parseJson,
 } from '@metamask/snaps-utils';
 import {
   assert,
   assertIsSemVerVersion,
   assertStruct,
-  getSafeJson,
   isObject,
   SemVerRange,
   SemVerVersion,
@@ -118,7 +118,7 @@ export class NpmLocation implements SnapLocation {
     }
 
     const vfile = await this.fetch('snap.manifest.json');
-    const result = getSafeJson(JSON.parse(vfile.toString()));
+    const result = parseJson(vfile.toString());
     vfile.result = createSnapManifest(result);
     this.validatedManifest = vfile as VirtualFile<SnapManifest>;
 

--- a/packages/snaps-controllers/src/snaps/location/npm.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.ts
@@ -12,6 +12,7 @@ import {
   assert,
   assertIsSemVerVersion,
   assertStruct,
+  getSafeJson,
   isObject,
   SemVerRange,
   SemVerVersion,
@@ -117,7 +118,7 @@ export class NpmLocation implements SnapLocation {
     }
 
     const vfile = await this.fetch('snap.manifest.json');
-    const result = JSON.parse(vfile.toString());
+    const result = getSafeJson(JSON.parse(vfile.toString()));
     vfile.result = createSnapManifest(result);
     this.validatedManifest = vfile as VirtualFile<SnapManifest>;
 

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -41,7 +41,7 @@
     "@metamask/providers": "^11.0.0",
     "@metamask/rpc-methods": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",
-    "@metamask/utils": "^6.0.0",
+    "@metamask/utils": "^6.0.1",
     "eth-rpc-errors": "^4.0.3",
     "json-rpc-engine": "^6.1.0",
     "nanoid": "^3.1.31",

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -47,7 +47,7 @@
     "@metamask/snaps-controllers": "workspace:^",
     "@metamask/snaps-ui": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",
-    "@metamask/utils": "^6.0.0",
+    "@metamask/utils": "^6.0.1",
     "@minoru/react-dnd-treeview": "^3.4.4",
     "@reduxjs/toolkit": "^1.9.5",
     "date-fns": "^2.30.0",

--- a/packages/snaps-simulator/src/features/polling/sagas.ts
+++ b/packages/snaps-simulator/src/features/polling/sagas.ts
@@ -2,11 +2,12 @@ import { detectSnapLocation } from '@metamask/snaps-controllers';
 import {
   getSnapPrefix,
   logError,
+  parseJson,
   SnapIdPrefixes,
   SnapManifest,
   VirtualFile,
 } from '@metamask/snaps-utils';
-import { getSafeJson, SemVerRange } from '@metamask/utils';
+import { SemVerRange } from '@metamask/utils';
 import equal from 'fast-deep-equal/es6';
 import { all, call, delay, put, select, takeLatest } from 'redux-saga/effects';
 
@@ -40,7 +41,7 @@ export function* fetchingSaga() {
     [location, 'fetch'],
     'snap.manifest.json',
   );
-  const parsedManifest = getSafeJson(JSON.parse(manifestFile.toString('utf8')));
+  const parsedManifest = parseJson(manifestFile.toString('utf8'));
   manifestFile.result = parsedManifest;
 
   const currentManifest: SnapManifest = yield select(getSnapManifest);

--- a/packages/snaps-simulator/src/features/polling/sagas.ts
+++ b/packages/snaps-simulator/src/features/polling/sagas.ts
@@ -6,7 +6,7 @@ import {
   SnapManifest,
   VirtualFile,
 } from '@metamask/snaps-utils';
-import { SemVerRange } from '@metamask/utils';
+import { getSafeJson, SemVerRange } from '@metamask/utils';
 import equal from 'fast-deep-equal/es6';
 import { all, call, delay, put, select, takeLatest } from 'redux-saga/effects';
 
@@ -40,9 +40,7 @@ export function* fetchingSaga() {
     [location, 'fetch'],
     'snap.manifest.json',
   );
-  const parsedManifest = JSON.parse(
-    manifestFile.toString('utf8'),
-  ) as SnapManifest;
+  const parsedManifest = getSafeJson(JSON.parse(manifestFile.toString('utf8')));
   manifestFile.result = parsedManifest;
 
   const currentManifest: SnapManifest = yield select(getSnapManifest);

--- a/packages/snaps-simulator/src/features/simulation/sagas.ts
+++ b/packages/snaps-simulator/src/features/simulation/sagas.ts
@@ -24,6 +24,7 @@ import {
   SnapRpcHookArgs,
   VirtualFile,
 } from '@metamask/snaps-utils';
+import { getSafeJson } from '@metamask/utils';
 import { PayloadAction } from '@reduxjs/toolkit';
 import { JsonRpcEngine } from 'json-rpc-engine';
 import { createEngineStream } from 'json-rpc-middleware-stream';
@@ -270,7 +271,7 @@ export function* permissionsSaga({
     // Payload is frozen for unknown reasons, this breaks our superstruct validation.
     // To circumvent we stringify and parse.
     const approvedPermissions = processSnapPermissions(
-      JSON.parse(JSON.stringify(payload.result.initialPermissions)),
+      getSafeJson(payload.result.initialPermissions),
     );
 
     // Grant all permissions

--- a/packages/snaps-types/package.json
+++ b/packages/snaps-types/package.json
@@ -32,7 +32,7 @@
     "@metamask/providers": "^11.0.0",
     "@metamask/rpc-methods": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",
-    "@metamask/utils": "^6.0.0"
+    "@metamask/utils": "^6.0.1"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.3.1",

--- a/packages/snaps-ui/package.json
+++ b/packages/snaps-ui/package.json
@@ -27,7 +27,7 @@
     "lint:ci": "yarn lint"
   },
   "dependencies": {
-    "@metamask/utils": "^6.0.0",
+    "@metamask/utils": "^6.0.1",
     "superstruct": "^1.0.3"
   },
   "devDependencies": {

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 94.14,
   "functions": 100,
-  "lines": 98.5,
+  "lines": 98.51,
   "statements": 94.64
 }

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -2,5 +2,5 @@
   "branches": 94.14,
   "functions": 100,
   "lines": 98.51,
-  "statements": 94.64
+  "statements": 94.66
 }

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -61,7 +61,7 @@
     "@metamask/providers": "^11.0.0",
     "@metamask/snaps-registry": "^1.2.1",
     "@metamask/snaps-ui": "workspace:^",
-    "@metamask/utils": "^6.0.0",
+    "@metamask/utils": "^6.0.1",
     "@noble/hashes": "^1.1.3",
     "@scure/base": "^1.1.1",
     "cron-parser": "^4.5.0",

--- a/packages/snaps-utils/src/fs.ts
+++ b/packages/snaps-utils/src/fs.ts
@@ -1,4 +1,4 @@
-import { Json } from '@metamask/utils';
+import { getSafeJson, Json } from '@metamask/utils';
 import { promises as fs } from 'fs';
 import os from 'os';
 import pathUtils from 'path';
@@ -74,7 +74,7 @@ export async function readJsonFile<Type extends Json = Json>(
 
     throw error;
   }
-  file.result = JSON.parse(file.toString());
+  file.result = getSafeJson(JSON.parse(file.toString()));
   return file as VirtualFile<Type>;
 }
 

--- a/packages/snaps-utils/src/fs.ts
+++ b/packages/snaps-utils/src/fs.ts
@@ -1,8 +1,9 @@
-import { getSafeJson, Json } from '@metamask/utils';
+import { Json } from '@metamask/utils';
 import { promises as fs } from 'fs';
 import os from 'os';
 import pathUtils from 'path';
 
+import { parseJson } from './json';
 import { readVirtualFile, VirtualFile } from './virtual-file';
 
 /**
@@ -74,7 +75,7 @@ export async function readJsonFile<Type extends Json = Json>(
 
     throw error;
   }
-  file.result = getSafeJson(JSON.parse(file.toString()));
+  file.result = parseJson(file.toString());
   return file as VirtualFile<Type>;
 }
 

--- a/packages/snaps-utils/src/index.browser.ts
+++ b/packages/snaps-utils/src/index.browser.ts
@@ -7,6 +7,7 @@ export * from './default-endowments';
 export * from './entropy';
 export * from './handlers';
 export * from './iframe';
+export * from './json';
 export * from './json-rpc';
 export * from './logging';
 export * from './manifest/index.browser';

--- a/packages/snaps-utils/src/index.ts
+++ b/packages/snaps-utils/src/index.ts
@@ -9,6 +9,7 @@ export * from './eval';
 export * from './fs';
 export * from './handlers';
 export * from './iframe';
+export * from './json';
 export * from './json-rpc';
 export * from './logging';
 export * from './manifest';

--- a/packages/snaps-utils/src/json.test.ts
+++ b/packages/snaps-utils/src/json.test.ts
@@ -1,0 +1,9 @@
+import { parseJson } from './json';
+
+describe('parseJson', () => {
+  it('strips __proto__ and constructor', () => {
+    const input =
+      '{ "test": { "__proto__": { "foo": "bar" } }, "test2": { "constructor": { "baz": "qux" } } }';
+    expect(parseJson(input)).toStrictEqual({ test: {}, test2: {} });
+  });
+});

--- a/packages/snaps-utils/src/json.ts
+++ b/packages/snaps-utils/src/json.ts
@@ -1,0 +1,15 @@
+import { getSafeJson } from '@metamask/utils';
+
+// TODO: Upstream this to @metamask/utils
+
+/**
+ * Parses JSON safely.
+ *
+ * Does multiple kinds of validation and strips unwanted properties like __proto__.
+ *
+ * @param json - A JSON string to be parsed.
+ * @returns The parsed JSON object.
+ */
+export function parseJson(json: string) {
+  return getSafeJson(JSON.parse(json));
+}

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@metamask/snaps-utils": "workspace:^",
-    "@metamask/utils": "^6.0.0",
+    "@metamask/utils": "^6.0.1",
     "webpack-sources": "^3.2.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3843,7 +3843,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^11.0.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
-    "@metamask/utils": ^6.0.0
+    "@metamask/utils": ^6.0.1
     "@swc/core": ^1.3.61
     "@swc/jest": ^0.2.26
     "@types/jest": ^27.5.1
@@ -4002,7 +4002,7 @@ __metadata:
     "@metamask/providers": ^11.0.0
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/snaps-utils": "workspace:^"
-    "@metamask/utils": ^6.0.0
+    "@metamask/utils": ^6.0.1
     "@swc/core": ^1.3.61
     "@swc/jest": ^0.2.26
     "@types/jest": ^27.5.1
@@ -4112,7 +4112,7 @@ __metadata:
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
     "@metamask/types": ^1.1.0
-    "@metamask/utils": ^6.0.0
+    "@metamask/utils": ^6.0.1
     "@noble/hashes": ^1.1.3
     "@swc/core": ^1.3.61
     "@swc/jest": ^0.2.26
@@ -4224,7 +4224,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^11.0.0
     "@metamask/snaps-browserify-plugin": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
-    "@metamask/utils": ^6.0.0
+    "@metamask/utils": ^6.0.1
     "@swc/core": ^1.3.61
     "@swc/jest": ^0.2.26
     "@types/browserify": ^12.0.37
@@ -4293,7 +4293,7 @@ __metadata:
     "@metamask/snaps-registry": ^1.2.1
     "@metamask/snaps-utils": "workspace:^"
     "@metamask/template-snap": ^0.7.0
-    "@metamask/utils": ^6.0.0
+    "@metamask/utils": ^6.0.1
     "@peculiar/webcrypto": ^1.3.3
     "@swc/core": ^1.3.61
     "@swc/jest": ^0.2.26
@@ -4379,7 +4379,7 @@ __metadata:
     "@metamask/providers": ^11.0.0
     "@metamask/rpc-methods": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
-    "@metamask/utils": ^6.0.0
+    "@metamask/utils": ^6.0.1
     "@swc/core": ^1.3.61
     "@swc/jest": ^0.2.26
     "@types/express": ^4.17.17
@@ -4512,7 +4512,7 @@ __metadata:
     "@metamask/snaps-controllers": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
-    "@metamask/utils": ^6.0.0
+    "@metamask/utils": ^6.0.1
     "@minoru/react-dnd-treeview": ^3.4.4
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.10
     "@redux-saga/is": ^1.1.3
@@ -4604,7 +4604,7 @@ __metadata:
     "@metamask/providers": ^11.0.0
     "@metamask/rpc-methods": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
-    "@metamask/utils": ^6.0.0
+    "@metamask/utils": ^6.0.1
     "@swc/core": ^1.3.61
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -4634,7 +4634,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^11.0.0
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
-    "@metamask/utils": ^6.0.0
+    "@metamask/utils": ^6.0.1
     "@swc/core": ^1.3.61
     "@swc/jest": ^0.2.26
     "@types/jest": ^27.5.1
@@ -4680,7 +4680,7 @@ __metadata:
     "@metamask/providers": ^11.0.0
     "@metamask/snaps-registry": ^1.2.1
     "@metamask/snaps-ui": "workspace:^"
-    "@metamask/utils": ^6.0.0
+    "@metamask/utils": ^6.0.1
     "@noble/hashes": ^1.1.3
     "@scure/base": ^1.1.1
     "@swc/core": ^1.3.61
@@ -4748,7 +4748,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
     "@metamask/snaps-utils": "workspace:^"
-    "@metamask/utils": ^6.0.0
+    "@metamask/utils": ^6.0.1
     "@swc/core": ^1.3.61
     "@swc/jest": ^0.2.26
     "@types/jest": ^27.5.1
@@ -4814,16 +4814,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@metamask/utils@npm:6.0.0"
+"@metamask/utils@npm:^6.0.0, @metamask/utils@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "@metamask/utils@npm:6.0.1"
   dependencies:
     "@ethereumjs/tx": ^4.1.2
     "@types/debug": ^4.1.7
     debug: ^4.3.4
     semver: ^7.3.8
     superstruct: ^1.0.3
-  checksum: 502a75c82af729f813a08382e8ca5e3bfab7903a377b375e781ffcd5541e3a57b468a0daf02bb8e5c5bcb9051408f51c1ffb7a92b90bfd89946e7691c1117ca9
+  checksum: 6eeed00986866d4a674bf65c5f9e264fc133a368dbf0e28b9b090a7c04a89c3c543e8de8a752eff770d283b43a8e02648ba34b9077627dc7ee8c063b6167a2da
   languageName: node
   linkType: hard
 
@@ -20645,7 +20645,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^11.0.0
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
-    "@metamask/utils": ^6.0.0
+    "@metamask/utils": ^6.0.1
     "@types/jest": ^27.5.1
     "@types/node": ^17.0.36
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -21157,7 +21157,7 @@ __metadata:
     "@metamask/key-tree": ^7.0.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
-    "@metamask/utils": ^6.0.0
+    "@metamask/utils": ^6.0.1
     "@noble/secp256k1": ^1.7.1
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -21186,7 +21186,7 @@ __metadata:
     "@metamask/key-tree": ^7.0.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
-    "@metamask/utils": ^6.0.0
+    "@metamask/utils": ^6.0.1
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
     async-mutex: ^0.4.0
@@ -21214,7 +21214,7 @@ __metadata:
     "@metamask/key-tree": ^7.0.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
-    "@metamask/utils": ^6.0.0
+    "@metamask/utils": ^6.0.1
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
     buffer: ^6.0.3
@@ -22529,7 +22529,7 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
-    "@metamask/utils": ^6.0.0
+    "@metamask/utils": ^6.0.1
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
     eslint: ^8.27.0


### PR DESCRIPTION
Improve JSON parsing safety by using `getSafeJson` for most `JSON.parse` results and bumping `metamask/utils` to `6.0.1`.

Fixes https://github.com/MetaMask/MetaMask-planning/issues/712