### PR TITLE
Add `onInstall` and `onUpdate` lifecycle hooks

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9zlU1HnaCKIKeIYLWAZMpKKGhniZz3uCfL6lMi6HxmU=",
+    "shasum": "UWS774A057OPPbfbF560vMKxWamt+1/oxxtaKyw6Ygk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "O/hU1ijMPV/s8oFW2ufMWkdxtMV4XeMaTp3zPCk2BJc=",
+    "shasum": "eCb1sigUniss1aXLXBl9jJcUQQtIhZfZahNrbO3RgA4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "BKE3Xot/5UBW4JW7LIvgSU3LFQSMm9uVXxfZ06ncSNQ=",
+    "shasum": "K3Qz1EDr9DbyFctPqTYpqKATbS4yPmGTtoal+Qs0DRI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "p0/vYkT6LNlh04FziN5GIRFMu5ZwDem1vRbb7oZKm1g=",
+    "shasum": "wQYM7aP7SCPi76ErAx/FZVOe2YYhFNonL6NvawnfMaA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "zvfceJe/kFt03kbYEw5LY3I+AmihPf0On17ZZToiYLI=",
+    "shasum": "8+6yAS0XlEaR25jttszv4cm5rzi2ePeSlbdaWjOSYiU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "RmHC4ZeTRV2NPwb6z/oYxWvu0soosxBJVe9uDfDuofc=",
+    "shasum": "KWg2oIMWJQZvvHcRfmQsUho7TpR0KNawcujbB9XRg7o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "nhbrPTV2JarY/zlPvPmtWnlS6sgdDEev3TYiH4TeJJM=",
+    "shasum": "aSevBsiHEnYYo3QP9zYOR0N6Hf0vSELyTjR5GjJgSJI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 88.64,
+  "branches": 88.88,
   "functions": 95.69,
-  "lines": 96.78,
-  "statements": 96.43
+  "lines": 96.89,
+  "statements": 96.54
 }

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 88.64,
-  "functions": 95.97,
+  "functions": 95.69,
   "lines": 96.78,
   "statements": 96.43
 }

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.ts
@@ -397,26 +397,6 @@ export abstract class AbstractExecutionService<WorkerType>
     this.#snapRpcHooks.set(snapId, rpcHook);
   }
 
