### PR TITLE
Add wildcard exports to all packages

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -178,31 +178,29 @@ gen_enforced_field(WorkspaceCwd, 'exports["."].import', './dist/esm/index.js') :
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
 
-% The dependency must be importable from subpaths.
-gen_enforced_field(WorkspaceCwd, 'exports["./*"].types', './dist/types/*.d.ts') :-
+% The dependency must be importable from `./dist/cjs` and `./dist/esm` subpaths,
+% for backwards compatibility with older versions of the package.
+gen_enforced_field(WorkspaceCwd, 'exports["./dist/esm/*"].types', './dist/types/*.d.ts') :-
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'exports["./*"].require', './dist/cjs/*.js') :-
+gen_enforced_field(WorkspaceCwd, 'exports["./dist/esm/*"].require', './dist/cjs/*.js') :-
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'exports["./*"].import', './dist/esm/*.js') :-
+gen_enforced_field(WorkspaceCwd, 'exports["./dist/esm/*"].import', './dist/esm/*.js') :-
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
-
-% The dependency must be importable from `./dist` subpaths, for backwards
-% compatibility with older versions of the package.
-gen_enforced_field(WorkspaceCwd, 'exports["./dist/*"].types', './dist/types/*.d.ts') :-
+gen_enforced_field(WorkspaceCwd, 'exports["./dist/cjs/*"].types', './dist/types/*.d.ts') :-
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'exports["./dist/*"].require', './dist/cjs/*.js') :-
+gen_enforced_field(WorkspaceCwd, 'exports["./dist/cjs/*"].require', './dist/cjs/*.js') :-
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'exports["./dist/*"].import', './dist/esm/*.js') :-
+gen_enforced_field(WorkspaceCwd, 'exports["./dist/cjs/*"].import', './dist/esm/*.js') :-
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
@@ -212,7 +210,11 @@ gen_enforced_field(WorkspaceCwd, 'typesVersions["*"]["*"]', ['./dist/types/*']) 
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'typesVersions["*"]["./dist/*"]', ['./dist/types/*']) :-
+gen_enforced_field(WorkspaceCwd, 'typesVersions["*"]["./dist/esm/*"]', ['./dist/types/*']) :-
+  \+ is_example(WorkspaceCwd),
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+gen_enforced_field(WorkspaceCwd, 'typesVersions["*"]["./dist/cjs/*"]', ['./dist/types/*']) :-
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.

--- a/constraints.pro
+++ b/constraints.pro
@@ -192,8 +192,27 @@ gen_enforced_field(WorkspaceCwd, 'exports["./*"].import', './dist/esm/*.js') :-
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
 
+% The dependency must be importable from `./dist` subpaths, for backwards
+% compatibility with older versions of the package.
+gen_enforced_field(WorkspaceCwd, 'exports["./dist/*"].types', './dist/types/*.d.ts') :-
+  \+ is_example(WorkspaceCwd),
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+gen_enforced_field(WorkspaceCwd, 'exports["./dist/*"].require', './dist/cjs/*.js') :-
+  \+ is_example(WorkspaceCwd),
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+gen_enforced_field(WorkspaceCwd, 'exports["./dist/*"].import', './dist/esm/*.js') :-
+  \+ is_example(WorkspaceCwd),
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+
 % The dependency types must be importable from subpaths.
 gen_enforced_field(WorkspaceCwd, 'typesVersions["*"]["*"]', ['./dist/types/*']) :-
+  \+ is_example(WorkspaceCwd),
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+gen_enforced_field(WorkspaceCwd, 'typesVersions["*"]["./dist/*"]', ['./dist/types/*']) :-
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.

--- a/constraints.pro
+++ b/constraints.pro
@@ -184,7 +184,7 @@ gen_enforced_field(WorkspaceCwd, 'exports["./dist/esm/*"].types', './dist/types/
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'exports["./dist/esm/*"].require', './dist/cjs/*.js') :-
+gen_enforced_field(WorkspaceCwd, 'exports["./dist/esm/*"].require', null) :-
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
@@ -200,7 +200,7 @@ gen_enforced_field(WorkspaceCwd, 'exports["./dist/cjs/*"].require', './dist/cjs/
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'exports["./dist/cjs/*"].import', './dist/esm/*.js') :-
+gen_enforced_field(WorkspaceCwd, 'exports["./dist/cjs/*"].import', null) :-
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.

--- a/constraints.pro
+++ b/constraints.pro
@@ -192,6 +192,12 @@ gen_enforced_field(WorkspaceCwd, 'exports["./*"].import', './dist/esm/*.js') :-
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
 
