### PR TITLE
Bump semver to ensure signed provenance, CVE fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^4.1.2",
-    "semver": "^7.3.7",
+    "semver": "^7.5.4",
     "simple-git-hooks": "^2.7.0",
     "ts-node": "^10.9.1",
     "typescript": "~4.8.4"

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -62,7 +62,7 @@
     "@swc/core": "^1.3.66",
     "@swc/jest": "^0.2.26",
     "@types/jest": "^27.5.1",
-    "@types/semver": "^7.3.10",
+    "@types/semver": "^7.5.0",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
     "deepmerge": "^4.2.2",

--- a/packages/snaps-ui/package.json
+++ b/packages/snaps-ui/package.json
@@ -49,7 +49,7 @@
     "@swc/core": "^1.3.66",
     "@swc/jest": "^0.2.26",
     "@types/jest": "^27.5.1",
-    "@types/semver": "^7.3.10",
+    "@types/semver": "^7.5.0",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
     "deepmerge": "^4.2.2",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -83,7 +83,7 @@
     "fast-json-stable-stringify": "^2.1.0",
     "is-svg": "^4.4.0",
     "rfdc": "^1.3.0",
-    "semver": "^7.3.7",
+    "semver": "^7.5.4",
     "ses": "^0.18.1",
     "superstruct": "^1.0.3",
     "validate-npm-package-name": "^5.0.0"
@@ -104,7 +104,7 @@
     "@types/jest": "^27.5.1",
     "@types/mocha": "^10.0.1",
     "@types/node": "^20.3.1",
-    "@types/semver": "^7.3.10",
+    "@types/semver": "^7.5.0",
     "@types/validate-npm-package-name": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5044,7 +5044,7 @@ __metadata:
     "@swc/core": ^1.3.66
     "@swc/jest": ^0.2.26
     "@types/jest": ^27.5.1
-    "@types/semver": ^7.3.10
+    "@types/semver": ^7.5.0
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
     deepmerge: ^4.2.2
@@ -5281,7 +5281,7 @@ __metadata:
     "@swc/core": ^1.3.66
     "@swc/jest": ^0.2.26
     "@types/jest": ^27.5.1
-    "@types/semver": ^7.3.10
+    "@types/semver": ^7.5.0
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
     deepmerge: ^4.2.2
@@ -5333,7 +5333,7 @@ __metadata:
     "@types/jest": ^27.5.1
     "@types/mocha": ^10.0.1
     "@types/node": ^20.3.1
-    "@types/semver": ^7.3.10
+    "@types/semver": ^7.5.0
     "@types/validate-npm-package-name": ^4.0.0
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -5369,7 +5369,7 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.11
     rfdc: ^1.3.0
     rimraf: ^4.1.2
-    semver: ^7.3.7
+    semver: ^7.5.4
     serve-handler: ^6.1.5
     ses: ^0.18.1
     superstruct: ^1.0.3
@@ -7263,7 +7263,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:^7.3.10, @types/semver@npm:^7.3.12, @types/semver@npm:^7.3.6":
+"@types/semver@npm:^7.3.12, @types/semver@npm:^7.3.6, @types/semver@npm:^7.5.0":
   version: 7.5.0
   resolution: "@types/semver@npm:7.5.0"
   checksum: 0a64b9b9c7424d9a467658b18dd70d1d781c2d6f033096a6e05762d20ebbad23c1b69b0083b0484722aabf35640b78ccc3de26368bcae1129c87e9df028a22e2
@@ -19948,7 +19948,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^4.1.2
-    semver: ^7.3.7
+    semver: ^7.5.4
     simple-git-hooks: ^2.7.0
     ts-node: ^10.9.1
     typescript: ~4.8.4
@@ -20134,7 +20134,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.0":
+"semver@npm:^7.0.0, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.0, semver@npm:^7.5.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:


### PR DESCRIPTION
Problem: Many snaps recently audited used vulnerable package during audits/reviews.

Solutions: Bumping semver to ^7.5.4 (latest) in MetaMask/snaps and MetaMask/utils to ensure snap authors (and all other future imports) use version [built/signed with provenance](https://www.npmjs.com/package/semver?activeTab=versions) (new in >= 7.5.1) and fix [CVE-2022-25883](https://www.cve.org/CVERecord?id=CVE-2022-25883) (>= 7.5.2).

I spoke with @FrederikBolding yesterday, related PRs:
- MetaMask/snaps PR https://github.com/MetaMask/snaps/pull/1603 (approved 2023-07-14)
- MetaMask/snaps PR https://github.com/MetaMask/snaps/pull/1631 (this PR)
- MetaMask/utils PR https://github.com/MetaMask/utils/pull/123