### PR TITLE
Remove unnecessary exports fields and fix missing build files

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -153,68 +153,15 @@ gen_enforced_field(WorkspaceCwd, 'types', './dist/types/index.d.ts') :-
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'exports["."].types', './dist/types/index.d.ts') :-
-  \+ is_example(WorkspaceCwd),
-  \+ workspace_field(WorkspaceCwd, 'private', true),
-  WorkspaceCwd \= '.'.
 
 % The entrypoint for the dependency must be `./dist/cjs/index.js`.
 gen_enforced_field(WorkspaceCwd, 'main', './dist/cjs/index.js') :-
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'exports["."].require', './dist/cjs/index.js') :-
-  \+ is_example(WorkspaceCwd),
-  \+ workspace_field(WorkspaceCwd, 'private', true),
-  WorkspaceCwd \= '.'.
 
 % The module entrypoint for the dependency must be `./dist/esm/index.js`.
 gen_enforced_field(WorkspaceCwd, 'module', './dist/esm/index.js') :-
-  \+ is_example(WorkspaceCwd),
-  \+ workspace_field(WorkspaceCwd, 'private', true),
-  WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'exports["."].import', './dist/esm/index.js') :-
-  \+ is_example(WorkspaceCwd),
-  \+ workspace_field(WorkspaceCwd, 'private', true),
-  WorkspaceCwd \= '.'.
-
-% The dependency must be importable from `./dist/cjs` and `./dist/esm` subpaths,
-% for backwards compatibility with older versions of the package.
-gen_enforced_field(WorkspaceCwd, 'exports["./dist/esm/*"].types', './dist/types/*.d.ts') :-
-  \+ is_example(WorkspaceCwd),
-  \+ workspace_field(WorkspaceCwd, 'private', true),
-  WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'exports["./dist/esm/*"].require', null) :-
-  \+ is_example(WorkspaceCwd),
-  \+ workspace_field(WorkspaceCwd, 'private', true),
-  WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'exports["./dist/esm/*"].import', './dist/esm/*.js') :-
-  \+ is_example(WorkspaceCwd),
-  \+ workspace_field(WorkspaceCwd, 'private', true),
-  WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'exports["./dist/cjs/*"].types', './dist/types/*.d.ts') :-
-  \+ is_example(WorkspaceCwd),
-  \+ workspace_field(WorkspaceCwd, 'private', true),
-  WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'exports["./dist/cjs/*"].require', './dist/cjs/*.js') :-
-  \+ is_example(WorkspaceCwd),
-  \+ workspace_field(WorkspaceCwd, 'private', true),
-  WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'exports["./dist/cjs/*"].import', null) :-
-  \+ is_example(WorkspaceCwd),
-  \+ workspace_field(WorkspaceCwd, 'private', true),
-  WorkspaceCwd \= '.'.
-
-% The dependency types must be importable from subpaths.
-gen_enforced_field(WorkspaceCwd, 'typesVersions["*"]["*"]', ['./dist/types/*']) :-
-  \+ is_example(WorkspaceCwd),
-  \+ workspace_field(WorkspaceCwd, 'private', true),
-  WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'typesVersions["*"]["./dist/esm/*"]', ['./dist/types/*']) :-
-  \+ is_example(WorkspaceCwd),
-  \+ workspace_field(WorkspaceCwd, 'private', true),
-  WorkspaceCwd \= '.'.
-gen_enforced_field(WorkspaceCwd, 'typesVersions["*"]["./dist/cjs/*"]', ['./dist/types/*']) :-
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.'.

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -8,37 +8,9 @@
   },
   "license": "ISC",
   "sideEffects": false,
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
-    },
-    "./dist/cjs/*": {
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/types/*.d.ts"
-    },
-    "./dist/esm/*": {
-      "import": "./dist/esm/*.js",
-      "types": "./dist/types/*.d.ts"
-    }
-  },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/types/*"
-      ],
-      "./dist/cjs/*": [
-        "./dist/types/*"
-      ],
-      "./dist/esm/*": [
-        "./dist/types/*"
-      ]
-    }
-  },
   "bin": "./dist/cjs/main.js",
   "files": [
     "dist/cjs/**",

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -7,37 +7,9 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "sideEffects": false,
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
-    },
-    "./dist/cjs/*": {
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/types/*.d.ts"
-    },
-    "./dist/esm/*": {
-      "import": "./dist/esm/*.js",
-      "types": "./dist/types/*.d.ts"
-    }
-  },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/types/*"
-      ],
-      "./dist/cjs/*": [
-        "./dist/types/*"
-      ],
-      "./dist/esm/*": [
-        "./dist/types/*"
-      ]
-    }
-  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -9,37 +9,9 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "sideEffects": false,
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
-    },
-    "./dist/cjs/*": {
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/types/*.d.ts"
-    },
-    "./dist/esm/*": {
-      "import": "./dist/esm/*.js",
-      "types": "./dist/types/*.d.ts"
-    }
-  },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/types/*"
-      ],
-      "./dist/cjs/*": [
-        "./dist/types/*"
-      ],
-      "./dist/esm/*": [
-        "./dist/types/*"
-      ]
-    }
-  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -8,37 +8,9 @@
   },
   "license": "ISC",
   "sideEffects": false,
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
-    },
-    "./dist/cjs/*": {
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/types/*.d.ts"
-    },
-    "./dist/esm/*": {
-      "import": "./dist/esm/*.js",
-      "types": "./dist/types/*.d.ts"
-    }
-  },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/types/*"
-      ],
-      "./dist/cjs/*": [
-        "./dist/types/*"
-      ],
-      "./dist/esm/*": [
-        "./dist/types/*"
-      ]
-    }
-  },
   "bin": {
     "mm-snap": "./dist/cjs/main.js"
   },

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -7,29 +7,6 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "sideEffects": false,
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
-    },
-    "./dist/cjs/services": {
-      "default": "./dist/cjs/services/index.js",
-      "browser": "./dist/cjs/services/browser.js"
-    },
-    "./dist/esm/services": {
-      "default": "./dist/esm/services/index.js",
-      "browser": "./dist/esm/services/browser.js"
-    },
-    "./dist/cjs/*": {
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/types/*.d.ts"
-    },
-    "./dist/esm/*": {
-      "import": "./dist/esm/*.js",
-      "types": "./dist/types/*.d.ts"
-    }
-  },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "browser": {
@@ -37,19 +14,6 @@
     "./dist/esm/services": "./dist/esm/services/browser.js"
   },
   "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/types/*"
-      ],
-      "./dist/cjs/*": [
-        "./dist/types/*"
-      ],
-      "./dist/esm/*": [
-        "./dist/types/*"
-      ]
-    }
-  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -7,38 +7,9 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "sideEffects": false,
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
-    },
-    "./package.json": "./package.json",
-    "./dist/cjs/*": {
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/types/*.d.ts"
-    },
-    "./dist/esm/*": {
-      "import": "./dist/esm/*.js",
-      "types": "./dist/types/*.d.ts"
-    }
-  },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/types/*"
-      ],
-      "./dist/cjs/*": [
-        "./dist/types/*"
-      ],
-      "./dist/esm/*": [
-        "./dist/types/*"
-      ]
-    }
-  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/cjs/**",
     "dist/esm/**",
-    "dist/types/**"
+    "dist/types/**",
+    "dist/browserify/**"
   ],
   "scripts": {
     "test": "rimraf coverage && jest && yarn test:browser && yarn posttest",

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -3,41 +3,9 @@
   "version": "0.35.1-flask.1",
   "description": "A Jest preset for end-to-end testing MetaMask Snaps, including a Jest environment, and a set of Jest matchers.",
   "sideEffects": false,
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
-    },
-    "./jest-preset": {
-      "import": "./jest-preset.js",
-      "require": "./jest-preset.js"
-    },
-    "./dist/cjs/*": {
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/types/*.d.ts"
-    },
-    "./dist/esm/*": {
-      "import": "./dist/esm/*.js",
-      "types": "./dist/types/*.d.ts"
-    }
-  },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/types/*"
-      ],
-      "./dist/cjs/*": [
-        "./dist/types/*"
-      ],
-      "./dist/esm/*": [
-        "./dist/types/*"
-      ]
-    }
-  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -10,37 +10,9 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "sideEffects": false,
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
-    },
-    "./dist/cjs/*": {
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/types/*.d.ts"
-    },
-    "./dist/esm/*": {
-      "import": "./dist/esm/*.js",
-      "types": "./dist/types/*.d.ts"
-    }
-  },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/types/*"
-      ],
-      "./dist/cjs/*": [
-        "./dist/types/*"
-      ],
-      "./dist/esm/*": [
-        "./dist/types/*"
-      ]
-    }
-  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -11,43 +11,14 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "sideEffects": false,
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
-    },
-    "./package.json": "./package.json",
-    "./dist/cjs/*": {
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/types/*.d.ts"
-    },
-    "./dist/esm/*": {
-      "import": "./dist/esm/*.js",
-      "types": "./dist/types/*.d.ts"
-    }
-  },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/types/*"
-      ],
-      "./dist/cjs/*": [
-        "./dist/types/*"
-      ],
-      "./dist/esm/*": [
-        "./dist/types/*"
-      ]
-    }
-  },
   "files": [
-    "dist/cjs",
-    "dist/esm",
-    "dist/src",
-    "dist/webpack"
+    "dist/cjs/**",
+    "dist/esm/**",
+    "dist/src/**",
+    "dist/webpack/**"
   ],
   "scripts": {
     "build": "yarn build:source && yarn build:types && yarn build:webpack",

--- a/packages/snaps-types/package.json
+++ b/packages/snaps-types/package.json
@@ -7,37 +7,9 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "sideEffects": false,
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
-    },
-    "./dist/cjs/*": {
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/types/*.d.ts"
-    },
-    "./dist/esm/*": {
-      "import": "./dist/esm/*.js",
-      "types": "./dist/types/*.d.ts"
-    }
-  },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/types/*"
-      ],
-      "./dist/cjs/*": [
-        "./dist/types/*"
-      ],
-      "./dist/esm/*": [
-        "./dist/types/*"
-      ]
-    }
-  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-ui/package.json
+++ b/packages/snaps-ui/package.json
@@ -6,37 +6,9 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "sideEffects": false,
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
-    },
-    "./dist/cjs/*": {
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/types/*.d.ts"
-    },
-    "./dist/esm/*": {
-      "import": "./dist/esm/*.js",
-      "types": "./dist/types/*.d.ts"
-    }
-  },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/types/*"
-      ],
-      "./dist/cjs/*": [
-        "./dist/types/*"
-      ],
-      "./dist/esm/*": [
-        "./dist/types/*"
-      ]
-    }
-  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -11,8 +11,8 @@
       "browser": {
         "default": "./dist/index.browser.js"
       },
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
     },
     "./test-utils": {
       "import": "./dist/esm/test-utils/index.js",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -9,25 +9,15 @@
   "exports": {
     ".": {
       "browser": {
-        "import": "./dist/esm/index.browser.js",
-        "require": "./dist/cjs/index.browser.js"
+        "default": "./dist/index.browser.js"
       },
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
     },
     "./test-utils": {
       "import": "./dist/esm/test-utils/index.js",
       "require": "./dist/cjs/test-utils/index.js",
       "types": "./dist/types/test-utils/index.d.ts"
-    },
-    "./dist/cjs/*": {
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/types/*.d.ts"
-    },
-    "./dist/esm/*": {
-      "import": "./dist/esm/*.js",
-      "types": "./dist/types/*.d.ts"
     }
   },
   "main": "./dist/cjs/index.js",
@@ -40,13 +30,10 @@
   "typesVersions": {
     "*": {
       "*": [
-        "./dist/types/*"
+        "dist/index.d.ts"
       ],
-      "./dist/cjs/*": [
-        "./dist/types/*"
-      ],
-      "./dist/esm/*": [
-        "./dist/types/*"
+      "test-utils": [
+        "dist/test-utils/index.d.ts"
       ]
     }
   },

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -31,10 +31,10 @@
   "typesVersions": {
     "*": {
       "*": [
-        "dist/types/index.d.ts"
+        "./dist/types/index.d.ts"
       ],
       "test-utils": [
-        "dist/types/test-utils/index.d.ts"
+        "./dist/types/test-utils/index.d.ts"
       ]
     }
   },

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -31,10 +31,10 @@
   "typesVersions": {
     "*": {
       "*": [
-        "dist/index.d.ts"
+        "dist/types/index.d.ts"
       ],
       "test-utils": [
-        "dist/test-utils/index.d.ts"
+        "dist/types/test-utils/index.d.ts"
       ]
     }
   },

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "browser": {
-        "default": "./dist/index.browser.js"
+        "import": "./dist/esm/index.browser.js",
+        "require": "./dist/cjs/index.browser.js"
       },
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -10,37 +10,9 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "sideEffects": false,
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
-    },
-    "./dist/cjs/*": {
-      "require": "./dist/cjs/*.js",
-      "types": "./dist/types/*.d.ts"
-    },
-    "./dist/esm/*": {
-      "import": "./dist/esm/*.js",
-      "types": "./dist/types/*.d.ts"
-    }
-  },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/types/*"
-      ],
-      "./dist/cjs/*": [
-        "./dist/types/*"
-      ],
-      "./dist/esm/*": [
-        "./dist/types/*"
-      ]
-    }
-  },
   "files": [
     "dist/cjs/**",
     "dist/esm/**",


### PR DESCRIPTION
This removes unnecessary exports fields, as Node.js is able to resolve these based on the file system. It also fixes an issue with missing build files in the `snaps-simulator` package.