### PR TITLE
Loosen allowlist requirements

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 91.4,
-  "functions": 96.92,
-  "lines": 98,
+  "functions": 96.93,
+  "lines": 98.01,
   "statements": 97.73
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -773,14 +773,15 @@ describe('SnapController', () => {
   });
 
   it('throws an error if snap is not on allowlist and allowlisting is required', async () => {
-    const { manifest, sourceCode, svgIcon } = await getMockSnapFilesWithUpdatedChecksum({
-      manifest: getSnapManifest({
-        initialPermissions: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          snap_getBip44Entropy: [{ coinType: 1 }],
-        },
-      }),
-    });
+    const { manifest, sourceCode, svgIcon } =
+      await getMockSnapFilesWithUpdatedChecksum({
+        manifest: getSnapManifest({
+          initialPermissions: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            snap_getBip44Entropy: [{ coinType: 1 }],
+          },
+        }),
+      });
 
     const controller = getSnapController(
       getSnapControllerOptions({

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -585,7 +585,11 @@ describe('SnapController', () => {
     );
 
     expect(messenger.call).toHaveBeenNthCalledWith(2, 'SnapsRegistry:get', {
-      [MOCK_SNAP_ID]: { version: '1.0.0', checksum: DEFAULT_SNAP_SHASUM },
+      [MOCK_SNAP_ID]: {
+        version: '1.0.0',
+        checksum: DEFAULT_SNAP_SHASUM,
+        permissions: getSnapManifest().initialPermissions,
+      },
     });
 
     expect(messenger.call).toHaveBeenNthCalledWith(
@@ -769,11 +773,22 @@ describe('SnapController', () => {
   });
 
   it('throws an error if snap is not on allowlist and allowlisting is required', async () => {
+    const { manifest, sourceCode, svgIcon } = await getMockSnapFilesWithUpdatedChecksum({
+      manifest: getSnapManifest({
+        initialPermissions: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          snap_getBip44Entropy: [{ coinType: 1 }],
+        },
+      }),
+    });
+
     const controller = getSnapController(
       getSnapControllerOptions({
         featureFlags: { requireAllowlist: true },
-        detectSnapLocation: (_location, options) =>
-          new LoopbackLocation(options),
+        detectSnapLocation: loopbackDetect({
+          manifest: manifest.result,
+          files: [sourceCode, svgIcon as VirtualFile],
+        }),
       }),
     );
 
@@ -782,7 +797,7 @@ describe('SnapController', () => {
         [MOCK_SNAP_ID]: { version: DEFAULT_REQUESTED_SNAP_VERSION },
       }),
     ).rejects.toThrow(
-      'Failed to fetch snap "npm:@metamask/example-snap": The snap is not on the allowlist.',
+      'Cannot install version "1.0.0" of snap "npm:@metamask/example-snap": The snap is not on the allowlist.',
     );
 
     controller.destroy();

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -41,6 +41,7 @@ import type {
   PersistedSnap,
   Snap,
   SnapManifest,
+  SnapPermissions,
   SnapRpcHookArgs,
   StatusContext,
   StatusEvents,
@@ -103,6 +104,7 @@ import type {
   TerminateSnapAction,
 } from '../services';
 import { fetchSnap, hasTimedOut, setDiff, withTimeout } from '../utils';
+import { ALLOWED_PERMISSIONS } from './constants';
 import {
   getMaxRequestTimeCaveat,
   handlerEndowments,
@@ -1193,7 +1195,10 @@ export class SnapController extends BaseController<
     this.messagingSystem.publish(`${controllerName}:snapUnblocked`, snapId);
   }
 
-  async #assertIsInstallAllowed(snapId: SnapId, snapInfo: SnapsRegistryInfo) {
+  async #assertIsInstallAllowed(
+    snapId: SnapId,
+    snapInfo: SnapsRegistryInfo & { permissions: SnapPermissions },
+  ) {
     const results = await this.messagingSystem.call('SnapsRegistry:get', {
       [snapId]: snapInfo,
     });
@@ -1206,8 +1211,15 @@ export class SnapController extends BaseController<
           result.reason?.explanation ?? ''
         }`,
       );
-    } else if (
+    }
+
+    const isAllowlistingRequired = !Object.keys(snapInfo.permissions).every(
+      (permission) => ALLOWED_PERMISSIONS.includes(permission),
+    );
+
+    if (
       this.#featureFlags.requireAllowlist &&
+      isAllowlistingRequired &&
       result.status !== SnapsRegistryStatus.Verified
     ) {
       throw new Error(
@@ -2190,6 +2202,7 @@ export class SnapController extends BaseController<
       await this.#assertIsInstallAllowed(snapId, {
         version: newVersion,
         checksum: manifest.source.shasum,
+        permissions: manifest.initialPermissions,
       });
 
       const processedPermissions = processSnapPermissions(
@@ -2363,6 +2376,7 @@ export class SnapController extends BaseController<
         await this.#assertIsInstallAllowed(snapId, {
           version: manifest.version,
           checksum: manifest.source.shasum,
+          permissions: manifest.initialPermissions,
         });
 
         return this.#set({

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1213,8 +1213,8 @@ export class SnapController extends BaseController<
       );
     }
 
-    const isAllowlistingRequired = !Object.keys(snapInfo.permissions).every(
-      (permission) => ALLOWED_PERMISSIONS.includes(permission),
+    const isAllowlistingRequired = Object.keys(snapInfo.permissions).some(
+      (permission) => !ALLOWED_PERMISSIONS.includes(permission),
     );
 
     if (

--- a/packages/snaps-controllers/src/snaps/constants.ts
+++ b/packages/snaps-controllers/src/snaps/constants.ts
@@ -9,4 +9,7 @@ export const ALLOWED_PERMISSIONS = Object.freeze([
   SnapEndowments.Cronjob,
   SnapEndowments.HomePage,
   SnapEndowments.LifecycleHooks,
+  SnapEndowments.EthereumProvider,
+  SnapEndowments.TransactionInsight,
+  SnapEndowments.SignatureInsight,
 ]);

--- a/packages/snaps-controllers/src/snaps/constants.ts
+++ b/packages/snaps-controllers/src/snaps/constants.ts
@@ -1,0 +1,12 @@
+import { SnapEndowments } from './endowments';
+
+// These permissions are allowed without being on the allowlist.
+export const ALLOWED_PERMISSIONS = Object.freeze([
+  'snap_dialog',
+  'snap_manageState',
+  'snap_notify',
+  'snap_getLocale',
+  SnapEndowments.Cronjob,
+  SnapEndowments.HomePage,
+  SnapEndowments.LifecycleHooks,
+]);


### PR DESCRIPTION
Allows snaps with certain permissions to be installed without being on the allowlist even when the allowlist feature flag is set.