-  /**
-   * Gets the job id for a given snap.
-   *
-   * @param snapId - A given snap id.
-   * @returns The ID of the snap's job.
-   */
-  #getJobForSnap(snapId: string): string | undefined {
-    return this.#snapToJobMap.get(snapId);
-  }
-
-  /**
-   * Gets the snap id for a given job.
-   *
-   * @param jobId - A given job id.
-   * @returns The ID of the snap that is running the job.
-   */
-  #getSnapForJob(jobId: string): string | undefined {
-    return this.#jobToSnapMap.get(jobId);
-  }
-
   #mapSnapAndJob(snapId: string, jobId: string): void {
     this.#snapToJobMap.set(snapId, jobId);
     this.#jobToSnapMap.set(jobId, snapId);

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -8,12 +8,12 @@ import { WALLET_SNAP_PERMISSION_KEY } from '@metamask/rpc-methods';
 import type { SnapPermissions, ValidatedSnapId } from '@metamask/snaps-utils';
 import {
   DEFAULT_ENDOWMENTS,
+  DEFAULT_REQUESTED_SNAP_VERSION,
   getSnapChecksum,
   HandlerType,
   SnapCaveatType,
   SnapStatus,
   VirtualFile,
-  DEFAULT_REQUESTED_SNAP_VERSION,
 } from '@metamask/snaps-utils';
 import {
   DEFAULT_SNAP_BUNDLE,
@@ -29,7 +29,7 @@ import {
   MOCK_ORIGIN,
   MOCK_SNAP_ID,
 } from '@metamask/snaps-utils/test-utils';
-import type { SemVerVersion, SemVerRange } from '@metamask/utils';
+import type { SemVerRange, SemVerVersion } from '@metamask/utils';
 import { AssertionError } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
 import fetchMock from 'jest-fetch-mock';
@@ -41,6 +41,7 @@ import type { Duplex } from 'stream';
 import type { NodeThreadExecutionService } from '../services';
 import { setupMultiplex } from '../services';
 import {
+  approvalControllerMock,
   ExecutionEnvironmentStub,
   getControllerMessenger,
   getNodeEESMessenger,
@@ -50,19 +51,18 @@ import {
   getSnapControllerOptions,
   getSnapControllerWithEES,
   getSnapControllerWithEESOptions,
+  loopbackDetect,
+  LoopbackLocation,
   MOCK_BLOCK_NUMBER,
   MOCK_DAPP_SUBJECT_METADATA,
   MOCK_DAPPS_RPC_ORIGINS_PERMISSION,
-  MOCK_RPC_ORIGINS_PERMISSION,
-  MOCK_SNAP_SUBJECT_METADATA,
-  sleep,
-  loopbackDetect,
-  LoopbackLocation,
-  MockSnapsRegistry,
-  MOCK_WALLET_SNAP_PERMISSION,
   MOCK_ORIGIN_PERMISSIONS,
-  approvalControllerMock,
+  MOCK_RPC_ORIGINS_PERMISSION,
   MOCK_SNAP_PERMISSIONS,
+  MOCK_SNAP_SUBJECT_METADATA,
+  MOCK_WALLET_SNAP_PERMISSION,
+  MockSnapsRegistry,
+  sleep,
 } from '../test-utils';
 import { delay } from '../utils';
 import { handlerEndowments, SnapEndowments } from './endowments';
@@ -545,7 +545,7 @@ describe('SnapController', () => {
     await service.terminateAllSnaps();
   });
 
-  it('installs a Snap via installSnaps', async () => {
+  it('installs a snap via installSnaps', async () => {
     const messenger = getSnapControllerMessenger();
     const snapController = getSnapController(
       getSnapControllerOptions({
@@ -589,7 +589,7 @@ describe('SnapController', () => {
       [MOCK_SNAP_ID]: expectedSnapObject,
     });
 
-    expect(messenger.call).toHaveBeenCalledTimes(8);
+    expect(messenger.call).toHaveBeenCalledTimes(12);
 
     expect(messenger.call).toHaveBeenNthCalledWith(
       1,
@@ -769,7 +769,7 @@ describe('SnapController', () => {
     controller.destroy();
   });
 
-  it('reuses an already installed Snap if it satisfies the requested SemVer range', async () => {
+  it('reuses an already installed snap if it satisfies the requested SemVer range', async () => {
     const messenger = getSnapControllerMessenger();
     const controller = getSnapController(
       getSnapControllerOptions({
@@ -790,6 +790,7 @@ describe('SnapController', () => {
 
     expect(newSnap).toStrictEqual(getSnapObject());
     expect(authorizeSpy).not.toHaveBeenCalled();
+    expect(messenger.call).not.toHaveBeenCalled();
 
     controller.destroy();
   });
@@ -1859,7 +1860,7 @@ describe('SnapController', () => {
 
       expect(result).toStrictEqual({ [MOCK_LOCAL_SNAP_ID]: truncatedSnap });
 
-      expect(messenger.call).toHaveBeenCalledTimes(10);
+      expect(messenger.call).toHaveBeenCalledTimes(14);
 
       expect(messenger.call).toHaveBeenNthCalledWith(
         1,
@@ -2014,7 +2015,7 @@ describe('SnapController', () => {
         [MOCK_LOCAL_SNAP_ID]: truncatedSnap,
       });
 
-      expect(messenger.call).toHaveBeenCalledTimes(19);
+      expect(messenger.call).toHaveBeenCalledTimes(27);
 
       expect(messenger.call).toHaveBeenNthCalledWith(
         1,
@@ -2112,7 +2113,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        9,
+        13,
         'ApprovalController:addRequest',
         expect.objectContaining({
           type: SNAP_APPROVAL_INSTALL,
@@ -2132,13 +2133,13 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        10,
+        14,
         'ExecutionService:terminateSnap',
         MOCK_LOCAL_SNAP_ID,
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        14,
+        18,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -2150,7 +2151,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        15,
+        19,
         'PermissionController:grantPermissions',
         {
           approvedPermissions: permissions,
@@ -2167,7 +2168,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        16,
+        20,
         'ApprovalController:addRequest',
         expect.objectContaining({
           id: expect.any(String),
@@ -2188,20 +2189,20 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        17,
+        21,
         'ExecutionService:executeSnap',
         expect.objectContaining({ snapId: MOCK_LOCAL_SNAP_ID }),
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        18,
+        22,
         'PermissionController:hasPermission',
         MOCK_LOCAL_SNAP_ID,
         SnapEndowments.LongRunning,
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        19,
+        23,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -2361,7 +2362,7 @@ describe('SnapController', () => {
       expect(result).toStrictEqual({
         [MOCK_SNAP_ID]: truncatedSnap,
       });
-      expect(messenger.call).toHaveBeenCalledTimes(8);
+      expect(messenger.call).toHaveBeenCalledTimes(12);
 
       expect(messenger.call).toHaveBeenNthCalledWith(
         1,
@@ -2519,7 +2520,7 @@ describe('SnapController', () => {
           [MOCK_SNAP_ID]: {},
         }),
       ).rejects.toThrow(
-        'A snap must request at least one of the following permissions: endowment:rpc, endowment:transaction-insight, endowment:cronjob.',
+        'A snap must request at least one of the following permissions: endowment:rpc, endowment:transaction-insight, endowment:cronjob, endowment:lifecycle-hooks.',
       );
 
       controller.destroy();
@@ -2699,7 +2700,7 @@ describe('SnapController', () => {
           messenger,
           detectSnapLocation: loopbackDetect({
             manifest,
-            files: [sourceCode, svgIcon],
+            files: [sourceCode, svgIcon as VirtualFile],
           }),
         }),
       );
@@ -2916,10 +2917,10 @@ describe('SnapController', () => {
         [MOCK_SNAP_ID]: { version: newVersionRange },
       });
 
-      expect(messenger.call).toHaveBeenCalledTimes(17);
+      expect(messenger.call).toHaveBeenCalledTimes(25);
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        10,
+        14,
         'ApprovalController:addRequest',
         {
           origin: MOCK_ORIGIN,
@@ -2941,13 +2942,13 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        12,
+        16,
         'PermissionController:getPermissions',
         MOCK_SNAP_ID,
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        13,
+        17,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -2963,7 +2964,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        14,
+        18,
         'ApprovalController:addRequest',
         expect.objectContaining({
           id: expect.any(String),
@@ -2984,20 +2985,20 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        15,
+        19,
         'ExecutionService:executeSnap',
         expect.objectContaining({}),
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        16,
+        20,
         'PermissionController:hasPermission',
         MOCK_SNAP_ID,
         SnapEndowments.LongRunning,
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        17,
+        23,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -3511,10 +3512,10 @@ describe('SnapController', () => {
           date: expect.any(Number),
         },
       ]);
-      expect(callActionSpy).toHaveBeenCalledTimes(17);
+      expect(callActionSpy).toHaveBeenCalledTimes(25);
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        10,
+        14,
         'ApprovalController:addRequest',
         {
           origin: MOCK_ORIGIN,
@@ -3536,13 +3537,13 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        12,
+        16,
         'PermissionController:getPermissions',
         MOCK_SNAP_ID,
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        13,
+        17,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -3558,7 +3559,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        14,
+        18,
         'ApprovalController:addRequest',
         expect.objectContaining({
           id: expect.any(String),
@@ -3579,20 +3580,20 @@ describe('SnapController', () => {
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        15,
+        19,
         'ExecutionService:executeSnap',
         expect.objectContaining({}),
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        16,
+        20,
         'PermissionController:hasPermission',
         MOCK_SNAP_ID,
         SnapEndowments.LongRunning,
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        17,
+        23,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -3693,7 +3694,7 @@ describe('SnapController', () => {
 
       const isRunning = controller.isRunning(MOCK_SNAP_ID);
 
-      expect(callActionSpy).toHaveBeenCalledTimes(11);
+      expect(callActionSpy).toHaveBeenCalledTimes(15);
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
         1,
@@ -3787,7 +3788,7 @@ describe('SnapController', () => {
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        11,
+        13,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -4044,10 +4045,10 @@ describe('SnapController', () => {
 
       await controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID, detect());
 
-      expect(callActionSpy).toHaveBeenCalledTimes(19);
+      expect(callActionSpy).toHaveBeenCalledTimes(27);
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        10,
+        14,
         'ApprovalController:addRequest',
         {
           origin: MOCK_ORIGIN,
@@ -4069,7 +4070,7 @@ describe('SnapController', () => {
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        13,
+        17,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -4091,7 +4092,7 @@ describe('SnapController', () => {
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        14,
+        18,
         'ApprovalController:addRequest',
         {
           origin: MOCK_ORIGIN,
@@ -4113,13 +4114,13 @@ describe('SnapController', () => {
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        15,
+        19,
         'PermissionController:revokePermissions',
         { [MOCK_SNAP_ID]: ['snap_manageState'] },
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        16,
+        20,
         'PermissionController:grantPermissions',
         {
           approvedPermissions: { 'endowment:network-access': {} },
@@ -4136,20 +4137,20 @@ describe('SnapController', () => {
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        17,
+        21,
         'ExecutionService:executeSnap',
         expect.anything(),
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        18,
+        22,
         'PermissionController:hasPermission',
         MOCK_SNAP_ID,
         SnapEndowments.LongRunning,
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        19,
+        25,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -5467,6 +5468,252 @@ describe('SnapController', () => {
           ['snap_notify'],
         ),
       ).toThrow('Non-dynamic permissions cannot be revoked');
+
+      snapController.destroy();
+    });
+  });
+
+  describe('SnapController:snapInstalled', () => {
+    it('calls the `onInstall` lifecycle hook', async () => {
+      const messenger = getSnapControllerMessenger();
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(getPersistedSnapObject()),
+          },
+        }),
+      );
+
+      messenger.publish('SnapController:snapInstalled', getTruncatedSnap());
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        1,
+        'PermissionController:hasPermission',
+        MOCK_SNAP_ID,
+        SnapEndowments.LifecycleHooks,
+      );
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        3,
+        'ExecutionService:executeSnap',
+        expect.any(Object),
+      );
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        5,
+        'ExecutionService:handleRpcRequest',
+        MOCK_SNAP_ID,
+        {
+          handler: HandlerType.OnInstall,
+          origin: '',
+          request: {
+            jsonrpc: '2.0',
+            id: expect.any(String),
+            method: HandlerType.OnInstall,
+          },
+        },
+      );
+
+      snapController.destroy();
+    });
+
+    it('does not call the `onInstall` lifecycle hook if the snap does not have the `endowment:lifecycle-hooks` permission', async () => {
+      const rootMessenger = getControllerMessenger();
+      const messenger = getSnapControllerMessenger(rootMessenger);
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(getPersistedSnapObject()),
+          },
+        }),
+      );
+
+      rootMessenger.registerActionHandler(
+        'PermissionController:hasPermission',
+        () => false,
+      );
+
+      messenger.publish('SnapController:snapInstalled', getTruncatedSnap());
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(messenger.call).toHaveBeenCalledTimes(1);
+      expect(messenger.call).not.toHaveBeenCalledWith(
+        'ExecutionService:handleRpcRequest',
+        MOCK_SNAP_ID,
+        {
+          handler: HandlerType.OnInstall,
+          origin: '',
+          request: {
+            jsonrpc: '2.0',
+            id: expect.any(String),
+            method: HandlerType.OnInstall,
+          },
+        },
+      );
+
+      snapController.destroy();
+    });
+
+    it('logs an error if the lifecycle hook call fails', async () => {
+      const log = jest.spyOn(console, 'error').mockImplementation();
+
+      const rootMessenger = getControllerMessenger();
+      const messenger = getSnapControllerMessenger(rootMessenger);
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(getPersistedSnapObject()),
+          },
+        }),
+      );
+
+      const error = new Error('Failed to call lifecycle hook.');
+      rootMessenger.registerActionHandler(
+        'PermissionController:hasPermission',
+        () => {
+          throw error;
+        },
+      );
+
+      messenger.publish('SnapController:snapInstalled', getTruncatedSnap());
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(log).toHaveBeenCalledWith(
+        `Error when calling \`onInstall\` lifecycle hook for snap "${MOCK_SNAP_ID}": ${error.message}`,
+      );
+
+      snapController.destroy();
+    });
+  });
+
+  describe('SnapController:snapUpdated', () => {
+    it('calls the `onUpdate` lifecycle hook', async () => {
+      const messenger = getSnapControllerMessenger();
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(getPersistedSnapObject()),
+          },
+        }),
+      );
+
+      messenger.publish(
+        'SnapController:snapUpdated',
+        getTruncatedSnap(),
+        '0.9.0',
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        1,
+        'PermissionController:hasPermission',
+        MOCK_SNAP_ID,
+        SnapEndowments.LifecycleHooks,
+      );
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        3,
+        'ExecutionService:executeSnap',
+        expect.any(Object),
+      );
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        5,
+        'ExecutionService:handleRpcRequest',
+        MOCK_SNAP_ID,
+        {
+          handler: HandlerType.OnUpdate,
+          origin: '',
+          request: {
+            jsonrpc: '2.0',
+            id: expect.any(String),
+            method: HandlerType.OnUpdate,
+          },
+        },
+      );
+
+      snapController.destroy();
+    });
+
+    it('does not call the `onUpdate` lifecycle hook if the snap does not have the `endowment:lifecycle-hooks` permission', async () => {
+      const rootMessenger = getControllerMessenger();
+      const messenger = getSnapControllerMessenger(rootMessenger);
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(getPersistedSnapObject()),
+          },
+        }),
+      );
+
+      rootMessenger.registerActionHandler(
+        'PermissionController:hasPermission',
+        () => false,
+      );
+
+      messenger.publish('SnapController:snapInstalled', getTruncatedSnap());
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(messenger.call).toHaveBeenCalledTimes(1);
+      expect(messenger.call).not.toHaveBeenCalledWith(
+        'ExecutionService:handleRpcRequest',
+        MOCK_SNAP_ID,
+        {
+          handler: HandlerType.OnUpdate,
+          origin: '',
+          request: {
+            jsonrpc: '2.0',
+            id: expect.any(String),
+            method: HandlerType.OnUpdate,
+          },
+        },
+      );
+
+      snapController.destroy();
+    });
+
+    it('logs an error if the lifecycle hook call fails', async () => {
+      const log = jest.spyOn(console, 'error').mockImplementation();
+
+      const rootMessenger = getControllerMessenger();
+      const messenger = getSnapControllerMessenger(rootMessenger);
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(getPersistedSnapObject()),
+          },
+        }),
+      );
+
+      const error = new Error('Failed to call lifecycle hook.');
+      rootMessenger.registerActionHandler(
+        'PermissionController:hasPermission',
+        () => {
+          throw error;
+        },
+      );
+
+      messenger.publish(
+        'SnapController:snapUpdated',
+        getTruncatedSnap(),
+        '0.9.0',
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(log).toHaveBeenCalledWith(
+        `Error when calling \`onUpdate\` lifecycle hook for snap "${MOCK_SNAP_ID}": ${error.message}`,
+      );
 
       snapController.destroy();
     });

--- a/packages/snaps-controllers/src/snaps/endowments/enum.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/enum.ts
@@ -6,4 +6,5 @@ export enum SnapEndowments {
   EthereumProvider = 'endowment:ethereum-provider',
   Rpc = 'endowment:rpc',
   WebAssemblyAccess = 'endowment:webassembly',
+  LifecycleHooks = 'endowment:lifecycle-hooks',
 }

--- a/packages/snaps-controllers/src/snaps/endowments/index.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/index.ts
@@ -8,6 +8,7 @@ import {
   getCronjobCaveatMapper,
 } from './cronjob';
 import { ethereumProviderEndowmentBuilder } from './ethereum-provider';
+import { lifecycleHooksEndowmentBuilder } from './lifecycle-hooks';
 import { longRunningEndowmentBuilder } from './long-running';
 import { networkAccessEndowmentBuilder } from './network-access';
 import {
@@ -32,6 +33,7 @@ export const endowmentPermissionBuilders = {
     ethereumProviderEndowmentBuilder,
   [rpcEndowmentBuilder.targetName]: rpcEndowmentBuilder,
   [webAssemblyEndowmentBuilder.targetName]: webAssemblyEndowmentBuilder,
+  [lifecycleHooksEndowmentBuilder.targetName]: lifecycleHooksEndowmentBuilder,
 } as const;
 
 export const endowmentCaveatSpecifications = {
@@ -54,6 +56,8 @@ export const handlerEndowments: Record<HandlerType, string> = {
   [HandlerType.OnRpcRequest]: rpcEndowmentBuilder.targetName,
   [HandlerType.OnTransaction]: transactionInsightEndowmentBuilder.targetName,
   [HandlerType.OnCronjob]: cronjobEndowmentBuilder.targetName,
+  [HandlerType.OnInstall]: lifecycleHooksEndowmentBuilder.targetName,
+  [HandlerType.OnUpdate]: lifecycleHooksEndowmentBuilder.targetName,
 };
 
 export * from './enum';

--- a/packages/snaps-controllers/src/snaps/endowments/lifecycle-hooks.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/lifecycle-hooks.ts
@@ -1,0 +1,45 @@
+import type {
+  PermissionSpecificationBuilder,
+  EndowmentGetterParams,
+  ValidPermissionSpecification,
+} from '@metamask/permission-controller';
+import { PermissionType, SubjectType } from '@metamask/permission-controller';
+import type { NonEmptyArray } from '@metamask/utils';
+
+import { SnapEndowments } from './enum';
+
+const permissionName = SnapEndowments.LifecycleHooks;
+
+type LifecycleHooksEndowmentSpecification = ValidPermissionSpecification<{
+  permissionType: PermissionType.Endowment;
+  targetName: typeof permissionName;
+  endowmentGetter: (_options?: EndowmentGetterParams) => undefined;
+  allowedCaveats: Readonly<NonEmptyArray<string>> | null;
+}>;
+
+/**
+ * `endowment:lifecycle-hooks` returns nothing; it is intended to be used as a
+ * flag by the snap controller to detect whether the snap has the capability to
+ * use lifecycle hooks.
+ *
+ * @param _builderOptions - Optional specification builder options.
+ * @returns The specification for the `lifecycle-hooks` endowment.
+ */
+const specificationBuilder: PermissionSpecificationBuilder<
+  PermissionType.Endowment,
+  any,
+  LifecycleHooksEndowmentSpecification
+> = (_builderOptions?: unknown) => {
+  return {
+    permissionType: PermissionType.Endowment,
+    targetName: permissionName,
+    allowedCaveats: null,
+    endowmentGetter: (_getterOptions?: EndowmentGetterParams) => undefined,
+    subjectTypes: [SubjectType.Snap],
+  };
+};
+
+export const lifecycleHooksEndowmentBuilder = Object.freeze({
+  targetName: permissionName,
+  specificationBuilder,
+} as const);

--- a/packages/snaps-controllers/src/snaps/permission.test.ts
+++ b/packages/snaps-controllers/src/snaps/permission.test.ts
@@ -28,6 +28,15 @@ describe('buildSnapEndowmentSpecifications', () => {
           ],
           "targetName": "endowment:ethereum-provider",
         },
+        "endowment:lifecycle-hooks": {
+          "allowedCaveats": null,
+          "endowmentGetter": [Function],
+          "permissionType": "Endowment",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetName": "endowment:lifecycle-hooks",
+        },
         "endowment:long-running": {
           "allowedCaveats": null,
           "endowmentGetter": [Function],

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -257,6 +257,10 @@ export const getControllerMessenger = (registry = new MockSnapsRegistry()) => {
   );
 
   messenger.registerActionHandler('ExecutionService:executeSnap', asyncNoOp);
+  messenger.registerActionHandler(
+    'ExecutionService:handleRpcRequest',
+    asyncNoOp,
+  );
   messenger.registerActionHandler('ExecutionService:terminateSnap', asyncNoOp);
   messenger.registerActionHandler(
     'ExecutionService:terminateAllSnaps',

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 77.37,
-  "functions": 91.91,
-  "lines": 90.46,
-  "statements": 90.35
+  "branches": 78.57,
+  "functions": 91.79,
+  "lines": 90.7,
+  "statements": 90.58
 }

--- a/packages/snaps-execution-environments/lavamoat/browserify/iframe/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/iframe/policy.json
@@ -315,6 +315,7 @@
       },
       "packages": {
         "@metamask/utils": true,
+        "external:../snaps-utils/src/handlers.ts": true,
         "superstruct": true
       }
     },

--- a/packages/snaps-execution-environments/lavamoat/browserify/node-process/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/node-process/policy.json
@@ -379,6 +379,7 @@
       },
       "packages": {
         "@metamask/utils": true,
+        "external:../snaps-utils/src/handlers.ts": true,
         "superstruct": true
       }
     },

--- a/packages/snaps-execution-environments/lavamoat/browserify/node-thread/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/node-thread/policy.json
@@ -379,6 +379,7 @@
       },
       "packages": {
         "@metamask/utils": true,
+        "external:../snaps-utils/src/handlers.ts": true,
         "superstruct": true
       }
     },

--- a/packages/snaps-execution-environments/lavamoat/browserify/offscreen/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/offscreen/policy.json
@@ -175,6 +175,7 @@
       },
       "packages": {
         "@metamask/utils": true,
+        "external:../snaps-utils/src/handlers.ts": true,
         "superstruct": true
       }
     },

--- a/packages/snaps-execution-environments/lavamoat/browserify/worker-executor/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/worker-executor/policy.json
@@ -315,6 +315,7 @@
       },
       "packages": {
         "@metamask/utils": true,
+        "external:../snaps-utils/src/handlers.ts": true,
         "superstruct": true
       }
     },

--- a/packages/snaps-execution-environments/lavamoat/browserify/worker-pool/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/worker-pool/policy.json
@@ -175,6 +175,7 @@
       },
       "packages": {
         "@metamask/utils": true,
+        "external:../snaps-utils/src/handlers.ts": true,
         "superstruct": true
       }
     },

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -8,7 +8,11 @@ import type {
   HandlerType,
   SnapExportsParameters,
 } from '@metamask/snaps-utils';
-import { SNAP_EXPORT_NAMES, logError } from '@metamask/snaps-utils';
+import {
+  SNAP_EXPORT_NAMES,
+  logError,
+  SNAP_EXPORTS,
+} from '@metamask/snaps-utils';
 import type {
   JsonRpcNotification,
   JsonRpcId,
@@ -47,7 +51,6 @@ import {
   PingRequestArgumentsStruct,
   SnapRpcRequestArgumentsStruct,
   TerminateRequestArgumentsStruct,
-  validateExport,
 } from './validation';
 
 type EvaluationData = {
@@ -127,14 +130,24 @@ export class BaseSnapExecutor {
 
     this.methods = getCommandMethodImplementations(
       this.startSnap.bind(this),
-      async (target, handlerName, args) => {
+      async (target, handlerType, args) => {
         const data = this.snapData.get(target);
-        // We're capturing the handler in case someone modifies the data object before the call
-        const handler = data?.exports[handlerName];
+        // We're capturing the handler in case someone modifies the data object
+        // before the call.
+        const handler = data?.exports[handlerType];
+        const { required } = SNAP_EXPORTS[handlerType];
+
         assert(
-          handler !== undefined,
-          `No ${handlerName} handler exported for snap "${target}`,
+          !required || handler !== undefined,
+          `No ${handlerType} handler exported for snap "${target}`,
         );
+
+        // Certain handlers are not required. If they are not exported, we
+        // return null.
+        if (!handler) {
+          return null;
+        }
+
         // TODO: fix handler args type cast
         let result = await this.executeInSnapContext(target, () =>
           handler(args as any),
@@ -371,14 +384,15 @@ export class BaseSnapExecutor {
 
   private registerSnapExports(snapId: string, snapModule: any) {
     const data = this.snapData.get(snapId);
-    // Somebody deleted the Snap before we could register
+    // Somebody deleted the snap before we could register.
     if (!data) {
       return;
     }
 
     data.exports = SNAP_EXPORT_NAMES.reduce((acc, exportName) => {
       const snapExport = snapModule.exports[exportName];
-      if (validateExport(exportName, snapExport)) {
+      const { validator } = SNAP_EXPORTS[exportName];
+      if (validator(snapExport)) {
         return { ...acc, [exportName]: snapExport };
       }
       return acc;

--- a/packages/snaps-execution-environments/src/common/commands.ts
+++ b/packages/snaps-execution-environments/src/common/commands.ts
@@ -49,6 +49,8 @@ export function getHandlerArguments(
       return { origin, request };
 
     case HandlerType.OnCronjob:
+    case HandlerType.OnInstall:
+    case HandlerType.OnUpdate:
       return { request };
 
     default:

--- a/packages/snaps-execution-environments/src/common/validation.ts
+++ b/packages/snaps-execution-environments/src/common/validation.ts
@@ -24,36 +24,6 @@ import {
   union,
 } from 'superstruct';
 
-const VALIDATION_FUNCTIONS = {
-  [HandlerType.OnRpcRequest]: validateFunctionExport,
-  [HandlerType.OnTransaction]: validateFunctionExport,
-  [HandlerType.OnCronjob]: validateFunctionExport,
-};
-
-/**
- * Validates a function export.
- *
- * @param snapExport - The export itself.
- * @returns True if the export matches the expected shape, false otherwise.
- */
-function validateFunctionExport(
-  snapExport: unknown,
-): snapExport is (...args: unknown[]) => unknown {
-  return typeof snapExport === 'function';
-}
-
-/**
- * Validates a given snap export.
- *
- * @param type - The type of export expected.
- * @param snapExport - The export itself.
- * @returns True if the export matches the expected shape, false otherwise.
- */
-export function validateExport(type: HandlerType, snapExport: unknown) {
-  const validationFunction = VALIDATION_FUNCTIONS[type];
-  return validationFunction?.(snapExport) ?? false;
-}
-
 export const JsonRpcRequestWithoutIdStruct = assign(
   omit(JsonRpcRequestStruct, ['id']),
   object({

--- a/packages/snaps-types/src/types.ts
+++ b/packages/snaps-types/src/types.ts
@@ -20,4 +20,6 @@ export type {
   OnRpcRequestHandler,
   OnTransactionHandler,
   OnTransactionResponse,
+  OnInstallHandler,
+  OnUpdateHandler,
 } from '@metamask/snaps-utils';

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 94.89,
+  "branches": 94.97,
   "functions": 100,
-  "lines": 98.62,
-  "statements": 95.81
+  "lines": 98.64,
+  "statements": 95.88
 }

--- a/packages/snaps-utils/src/errors.test.ts
+++ b/packages/snaps-utils/src/errors.test.ts
@@ -1,0 +1,20 @@
+import { ethErrors } from 'eth-rpc-errors';
+
+import { getErrorMessage } from './errors';
+
+describe('getErrorMessage', () => {
+  it('returns the error message if the error is an object with a message property', () => {
+    expect(getErrorMessage(new Error('foo'))).toBe('foo');
+    expect(getErrorMessage({ message: 'foo' })).toBe('foo');
+    expect(getErrorMessage(ethErrors.rpc.invalidParams('foo'))).toBe('foo');
+  });
+
+  it('returns the error converted to a string if the error does not have a message property', () => {
+    expect(getErrorMessage('foo')).toBe('foo');
+    expect(getErrorMessage(123)).toBe('123');
+    expect(getErrorMessage(true)).toBe('true');
+    expect(getErrorMessage(null)).toBe('null');
+    expect(getErrorMessage(undefined)).toBe('undefined');
+    expect(getErrorMessage({ foo: 'bar' })).toBe('[object Object]');
+  });
+});

--- a/packages/snaps-utils/src/errors.ts
+++ b/packages/snaps-utils/src/errors.ts
@@ -1,0 +1,22 @@
+import { hasProperty, isObject } from '@metamask/utils';
+
+/**
+ * Get the error message from an unknown error type.
+ *
+ * - If the error is an object with a `message` property, return the message.
+ * - Otherwise, return the error converted to a string.
+ *
+ * @param error - The error to get the message from.
+ * @returns The error message.
+ */
+export function getErrorMessage(error: unknown) {
+  if (
+    isObject(error) &&
+    hasProperty(error, 'message') &&
+    typeof error.message === 'string'
+  ) {
+    return error.message;
+  }
+
+  return String(error);
+}

--- a/packages/snaps-utils/src/eval-worker.ts
+++ b/packages/snaps-utils/src/eval-worker.ts
@@ -3,8 +3,8 @@ import 'ses/lockdown';
 
 import { readFileSync } from 'fs';
 
+import type { HandlerType } from './handlers';
 import { generateMockEndowments } from './mock';
-import type { HandlerType } from './types';
 import { SNAP_EXPORT_NAMES } from './types';
 
 declare let lockdown: any, Compartment: any;

--- a/packages/snaps-utils/src/handlers.test.ts
+++ b/packages/snaps-utils/src/handlers.test.ts
@@ -1,0 +1,13 @@
+import { SNAP_EXPORTS } from './handlers';
+
+describe('SNAP_EXPORTS', () => {
+  describe('validator', () => {
+    it.each(Object.values(SNAP_EXPORTS))(
+      'validates that the snap export is a function',
+      ({ validator }) => {
+        expect(validator(() => undefined)).toBe(true);
+        expect(validator('')).toBe(false);
+      },
+    );
+  });
+});

--- a/packages/snaps-utils/src/handlers.ts
+++ b/packages/snaps-utils/src/handlers.ts
@@ -1,5 +1,75 @@
 import type { Component } from '@metamask/snaps-ui';
-import type { Json, JsonRpcRequest } from '@metamask/utils';
+import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
+
+export enum HandlerType {
+  OnRpcRequest = 'onRpcRequest',
+  OnTransaction = 'onTransaction',
+  OnCronjob = 'onCronjob',
+  OnInstall = 'onInstall',
+  OnUpdate = 'onUpdate',
+}
+
+type SnapHandler = {
+  /**
+   * The type of handler.
+   */
+  type: HandlerType;
+
+  /**
+   * Whether the handler is required, i.e., whether the request will fail if the
+   * handler is called, but the snap does not export it.
+   *
+   * This is primarily used for the lifecycle handlers, which are optional.
+   */
+  required: boolean;
+
+  /**
+   * Validate the given snap export. This should return a type guard for the
+   * handler type.
+   *
+   * @param snapExport - The export to validate.
+   * @returns Whether the export is valid.
+   */
+  validator: (snapExport: unknown) => boolean;
+};
+
+export const SNAP_EXPORTS = {
+  [HandlerType.OnRpcRequest]: {
+    type: HandlerType.OnRpcRequest,
+    required: true,
+    validator: (snapExport: unknown): snapExport is OnRpcRequestHandler => {
+      return typeof snapExport === 'function';
+    },
+  },
+  [HandlerType.OnTransaction]: {
+    type: HandlerType.OnTransaction,
+    required: true,
+    validator: (snapExport: unknown): snapExport is OnTransactionHandler => {
+      return typeof snapExport === 'function';
+    },
+  },
+  [HandlerType.OnCronjob]: {
+    type: HandlerType.OnCronjob,
+    required: true,
+    validator: (snapExport: unknown): snapExport is OnCronjobHandler => {
+      return typeof snapExport === 'function';
+    },
+  },
+  [HandlerType.OnInstall]: {
+    type: HandlerType.OnInstall,
+    required: false,
+    validator: (snapExport: unknown): snapExport is OnInstallHandler => {
+      return typeof snapExport === 'function';
+    },
+  },
+  [HandlerType.OnUpdate]: {
+    type: HandlerType.OnUpdate,
+    required: false,
+    validator: (snapExport: unknown): snapExport is OnUpdateHandler => {
+      return typeof snapExport === 'function';
+    },
+  },
+} as const;
 
 /**
  * The `onRpcRequest` handler. This is called whenever a JSON-RPC request is
@@ -11,15 +81,11 @@ import type { Json, JsonRpcRequest } from '@metamask/utils';
  * @param args.request - The JSON-RPC request sent to the snap.
  * @returns The JSON-RPC response. This must be a JSON-serializable value.
  */
-export type OnRpcRequestHandler<
-  Params extends Json[] | Record<string, Json> | undefined =
-    | Json[]
-    | Record<string, Json>
-    | undefined,
-> = (args: {
-  origin: string;
-  request: JsonRpcRequest<Params>;
-}) => Promise<unknown>;
+export type OnRpcRequestHandler<Params extends JsonRpcParams = JsonRpcParams> =
+  (args: {
+    origin: string;
+    request: JsonRpcRequest<Params>;
+  }) => Promise<unknown>;
 
 /**
  * The response from a snap's `onTransaction` handler.
@@ -59,20 +125,45 @@ export type OnTransactionHandler = (args: {
  * @param args - The request arguments.
  * @param args.request - The JSON-RPC request sent to the snap.
  */
-export type OnCronjobHandler<
-  Params extends Json[] | Record<string, Json> | undefined =
-    | Json[]
-    | Record<string, Json>
-    | undefined,
-> = (args: { request: JsonRpcRequest<Params> }) => Promise<unknown>;
+export type OnCronjobHandler<Params extends JsonRpcParams = JsonRpcParams> =
+  (args: { request: JsonRpcRequest<Params> }) => Promise<unknown>;
+
+/**
+ * A handler that can be used for the lifecycle hooks.
+ */
+export type LifecycleEventHandler = (args: {
+  request: JsonRpcRequest;
+}) => Promise<unknown>;
+
+/**
+ * The `onInstall` handler. This is called after the snap is installed.
+ *
+ * This type is an alias for {@link LifecycleEventHandler}.
+ */
+export type OnInstallHandler = LifecycleEventHandler;
+
+/**
+ * The `onUpdate` handler. This is called after the snap is updated.
+ *
+ * This type is an alias for {@link LifecycleEventHandler}.
+ */
+export type OnUpdateHandler = LifecycleEventHandler;
+
+/**
+ * Utility type for getting the handler function type from a handler type.
+ */
+export type HandlerFunction<Type extends SnapHandler> =
+  Type['validator'] extends (snapExport: unknown) => snapExport is infer Handler
+    ? Handler
+    : never;
 
 /**
  * All the function-based handlers that a snap can implement.
  */
 export type SnapFunctionExports = {
-  onRpcRequest?: OnRpcRequestHandler;
-  onTransaction?: OnTransactionHandler;
-  onCronjob?: OnCronjobHandler;
+  [Key in keyof typeof SNAP_EXPORTS]?: HandlerFunction<
+    typeof SNAP_EXPORTS[Key]
+  >;
 };
 
 /**

--- a/packages/snaps-utils/src/index.browser.ts
+++ b/packages/snaps-utils/src/index.browser.ts
@@ -6,6 +6,7 @@ export * from './deep-clone';
 export * from './default-endowments';
 export * from './entropy';
 export * from './enum';
+export * from './errors';
 export * from './handlers';
 export * from './iframe';
 export * from './json';

--- a/packages/snaps-utils/src/index.ts
+++ b/packages/snaps-utils/src/index.ts
@@ -7,6 +7,7 @@ export * from './default-endowments';
 export * from './entropy';
 export * from './enum';
 export * from './eval';
+export * from './errors';
 export * from './fs';
 export * from './handlers';
 export * from './iframe';

--- a/packages/snaps-utils/src/types.ts
+++ b/packages/snaps-utils/src/types.ts
@@ -17,6 +17,7 @@ import {
 
 import type { SnapCaveatType } from './caveats';
 import type { SnapFunctionExports } from './handlers';
+import { HandlerType } from './handlers';
 import type { SnapManifest } from './manifest';
 import type { VirtualFile } from './virtual-file';
 
@@ -129,12 +130,6 @@ export enum SNAP_STREAM_NAMES {
   COMMAND = 'command',
 }
 /* eslint-enable @typescript-eslint/naming-convention */
-
-export enum HandlerType {
-  OnRpcRequest = 'onRpcRequest',
-  OnTransaction = 'onTransaction',
-  OnCronjob = 'onCronjob',
-}
 
 export const SNAP_EXPORT_NAMES = Object.values(HandlerType);
 


### PR DESCRIPTION
This adds two new snap exports:

- `onInstall` which is called after a snap is installed.
- `onUpdate` which is called after a snap is updated.

Snaps with the `endowment:lifecycle-hooks` will be able to use these hooks.

To make it a bit easier to add more exports in the future, I've slightly refactored `snaps-utils` so most stuff related to handlers is now defined in a single place (except for `handlerEndowments` as that would require a larger refactor).

This pull request also introduces the concept of "required" and "non-required" handlers. Required handlers must be defined by a snap when they are called, otherwise an error is thrown. This applies to all the existing handlers before this pull request. Non-required handlers do not need to be defined, and do not throw an error when they are not specified by the snap. This is useful for the lifecycle hooks, since a snap may not want to implement all of them.

Related to MetaMask/metamask-planning#919.
Closes MetaMask/metamask-planning#1057.