### PR TITLE
Update setup script path in `snaps-jest` README file

### DIFF
--- a/packages/snaps-jest/README.md
+++ b/packages/snaps-jest/README.md
@@ -57,7 +57,7 @@ matchers by adding them to your Jest configuration manually:
 ```js
 module.exports = {
   testEnvironment: '@metamask/snaps-jest',
-  setupFilesAfterEnv: ['@metamask/snaps-jest/dist/setup.js'],
+  setupFilesAfterEnv: ['@metamask/snaps-jest/dist/cjs/setup.js'],
 };
 ```
 


### PR DESCRIPTION
The output path was recently changed, but not updated in the README.