### PR TITLE
Fail CI if cache is unable to restore

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -158,7 +158,6 @@ jobs:
           path: |
             packages/snaps-simulator/vendor
           key: webpack-vendor-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-          fail-on-cache-miss: true
       - name: Build Webpack vendor
         if: steps.cache-webpack-vendor.outputs.cache-hit != 'true'
         run: yarn workspace @metamask/snaps-simulator run build:vendor

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -121,12 +121,14 @@ jobs:
             packages/*/dist/esm
             packages/*/dist/cjs
           key: build-source-${{ runner.os }}-${{ github.sha }}
+          fail-on-cache-miss: true
       - name: Restore types files
         uses: actions/cache@v3
         with:
           path: |
             packages/*/dist/types
           key: build-types-${{ runner.os }}-${{ github.sha }}
+          fail-on-cache-miss: true
       - name: Post-build
         run: yarn build:post-tsc:ci
 
@@ -148,6 +150,7 @@ jobs:
           path: |
             packages/snaps-execution-environments/dist/browserify
           key: snaps-execution-environments-build-${{ runner.os }}-18.x-${{ github.sha }}
+          fail-on-cache-miss: true
       - name: Cache Webpack vendor
         id: cache-webpack-vendor
         uses: actions/cache@v3
@@ -155,6 +158,7 @@ jobs:
           path: |
             packages/snaps-simulator/vendor
           key: webpack-vendor-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          fail-on-cache-miss: true
       - name: Build Webpack vendor
         if: steps.cache-webpack-vendor.outputs.cache-hit != 'true'
         run: yarn workspace @metamask/snaps-simulator run build:vendor
@@ -266,6 +270,7 @@ jobs:
           path: |
             packages/snaps-execution-environments/dist/browserify
           key: snaps-execution-environments-build-${{ runner.os }}-${{ matrix.node-version }}-${{ github.sha }}
+          fail-on-cache-miss: true
       - run: yarn --immutable --immutable-cache
       - name: Install Google Chrome
         run: yarn install-chrome
@@ -335,6 +340,7 @@ jobs:
           path: |
             packages/snaps-execution-environments/dist/browserify
           key: snaps-execution-environments-build-${{ runner.os }}-${{ matrix.node-version }}-${{ github.sha }}
+          fail-on-cache-miss: true
       - name: Restore build files
         uses: actions/cache@v3
         with:
@@ -342,18 +348,21 @@ jobs:
             packages/*/dist/esm
             packages/*/dist/cjs
           key: build-source-${{ runner.os }}-${{ github.sha }}
+          fail-on-cache-miss: true
       - name: Restore types files
         uses: actions/cache@v3
         with:
           path: |
             packages/*/dist/types
           key: build-types-${{ runner.os }}-${{ github.sha }}
+          fail-on-cache-miss: true
       - name: Restore "@metamask/snaps-simulator" build
         uses: actions/cache@v3
         with:
           path: |
             packages/snaps-simulator/dist/webpack
           key: e2e-simulator-build-${{ runner.os }}-${{ github.sha }}
+          fail-on-cache-miss: true
       - run: yarn --immutable --immutable-cache
       - name: Install Google Chrome
         run: yarn install-chrome

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Download actionlint
         id: download-actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.23
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.25
         shell: bash
       - name: Check workflow files
         run: ${{ steps.download-actionlint.outputs.executable }} -color

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -92,6 +92,7 @@ jobs:
             ./packages/**/dist
             ./node_modules
           key: ${{ github.sha }}
+          fail-on-cache-miss: true
       - run: npm config set ignore-scripts true
       - name: Dry Run Publish
         uses: MetaMask/action-npm-publish@v4
@@ -114,6 +115,7 @@ jobs:
             ./packages/**/dist
             ./node_modules
           key: ${{ github.sha }}
+          fail-on-cache-miss: true
       - name: Publish ${{ needs.get-release-tag.outputs.tag }} to NPM
         uses: MetaMask/action-npm-publish@v4
         with:


### PR DESCRIPTION
In certain cases if GitHub Actions is unable to restore the cache, the rest of the workflow will fail too. In this case it's better to fail quickly, to give quicker feedback and make debugging easier (i.e., you can immediately see what failed).