### PR TITLE
Fix transaction insights example snap npm name

### DIFF
--- a/packages/test-snaps/src/features/snaps/transaction-insights/constants.ts
+++ b/packages/test-snaps/src/features/snaps/transaction-insights/constants.ts
@@ -1,6 +1,6 @@
 import packageJson from '@metamask/insights-example-snap/package.json';
 
 export const TRANSACTION_INSIGHTS_SNAP_ID =
-  'npm:@metamask/transaction-insights-example-snap';
+  'npm:@metamask/insights-example-snap';
 export const TRANSACTION_INSIGHTS_SNAP_PORT = 8018;
 export const TRANSACTION_INSIGHTS_VERSION = packageJson.version;


### PR DESCRIPTION
It was incorrectly listed as `npm:@metamask/transaction-insights-example-snap` rather than `npm:@metamask/insights-example-snap`