### PR TITLE
Add export for `getRpcCaveatOrigins`

### DIFF
--- a/packages/snaps-controllers/src/snaps/endowments/index.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/index.ts
@@ -57,4 +57,5 @@ export const handlerEndowments: Record<HandlerType, string> = {
 };
 
 export * from './enum';
+export { getRpcCaveatOrigins } from './rpc';
 export { getTransactionOriginCaveat } from './transaction-insight';


### PR DESCRIPTION
Adds an export for `getRpcCaveatOrigins` since it is used in the extension.