### PR TITLE
Add `get-locale` snap to examples list

### DIFF
--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -33,6 +33,9 @@ The following is a list of the snaps in this directory.
   and corresponding `ethereum` provider to interact with the Ethereum blockchain
   from a snap. This also demonstrates how a snap can access a user's existing
   Ethereum accounts.
+- [**`packages/get-locale`**](./packages/get-locale): This snap demonstrates how
+  to use the `snap_getLocale` method to get the user's locale and translate
+  messages.
 - [**`packages/invoke-snap`**](./packages/invoke-snap): These snaps demonstrate
   how to use the `snap_invokeSnap` method to invoke another snap.
 - [**`packages/json-rpc`**](./packages/json-rpc): This snap demonstrates how to


### PR DESCRIPTION
The `get-locale` example snap was missing from the list in the examples `README`.