### PR TITLE
Add missing `publishConfig` to `snaps-jest` and `snaps-simulator`

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -228,6 +228,13 @@ gen_enforced_field(WorkspaceCwd, 'scripts.publish:preview', 'yarn npm publish --
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
 
+gen_enforced_field(WorkspaceCwd, 'publishConfig.access', 'public') :-
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+gen_enforced_field(WorkspaceCwd, 'publishConfig.registry', 'https://registry.npmjs.org/') :-
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  WorkspaceCwd \= '.'.
+
 % Ensure all examples have the same scripts.
 gen_enforced_field(WorkspaceCwd, 'scripts.build', 'mm-snap build') :-
   is_example(WorkspaceCwd),

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -112,5 +112,9 @@
     "rimraf": "^4.1.2",
     "typescript": "~4.8.4"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "packageManager": "yarn@3.4.1"
 }

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -182,5 +182,9 @@
   "engines": {
     "node": ">=16.0.0"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "packageManager": "yarn@3.2.1"
 }


### PR DESCRIPTION
The `@metamask/snaps-jest` and `@metamask/snaps-simulator` packages were missing a `publishConfig`, causing the release to fail. This adds the missing `publishConfig`, as well as some Yarn constraints to prevent this in the future.