### PR TITLE
Update GitHub link in snaps-simulator

### DIFF
--- a/packages/snaps-simulator/src/features/navigation/components/Bottom.tsx
+++ b/packages/snaps-simulator/src/features/navigation/components/Bottom.tsx
@@ -16,7 +16,7 @@ export const Bottom: FunctionComponent = () => {
   return (
     <List borderTop="1px solid" borderTopColor="border.default" padding="2">
       <Item
-        path="https://github.com/MetaMask/snaps-simulator"
+        path="https://github.com/MetaMask/snaps/tree/main/packages/snaps-simulator"
         isExternal={true}
         tag="github"
       >


### PR DESCRIPTION
Updates GitHub link in snaps-simulator to point to the new location of the source code.

Fixes #1609 