### PR TITLE
Bump `semver` as requested by Dependabot

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "YpSwaQpD7KuiemKqUorNWkk7Rlx21pLDN6oaS2zdj44=",
+    "shasum": "NkYYe0cgXkcH4JuhebZKhCHwGHu/Almvj+MZLEfiMEo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VgwyEARSz/pA3LW1v/xJzN3kQO2/PdCLKOhRxgpC71U=",
+    "shasum": "9T7lgA1zzC0qJjWIZ7LCVQo3dff42PCNyjiXMK1vutc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "otZBEQFtelnnzeARaVPIjDmwUMuGd8Y1Ohj7sI1sCD4=",
+    "shasum": "/DAQYrzAjQLh/VJPMtnkx6uBTDKVM07BPhvQ24Ph09g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VAexg9OUpxq2zvJAsCzluSPigSqxyn3OlDv4R6FenUg=",
+    "shasum": "o8zw1JqQFhMDFt7zvERtKTbYUv6HqNgWm3dxEj8kM00=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0mP6AOf+F28kc3D1MgwVyzEBUXJIGbFCdSpqGXJL+VU=",
+    "shasum": "RIWhVmkmDL6sJaI2QNK/DHm71Q8XfiY0s/n2zuX0iSc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8P2IXCDrw5lAOJI1TENWupRs+LvngPLJ+5I7Scvgq8U=",
+    "shasum": "hDg+t52amBxVgCC0wztsf35MJhTfV3QQXDiHkvh9qFI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "K7cSi+MJii71Y0coeIaTfnZZB7iTwR6voeuMerNSGUM=",
+    "shasum": "Y8vMeseYkAI3Zn47y82K0IM01YmUWPPN8AV0i8MaGoM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1XoBW6W7yz4weqgBws0Vk9v0ngxfR4c8mOtgp7N2wbU=",
+    "shasum": "piWUwp1byAIDMtUgbpmn8eonefOH8LpIzdMANlV6gZ8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8Bf8JeVt5lstgYlBIT5LpZ3SWu2vIkP5+xwuxhVAGJM=",
+    "shasum": "+E0Jl29UbQBK8/jyr/3GrG+t+LraB8XkDfS35R8VlYg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "J1Hm1c8ast7rED9OYxU/DZtXQEf4AVOrPpBDJ0vPZjI=",
+    "shasum": "nkJ/QmeCtECTeyy8RZN/aBYt50vMUhSKOd1sTompMe8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AGJmSNMDeEa0vbBW5+CvKgc4DD5gKPqB9uGjdd2px64=",
+    "shasum": "ydYjquUr17K+rHh1gXHQ4AR+9JbaaT25fLZ9s0vG8Q0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vkuON4Eo4HIfK4zBlpTv9Lc7i8HCPmbEqWKpf3miEBQ=",
+    "shasum": "ACFYw9lF/XdoPUvaWRrjLfMSAu9+G0JLdwgyAZKHxJg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "NnhnGH9HbOTtVLYQx8I1E3dcWkXx7LHeV7hNihZSk9I=",
+    "shasum": "AlIXD3sLsXQXDd7SdahvEpSwxGlQjwCP1n2UpRd2N3M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "kKYMD/djZ5hJJiafR39ee6b7GqrwGjzXPuzSUdWd0E0=",
+    "shasum": "hEoEI8+viwcmTE865dUS6IpT1S1NIwLjQBhGYUOvdcA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "mLFqfbhNRQFbQccx9F+MGknX99OKoB4rQixyvpNgLwg=",
+    "shasum": "PwNqF2AkfoWVGF7+PfTnErLPRAkPksPE3TuruPU09jQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "kNMsDGXYSLZVzFo6winoWDaBz0ynLcqStkGB4Ww9Ckk=",
+    "shasum": "g+jDLnGw1e40v8PsJcUzQWSPF2awLaBhOOKsg1VI4Lk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LWLAdi21QxyYpRZKWviGTNlHlLmXJTYTr5o8fxyMxMk=",
+    "shasum": "ZcczzyxtW1zXtWEsKUWXNWRGPSiN4LzwWW5N4A82gkI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OTOsgQsBhUfshlwxRUnF/yvKTRmNcdLdjVAwZu7Dcg0=",
+    "shasum": "iuv+M+I8vcNLfSZeaAxSw8dsWIjSWbTzxZXVCt/23pc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20404,31 +20404,31 @@ __metadata:
   linkType: hard
 
 "semver@npm:2 || 3 || 4 || 5":
-  version: 5.7.1
-  resolution: "semver@npm:5.7.1"
+  version: 5.7.2
+  resolution: "semver@npm:5.7.2"
   bin:
-    semver: ./bin/semver
-  checksum: 57fd0acfd0bac382ee87cd52cd0aaa5af086a7dc8d60379dfe65fea491fb2489b6016400813930ecd61fd0952dae75c115287a1b16c234b1550887117744dfaf
+    semver: bin/semver
+  checksum: fb4ab5e0dd1c22ce0c937ea390b4a822147a9c53dbd2a9a0132f12fe382902beef4fbf12cf51bb955248d8d15874ce8cd89532569756384f994309825f10b686
   languageName: node
   linkType: hard
 
 "semver@npm:^6.0.0, semver@npm:^6.1.1, semver@npm:^6.1.2, semver@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "semver@npm:6.3.0"
+  version: 6.3.1
+  resolution: "semver@npm:6.3.1"
   bin:
-    semver: ./bin/semver.js
-  checksum: 1b26ecf6db9e8292dd90df4e781d91875c0dcc1b1909e70f5d12959a23c7eebb8f01ea581c00783bbee72ceeaad9505797c381756326073850dc36ed284b21b9
+    semver: bin/semver.js
+  checksum: ae47d06de28836adb9d3e25f22a92943477371292d9b665fb023fae278d345d508ca1958232af086d85e0155aee22e313e100971898bbb8d5d89b8b1d4054ca2
   languageName: node
   linkType: hard
 
 "semver@npm:^7.0.0, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.0":
-  version: 7.5.1
-  resolution: "semver@npm:7.5.1"
+  version: 7.5.4
+  resolution: "semver@npm:7.5.4"
   dependencies:
     lru-cache: ^6.0.0
   bin:
     semver: bin/semver.js
-  checksum: d16dbedad53c65b086f79524b9ef766bf38670b2395bdad5c957f824dcc566b624988013564f4812bcace3f9d405355c3635e2007396a39d1bffc71cfec4a2fc
+  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Dependabot is trying to bump `semver` but failing. Doing it manually to get some DOS vulns fixed.

https://github.com/MetaMask/snaps/security/dependabot/74
https://github.com/MetaMask/snaps/security/dependabot/73
https://github.com/MetaMask/snaps/security/dependabot/72