### PR TITLE
correct curve name in snap_getBip32PublicKey

### DIFF
--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -56,7 +56,7 @@ type GetBip32PublicKeyParameters = {
 export const Bip32PublicKeyArgsStruct = bip32entropy(
   object({
     path: Bip32PathStruct,
-    curve: enums(['ed225519', 'secp256k1']),
+    curve: enums(['ed25519', 'secp256k1']),
     compressed: optional(boolean()),
   }),
 );


### PR DESCRIPTION
redundant  number in `ed225519`
```
export const Bip32PublicKeyArgsStruct = bip32entropy(
  object({
    path: Bip32PathStruct,
    curve: enums(['ed225519', 'secp256k1']),
    compressed: optional(boolean()),
  }),
);
```