### PR TITLE
Fix ed25519 public key derivation

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "aBFG5xpBhXWaUAzWv6NKCp0I50IsCLdQh2s8oR96WSo=",
+    "shasum": "/QV81EnSq055+7N2GzUBczUyCwsuXuxgsDZHmnPHwZY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "fLLhmwTlRZ7D+7TLuy23uRq1GCAYctgUcC0S/gWIxJU=",
+    "shasum": "K9oeS4fc3Huhak9rmgNQVxGXjnYJqXgCl8rMLCql7dE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LNZWM1v0Sw82vgEIaEm3eXsZZ2LBrHKy6BN0SBppDew=",
+    "shasum": "21KODBClRR02QKxG8NFmxFk67yNohnmbdpAz9wCeEjk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "JEabvrSyiXRBsl7rSlhOV7qwx2cNkQeWYFYAa+iJiBs=",
+    "shasum": "duUVcic1OaNIyQnSGn9Wk7ERsGFRHxQek95a8tkGnFc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "02bUA9bfBIJjdyUoHniBW08Vse3hjpEr+rgVpPrwYFo=",
+    "shasum": "1YNjbZ2C2L9JkTHELN7EAKg+sb2b9sQ1g6YTpIuVSyw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "lhPEfZ6JNEuFoMLtuexzZaYmrdYppV99O8WyaikSk9k=",
+    "shasum": "3+Bhwz5DCqf5mjikQvLD0UFAwc9c5IrJHa6O2hZtc7w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "qb1ShaujP9yjoE415YrJYDjtneWSJ/hXc7wnk9BZfKI=",
+    "shasum": "6qJZqm+GplkrsrgRo/FsaoftXKA91SjYJAkfgpfXLHo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -10,7 +10,7 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 86.95,
+      branches: 86.84,
       functions: 100,
       lines: 97.95,
       statements: 96.44,

