### PR TITLE
Fix `MockSnapsRegistry` not matching `SnapsRegistry` interface

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -4603,7 +4603,7 @@ describe('SnapController', () => {
       );
       await snapController.updateBlockedSnaps();
 
-      expect(registry.updateDatabase).toHaveBeenCalled();
+      expect(registry.update).toHaveBeenCalled();
 
       snapController.destroy();
     });

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -278,7 +278,7 @@ export const getControllerMessenger = (registry = new MockSnapsRegistry()) => {
 
   messenger.registerActionHandler(
     'SnapsRegistry:update',
-    registry.updateDatabase.bind(registry),
+    registry.update.bind(registry),
   );
 
   jest.spyOn(messenger, 'call');

--- a/packages/snaps-controllers/src/test-utils/registry.ts
+++ b/packages/snaps-controllers/src/test-utils/registry.ts
@@ -16,5 +16,5 @@ export class MockSnapsRegistry implements SnapsRegistry {
 
   getMetadata = jest.fn().mockResolvedValue(null);
 
-  updateDatabase = jest.fn();
+  update = jest.fn();
 }


### PR DESCRIPTION
This causes a type error if you are running tests with type checking, which we aren't on main. But perhaps we should be?