+% The dependency types must be importable from subpaths.
+gen_enforced_field(WorkspaceCwd, 'typesVersions["*"]["*"]', ['./dist/types/*']) :-
+  \+ is_example(WorkspaceCwd),
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+
 % Dependencies must have preview scripts.
 gen_enforced_field(WorkspaceCwd, 'scripts.prepare-manifest:preview', '../../scripts/prepare-preview-manifest.sh') :-
   \+ workspace_field(WorkspaceCwd, 'private', true),

--- a/constraints.pro
+++ b/constraints.pro
@@ -148,6 +148,50 @@ gen_enforced_field(WorkspaceCwd, 'sideEffects', 'false') :-
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
 
+% The type definitions entrypoint for the dependency must be `./dist/types/index.d.ts`.
+gen_enforced_field(WorkspaceCwd, 'types', './dist/types/index.d.ts') :-
+  \+ is_example(WorkspaceCwd),
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+gen_enforced_field(WorkspaceCwd, 'exports["."].types', './dist/types/index.d.ts') :-
+  \+ is_example(WorkspaceCwd),
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+
+% The entrypoint for the dependency must be `./dist/cjs/index.js`.
+gen_enforced_field(WorkspaceCwd, 'main', './dist/cjs/index.js') :-
+  \+ is_example(WorkspaceCwd),
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+gen_enforced_field(WorkspaceCwd, 'exports["."].require', './dist/cjs/index.js') :-
+  \+ is_example(WorkspaceCwd),
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+
+% The module entrypoint for the dependency must be `./dist/esm/index.js`.
+gen_enforced_field(WorkspaceCwd, 'module', './dist/esm/index.js') :-
+  \+ is_example(WorkspaceCwd),
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+gen_enforced_field(WorkspaceCwd, 'exports["."].import', './dist/esm/index.js') :-
+  \+ is_example(WorkspaceCwd),
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+
+% The dependency must be importable from subpaths.
+gen_enforced_field(WorkspaceCwd, 'exports["./*"].types', './dist/types/*.d.ts') :-
+  \+ is_example(WorkspaceCwd),
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+gen_enforced_field(WorkspaceCwd, 'exports["./*"].require', './dist/cjs/*.js') :-
+  \+ is_example(WorkspaceCwd),
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+gen_enforced_field(WorkspaceCwd, 'exports["./*"].import', './dist/esm/*.js') :-
+  \+ is_example(WorkspaceCwd),
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+
 % Dependencies must have preview scripts.
 gen_enforced_field(WorkspaceCwd, 'scripts.prepare-manifest:preview', '../../scripts/prepare-preview-manifest.sh') :-
   \+ workspace_field(WorkspaceCwd, 'private', true),

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -18,6 +18,11 @@
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
+    },
+    "./dist/*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
@@ -26,6 +31,9 @@
   "typesVersions": {
     "*": {
       "*": [
+        "./dist/types/*"
+      ],
+      "./dist/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -15,13 +15,11 @@
       "types": "./dist/types/index.d.ts"
     },
     "./dist/cjs/*": {
-      "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
     "./dist/esm/*": {
       "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     }
   },

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -13,6 +13,11 @@
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
+    },
+    "./*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -14,12 +14,12 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
     },
-    "./*": {
+    "./dist/cjs/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
-    "./dist/*": {
+    "./dist/esm/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
@@ -33,7 +33,10 @@
       "*": [
         "./dist/types/*"
       ],
-      "./dist/*": [
+      "./dist/cjs/*": [
+        "./dist/types/*"
+      ],
+      "./dist/esm/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -23,6 +23,13 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/types/*"
+      ]
+    }
+  },
   "bin": "./dist/cjs/main.js",
   "files": [
     "dist/cjs/**",

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -13,12 +13,12 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
     },
-    "./*": {
+    "./dist/cjs/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
-    "./dist/*": {
+    "./dist/esm/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
@@ -32,7 +32,10 @@
       "*": [
         "./dist/types/*"
       ],
-      "./dist/*": [
+      "./dist/cjs/*": [
+        "./dist/types/*"
+      ],
+      "./dist/esm/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -12,11 +12,16 @@
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
+    },
+    "./*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -14,13 +14,11 @@
       "types": "./dist/types/index.d.ts"
     },
     "./dist/cjs/*": {
-      "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
     "./dist/esm/*": {
       "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     }
   },

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -17,6 +17,11 @@
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
+    },
+    "./dist/*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
@@ -25,6 +30,9 @@
   "typesVersions": {
     "*": {
       "*": [
+        "./dist/types/*"
+      ],
+      "./dist/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -22,6 +22,13 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/types/*"
+      ]
+    }
+  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -19,6 +19,11 @@
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
+    },
+    "./dist/*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
@@ -27,6 +32,9 @@
   "typesVersions": {
     "*": {
       "*": [
+        "./dist/types/*"
+      ],
+      "./dist/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -16,13 +16,11 @@
       "types": "./dist/types/index.d.ts"
     },
     "./dist/cjs/*": {
-      "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
     "./dist/esm/*": {
       "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     }
   },

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -14,11 +14,16 @@
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
+    },
+    "./*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -15,12 +15,12 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
     },
