### PR TITLE
Allow disabling markdown for text component

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hYH6apk+FDhOoKr5E1J1Z9IjG2dBFEjWrcIQBBX0vao=",
+    "shasum": "kXfTl1z7o8fbouKsRpNRwTD0nR15EUip+CrQIlSqRX4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6+UtgKkhiZK57L3578REjx/emATnIaMcxUBeaV7N89I=",
+    "shasum": "M5B5JFmyWjdWkalX8J22X6D6QyrkvJOLwJVe8KbBsac=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Qe1fTSE4mkPw1VRavz+KdxMRjUUofSvamyVmdP75jtQ=",
+    "shasum": "+mH1mZVn3Z4iwb3WuaQiepE8F7TTfnJqu/bVoKrg1to=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4jcE8H3Y1yGdDPrbir9PLOWD6vDUZKAVKD1HT4AIAow=",
+    "shasum": "dqhmWvqLvz3C8foSNLuFPlhfs+bogojTS6p+FIagDdw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "sg3EZMGlxbC6nJiu7xzYgIiFt45IW8IKd3TO2o1NUAg=",
+    "shasum": "tShQOZMx8KMQPn0hF/ByQMZRmnvGpJJOutGDHxnBXVw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "eAMGGDbbiEcrNBTSYXNb9gSlVOZNr/8PQ93DA8SlaMk=",
+    "shasum": "ydW7TmQPhUM0ucoWRQ0K1n23q0TuVoe2KjY3p4BUWPI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "QHfkASAd0g8ljW4MNMyFCivlCo9Mg9F9z5Ih2Cq2Q+s=",
+    "shasum": "JPrc8/Fdr1GP8W13n2gjjC53wwhqOAmghGHPq6mllCM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "mlQaPj52syYc2BpxuVkTC3NcieuxYik8xA779FU63mo=",
+    "shasum": "hbOUal7VrGNmWxmXGdHns/M+rQsXUBGJvGvjfreMWmg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "dXO6BB6z0MiSdFlrA12FAkR+yygHWLDlIfDa+5qqQYg=",
+    "shasum": "1YJDMtbAoDRUeKx2G5lwhscdBPSM6SRSqyvCJdSwdak=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "BV3eoHT26PhmrnMS6NYwgcFlyX8cRZsQ/xvT316N154=",
+    "shasum": "eeQ1BHMHXRhrzpvZ6M3glmxqYaNT5MM+jqMh1mSwK/k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-ui/src/builder.test.ts
+++ b/packages/snaps-ui/src/builder.test.ts
@@ -192,6 +192,18 @@ describe('text', () => {
       type: NodeType.Text,
       value: 'foo bar',
     });
+
+    expect(text({ value: 'foo bar', markdown: false })).toStrictEqual({
+      type: NodeType.Text,
+      value: 'foo bar',
+      markdown: false,
+    });
+
+    expect(text({ value: 'foo bar', markdown: true })).toStrictEqual({
+      type: NodeType.Text,
+      value: 'foo bar',
+      markdown: true,
+    });
   });
 
   it('creates a text component using the shorthand form', () => {
@@ -203,6 +215,18 @@ describe('text', () => {
     expect(text('foo bar')).toStrictEqual({
       type: NodeType.Text,
       value: 'foo bar',
+    });
+
+    expect(text('Hello, world!', false)).toStrictEqual({
+      type: NodeType.Text,
+      value: 'Hello, world!',
+      markdown: false,
+    });
+
+    expect(text('Hello, world!', true)).toStrictEqual({
+      type: NodeType.Text,
+      value: 'Hello, world!',
+      markdown: true,
     });
   });
 

--- a/packages/snaps-ui/src/builder.ts
+++ b/packages/snaps-ui/src/builder.ts
@@ -76,10 +76,14 @@ function createBuilder<
     // Node passed as an array of arguments.
     const node = keys.reduce<Partial<Component>>(
       (partialNode, key, index) => {
-        return {
-          ...partialNode,
-          [key]: args[index],
-        };
+        if (args[index] !== undefined) {
+          return {
+            ...partialNode,
+            [key]: args[index],
+          };
+        }
+
+        return partialNode;
       },
       { type },
     );
@@ -171,13 +175,16 @@ export const spinner = createBuilder(NodeType.Spinner, SpinnerStruct);
  * Create a {@link Text} node.
  *
  * @param args - The node arguments. This can be either a string, or an object
- * with a `text` property.
+ * with a `value` property.
  * @param args.text - The text content of the node.
  * @returns The text node as object.
  * @example
  * ```typescript
- * const node = text({ text: 'Hello, world!' });
+ * const node = text({ value: 'Hello, world!' });
  * const node = text('Hello, world!');
  * ```
  */
-export const text = createBuilder(NodeType.Text, TextStruct, ['value']);
+export const text = createBuilder(NodeType.Text, TextStruct, [
+  'value',
+  'markdown',
+]);

--- a/packages/snaps-ui/src/builder.ts
+++ b/packages/snaps-ui/src/builder.ts
@@ -174,14 +174,18 @@ export const spinner = createBuilder(NodeType.Spinner, SpinnerStruct);
 /**
  * Create a {@link Text} node.
  *
- * @param args - The node arguments. This can be either a string, or an object
- * with a `value` property.
- * @param args.text - The text content of the node.
+ * @param args - The node arguments. This can be either a string
+ * and a boolean, or an object with a `value` property
+ * and an optional `markdown` property.
+ * @param args.value - The text content of the node.
+ * @param args.markdown - An optional flag to enable/disable markdown.
  * @returns The text node as object.
  * @example
  * ```typescript
  * const node = text({ value: 'Hello, world!' });
  * const node = text('Hello, world!');
+ * const node = text({ value: 'Hello, world!', markdown: false });
+ * const node = text('Hello, world!', false);
  * ```
  */
 export const text = createBuilder(NodeType.Text, TextStruct, [

--- a/packages/snaps-ui/src/nodes.ts
+++ b/packages/snaps-ui/src/nodes.ts
@@ -1,10 +1,12 @@
 import {
   array,
   assign,
+  boolean,
   Infer,
   lazy,
   literal,
   object,
+  optional,
   string,
   Struct,
   union,
@@ -144,6 +146,7 @@ export const TextStruct = assign(
   object({
     type: literal(NodeType.Text),
     value: string(),
+    markdown: optional(boolean()),
   }),
 );
 
@@ -153,6 +156,8 @@ export const TextStruct = assign(
  * @property type - The type of the node, must be the string 'text'.
  * @property value - The text content of the node, either as plain text, or as a
  * markdown string.
+ * @property markdown - A flag to enable/disable markdown, if nothing is specified
+ * markdown will be enabled.
  */
 export type Text = Infer<typeof TextStruct>;
 


### PR DESCRIPTION
Fixes #1587 

Allow disabling markdown for the snaps-ui text component.

Markdown can be disabled by specifying either:
```
text('Hello world', false)

text({ value: 'foo bar', markdown: false }
```

If no flag is specified, we will assume markdown to be **enabled**, this way the API is backwards compatible.

This will need changes on the extension-side as well and should probably be cherry-picked to the audit branch.