### PR TITLE
Default to newline instead of empty string for network mocking

### DIFF
--- a/packages/snaps-jest/src/internals/network.ts
+++ b/packages/snaps-jest/src/internals/network.ts
@@ -62,7 +62,10 @@ const MockOptionsBaseStruct = object({
       status: defaulted(number(), 200),
       headers: defaulted(record(string(), unknown()), DEFAULT_HEADERS),
       contentType: defaulted(string(), 'text/plain'),
-      body: defaulted(string(), ''),
+
+      // Note: We default to a newline here, because the fetch request never
+      // resolves if the body is empty.
+      body: defaulted(string(), '\n'),
     }),
     {},
   ),


### PR DESCRIPTION
For some reason, when mocking the network with an empty string as body, the request never resolves. When using a newline, this is not an issue.