### PR TITLE
Remove concurrency group from GitHub Pages workflow

### DIFF
--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -1,8 +1,5 @@
 name: Publish to GitHub Pages
 
-concurrency:
-  group: ${{ github.ref }}
-
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
The concurrency group doesn't support queuing more than one job, so if there's a job pending and another job is added to the queue, the pending job will just be cancelled. We will find a better solution for this as part of #1600.