--- a/packages/rpc-methods/src/restricted/getBip32Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip32Entropy.ts
@@ -1,9 +1,4 @@
-import type {
-  BIP32Node,
-  JsonSLIP10Node,
-  SLIP10PathNode,
-} from '@metamask/key-tree';
-import { SLIP10Node } from '@metamask/key-tree';
+import type { JsonSLIP10Node } from '@metamask/key-tree';
 import type {
   PermissionSpecificationBuilder,
   PermissionValidatorConstraint,
@@ -18,6 +13,7 @@ import { assert } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
 
 import type { MethodHooksObject } from '../utils';
+import { getNode } from '../utils';
 
 const targetName = 'snap_getBip32Entropy';
 
@@ -113,16 +109,10 @@ export function getBip32EntropyImplementation({
     const { params } = args;
     assert(params);
 
-    const prefix = params.curve === 'ed25519' ? 'slip10' : 'bip32';
-
-    const node = await SLIP10Node.fromDerivationPath({
+    const node = await getNode({
       curve: params.curve,
-      derivationPath: [
-        await getMnemonic(),
-        ...(params.path.slice(1).map((index) => `${prefix}:${index}`) as
-          | BIP32Node[]
-          | SLIP10PathNode[]),
-      ],
+      path: params.path,
+      secretRecoveryPhrase: await getMnemonic(),
     });
 
     return node.toJSON();

--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.test.ts
@@ -79,6 +79,28 @@ describe('getBip32PublicKeyImplementation', () => {
       );
     });
 
+    it('derives the ed25519 public key from the path', async () => {
+      const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const getMnemonic = jest
+        .fn()
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES);
+
+      expect(
+        await getBip32PublicKeyImplementation({
+          getUnlockPromise,
+          getMnemonic,
+          // @ts-expect-error Missing other required properties.
+        })({
+          params: {
+            path: ['m', "44'", "1'", "0'", "0'", "1'"],
+            curve: 'ed25519',
+          },
+        }),
+      ).toMatchInlineSnapshot(
+        `"0x0012affaf55babdfb59b76adcf00f69442f019974124639108470409d47e25e19f"`,
+      );
+    });
+
     it('derives the compressed public key from the path', async () => {
       const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
       const getMnemonic = jest

--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -1,5 +1,3 @@
-import type { BIP32Node } from '@metamask/key-tree';
-import { SLIP10Node } from '@metamask/key-tree';
 import type {
   PermissionSpecificationBuilder,
   PermissionValidatorConstraint,
@@ -18,6 +16,7 @@ import { ethErrors } from 'eth-rpc-errors';
 import { boolean, enums, object, optional } from 'superstruct';
 
 import type { MethodHooksObject } from '../utils';
+import { getNode } from '../utils';
 
 const targetName = 'snap_getBip32PublicKey';
 
@@ -56,7 +55,7 @@ type GetBip32PublicKeyParameters = {
 export const Bip32PublicKeyArgsStruct = bip32entropy(
   object({
     path: Bip32PathStruct,
-    curve: enums(['ed225519', 'secp256k1']),
+    curve: enums(['ed25519', 'secp256k1']),
     compressed: optional(boolean()),
   }),
 );
@@ -132,15 +131,10 @@ export function getBip32PublicKeyImplementation({
     );
 
     const { params } = args;
-
-    const node = await SLIP10Node.fromDerivationPath({
+    const node = await getNode({
       curve: params.curve,
-      derivationPath: [
-        await getMnemonic(),
-        ...params.path
-          .slice(1)
-          .map<BIP32Node>((index) => `bip32:${index}` as BIP32Node),
-      ],
+      path: params.path,
+      secretRecoveryPhrase: await getMnemonic(),
     });
 
     if (params.compressed) {

--- a/packages/rpc-methods/src/utils.test.ts
+++ b/packages/rpc-methods/src/utils.test.ts
@@ -2,7 +2,7 @@ import { SIP_6_MAGIC_VALUE } from '@metamask/snaps-utils';
 import { TEST_SECRET_RECOVERY_PHRASE_BYTES } from '@metamask/snaps-utils/test-utils';
 
 import { ENTROPY_VECTORS } from './__fixtures__';
-import { deriveEntropy } from './utils';
+import { deriveEntropy, getNode, getPathPrefix } from './utils';
 
 describe('deriveEntropy', () => {
   it.each(ENTROPY_VECTORS)(
@@ -18,4 +18,58 @@ describe('deriveEntropy', () => {
       ).toStrictEqual(entropy);
     },
   );
+});
+
+describe('getPathPrefix', () => {
+  it('returns "bip32" for "secp256k1"', () => {
+    expect(getPathPrefix('secp256k1')).toBe('bip32');
+  });
+
+  it('returns "slip10" for "ed25519"', () => {
+    expect(getPathPrefix('ed25519')).toBe('slip10');
+  });
+});
+
+describe('getNode', () => {
+  it('returns a secp256k1 node', async () => {
+    const node = await getNode({
+      curve: 'secp256k1',
+      path: ['m', "44'", "1'"],
+      secretRecoveryPhrase: TEST_SECRET_RECOVERY_PHRASE_BYTES,
+    });
+
+    expect(node).toMatchInlineSnapshot(`
+      {
+        "chainCode": "0x50ccfa58a885b48b5eed09486b3948e8454f34856fb81da5d7b8519d7997abd1",
+        "curve": "secp256k1",
+        "depth": 2,
+        "index": 2147483649,
+        "masterFingerprint": 1404659567,
+        "parentFingerprint": 1829122711,
+        "privateKey": "0xc73cedb996e7294f032766853a8b7ba11ab4ce9755fc052f2f7b9000044c99af",
+        "publicKey": "0x048e129862c1de5ca86468add43b001d32fd34b8113de716ecd63fa355b7f1165f0e76f5dc6095100f9fdaa76ddf28aa3f21406ac5fda7c71ffbedb45634fe2ceb",
+      }
+    `);
+  });
+
+  it('returns an ed25519 node', async () => {
+    const node = await getNode({
+      curve: 'ed25519',
+      path: ['m', "44'", "1'"],
+      secretRecoveryPhrase: TEST_SECRET_RECOVERY_PHRASE_BYTES,
+    });
+
+    expect(node).toMatchInlineSnapshot(`
+      {
+        "chainCode": "0xcecf799c541108016e8febb5956379533702574d509b52e1078df95fbc6ae054",
+        "curve": "ed25519",
+        "depth": 2,
+        "index": 2147483649,
+        "masterFingerprint": 650419359,
+        "parentFingerprint": 4080844380,
+        "privateKey": "0x9dee85af06f9b94d2451549f5a9b0a3bbba9e2513daebc793ca5c9a13e80cafa",
+        "publicKey": "0x00c9aaf347832dc3b1dbb7aab4f41e5e04c64446b819c0761571c27b9f90eacb27",
+      }
+    `);
+  });
 });

--- a/packages/rpc-methods/src/utils.ts
+++ b/packages/rpc-methods/src/utils.ts
@@ -1,4 +1,8 @@
-import type { HardenedBIP32Node, BIP32Node } from '@metamask/key-tree';
+import type {
+  HardenedBIP32Node,
+  BIP32Node,
+  SLIP10PathNode,
+} from '@metamask/key-tree';
 import { SLIP10Node } from '@metamask/key-tree';
 import type { MagicValue } from '@metamask/snaps-utils';
 import type { Hex } from '@metamask/utils';
@@ -199,9 +203,9 @@ export async function getNode({
     curve,
     derivationPath: [
       secretRecoveryPhrase,
-      ...path
-        .slice(1)
-        .map<BIP32Node>((index) => `${prefix}:${index}` as BIP32Node),
+      ...(path.slice(1).map((index) => `${prefix}:${index}`) as
+        | BIP32Node[]
+        | SLIP10PathNode[]),
     ],
   });
 }


### PR DESCRIPTION
This is a replacement for #1651. In addition to fixing a typo in "ed225519," this also adds actual support for deriving public keys with `ed25519`. I've also cleared up some logic that was duplicated for `snap_getBip32PublicKey` and `snap_getBip32Entropy`.