### PR TITLE
Bump action-npm-publish to v4

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -115,7 +115,7 @@ jobs:
             ./node_modules
           key: ${{ github.sha }}
       - name: Publish ${{ needs.get-release-tag.outputs.tag }} to NPM
-        uses: MetaMask/action-npm-publish@v3
+        uses: MetaMask/action-npm-publish@v4
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
           npm-tag: ${{ needs.get-release-tag.outputs.tag }}


### PR DESCRIPTION
v3 doesn't support using the NPM tag to check if a new version should be released. This fixes a deployment issue after #1629.