### PR TITLE
Add missing `prepare-manifest:preview` and `publish:preview` scripts

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -148,6 +148,15 @@ gen_enforced_field(WorkspaceCwd, 'sideEffects', 'false') :-
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
 
+% Dependencies must have preview scripts.
+gen_enforced_field(WorkspaceCwd, 'scripts.prepare-manifest:preview', '../../scripts/prepare-preview-manifest.sh') :-
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  \+ is_example(WorkspaceCwd),
+  WorkspaceCwd \= '.'.
+gen_enforced_field(WorkspaceCwd, 'scripts.publish:preview', 'yarn npm publish --tag preview') :-
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+
 % Ensure all examples have the same scripts.
 gen_enforced_field(WorkspaceCwd, 'scripts.build', 'mm-snap build') :-
   is_example(WorkspaceCwd),
@@ -184,6 +193,11 @@ gen_enforced_field(WorkspaceCwd, 'scripts.lint:misc', 'prettier --no-error-on-un
   is_nested_example(WorkspaceCwd).
 gen_enforced_field(WorkspaceCwd, 'scripts.lint:changelog', 'yarn auto-changelog validate') :-
   is_example(WorkspaceCwd).
+gen_enforced_field(WorkspaceCwd, 'scripts.prepare-manifest:preview', '../../../../scripts/prepare-preview-manifest.sh') :-
+  is_example(WorkspaceCwd),
+  \+ is_nested_example(WorkspaceCwd).
+gen_enforced_field(WorkspaceCwd, 'scripts.prepare-manifest:preview', '../../../../../../scripts/prepare-preview-manifest.sh') :-
+  is_nested_example(WorkspaceCwd).
 
 % Ensure all examples have the same `main` and `types` fields.
 gen_enforced_field(WorkspaceCwd, 'main', 'dist/bundle.js') :-

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -30,7 +30,9 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check && yarn lint:changelog",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "publish:package": "../../scripts/publish-package.sh",
-    "lint:ci": "yarn lint"
+    "lint:ci": "yarn lint",
+    "prepare-manifest:preview": "../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@babel/core": "^7.20.12",

--- a/packages/examples/packages/bip32/package.json
+++ b/packages/examples/packages/bip32/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "start": "mm-snap watch",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/key-tree": "^7.1.1",

--- a/packages/examples/packages/bip44/package.json
+++ b/packages/examples/packages/bip44/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "start": "mm-snap watch",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/key-tree": "^7.1.1",

--- a/packages/examples/packages/browserify-plugin/package.json
+++ b/packages/examples/packages/browserify-plugin/package.json
@@ -25,7 +25,9 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^5.1.1",

--- a/packages/examples/packages/cronjobs/package.json
+++ b/packages/examples/packages/cronjobs/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "start": "mm-snap watch",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^5.1.1",

--- a/packages/examples/packages/dialogs/package.json
+++ b/packages/examples/packages/dialogs/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "start": "mm-snap watch",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^5.1.1",

--- a/packages/examples/packages/errors/package.json
+++ b/packages/examples/packages/errors/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "start": "mm-snap watch",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/snaps-types": "workspace:^"

--- a/packages/examples/packages/ethereum-provider/package.json
+++ b/packages/examples/packages/ethereum-provider/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "start": "mm-snap watch",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^5.1.1",

--- a/packages/examples/packages/ethers-js/package.json
+++ b/packages/examples/packages/ethers-js/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "start": "mm-snap watch",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^5.1.1",

--- a/packages/examples/packages/get-entropy/package.json
+++ b/packages/examples/packages/get-entropy/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "start": "mm-snap watch",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^5.1.1",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../../../.gitignore",
     "start": "mm-snap watch",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/key-tree": "^7.1.1",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../../../.gitignore",
     "start": "mm-snap watch",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/key-tree": "^7.1.1",

--- a/packages/examples/packages/json-rpc/package.json
+++ b/packages/examples/packages/json-rpc/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "start": "mm-snap watch",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^5.1.1",

--- a/packages/examples/packages/manage-state/package.json
+++ b/packages/examples/packages/manage-state/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "start": "mm-snap watch",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^5.1.1",

--- a/packages/examples/packages/network-access/package.json
+++ b/packages/examples/packages/network-access/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "start": "mm-snap watch",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^5.1.1",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LKLd6rGoZgiBdMHZelvoYhNVscfrS5QPUIROma1ZZNY=",
+    "shasum": "Lz6o851C20cg9Yph7rmgGgbM85c8kvn94vSD3s+7ebM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/package.json
+++ b/packages/examples/packages/notifications/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "start": "mm-snap watch",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^5.1.1",

--- a/packages/examples/packages/rollup-plugin/package.json
+++ b/packages/examples/packages/rollup-plugin/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "test": "yarn test:e2e",
     "test:e2e": "jest",
-    "start": "rollup watch"
+    "start": "rollup watch",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^5.1.1",

--- a/packages/examples/packages/transaction-insights/package.json
+++ b/packages/examples/packages/transaction-insights/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "start": "mm-snap watch",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/snaps-types": "workspace:^",

--- a/packages/examples/packages/wasm/package.json
+++ b/packages/examples/packages/wasm/package.json
@@ -27,7 +27,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "start": "webpack watch",
     "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test:e2e": "jest",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^5.1.1",

--- a/packages/examples/packages/webpack-plugin/package.json
+++ b/packages/examples/packages/webpack-plugin/package.json
@@ -26,7 +26,9 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "test": "yarn test:e2e",
     "test:e2e": "jest",
-    "start": "webpack watch"
+    "start": "webpack watch",
+    "prepare-manifest:preview": "../../../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^5.1.1",

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -35,7 +35,9 @@
     "test:ci": "yarn test",
     "test:watch": "jest --watch",
     "clean": "rimraf '*.tsbuildinfo' 'dist/*'",
-    "lint:ci": "yarn lint"
+    "lint:ci": "yarn lint",
+    "prepare-manifest:preview": "../../scripts/prepare-preview-manifest.sh",
+    "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
     "@chakra-ui/anatomy": "^2.1.1",


### PR DESCRIPTION
Some packages were missing the `prepare-manifest:preview` and `publish:preview` scripts, meaning that they wouldn't be published properly when using preview releases. This adds a Yarn constraint and adds the missing scripts to those packages.