-    "./*": {
+    "./dist/cjs/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
-    "./dist/*": {
+    "./dist/esm/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
@@ -34,7 +34,10 @@
       "*": [
         "./dist/types/*"
       ],
-      "./dist/*": [
+      "./dist/cjs/*": [
+        "./dist/types/*"
+      ],
+      "./dist/esm/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -24,6 +24,13 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/types/*"
+      ]
+    }
+  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -18,6 +18,11 @@
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
+    },
+    "./dist/*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
@@ -26,6 +31,9 @@
   "typesVersions": {
     "*": {
       "*": [
+        "./dist/types/*"
+      ],
+      "./dist/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -13,11 +13,16 @@
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
+    },
+    "./*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "bin": {
     "mm-snap": "./dist/cjs/main.js"
   },

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -23,6 +23,13 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/types/*"
+      ]
+    }
+  },
   "bin": {
     "mm-snap": "./dist/cjs/main.js"
   },

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -15,13 +15,11 @@
       "types": "./dist/types/index.d.ts"
     },
     "./dist/cjs/*": {
-      "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
     "./dist/esm/*": {
       "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     }
   },

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -14,12 +14,12 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
     },
-    "./*": {
+    "./dist/cjs/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
-    "./dist/*": {
+    "./dist/esm/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
@@ -33,7 +33,10 @@
       "*": [
         "./dist/types/*"
       ],
-      "./dist/*": [
+      "./dist/cjs/*": [
+        "./dist/types/*"
+      ],
+      "./dist/esm/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -20,6 +20,11 @@
     "./dist/esm/services": {
       "default": "./dist/esm/services/index.js",
       "browser": "./dist/esm/services/browser.js"
+    },
+    "./*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
@@ -28,7 +33,7 @@
     "./dist/cjs/services": "./dist/cjs/services/browser.js",
     "./dist/esm/services": "./dist/esm/services/browser.js"
   },
-  "types": "dist/types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -34,6 +34,13 @@
     "./dist/esm/services": "./dist/esm/services/browser.js"
   },
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/types/*"
+      ]
+    }
+  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -21,12 +21,12 @@
       "default": "./dist/esm/services/index.js",
       "browser": "./dist/esm/services/browser.js"
     },
-    "./*": {
+    "./dist/cjs/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
-    "./dist/*": {
+    "./dist/esm/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
@@ -44,7 +44,10 @@
       "*": [
         "./dist/types/*"
       ],
-      "./dist/*": [
+      "./dist/cjs/*": [
+        "./dist/types/*"
+      ],
+      "./dist/esm/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -22,13 +22,11 @@
       "browser": "./dist/esm/services/browser.js"
     },
     "./dist/cjs/*": {
-      "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
     "./dist/esm/*": {
       "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     }
   },

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -25,6 +25,11 @@
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
+    },
+    "./dist/*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
@@ -37,6 +42,9 @@
   "typesVersions": {
     "*": {
       "*": [
+        "./dist/types/*"
+      ],
+      "./dist/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -18,6 +18,11 @@
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
+    },
+    "./dist/*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
@@ -26,6 +31,9 @@
   "typesVersions": {
     "*": {
       "*": [
+        "./dist/types/*"
+      ],
+      "./dist/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -23,6 +23,13 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/types/*"
+      ]
+    }
+  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -14,12 +14,12 @@
       "types": "./dist/types/index.d.ts"
     },
     "./package.json": "./package.json",
-    "./*": {
+    "./dist/cjs/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
-    "./dist/*": {
+    "./dist/esm/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
@@ -33,7 +33,10 @@
       "*": [
         "./dist/types/*"
       ],
-      "./dist/*": [
+      "./dist/cjs/*": [
+        "./dist/types/*"
+      ],
+      "./dist/esm/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -15,13 +15,11 @@
     },
     "./package.json": "./package.json",
     "./dist/cjs/*": {
-      "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
     "./dist/esm/*": {
       "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     }
   },

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -13,11 +13,16 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
+    }
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -14,13 +14,11 @@
       "require": "./jest-preset.js"
     },
     "./dist/cjs/*": {
-      "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
     "./dist/esm/*": {
       "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     }
   },

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -13,12 +13,12 @@
       "import": "./jest-preset.js",
       "require": "./jest-preset.js"
     },
-    "./*": {
+    "./dist/cjs/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
-    "./dist/*": {
+    "./dist/esm/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
@@ -32,7 +32,10 @@
       "*": [
         "./dist/types/*"
       ],
-      "./dist/*": [
+      "./dist/cjs/*": [
+        "./dist/types/*"
+      ],
+      "./dist/esm/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -12,11 +12,16 @@
     "./jest-preset": {
       "import": "./jest-preset.js",
       "require": "./jest-preset.js"
+    },
+    "./*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -17,6 +17,11 @@
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
+    },
+    "./dist/*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
@@ -25,6 +30,9 @@
   "typesVersions": {
     "*": {
       "*": [
+        "./dist/types/*"
+      ],
+      "./dist/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -22,6 +22,13 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/types/*"
+      ]
+    }
+  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -25,6 +25,13 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/types/*"
+      ]
+    }
+  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -16,12 +16,12 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
     },
-    "./*": {
+    "./dist/cjs/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
-    "./dist/*": {
+    "./dist/esm/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
@@ -35,7 +35,10 @@
       "*": [
         "./dist/types/*"
       ],
-      "./dist/*": [
+      "./dist/cjs/*": [
+        "./dist/types/*"
+      ],
+      "./dist/esm/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -20,6 +20,11 @@
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
+    },
+    "./dist/*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
@@ -28,6 +33,9 @@
   "typesVersions": {
     "*": {
       "*": [
+        "./dist/types/*"
+      ],
+      "./dist/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -15,11 +15,16 @@
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
+    },
+    "./*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -17,13 +17,11 @@
       "types": "./dist/types/index.d.ts"
     },
     "./dist/cjs/*": {
-      "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
     "./dist/esm/*": {
       "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     }
   },

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -27,6 +27,13 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/types/*"
+      ]
+    }
+  },
   "files": [
     "dist/cjs",
     "dist/esm",

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -22,6 +22,11 @@
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
+    },
+    "./dist/*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
@@ -30,6 +35,9 @@
   "typesVersions": {
     "*": {
       "*": [
+        "./dist/types/*"
+      ],
+      "./dist/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -18,12 +18,12 @@
       "types": "./dist/types/index.d.ts"
     },
     "./package.json": "./package.json",
-    "./*": {
+    "./dist/cjs/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
-    "./dist/*": {
+    "./dist/esm/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
@@ -37,7 +37,10 @@
       "*": [
         "./dist/types/*"
       ],
-      "./dist/*": [
+      "./dist/cjs/*": [
+        "./dist/types/*"
+      ],
+      "./dist/esm/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -19,13 +19,11 @@
     },
     "./package.json": "./package.json",
     "./dist/cjs/*": {
-      "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
     "./dist/esm/*": {
       "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     }
   },

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -15,13 +15,18 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/types/index.d.ts"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
+    }
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "dist/src/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "files": [
     "dist/cjs",
     "dist/esm",

--- a/packages/snaps-types/package.json
+++ b/packages/snaps-types/package.json
@@ -13,12 +13,12 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
     },
-    "./*": {
+    "./dist/cjs/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
-    "./dist/*": {
+    "./dist/esm/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
@@ -32,7 +32,10 @@
       "*": [
         "./dist/types/*"
       ],
-      "./dist/*": [
+      "./dist/cjs/*": [
+        "./dist/types/*"
+      ],
+      "./dist/esm/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-types/package.json
+++ b/packages/snaps-types/package.json
@@ -12,11 +12,16 @@
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
+    },
+    "./*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-types/package.json
+++ b/packages/snaps-types/package.json
@@ -14,13 +14,11 @@
       "types": "./dist/types/index.d.ts"
     },
     "./dist/cjs/*": {
-      "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
     "./dist/esm/*": {
       "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     }
   },

--- a/packages/snaps-types/package.json
+++ b/packages/snaps-types/package.json
@@ -17,6 +17,11 @@
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
+    },
+    "./dist/*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
@@ -25,6 +30,9 @@
   "typesVersions": {
     "*": {
       "*": [
+        "./dist/types/*"
+      ],
+      "./dist/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-types/package.json
+++ b/packages/snaps-types/package.json
@@ -22,6 +22,13 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/types/*"
+      ]
+    }
+  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-ui/package.json
+++ b/packages/snaps-ui/package.json
@@ -21,6 +21,13 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/types/*"
+      ]
+    }
+  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-ui/package.json
+++ b/packages/snaps-ui/package.json
@@ -11,11 +11,16 @@
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
+    },
+    "./*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-ui/package.json
+++ b/packages/snaps-ui/package.json
@@ -13,13 +13,11 @@
       "types": "./dist/types/index.d.ts"
     },
     "./dist/cjs/*": {
-      "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
     "./dist/esm/*": {
       "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     }
   },

--- a/packages/snaps-ui/package.json
+++ b/packages/snaps-ui/package.json
@@ -12,12 +12,12 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
     },
-    "./*": {
+    "./dist/cjs/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
-    "./dist/*": {
+    "./dist/esm/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
@@ -31,7 +31,10 @@
       "*": [
         "./dist/types/*"
       ],
-      "./dist/*": [
+      "./dist/cjs/*": [
+        "./dist/types/*"
+      ],
+      "./dist/esm/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-ui/package.json
+++ b/packages/snaps-ui/package.json
@@ -16,6 +16,11 @@
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
+    },
+    "./dist/*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
@@ -24,6 +29,9 @@
   "typesVersions": {
     "*": {
       "*": [
+        "./dist/types/*"
+      ],
+      "./dist/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -20,6 +20,11 @@
       "import": "./dist/esm/test-utils/index.js",
       "require": "./dist/cjs/test-utils/index.js",
       "types": "./dist/types/test-utils/index.d.ts"
+    },
+    "./*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
@@ -28,6 +33,7 @@
     "./dist/cjs/index.js": "./dist/cjs/index.browser.js",
     "./dist/esm/index.js": "./dist/esm/index.browser.js"
   },
+  "types": "./dist/types/index.d.ts",
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -21,12 +21,12 @@
       "require": "./dist/cjs/test-utils/index.js",
       "types": "./dist/types/test-utils/index.d.ts"
     },
-    "./*": {
+    "./dist/cjs/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
-    "./dist/*": {
+    "./dist/esm/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
@@ -44,7 +44,10 @@
       "*": [
         "./dist/types/*"
       ],
-      "./dist/*": [
+      "./dist/cjs/*": [
+        "./dist/types/*"
+      ],
+      "./dist/esm/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -22,13 +22,11 @@
       "types": "./dist/types/test-utils/index.d.ts"
     },
     "./dist/cjs/*": {
-      "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
     "./dist/esm/*": {
       "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     }
   },

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -25,6 +25,11 @@
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
+    },
+    "./dist/*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
@@ -37,6 +42,9 @@
   "typesVersions": {
     "*": {
       "*": [
+        "./dist/types/*"
+      ],
+      "./dist/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -34,6 +34,13 @@
     "./dist/esm/index.js": "./dist/esm/index.browser.js"
   },
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/types/*"
+      ]
+    }
+  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -25,6 +25,13 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/types/*"
+      ]
+    }
+  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -16,12 +16,12 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
     },
-    "./*": {
+    "./dist/cjs/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
-    "./dist/*": {
+    "./dist/esm/*": {
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
@@ -35,7 +35,10 @@
       "*": [
         "./dist/types/*"
       ],
-      "./dist/*": [
+      "./dist/cjs/*": [
+        "./dist/types/*"
+      ],
+      "./dist/esm/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -20,6 +20,11 @@
       "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
+    },
+    "./dist/*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
@@ -28,6 +33,9 @@
   "typesVersions": {
     "*": {
       "*": [
+        "./dist/types/*"
+      ],
+      "./dist/*": [
         "./dist/types/*"
       ]
     }

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -15,11 +15,16 @@
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
+    },
+    "./*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js",
+      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -17,13 +17,11 @@
       "types": "./dist/types/index.d.ts"
     },
     "./dist/cjs/*": {
-      "import": "./dist/esm/*.js",
       "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     },
     "./dist/esm/*": {
       "import": "./dist/esm/*.js",
-      "require": "./dist/cjs/*.js",
       "types": "./dist/types/*.d.ts"
     }
   },


### PR DESCRIPTION
This adds wildcard exports (`./dist/cjs/*` and `./dist/esm/*`) to all packages, which makes it possible to import them from a subpath. Before, the following would fail:

```
require('@metamask/snaps-ui/dist/cjs/validation');
```

After this change, this will work as expected, and import the best version (ESM or CJS), regardless of the path used. This is a bit hacky, but Browserify doesn't support the `exports` field, so I'm not sure how to work around this otherwise.