### PR TITLE
Fix test-snaps site port to 9000

### DIFF
--- a/packages/test-snaps/webpack.config.ts
+++ b/packages/test-snaps/webpack.config.ts
@@ -105,7 +105,7 @@ const config: Configuration & Record<'devServer', DevServerConfiguration> = {
     },
   },
   devServer: {
-    port: 8000,
+    port: 9000,
     historyApiFallback: true,
   },
 };


### PR DESCRIPTION
see issue #1592 
this changes the test-snaps local server port to 9000