### PR TITLE
Move source code and snap state back to controller state

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 88.73,
-  "functions": 95.97,
-  "lines": 96.8,
-  "statements": 96.45
+  "branches": 88.64,
+  "functions": 95.95,
+  "lines": 96.77,
+  "statements": 96.42
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -117,10 +117,7 @@ describe('SnapController', () => {
     const snapState = await snapController.getSnapState(snap.id);
     expect(snapState).toStrictEqual(state);
 
-    expect(
-      // @ts-expect-error Accessing private property
-      snapController.snapsRuntimeData.get(MOCK_SNAP_ID).state,
-    ).toStrictEqual(state);
+    expect(snapController.state.snapStates[MOCK_SNAP_ID]).toStrictEqual(state);
     snapController.destroy();
     await service.terminateAllSnaps();
   });
@@ -5094,10 +5091,9 @@ describe('SnapController', () => {
       );
 
       expect(updateSnapStateSpy).toHaveBeenCalledTimes(1);
-      expect(
-        // @ts-expect-error Accessing private property
-        snapController.snapsRuntimeData.get(MOCK_SNAP_ID).state,
-      ).toStrictEqual(state);
+      expect(snapController.state.snapStates[MOCK_SNAP_ID]).toStrictEqual(
+        state,
+      );
 
       snapController.destroy();
     });

--- a/packages/snaps-utils/src/snaps.ts
+++ b/packages/snaps-utils/src/snaps.ts
@@ -81,12 +81,7 @@ export type VersionHistory = {
   date: number;
 };
 
-export type PersistedSnap = Snap & {
-  /**
-   * The source code of the Snap.
-   */
-  sourceCode: string;
-};
+export type PersistedSnap = Snap;
 
 /**
  * A Snap as it exists in {@link SnapController} state.
@@ -107,6 +102,11 @@ export type Snap = {
    * installed.
    */
   initialPermissions: SnapPermissions;
+
+  /**
+   * The source code of the Snap.
+   */
+  sourceCode: string;
 
   /**
    * The Snap's manifest file.

--- a/packages/snaps-utils/src/test-utils/snap.ts
+++ b/packages/snaps-utils/src/test-utils/snap.ts
@@ -54,6 +54,7 @@ export const getSnapObject = ({
   enabled = true,
   id = MOCK_SNAP_ID,
   initialPermissions = getSnapManifest().initialPermissions,
+  sourceCode = DEFAULT_SNAP_BUNDLE,
   manifest = getSnapManifest(),
   status = SnapStatus.Stopped,
   version = getSnapManifest().version,
@@ -64,6 +65,7 @@ export const getSnapObject = ({
   return {
     blocked,
     initialPermissions,
+    sourceCode,
     id,
     version: version as SemVerVersion,
     manifest,


### PR DESCRIPTION
Moves the source code and snap state from `SnapRuntimeData` to the `SnapController` state. This fixes a bug with persistence of snap state and source code changes. This change by itself will worsen performance of the extension, so it should be coupled with a change to filter source code and snap state from the state piped to the extension UI.

This PR also allows us to move `snapsRuntimeData` to hash private.

Fixes #1633