### PR TITLE
Make `manageAccounts` arguments extend `RestrictedMethodParameters`

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "/QV81EnSq055+7N2GzUBczUyCwsuXuxgsDZHmnPHwZY=",
+    "shasum": "VJroCMS493dgUeOU7fXC66YEePEQFYL5DSkD+kas+Ak=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "K9oeS4fc3Huhak9rmgNQVxGXjnYJqXgCl8rMLCql7dE=",
+    "shasum": "79GScHi2aSAhHABs46J2/+1gK3GuA6GlRPNzAqGuNmo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "21KODBClRR02QKxG8NFmxFk67yNohnmbdpAz9wCeEjk=",
+    "shasum": "E4y5SmS51oE0j9COiVtvbohiwoIw5JYKC1JZPcb9LME=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "duUVcic1OaNIyQnSGn9Wk7ERsGFRHxQek95a8tkGnFc=",
+    "shasum": "0MxbHGE/PcS/m0McMc0Du38878SLnyNESAlXTOjOOW0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+S8PBxtQmpQ49gKMn3WkfBMqRkOrQAzj82BvLLS3tgw=",
+    "shasum": "z/Fn/aRtlzEdKL+p3+u18cAAuUHIDDydT/wi57XETAo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1YNjbZ2C2L9JkTHELN7EAKg+sb2b9sQ1g6YTpIuVSyw=",
+    "shasum": "n5GVAvqU3Ajf5v0YPzdd7pyH76KIuwIQIcY9Tqd2JiE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3+Bhwz5DCqf5mjikQvLD0UFAwc9c5IrJHa6O2hZtc7w=",
+    "shasum": "htJUow/3nR92TJFNw3E6z4e7HYp2dMKN+3uIuu3oJI4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6qJZqm+GplkrsrgRo/FsaoftXKA91SjYJAkfgpfXLHo=",
+    "shasum": "AS0bbZ8/1DoqLSAgZdT2Ll/saNKmUBpd8OeR8ENwyG4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/rpc-methods/src/restricted/manageAccounts.test.ts
+++ b/packages/rpc-methods/src/restricted/manageAccounts.test.ts
@@ -104,7 +104,7 @@ describe('manageAccountsImplementation', () => {
         params: {},
       }),
     ).rejects.toThrow(
-      'At path: method -- Expected a string, but received: undefined',
+      'Expected the value to satisfy a union of `object | object`, but received: [object Object]',
     );
   });
 
@@ -128,7 +128,7 @@ describe('manageAccountsImplementation', () => {
         params: { method: 123, params: {} },
       }),
     ).rejects.toThrow(
-      'At path: method -- Expected a string, but received: 123',
+      'Expected the value to satisfy a union of `object | object`, but received: [object Object]',
     );
   });
 

--- a/packages/rpc-methods/src/restricted/manageAccounts.ts
+++ b/packages/rpc-methods/src/restricted/manageAccounts.ts
@@ -7,20 +7,17 @@ import { SubjectType, PermissionType } from '@metamask/permission-controller';
 import type { Json, NonEmptyArray } from '@metamask/utils';
 import { JsonStruct } from '@metamask/utils';
 import type { Infer } from 'superstruct';
-import {
-  assert,
-  string,
-  object,
-  optional,
-  union,
-  array,
-  record,
-} from 'superstruct';
+import { assert, string, object, union, array, record } from 'superstruct';
 
-const SnapMessageStruct = object({
-  method: string(),
-  params: optional(union([array(JsonStruct), record(string(), JsonStruct)])),
-});
+const SnapMessageStruct = union([
+  object({
+    method: string(),
+  }),
+  object({
+    method: string(),
+    params: union([array(JsonStruct), record(string(), JsonStruct)]),
+  }),
+]);
 
 type Message = Infer<typeof SnapMessageStruct>;
 
@@ -97,7 +94,7 @@ export function manageAccountsImplementation({
 }: ManageAccountsMethodHooks) {
   return async function manageAccounts(
     options: RestrictedMethodOptions<Message>,
-  ): Promise<string[] | Json | boolean> {
+  ): Promise<Json> {
     const {
       context: { origin },
       params,


### PR DESCRIPTION
The arguments of a restricted method must extend the `RestrictedMethodParameters` type, which is defined as:

    Json[] | Record<string, Json> | void

However, the current definition of `SnapMessageStruct` is not a valid JSON value due to the presence of an optional field. This optional field is incorrectly inferred by superstruct as `params?: ... | undefined`.

This PR adds a workaround to make `SnapMessageStruct` a valid JSON using the following pattern:

    { A, B? } -> { A } | { A, B }

See: https://github.com/ianstormtaylor/superstruct/issues/983
Fixes: https://github.com/MetaMask/accounts-planning/issues/41