### PR TITLE
Fix npm name of network access snap

### DIFF
--- a/packages/test-snaps/src/features/snaps/network-access/constants.ts
+++ b/packages/test-snaps/src/features/snaps/network-access/constants.ts
@@ -1,3 +1,2 @@
-export const NETWORK_ACCESS_SNAP_ID =
-  'npm:@metamask/network-access-example-snap';
+export const NETWORK_ACCESS_SNAP_ID = 'npm:@metamask/network-example-snap';
 export const NETWORK_ACCESS_PORT = 8015;


### PR DESCRIPTION
missed in the last corrections pr - should be npm@network-example-snap not npm@network-access-example-snap