### PR TITLE
Fix example snaps names in test-snaps page

### DIFF
--- a/packages/test-snaps/src/features/snaps/cronjobs/constants.ts
+++ b/packages/test-snaps/src/features/snaps/cronjobs/constants.ts
@@ -1,2 +1,2 @@
-export const CRONJOBS_SNAP_ID = 'npm:@metamask/cronjobs-example-snap';
+export const CRONJOBS_SNAP_ID = 'npm:@metamask/cronjob-example-snap';
 export const CRONJOBS_SNAP_PORT = 8004;

--- a/packages/test-snaps/src/features/snaps/dialogs/constants.ts
+++ b/packages/test-snaps/src/features/snaps/dialogs/constants.ts
@@ -1,2 +1,2 @@
-export const DIALOGS_SNAP_ID = 'npm:@metamask/dialogs-example-snap';
+export const DIALOGS_SNAP_ID = 'npm:@metamask/dialog-example-snap';
 export const DIALOGS_SNAP_PORT = 8005;

--- a/packages/test-snaps/src/features/snaps/errors/constants.ts
+++ b/packages/test-snaps/src/features/snaps/errors/constants.ts
@@ -1,2 +1,2 @@
-export const ERRORS_SNAP_ID = 'npm:@metamask/errors-example-snap';
+export const ERRORS_SNAP_ID = 'npm:@metamask/error-example-snap';
 export const ERRORS_SNAP_PORT = 8006;

--- a/packages/test-snaps/src/features/snaps/notifications/constants.ts
+++ b/packages/test-snaps/src/features/snaps/notifications/constants.ts
@@ -1,2 +1,2 @@
-export const NOTIFICATIONS_SNAP_ID = 'npm:@metamask/notifications-example-snap';
+export const NOTIFICATIONS_SNAP_ID = 'npm:@metamask/notification-example-snap';
 export const NOTIFICATIONS_SNAP_PORT = 8016;


### PR DESCRIPTION
cronjob, error, dialog and notification had the names pulralized in the "features" for the test-snaps page but not in the individual package.json files.
we've reverted the names to singular so not to complicate the npm repository