### PR TITLE
Fix CLI usage of SWC

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/utils": "^6.0.1",
     "@swc/cli": "^0.1.62",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@types/jest": "^27.5.1",
     "@types/node": "^20.3.1",
     "@typescript-eslint/eslint-plugin": "^5.42.1",

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -63,7 +63,7 @@
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/cli": "^0.1.62",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@types/jest": "^27.5.1",
     "@types/node": "^20.3.1",

--- a/packages/examples/packages/bip32/package.json
+++ b/packages/examples/packages/bip32/package.json
@@ -49,7 +49,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "eZGHREI+AiM35cg+ikWYpzt7Ut4bybWyipod2VYaj0k=",
+    "shasum": "aBFG5xpBhXWaUAzWv6NKCp0I50IsCLdQh2s8oR96WSo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/package.json
+++ b/packages/examples/packages/bip44/package.json
@@ -48,7 +48,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1EXWoSjXNhXjx0R5gKPQYM1mTRlPRdpkNBNtAsdn/Ow=",
+    "shasum": "fLLhmwTlRZ7D+7TLuy23uRq1GCAYctgUcC0S/gWIxJU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/package.json
+++ b/packages/examples/packages/browserify-plugin/package.json
@@ -43,7 +43,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-browserify-plugin": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/browserify/package.json
+++ b/packages/examples/packages/browserify/package.json
@@ -44,7 +44,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/cronjobs/package.json
+++ b/packages/examples/packages/cronjobs/package.json
@@ -45,7 +45,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/dialogs/package.json
+++ b/packages/examples/packages/dialogs/package.json
@@ -47,7 +47,7 @@
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
     "@metamask/utils": "^6.0.1",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "RP0U5IFHxErYbB/lmU3NQHvIYqdITlDq87sUQkuMwIo=",
+    "shasum": "LNZWM1v0Sw82vgEIaEm3eXsZZ2LBrHKy6BN0SBppDew=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/errors/package.json
+++ b/packages/examples/packages/errors/package.json
@@ -43,7 +43,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/ethereum-provider/package.json
+++ b/packages/examples/packages/ethereum-provider/package.json
@@ -46,7 +46,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/ethers-js/package.json
+++ b/packages/examples/packages/ethers-js/package.json
@@ -48,7 +48,7 @@
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
     "@metamask/utils": "^6.0.1",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/get-entropy/package.json
+++ b/packages/examples/packages/get-entropy/package.json
@@ -47,7 +47,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "H7kJgYqIQWSc43r74gVIAtmOARq75jz2K3fYtAaCoi8=",
+    "shasum": "JEabvrSyiXRBsl7rSlhOV7qwx2cNkQeWYFYAa+iJiBs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
@@ -47,7 +47,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/package.json
@@ -50,7 +50,7 @@
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
     "@noble/hashes": "^1.3.1",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cMT0eTB6rOnAmZCPyfrOW5pMmdgfqXLVfWYkWRSMuAk=",
+    "shasum": "02bUA9bfBIJjdyUoHniBW08Vse3hjpEr+rgVpPrwYFo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/package.json
+++ b/packages/examples/packages/json-rpc/package.json
@@ -44,7 +44,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/lifecycle-hooks/package.json
+++ b/packages/examples/packages/lifecycle-hooks/package.json
@@ -44,7 +44,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/manage-state/package.json
+++ b/packages/examples/packages/manage-state/package.json
@@ -44,7 +44,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "97AmEgRbuEZHg+hGusHA2sx1NVH/dj/xdXBGCgXmrb8=",
+    "shasum": "lhPEfZ6JNEuFoMLtuexzZaYmrdYppV99O8WyaikSk9k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/package.json
+++ b/packages/examples/packages/network-access/package.json
@@ -44,7 +44,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "/xrzK+LNyXfupec9dDNUM6AGROGkJzIzrnnn5++j/Z0=",
+    "shasum": "HECy9g+scV7zX7XWILT6iPuzyiY4KSPHIx5LAYq9gj0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/package.json
+++ b/packages/examples/packages/notifications/package.json
@@ -44,7 +44,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "t/nO4FI4ZsYgkk4NsiuSe3MkV4ifoYBmE3DiddRukUs=",
+    "shasum": "qb1ShaujP9yjoE415YrJYDjtneWSJ/hXc7wnk9BZfKI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/package.json
+++ b/packages/examples/packages/rollup-plugin/package.json
@@ -51,7 +51,7 @@
     "@rollup/plugin-commonjs": "^25.0.1",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/plugin-terser": "^0.4.3",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/transaction-insights/package.json
