### PR TITLE
Add script to spin up local instance of the Iframe Execution Environment

### DIFF
--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -33,7 +33,8 @@
     "auto-changelog-init": "auto-changelog init",
     "prepare-manifest:preview": "../../scripts/prepare-preview-manifest.sh",
     "publish:preview": "yarn npm publish --tag preview",
-    "lint:ci": "yarn lint"
+    "lint:ci": "yarn lint",
+    "start": "node scripts/start.js"
   },
   "dependencies": {
     "@metamask/object-multiplex": "^1.2.0",
@@ -46,6 +47,7 @@
     "json-rpc-engine": "^6.1.0",
     "nanoid": "^3.1.31",
     "pump": "^3.0.0",
+    "serve-handler": "^6.1.5",
     "ses": "^0.18.1",
     "stream-browserify": "^3.0.0",
     "superstruct": "^1.0.3"

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -47,7 +47,6 @@
     "json-rpc-engine": "^6.1.0",
     "nanoid": "^3.1.31",
     "pump": "^3.0.0",
-    "serve-handler": "^6.1.5",
     "ses": "^0.18.1",
     "stream-browserify": "^3.0.0",
     "superstruct": "^1.0.3"
@@ -105,6 +104,7 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "process": "^0.11.10",
     "rimraf": "^4.1.2",
+    "serve-handler": "^6.1.5",
     "terser": "^5.17.7",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",

--- a/packages/snaps-execution-environments/scripts/start.js
+++ b/packages/snaps-execution-environments/scripts/start.js
@@ -1,0 +1,53 @@
+const { logError, logInfo } = require('@metamask/snaps-utils');
+const http = require('http');
+const path = require('path');
+const serveHandler = require('serve-handler');
+
+const ROOT = path.resolve(__dirname, '..');
+const PUBLIC = path.join(ROOT, '/dist/browserify/iframe');
+
+start();
+
+/**
+ * Script to serve a local instance of the Iframe Execution Environment.
+ * Expects that the first positional argument to the Node process is a valid
+ * integer port.
+ */
+async function start() {
+  const port = parseInt(process.argv[2] ?? 8000, 10);
+  if (!Number.isSafeInteger(port) || port < 0) {
+    throw new Error(`Invalid port: "${port}"`);
+  }
+
+  const server = http.createServer(async (req, res) => {
+    await serveHandler(req, res, {
+      public: PUBLIC,
+      headers: [
+        {
+          source: '**/*',
+          headers: [
+            {
+              key: 'Cache-Control',
+              value: 'no-cache',
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  server.listen({ port }, () =>
+    logInfo(`Server listening on: http://localhost:${port}`),
+  );
+
+  server.on('error', (error) => {
+    logError('Server error', error);
+    process.exitCode = 1;
+    server.close();
+  });
+
+  server.on('close', () => {
+    logInfo('Server closed');
+    process.exitCode = 1;
+  });
+}

--- a/packages/snaps-execution-environments/scripts/start.js
+++ b/packages/snaps-execution-environments/scripts/start.js
@@ -1,4 +1,4 @@
-const { logError, logInfo } = require('@metamask/snaps-utils');
+/* eslint-disable no-console */
 const http = require('http');
 const path = require('path');
 const serveHandler = require('serve-handler');
@@ -37,17 +37,17 @@ async function start() {
   });
 
   server.listen({ port }, () =>
-    logInfo(`Server listening on: http://localhost:${port}`),
+    console.log(`Server listening on: http://localhost:${port}`),
   );
 
   server.on('error', (error) => {
-    logError('Server error', error);
+    console.error('Server error', error);
     process.exitCode = 1;
     server.close();
   });
 
   server.on('close', () => {
-    logInfo('Server closed');
+    console.log('Server closed');
     process.exitCode = 1;
   });
 }

--- a/packages/snaps-execution-environments/scripts/start.js
+++ b/packages/snaps-execution-environments/scripts/start.js
@@ -14,7 +14,7 @@ start();
  * integer port.
  */
 async function start() {
-  const port = parseInt(process.argv[2] ?? 8000, 10);
+  const port = parseInt(process.argv[2] ?? 6969, 10);
   if (!Number.isSafeInteger(port) || port < 0) {
     throw new Error(`Invalid port: "${port}"`);
   }

--- a/packages/snaps-execution-environments/scripts/start.js
+++ b/packages/snaps-execution-environments/scripts/start.js
@@ -14,7 +14,7 @@ start();
  * integer port.
  */
 async function start() {
-  const port = parseInt(process.argv[2] ?? 6969, 10);
+  const port = parseInt(process.argv[2] ?? 6363, 10);
   if (!Number.isSafeInteger(port) || port < 0) {
     throw new Error(`Invalid port: "${port}"`);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4459,6 +4459,7 @@ __metadata:
     process: ^0.11.10
     pump: ^3.0.0
     rimraf: ^4.1.2
+    serve-handler: ^6.1.5
     ses: ^0.18.1
     stream-browserify: ^3.0.0
     superstruct: ^1.0.3


### PR DESCRIPTION
This is meant to help incorporate changes made to the execution environment into the extension. The idea is to spin up a local instance and then use your local url in place of the hosted url in `builds.yml` in the `metamask-extension` repo.