### PR TITLE
Fix false positives when post processing code with HTML comment tokens

### DIFF
--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 94.14,
+  "branches": 94.47,
   "functions": 100,
-  "lines": 98.52,
-  "statements": 94.68
+  "lines": 98.54,
+  "statements": 94.73
 }

--- a/packages/snaps-utils/src/post-process.test.ts
+++ b/packages/snaps-utils/src/post-process.test.ts
@@ -309,6 +309,15 @@ describe('postProcessBundle', () => {
     `);
   });
 
+  it(`doesn't throw for strings that contain HTML comment tokens inside binary expressions`, () => {
+    const code = `
+      const foo = foo() + '<!-- bar -->' + baz();
+      const bar = foo() + \`<!-- bar -->\` + baz();
+    `;
+
+    expect(() => postProcessBundle(code)).not.toThrow();
+  });
+
   it.each(['const a = b <!-- c;', 'const a = b --> c;'])(
     'throws an error when HTML comment tokens are used as operators',
     (code) => {

--- a/packages/snaps-utils/src/post-process.ts
+++ b/packages/snaps-utils/src/post-process.ts
@@ -4,11 +4,14 @@ import {
   binaryExpression,
   Expression,
   Identifier,
+  isUnaryExpression,
+  isUpdateExpression,
   stringLiteral,
   TemplateElement,
   templateElement,
   templateLiteral,
 } from '@babel/types';
+import { assert } from '@metamask/utils';
 
 /**
  * Source map declaration taken from `@babel/core`. Babel doesn't export the
@@ -411,16 +414,50 @@ export function postProcessBundle(
     },
 
     BinaryExpression(path) {
-      const source = path.getSource();
+      const { node } = path;
 
-      // Throw an error if HTML comments are used as a binary expression.
-      if (source.includes('<!--') || source.includes('-->')) {
-        throw new Error(
-          'Using HTML comments (`<!--` and `-->`) as operators is not allowed. The behaviour of ' +
-            'these comments is ambiguous, and differs per browser and environment. If you want ' +
-            'to use them as operators, break them up into separate characters, i.e., `a-- > b` ' +
-            'and `a < ! --b`.',
+      if (
+        node.operator === '<' &&
+        isUnaryExpression(node.right) &&
+        isUpdateExpression(node.right.argument) &&
+        node.right.argument.operator === '--'
+      ) {
+        assert(node.left.end);
+        assert(node.right.argument.argument.start);
+
+        const expression = code.slice(
+          node.left.end,
+          node.right.argument.argument.start,
         );
+
+        if (expression.includes('<!--')) {
+          throw new Error(
+            'Using HTML comments (`<!--` and `-->`) as operators is not allowed. The behaviour of ' +
+              'these comments is ambiguous, and differs per browser and environment. If you want ' +
+              'to use them as operators, break them up into separate characters, i.e., `a-- > b` ' +
+              'and `a < ! --b`.',
+          );
+        }
+      }
+
+      if (
+        node.operator === '>' &&
+        isUpdateExpression(node.left) &&
+        node.left.operator === '--'
+      ) {
+        assert(node.left.argument.end);
+        assert(node.right.start);
+
+        const expression = code.slice(node.left.argument.end, node.right.start);
+
+        if (expression.includes('-->')) {
+          throw new Error(
+            'Using HTML comments (`<!--` and `-->`) as operators is not allowed. The behaviour of ' +
+              'these comments is ambiguous, and differs per browser and environment. If you want ' +
+              'to use them as operators, break them up into separate characters, i.e., `a-- > b` ' +
+              'and `a < ! --b`.',
+          );
+        }
       }
     },
   };

--- a/packages/snaps-utils/src/post-process.ts
+++ b/packages/snaps-utils/src/post-process.ts
@@ -416,6 +416,12 @@ export function postProcessBundle(
     BinaryExpression(path) {
       const { node } = path;
 
+      const errorMessage =
+        'Using HTML comments (`<!--` and `-->`) as operators is not allowed. The behaviour of ' +
+        'these comments is ambiguous, and differs per browser and environment. If you want ' +
+        'to use them as operators, break them up into separate characters, i.e., `a-- > b` ' +
+        'and `a < ! --b`.';
+
       if (
         node.operator === '<' &&
         isUnaryExpression(node.right) &&
@@ -431,12 +437,7 @@ export function postProcessBundle(
         );
 
         if (expression.includes('<!--')) {
-          throw new Error(
-            'Using HTML comments (`<!--` and `-->`) as operators is not allowed. The behaviour of ' +
-              'these comments is ambiguous, and differs per browser and environment. If you want ' +
-              'to use them as operators, break them up into separate characters, i.e., `a-- > b` ' +
-              'and `a < ! --b`.',
-          );
+          throw new Error(errorMessage);
         }
       }
 
@@ -451,12 +452,7 @@ export function postProcessBundle(
         const expression = code.slice(node.left.argument.end, node.right.start);
 
         if (expression.includes('-->')) {
-          throw new Error(
-            'Using HTML comments (`<!--` and `-->`) as operators is not allowed. The behaviour of ' +
-              'these comments is ambiguous, and differs per browser and environment. If you want ' +
-              'to use them as operators, break them up into separate characters, i.e., `a-- > b` ' +
-              'and `a < ! --b`.',
-          );
+          throw new Error(errorMessage);
         }
       }
     },

--- a/packages/snaps-utils/src/post-process.ts
+++ b/packages/snaps-utils/src/post-process.ts
@@ -11,7 +11,6 @@ import {
   templateElement,
   templateLiteral,
 } from '@babel/types';
-import { assert } from '@metamask/utils';
 
 /**
  * Source map declaration taken from `@babel/core`. Babel doesn't export the
@@ -426,11 +425,10 @@ export function postProcessBundle(
         node.operator === '<' &&
         isUnaryExpression(node.right) &&
         isUpdateExpression(node.right.argument) &&
-        node.right.argument.operator === '--'
+        node.right.argument.operator === '--' &&
+        node.left.end &&
+        node.right.argument.argument.start
       ) {
-        assert(node.left.end);
-        assert(node.right.argument.argument.start);
-
         const expression = code.slice(
           node.left.end,
           node.right.argument.argument.start,
@@ -444,11 +442,10 @@ export function postProcessBundle(
       if (
         node.operator === '>' &&
         isUpdateExpression(node.left) &&
-        node.left.operator === '--'
+        node.left.operator === '--' &&
+        node.left.argument.end &&
+        node.right.start
       ) {
-        assert(node.left.argument.end);
-        assert(node.right.start);
-
         const expression = code.slice(node.left.argument.end, node.right.start);
 
         if (expression.includes('-->')) {


### PR DESCRIPTION
Previously, our post processing would throw an error for code such as:

```ts
const foo = bar + `<!-- baz -->` + qux;
```

This is because we were looking at the entire source of the binary expression, rather than the individual `left` and `right` nodes. I fixed this by only checking the code between the left and right part.