+++ b/packages/examples/packages/transaction-insights/package.json
@@ -45,7 +45,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/wasm/.swcrc
+++ b/packages/examples/packages/wasm/.swcrc
@@ -3,8 +3,7 @@
   "jsc": {
     "parser": {
       "syntax": "typescript"
-    },
-    "target": "es2021"
+    }
   },
   "module": {
     "type": "es6"

--- a/packages/examples/packages/wasm/package.json
+++ b/packages/examples/packages/wasm/package.json
@@ -47,7 +47,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/examples/packages/webpack-plugin/package.json
+++ b/packages/examples/packages/webpack-plugin/package.json
@@ -45,7 +45,7 @@
     "@metamask/snaps-jest": "workspace:^",
     "@metamask/snaps-rollup-plugin": "workspace:^",
     "@metamask/snaps-webpack-plugin": "workspace:^",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@types/webpack-env": "^1.18.1",
     "@typescript-eslint/eslint-plugin": "^5.42.1",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5dAkk9qHzUv2n1ao+DjTbyYzRoCgTftuy9z4aIgODCg=",
+    "shasum": "aD0os62YMEOGXFoRtwrT8tCJQYEW+hoWDPe9rVR+Tvo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -55,7 +55,7 @@
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/cli": "^0.1.62",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@types/node": "^20.3.1",
     "@typescript-eslint/eslint-plugin": "^5.42.1",

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -49,7 +49,7 @@
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/cli": "^0.1.62",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@types/browserify": "^12.0.37",
     "@types/convert-source-map": "^1.5.2",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -58,7 +58,7 @@
     "@metamask/snaps-utils": "workspace:^",
     "@metamask/snaps-webpack-plugin": "workspace:^",
     "@metamask/utils": "^6.0.1",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "assert": "^2.0.0",
     "babelify": "^10.0.0",
     "browserify": "^17.0.0",

--- a/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
+++ b/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
@@ -23,7 +23,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               "parser": {
                 "syntax": "typescript",
               },
-              "target": "es2020",
             },
             "module": {
               "type": "commonjs",
@@ -159,7 +158,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               "parser": {
                 "syntax": "typescript",
               },
-              "target": "es2020",
             },
             "module": {
               "type": "commonjs",
@@ -295,7 +293,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               "parser": {
                 "syntax": "typescript",
               },
-              "target": "es2020",
             },
             "module": {
               "type": "commonjs",
@@ -431,7 +428,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               "parser": {
                 "syntax": "typescript",
               },
-              "target": "es2020",
             },
             "module": {
               "type": "commonjs",
@@ -559,7 +555,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               "parser": {
                 "syntax": "typescript",
               },
-              "target": "es2020",
             },
             "module": {
               "type": "commonjs",
@@ -700,7 +695,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               "parser": {
                 "syntax": "typescript",
               },
-              "target": "es2020",
             },
             "module": {
               "type": "commonjs",
@@ -836,7 +830,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               "parser": {
                 "syntax": "typescript",
               },
-              "target": "es2020",
             },
             "module": {
               "type": "commonjs",
@@ -972,7 +965,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               "parser": {
                 "syntax": "typescript",
               },
-              "target": "es2020",
             },
             "module": {
               "type": "commonjs",
@@ -1116,7 +1108,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               "parser": {
                 "syntax": "typescript",
               },
-              "target": "es2020",
             },
             "module": {
               "type": "commonjs",
@@ -1260,7 +1251,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               "parser": {
                 "syntax": "typescript",
               },
-              "target": "es2020",
             },
             "module": {
               "type": "commonjs",
@@ -1405,7 +1395,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               "parser": {
                 "syntax": "typescript",
               },
-              "target": "es2020",
             },
             "module": {
               "type": "commonjs",
@@ -1541,7 +1530,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               "parser": {
                 "syntax": "typescript",
               },
-              "target": "es2020",
             },
             "module": {
               "type": "commonjs",
@@ -1677,7 +1665,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               "parser": {
                 "syntax": "typescript",
               },
-              "target": "es2020",
             },
             "module": {
               "type": "commonjs",
@@ -1822,7 +1809,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               "parser": {
                 "syntax": "typescript",
               },
-              "target": "es2020",
             },
             "module": {
               "type": "commonjs",

--- a/packages/snaps-cli/src/webpack/utils.ts
+++ b/packages/snaps-cli/src/webpack/utils.ts
@@ -115,15 +115,6 @@ export async function getDefaultLoader({
       sourceMaps: Boolean(getDevTool(sourceMap)),
 
       jsc: {
-        /**
-         * MetaMask targets ES2020, so we set the target to ES2020. This
-         * ensures that the code is transpiled to ES2020, and that the
-         * necessary polyfills are added.
-         *
-         * @see https://swc.rs/docs/configuration/compilation#jsctarget
-         */
-        target: 'es2020',
-
         parser: {
           /**
            * This tells the parser to parse TypeScript files. If you

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -77,7 +77,7 @@
     "@metamask/template-snap": "^0.7.0",
     "@peculiar/webcrypto": "^1.3.3",
     "@swc/cli": "^0.1.62",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@types/chrome": "^0.0.237",
     "@types/concat-stream": "^2.0.0",

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -72,7 +72,7 @@
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/cli": "^0.1.62",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@types/express": "^4.17.17",
     "@types/jest": "^27.5.1",

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -59,7 +59,7 @@
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/cli": "^0.1.62",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@types/jest": "^27.5.1",
     "@types/semver": "^7.5.0",

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -50,7 +50,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@rollup/plugin-virtual": "^2.1.0",
     "@swc/cli": "^0.1.62",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@types/jest": "^27.5.1",
     "@typescript-eslint/eslint-plugin": "^5.42.1",

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -95,7 +95,7 @@
     "@redux-saga/is": "^1.1.3",
     "@redux-saga/symbols": "^1.1.3",
     "@swc/cli": "^0.1.62",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@testing-library/react": "^14.0.0",
     "@types/express": "^4.17.17",
     "@types/jest": "^27.5.1",

--- a/packages/snaps-types/package.json
+++ b/packages/snaps-types/package.json
@@ -48,7 +48,7 @@
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/cli": "^0.1.62",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/snaps-ui/package.json
+++ b/packages/snaps-ui/package.json
@@ -46,7 +46,7 @@
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/cli": "^0.1.62",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@types/jest": "^27.5.1",
     "@types/semver": "^7.5.0",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -99,7 +99,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/post-message-stream": "^6.1.2",
     "@swc/cli": "^0.1.62",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@types/jest": "^27.5.1",
     "@types/mocha": "^10.0.1",

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -51,7 +51,7 @@
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/cli": "^0.1.62",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@types/jest": "^27.5.1",
     "@types/webpack-sources": "^3.2.0",

--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -63,7 +63,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/providers": "^11.1.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
-    "@swc/core": "^1.3.66",
+    "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@types/jest": "^27.5.1",
     "@types/node": "^20.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3699,7 +3699,7 @@ __metadata:
     "@metamask/utils": ^6.0.1
     "@noble/ed25519": ^1.6.0
     "@noble/secp256k1": ^1.7.1
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -3739,7 +3739,7 @@ __metadata:
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/utils": ^6.0.1
     "@noble/bls12-381": ^1.2.0
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -3784,7 +3784,7 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -3821,7 +3821,7 @@ __metadata:
     "@metamask/snaps-browserify-plugin": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -3862,7 +3862,7 @@ __metadata:
     "@metamask/snaps-types": "workspace:^"
     "@metamask/utils": ^6.0.1
     "@noble/hashes": ^1.3.1
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -3919,7 +3919,7 @@ __metadata:
     "@metamask/utils": ^6.0.1
     "@noble/curves": ^1.1.0
     "@noble/hashes": ^1.3.1
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -3981,7 +3981,7 @@ __metadata:
     "@metamask/snaps-utils": "workspace:^"
     "@metamask/utils": ^6.0.1
     "@swc/cli": ^0.1.62
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@types/jest": ^27.5.1
     "@types/node": ^20.3.1
@@ -4029,7 +4029,7 @@ __metadata:
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -4069,7 +4069,7 @@ __metadata:
     "@metamask/snaps-types": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/utils": ^6.0.1
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -4104,7 +4104,7 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -4253,7 +4253,7 @@ __metadata:
     "@metamask/snaps-types": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/utils": ^6.0.1
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -4292,7 +4292,7 @@ __metadata:
     "@metamask/snaps-types": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/utils": ^6.0.1
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -4360,7 +4360,7 @@ __metadata:
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/utils": ^6.0.1
     "@noble/bls12-381": ^1.2.0
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -4397,7 +4397,7 @@ __metadata:
     "@metamask/snaps-types": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/utils": ^6.0.1
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -4460,7 +4460,7 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -4510,7 +4510,7 @@ __metadata:
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -4546,7 +4546,7 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -4582,7 +4582,7 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -4618,7 +4618,7 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -4721,7 +4721,7 @@ __metadata:
     "@rollup/plugin-commonjs": ^25.0.1
     "@rollup/plugin-node-resolve": ^15.1.0
     "@rollup/plugin-terser": ^0.4.3
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -4772,7 +4772,7 @@ __metadata:
     "@metamask/utils": ^6.0.1
     "@noble/hashes": ^1.3.1
     "@swc/cli": ^0.1.62
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@types/node": ^20.3.1
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -4835,7 +4835,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/snaps-utils": "workspace:^"
     "@swc/cli": ^0.1.62
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@types/browserify": ^12.0.37
     "@types/convert-source-map": ^1.5.2
@@ -4887,7 +4887,7 @@ __metadata:
     "@metamask/snaps-webpack-plugin": "workspace:^"
     "@metamask/utils": ^6.0.1
     "@swc/cli": ^0.1.62
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@types/browserify": ^12.0.37
     "@types/is-url": ^1.2.28
@@ -4987,7 +4987,7 @@ __metadata:
     "@metamask/utils": ^6.0.1
     "@peculiar/webcrypto": ^1.3.3
     "@swc/cli": ^0.1.62
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@types/chrome": ^0.0.237
     "@types/concat-stream": ^2.0.0
@@ -5074,7 +5074,7 @@ __metadata:
     "@metamask/snaps-utils": "workspace:^"
     "@metamask/utils": ^6.0.1
     "@swc/cli": ^0.1.62
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@types/express": ^4.17.17
     "@types/jest": ^27.5.1
@@ -5156,7 +5156,7 @@ __metadata:
     "@metamask/snaps-utils": "workspace:^"
     "@metamask/utils": ^6.0.1
     "@swc/cli": ^0.1.62
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@types/jest": ^27.5.1
     "@types/semver": ^7.5.0
@@ -5211,7 +5211,7 @@ __metadata:
     "@metamask/snaps-utils": "workspace:^"
     "@rollup/plugin-virtual": ^2.1.0
     "@swc/cli": ^0.1.62
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@types/jest": ^27.5.1
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -5270,7 +5270,7 @@ __metadata:
     "@redux-saga/symbols": ^1.1.3
     "@reduxjs/toolkit": ^1.9.5
     "@swc/cli": ^0.1.62
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@testing-library/react": ^14.0.0
     "@types/express": ^4.17.17
     "@types/jest": ^27.5.1
@@ -5361,7 +5361,7 @@ __metadata:
     "@metamask/snaps-utils": "workspace:^"
     "@metamask/utils": ^6.0.1
     "@swc/cli": ^0.1.62
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -5393,7 +5393,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/utils": ^6.0.1
     "@swc/cli": ^0.1.62
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@types/jest": ^27.5.1
     "@types/semver": ^7.5.0
@@ -5443,7 +5443,7 @@ __metadata:
     "@noble/hashes": ^1.3.1
     "@scure/base": ^1.1.1
     "@swc/cli": ^0.1.62
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@types/jest": ^27.5.1
     "@types/mocha": ^10.0.1
@@ -5512,7 +5512,7 @@ __metadata:
     "@metamask/snaps-utils": "workspace:^"
     "@metamask/utils": ^6.0.1
     "@swc/cli": ^0.1.62
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@types/jest": ^27.5.1
     "@types/webpack-sources": ^3.2.0
@@ -5576,7 +5576,7 @@ __metadata:
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.10
     "@popperjs/core": ^2.11.8
     "@reduxjs/toolkit": ^1.9.5
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@types/jest": ^27.5.1
     "@types/node": ^20.3.1
@@ -5672,7 +5672,7 @@ __metadata:
     "@metamask/snaps-types": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/utils": ^6.0.1
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -5711,7 +5711,7 @@ __metadata:
     "@metamask/snaps-rollup-plugin": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
     "@metamask/snaps-webpack-plugin": "workspace:^"
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@types/webpack-env": ^1.18.1
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -6480,90 +6480,90 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-arm64@npm:1.3.66":
-  version: 1.3.66
-  resolution: "@swc/core-darwin-arm64@npm:1.3.66"
+"@swc/core-darwin-arm64@npm:1.3.78":
+  version: 1.3.78
+  resolution: "@swc/core-darwin-arm64@npm:1.3.78"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-x64@npm:1.3.66":
-  version: 1.3.66
-  resolution: "@swc/core-darwin-x64@npm:1.3.66"
+"@swc/core-darwin-x64@npm:1.3.78":
+  version: 1.3.78
+  resolution: "@swc/core-darwin-x64@npm:1.3.78"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm-gnueabihf@npm:1.3.66":
-  version: 1.3.66
-  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.3.66"
+"@swc/core-linux-arm-gnueabihf@npm:1.3.78":
+  version: 1.3.78
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.3.78"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-gnu@npm:1.3.66":
-  version: 1.3.66
-  resolution: "@swc/core-linux-arm64-gnu@npm:1.3.66"
+"@swc/core-linux-arm64-gnu@npm:1.3.78":
+  version: 1.3.78
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.3.78"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-musl@npm:1.3.66":
-  version: 1.3.66
-  resolution: "@swc/core-linux-arm64-musl@npm:1.3.66"
+"@swc/core-linux-arm64-musl@npm:1.3.78":
+  version: 1.3.78
+  resolution: "@swc/core-linux-arm64-musl@npm:1.3.78"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-gnu@npm:1.3.66":
-  version: 1.3.66
-  resolution: "@swc/core-linux-x64-gnu@npm:1.3.66"
+"@swc/core-linux-x64-gnu@npm:1.3.78":
+  version: 1.3.78
+  resolution: "@swc/core-linux-x64-gnu@npm:1.3.78"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-musl@npm:1.3.66":
-  version: 1.3.66
-  resolution: "@swc/core-linux-x64-musl@npm:1.3.66"
+"@swc/core-linux-x64-musl@npm:1.3.78":
+  version: 1.3.78
+  resolution: "@swc/core-linux-x64-musl@npm:1.3.78"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@swc/core-win32-arm64-msvc@npm:1.3.66":
-  version: 1.3.66
-  resolution: "@swc/core-win32-arm64-msvc@npm:1.3.66"
+"@swc/core-win32-arm64-msvc@npm:1.3.78":
+  version: 1.3.78
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.3.78"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@swc/core-win32-ia32-msvc@npm:1.3.66":
-  version: 1.3.66
-  resolution: "@swc/core-win32-ia32-msvc@npm:1.3.66"
+"@swc/core-win32-ia32-msvc@npm:1.3.78":
+  version: 1.3.78
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.3.78"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@swc/core-win32-x64-msvc@npm:1.3.66":
-  version: 1.3.66
-  resolution: "@swc/core-win32-x64-msvc@npm:1.3.66"
+"@swc/core-win32-x64-msvc@npm:1.3.78":
+  version: 1.3.78
+  resolution: "@swc/core-win32-x64-msvc@npm:1.3.78"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@swc/core@npm:^1.3.10, @swc/core@npm:^1.3.66":
-  version: 1.3.66
-  resolution: "@swc/core@npm:1.3.66"
+"@swc/core@npm:1.3.78, @swc/core@npm:^1.3.10":
+  version: 1.3.78
+  resolution: "@swc/core@npm:1.3.78"
   dependencies:
-    "@swc/core-darwin-arm64": 1.3.66
-    "@swc/core-darwin-x64": 1.3.66
-    "@swc/core-linux-arm-gnueabihf": 1.3.66
-    "@swc/core-linux-arm64-gnu": 1.3.66
-    "@swc/core-linux-arm64-musl": 1.3.66
-    "@swc/core-linux-x64-gnu": 1.3.66
-    "@swc/core-linux-x64-musl": 1.3.66
-    "@swc/core-win32-arm64-msvc": 1.3.66
-    "@swc/core-win32-ia32-msvc": 1.3.66
-    "@swc/core-win32-x64-msvc": 1.3.66
+    "@swc/core-darwin-arm64": 1.3.78
+    "@swc/core-darwin-x64": 1.3.78
+    "@swc/core-linux-arm-gnueabihf": 1.3.78
+    "@swc/core-linux-arm64-gnu": 1.3.78
+    "@swc/core-linux-arm64-musl": 1.3.78
+    "@swc/core-linux-x64-gnu": 1.3.78
+    "@swc/core-linux-x64-musl": 1.3.78
+    "@swc/core-win32-arm64-msvc": 1.3.78
+    "@swc/core-win32-ia32-msvc": 1.3.78
+    "@swc/core-win32-x64-msvc": 1.3.78
   peerDependencies:
     "@swc/helpers": ^0.5.0
   dependenciesMeta:
@@ -6590,7 +6590,7 @@ __metadata:
   peerDependenciesMeta:
     "@swc/helpers":
       optional: true
-  checksum: e6029c648ba47c522bed51a9f2fee606f82de1f9233e2e89197e43b0a4867054174ca05e825e688cdc4de332221c0da2e12ba7ba875549e8b5432aa70fe19263
+  checksum: b7494c4ca9a2e968cd00430c9dbb5cc4f0c3dd3baaf66d129185c5a8816caf6424a2da8e0f181ed94e7c0c39f76046ee995d6c5ec08198d5f5d6f60735ffb1ab
   languageName: node
   linkType: hard
 
@@ -20043,7 +20043,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/utils": ^6.0.1
     "@swc/cli": ^0.1.62
-    "@swc/core": ^1.3.66
+    "@swc/core": 1.3.78
     "@types/jest": ^27.5.1
     "@types/node": ^20.3.1
     "@typescript-eslint/eslint-plugin": ^5.42.1


### PR DESCRIPTION
Using the CLI with the latest version of SWC would result in
> Module build failed (from ../../node_modules/swc-loader/src/index.js):
    Error: `env` and `jsc.target` cannot be used together

This happened because extra validation was added in SWC in a patch release. To fix we just remove `jsc.target` since the default behaviour before was to ignore it anyway. We also pin SWC to prevent issues like this in the future.