### PR TITLE
Release 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/example-snaps",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/examples/packages/bip32/CHANGELOG.md
+++ b/packages/examples/packages/bip32/CHANGELOG.md
@@ -7,16 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.37.3-flask.1]
-### Uncategorized
-- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix ed25519 public key derivation ([#1678](https://github.com/MetaMask/snaps/pull/1678))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
-- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
-- Update transaction insight response and add severity level enum ([#1653](https://github.com/MetaMask/snaps/pull/1653))
-- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
-- Implement `snap_getLocale` ([#1557](https://github.com/MetaMask/snaps/pull/1557))
-- Add `onInstall` and `onUpdate` lifecycle hooks ([#1643](https://github.com/MetaMask/snaps/pull/1643))
+### Changed
+- Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.37.2-flask.1]
 ### Changed

--- a/packages/examples/packages/bip32/CHANGELOG.md
+++ b/packages/examples/packages/bip32/CHANGELOG.md
@@ -6,11 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.3-flask.1]
+### Uncategorized
+- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix ed25519 public key derivation ([#1678](https://github.com/MetaMask/snaps/pull/1678))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+- Update transaction insight response and add severity level enum ([#1653](https://github.com/MetaMask/snaps/pull/1653))
+- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
+- Implement `snap_getLocale` ([#1557](https://github.com/MetaMask/snaps/pull/1557))
+- Add `onInstall` and `onUpdate` lifecycle hooks ([#1643](https://github.com/MetaMask/snaps/pull/1643))
+
 ## [0.37.2-flask.1]
 ### Changed
 - Release package independently ([#1600](https://github.com/MetaMask/snaps/pull/1600))
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@0.37.2-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@0.37.3-flask.1...HEAD
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@0.37.2-flask.1...@metamask/bip32-example-snap@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/bip32-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/bip32/package.json
+++ b/packages/examples/packages/bip32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/bip32-example-snap",
-  "version": "0.37.2-flask.1",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_getBip32Entropy`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.2-flask.1",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_getBip32Entropy`.",
   "proposedName": "BIP-32 Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VJroCMS493dgUeOU7fXC66YEePEQFYL5DSkD+kas+Ak=",
+    "shasum": "q09kHX1Yh6y5o3ttFwB+ZVM6FOElyy3qqvoyYCWHiSQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/CHANGELOG.md
+++ b/packages/examples/packages/bip44/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1-flask.1]
+### Uncategorized
+- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix ed25519 public key derivation ([#1678](https://github.com/MetaMask/snaps/pull/1678))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+- Update transaction insight response and add severity level enum ([#1653](https://github.com/MetaMask/snaps/pull/1653))
+- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
+- Implement `snap_getLocale` ([#1557](https://github.com/MetaMask/snaps/pull/1557))
+
 ## [0.38.0-flask.1]
 ### Changed
 - Update example to the new configuration format ([#1632](https://github.com/MetaMask/snaps/pull/1632))
@@ -17,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@0.38.0-flask.1...@metamask/bip44-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@0.37.2-flask.1...@metamask/bip44-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/bip44-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/bip44/CHANGELOG.md
+++ b/packages/examples/packages/bip44/CHANGELOG.md
@@ -7,15 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
-- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix ed25519 public key derivation ([#1678](https://github.com/MetaMask/snaps/pull/1678))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
-- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
-- Update transaction insight response and add severity level enum ([#1653](https://github.com/MetaMask/snaps/pull/1653))
-- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
-- Implement `snap_getLocale` ([#1557](https://github.com/MetaMask/snaps/pull/1557))
+### Changed
+- Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
 ### Changed

--- a/packages/examples/packages/bip44/package.json
+++ b/packages/examples/packages/bip44/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/bip44-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_getBip44Entropy`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_getBip44Entropy`.",
   "proposedName": "BIP-44 Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "79GScHi2aSAhHABs46J2/+1gK3GuA6GlRPNzAqGuNmo=",
+    "shasum": "w3Sp0Y7HB+uqHgv1L6S+V+Q7TW10/mUD7+jbbMUgz0g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/CHANGELOG.md
+++ b/packages/examples/packages/browserify-plugin/CHANGELOG.md
@@ -6,11 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.3-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+
 ## [0.37.2-flask.1]
 ### Changed
 - Release package independently ([#1600](https://github.com/MetaMask/snaps/pull/1600))
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@0.37.2-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@0.37.3-flask.1...HEAD
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@0.37.2-flask.1...@metamask/browserify-plugin-example-snap@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/browserify-plugin-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/browserify-plugin/CHANGELOG.md
+++ b/packages/examples/packages/browserify-plugin/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.37.3-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.37.2-flask.1]
 ### Changed

--- a/packages/examples/packages/browserify-plugin/package.json
+++ b/packages/examples/packages/browserify-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/browserify-plugin-example-snap",
-  "version": "0.37.2-flask.1",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating how to use the Browserify plugin to bundle a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.2-flask.1",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating how to use the Browserify plugin to bundle a snap.",
   "proposedName": "Browserify Plugin Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "rLS6W9OFdFVejTOVo0y3hysGlKn5xb7njbpmR3o6YWg=",
+    "shasum": "ZgiXnGDvL4FXnwTlJ1hrj1UK2GS8xTR8/t1BeQ5t90o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/CHANGELOG.md
+++ b/packages/examples/packages/browserify/CHANGELOG.md
@@ -6,10 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+
 ## [0.38.0-flask.1]
 ### Added
 - Add Browserify example snap ([#1632](https://github.com/MetaMask/snaps/pull/1632))
   - This snap demonstrates how to use the deprecated Browserify configuration format.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@0.38.0-flask.1...@metamask/browserify-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/browserify-example-snap@0.38.0-flask.1

--- a/packages/examples/packages/browserify/CHANGELOG.md
+++ b/packages/examples/packages/browserify/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
 ### Added

--- a/packages/examples/packages/browserify/package.json
+++ b/packages/examples/packages/browserify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/browserify-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating how to use Browserify to bundle a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating how to use the Browserify plugin to bundle a snap.",
   "proposedName": "Browserify Plugin Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "kAEeKWllguZCSOKVn5gOSizkIZk/RFayGY4fUIIhla8=",
+    "shasum": "lEnQ4LSn3Vs/i+0yewRLF3fDeKNHKF/UX1VmMVXBqsE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/CHANGELOG.md
+++ b/packages/examples/packages/cronjobs/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+
 ## [0.38.0-flask.1]
 ### Changed
 - Update example to the new configuration format ([#1632](https://github.com/MetaMask/snaps/pull/1632))
@@ -17,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@0.38.0-flask.1...@metamask/cronjob-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@0.37.2-flask.1...@metamask/cronjob-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/cronjob-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/cronjobs/CHANGELOG.md
+++ b/packages/examples/packages/cronjobs/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
 ### Changed

--- a/packages/examples/packages/cronjobs/package.json
+++ b/packages/examples/packages/cronjobs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/cronjob-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of cronjobs in snaps.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of cronjobs in snaps.",
   "proposedName": "Cronjob Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2X5dKpZLlpO/b3sL2FLCLAjGvsamMh4jP/HRkwWeknI=",
+    "shasum": "uMXNv7TEb5zPsMIS8kfcX5HbvPdjIiUdj3zP05DuV+w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/CHANGELOG.md
+++ b/packages/examples/packages/dialogs/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1-flask.1]
+### Uncategorized
+- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix ed25519 public key derivation ([#1678](https://github.com/MetaMask/snaps/pull/1678))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+- Update transaction insight response and add severity level enum ([#1653](https://github.com/MetaMask/snaps/pull/1653))
+- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
+- Implement `snap_getLocale` ([#1557](https://github.com/MetaMask/snaps/pull/1557))
+
 ## [0.38.0-flask.1]
 ### Changed
 - Update example to the new configuration format ([#1632](https://github.com/MetaMask/snaps/pull/1632))
@@ -17,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@0.38.0-flask.1...@metamask/dialog-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@0.37.2-flask.1...@metamask/dialog-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/dialog-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/dialogs/CHANGELOG.md
+++ b/packages/examples/packages/dialogs/CHANGELOG.md
@@ -7,15 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
-- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix ed25519 public key derivation ([#1678](https://github.com/MetaMask/snaps/pull/1678))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
-- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
-- Update transaction insight response and add severity level enum ([#1653](https://github.com/MetaMask/snaps/pull/1653))
-- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
-- Implement `snap_getLocale` ([#1557](https://github.com/MetaMask/snaps/pull/1557))
+### Changed
+- Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
 ### Changed

--- a/packages/examples/packages/dialogs/package.json
+++ b/packages/examples/packages/dialogs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/dialog-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_dialog`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_dialog`.",
   "proposedName": "Dialog Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "E4y5SmS51oE0j9COiVtvbohiwoIw5JYKC1JZPcb9LME=",
+    "shasum": "slwFtkG5J8ldBG0JUL3EvAW5+0NGKERXcXdlIyCImqM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/errors/CHANGELOG.md
+++ b/packages/examples/packages/errors/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+
 ## [0.38.0-flask.1]
 ### Changed
 - Update example to the new configuration format ([#1632](https://github.com/MetaMask/snaps/pull/1632))
@@ -17,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@0.38.0-flask.1...@metamask/error-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@0.37.2-flask.1...@metamask/error-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/error-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/errors/CHANGELOG.md
+++ b/packages/examples/packages/errors/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+### Changed
+- Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
 ### Changed

--- a/packages/examples/packages/errors/package.json
+++ b/packages/examples/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/error-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of error handling in snaps.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/errors/snap.manifest.json
+++ b/packages/examples/packages/errors/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of error handling in snaps.",
   "proposedName": "Error Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "WXWIhv3YhG8JuPwZ1SnTgFv9ZaBNAKOermQ5bWU8a1Q=",
+    "shasum": "fRj3eRk7NIBp3Bd/Ji3rCIcMQy65psytCBFIQFo2G6s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/CHANGELOG.md
+++ b/packages/examples/packages/ethereum-provider/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+
 ## [0.38.0-flask.1]
 ### Added
 - Add example JSON-RPC method using `personal_sign` ([#1601](https://github.com/MetaMask/snaps/pull/1601))
@@ -20,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@0.38.0-flask.1...@metamask/ethereum-provider-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@0.37.2-flask.1...@metamask/ethereum-provider-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/ethereum-provider-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/ethereum-provider/CHANGELOG.md
+++ b/packages/examples/packages/ethereum-provider/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
 ### Added

--- a/packages/examples/packages/ethereum-provider/package.json
+++ b/packages/examples/packages/ethereum-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ethereum-provider-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of the Ethereum Provider API and `endowment:ethereum-provider` permission.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of the Ethereum Provider API and `endowment:ethereum-provider` permission.",
   "proposedName": "Ethereum Provider Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "02i/AryMkfxh6jeOXWKjyaBCLCzaKXADhRc/dWfsmEg=",
+    "shasum": "+C2UG75icr02O2XPKLPaYAba1KsKg12qQDOMWmJ1li0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/CHANGELOG.md
+++ b/packages/examples/packages/ethers-js/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+
 ## [0.38.0-flask.1]
 ### Changed
 - Update example to the new configuration format ([#1632](https://github.com/MetaMask/snaps/pull/1632))
@@ -17,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@0.38.0-flask.1...@metamask/ethers-js-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@0.37.2-flask.1...@metamask/ethers-js-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/ethers-js-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/ethers-js/CHANGELOG.md
+++ b/packages/examples/packages/ethers-js/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
-- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+### Changed
+- Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
 ### Changed

--- a/packages/examples/packages/ethers-js/package.json
+++ b/packages/examples/packages/ethers-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ethers-js-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating how to use Ethers.js inside a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating how to use Ethers.js inside a snap.",
   "proposedName": "Ethers.js Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7S1kpjVAfg8m1sgWuUpmw1q6jpGjkCFd6aV4637nH7k=",
+    "shasum": "ydfyZetMKS1Z6iJEgaC51yZ2kPdCAwnciuM0TC9oDBs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/CHANGELOG.md
+++ b/packages/examples/packages/get-entropy/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1-flask.1]
+### Uncategorized
+- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix ed25519 public key derivation ([#1678](https://github.com/MetaMask/snaps/pull/1678))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+- Update transaction insight response and add severity level enum ([#1653](https://github.com/MetaMask/snaps/pull/1653))
+- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
+- Implement `snap_getLocale` ([#1557](https://github.com/MetaMask/snaps/pull/1557))
+
 ## [0.38.0-flask.1]
 ### Changed
 - Update example to the new configuration format ([#1632](https://github.com/MetaMask/snaps/pull/1632))
@@ -17,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@0.38.0-flask.1...@metamask/get-entropy-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@0.37.2-flask.1...@metamask/get-entropy-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/get-entropy-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/get-entropy/CHANGELOG.md
+++ b/packages/examples/packages/get-entropy/CHANGELOG.md
@@ -7,15 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
-- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix ed25519 public key derivation ([#1678](https://github.com/MetaMask/snaps/pull/1678))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
-- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
-- Update transaction insight response and add severity level enum ([#1653](https://github.com/MetaMask/snaps/pull/1653))
-- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
-- Implement `snap_getLocale` ([#1557](https://github.com/MetaMask/snaps/pull/1557))
+### Changed
+- Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
 ### Changed

--- a/packages/examples/packages/get-entropy/package.json
+++ b/packages/examples/packages/get-entropy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/get-entropy-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_getEntropy`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_getEntropy`.",
   "proposedName": "Get Entropy Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0MxbHGE/PcS/m0McMc0Du38878SLnyNESAlXTOjOOW0=",
+    "shasum": "RftaRiY4VJewuY8jTQPrtxJ4oqBK9h2E4bTMiNQJkgE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/CHANGELOG.md
+++ b/packages/examples/packages/get-locale/CHANGELOG.md
@@ -6,4 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/MetaMask/snaps/
+## [0.38.1-flask.1]
+### Uncategorized
+- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
+- Add example snap for `snap_getLocale` ([#1684](https://github.com/MetaMask/snaps/pull/1684))
+
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/get-locale-example-snap@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/get-locale-example-snap@0.38.1-flask.1

--- a/packages/examples/packages/get-locale/CHANGELOG.md
+++ b/packages/examples/packages/get-locale/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
-- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
+### Added
 - Add example snap for `snap_getLocale` ([#1684](https://github.com/MetaMask/snaps/pull/1684))
 
 [Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/get-locale-example-snap@0.38.1-flask.1...HEAD

--- a/packages/examples/packages/get-locale/package.json
+++ b/packages/examples/packages/get-locale/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/get-locale-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_getLocale`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_getLocale`.",
   "proposedName": "Get Locale Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "z/Fn/aRtlzEdKL+p3+u18cAAuUHIDDydT/wi57XETAo=",
+    "shasum": "7u3+H0DxS/50QglAzBGJptTwr1axVoUErCiXeL4eevY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/package.json
+++ b/packages/examples/packages/invoke-snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/invoke-snap-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "private": true,
   "description": "MetaMask example snaps demonstrating the use of `wallet_invokeSnap` to call a snap from another snap.",
   "repository": {

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/CHANGELOG.md
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+
 ## [0.38.0-flask.1]
 ### Changed
 - Update example to the new configuration format ([#1632](https://github.com/MetaMask/snaps/pull/1632))
@@ -17,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@0.38.0-flask.1...@metamask/consumer-signer-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@0.37.2-flask.1...@metamask/consumer-signer-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/consumer-signer-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/CHANGELOG.md
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
-- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+### Changed
+- Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
 ### Changed

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/consumer-signer-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
   "proposedName": "Consumer Signer Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xa4Z6yiRDeGVr0EkyApKxl2l9j3mpqHlepHFi6CSVH8=",
+    "shasum": "hHhutV7kZTzzzFIHFRoNYr/p7UtOF+McngxgpNvOH2M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/CHANGELOG.md
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/CHANGELOG.md
@@ -7,15 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
-- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix ed25519 public key derivation ([#1678](https://github.com/MetaMask/snaps/pull/1678))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
-- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
-- Update transaction insight response and add severity level enum ([#1653](https://github.com/MetaMask/snaps/pull/1653))
-- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
-- Implement `snap_getLocale` ([#1557](https://github.com/MetaMask/snaps/pull/1557))
+### Changed
+- Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
 ### Changed

--- a/packages/examples/packages/invoke-snap/packages/core-signer/CHANGELOG.md
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1-flask.1]
+### Uncategorized
+- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix ed25519 public key derivation ([#1678](https://github.com/MetaMask/snaps/pull/1678))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+- Update transaction insight response and add severity level enum ([#1653](https://github.com/MetaMask/snaps/pull/1653))
+- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
+- Implement `snap_getLocale` ([#1557](https://github.com/MetaMask/snaps/pull/1557))
+
 ## [0.38.0-flask.1]
 ### Changed
 - Update example to the new configuration format ([#1632](https://github.com/MetaMask/snaps/pull/1632))
@@ -17,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@0.38.0-flask.1...@metamask/core-signer-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@0.37.2-flask.1...@metamask/core-signer-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/core-signer-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/invoke-snap/packages/core-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-signer-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
   "proposedName": "Core Signer Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "n5GVAvqU3Ajf5v0YPzdd7pyH76KIuwIQIcY9Tqd2JiE=",
+    "shasum": "m2mNuobspP4m2LvZ0LJjMdD6KPkH1sLmMbH7YLypJ1w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/CHANGELOG.md
+++ b/packages/examples/packages/json-rpc/CHANGELOG.md
@@ -6,11 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.3-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+
 ## [0.37.2-flask.1]
 ### Changed
 - Release package independently ([#1600](https://github.com/MetaMask/snaps/pull/1600))
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@0.37.2-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@0.37.3-flask.1...HEAD
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@0.37.2-flask.1...@metamask/json-rpc-example-snap@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/json-rpc-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/json-rpc/CHANGELOG.md
+++ b/packages/examples/packages/json-rpc/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.37.3-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.37.2-flask.1]
 ### Changed

--- a/packages/examples/packages/json-rpc/package.json
+++ b/packages/examples/packages/json-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/json-rpc-example-snap",
-  "version": "0.37.2-flask.1",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating the use of the `endowment:rpc` permission.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.2-flask.1",
+  "version": "0.37.3-flask.1",
   "description": "An example snap to test JSON-RPC permissions.",
   "proposedName": "JSON-RPC Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wMGE+zthQo8NHhhFulqYOOrdxtCQkveQt8MgZIAQSUA=",
+    "shasum": "Vjp8paYaHuaEZzNA1KmLTSEHNvO5BxO5g8m58+92gDY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
+++ b/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
 ### Uncategorized

--- a/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
+++ b/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
@@ -6,10 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+
 ## [0.38.0-flask.1]
 ### Uncategorized
 - Add lifecycle hooks example snap ([#1645](https://github.com/MetaMask/snaps/pull/1645))
   - This snap demonstrates how to use the `onInstall` and `onUpdate` lifecycle hooks.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@0.38.0-flask.1...@metamask/lifecycle-hooks-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/lifecycle-hooks-example-snap@0.38.0-flask.1

--- a/packages/examples/packages/lifecycle-hooks/package.json
+++ b/packages/examples/packages/lifecycle-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/lifecycle-hooks-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of the `onInstall` and `onUpdate` lifecycle hooks.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of the `onInstall` and `onUpdate` lifecycle hooks.",
   "proposedName": "Lifecycle Hooks Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4DHXPu5lFAka46ohpDpyfwcSjT73s+nnZnO8PrVEr18=",
+    "shasum": "mzUpreZgfBcfKj7uBRvBfjQeuhj1a7PLajr1K3/CK+s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/CHANGELOG.md
+++ b/packages/examples/packages/manage-state/CHANGELOG.md
@@ -7,15 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
-- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix ed25519 public key derivation ([#1678](https://github.com/MetaMask/snaps/pull/1678))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
-- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
-- Update transaction insight response and add severity level enum ([#1653](https://github.com/MetaMask/snaps/pull/1653))
-- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
-- Implement `snap_getLocale` ([#1557](https://github.com/MetaMask/snaps/pull/1557))
+### Changed
+- Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
 ### Changed

--- a/packages/examples/packages/manage-state/CHANGELOG.md
+++ b/packages/examples/packages/manage-state/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1-flask.1]
+### Uncategorized
+- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix ed25519 public key derivation ([#1678](https://github.com/MetaMask/snaps/pull/1678))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+- Update transaction insight response and add severity level enum ([#1653](https://github.com/MetaMask/snaps/pull/1653))
+- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
+- Implement `snap_getLocale` ([#1557](https://github.com/MetaMask/snaps/pull/1557))
+
 ## [0.38.0-flask.1]
 ### Changed
 - Update example to the new configuration format ([#1632](https://github.com/MetaMask/snaps/pull/1632))
@@ -17,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@0.38.0-flask.1...@metamask/manage-state-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@0.37.2-flask.1...@metamask/manage-state-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/manage-state-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/manage-state/package.json
+++ b/packages/examples/packages/manage-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/manage-state-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_manageState`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_manageState`.",
   "proposedName": "Manage State Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "htJUow/3nR92TJFNw3E6z4e7HYp2dMKN+3uIuu3oJI4=",
+    "shasum": "mK8k9cUJX4aMrC0wnljGS7H9kDXY5h8atsu+Av3QyYI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/CHANGELOG.md
+++ b/packages/examples/packages/network-access/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+
 ## [0.38.0-flask.1]
 ### Changed
 - Update example to the new configuration format ([#1632](https://github.com/MetaMask/snaps/pull/1632))
@@ -17,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.38.0-flask.1...@metamask/network-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.37.2-flask.1...@metamask/network-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/network-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/network-access/CHANGELOG.md
+++ b/packages/examples/packages/network-access/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
-- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+### Changed
+- Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
 ### Changed

--- a/packages/examples/packages/network-access/package.json
+++ b/packages/examples/packages/network-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/network-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of the `endowment:network-access` permission in snaps.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of the `endowment:network-access` permission in snaps.",
   "proposedName": "Network Access Test Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "YfvuMw6ZdMHxXiU8xFIVBBwz2mYXpXtXAgXate6x8us=",
+    "shasum": "YXxtxjP6SbPiDHzskryvh0QA6Hvv/FurI+GwNN8WF0U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/CHANGELOG.md
+++ b/packages/examples/packages/notifications/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1-flask.1]
+### Uncategorized
+- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix ed25519 public key derivation ([#1678](https://github.com/MetaMask/snaps/pull/1678))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+- Update transaction insight response and add severity level enum ([#1653](https://github.com/MetaMask/snaps/pull/1653))
+- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
+- Implement `snap_getLocale` ([#1557](https://github.com/MetaMask/snaps/pull/1557))
+
 ## [0.38.0-flask.1]
 ### Changed
 - Update example to the new configuration format ([#1632](https://github.com/MetaMask/snaps/pull/1632))
@@ -17,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@0.38.0-flask.1...@metamask/notification-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@0.37.2-flask.1...@metamask/notification-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/notification-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/notifications/CHANGELOG.md
+++ b/packages/examples/packages/notifications/CHANGELOG.md
@@ -7,15 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
-- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix ed25519 public key derivation ([#1678](https://github.com/MetaMask/snaps/pull/1678))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
-- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
-- Update transaction insight response and add severity level enum ([#1653](https://github.com/MetaMask/snaps/pull/1653))
-- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
-- Implement `snap_getLocale` ([#1557](https://github.com/MetaMask/snaps/pull/1557))
+### Changed
+- Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
 ### Changed

--- a/packages/examples/packages/notifications/package.json
+++ b/packages/examples/packages/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/notification-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_notify`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_notify`.",
   "proposedName": "Notifications Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AS0bbZ8/1DoqLSAgZdT2Ll/saNKmUBpd8OeR8ENwyG4=",
+    "shasum": "yVIjEtJtZA6UXqh9auF2KfI2kBS3TU1kXTPKNUX+7Ms=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/CHANGELOG.md
+++ b/packages/examples/packages/rollup-plugin/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.37.3-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.37.2-flask.1]
 ### Changed

--- a/packages/examples/packages/rollup-plugin/CHANGELOG.md
+++ b/packages/examples/packages/rollup-plugin/CHANGELOG.md
@@ -6,11 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.3-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+
 ## [0.37.2-flask.1]
 ### Changed
 - Release package independently ([#1600](https://github.com/MetaMask/snaps/pull/1600))
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/rollup-plugin-example-snap@0.37.2-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/rollup-plugin-example-snap@0.37.3-flask.1...HEAD
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/rollup-plugin-example-snap@0.37.2-flask.1...@metamask/rollup-plugin-example-snap@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/rollup-plugin-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/rollup-plugin/package.json
+++ b/packages/examples/packages/rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/rollup-plugin-example-snap",
-  "version": "0.37.2-flask.1",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating how to use the Rollup plugin to bundle a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.2-flask.1",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating how to use the Rollup plugin to bundle a snap.",
   "proposedName": "Rollup Plugin Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2REWWW+3Gtx1BDzGvwaAyQHG5/XEEbffmDyvQbX9WnU=",
+    "shasum": "VurGsycbOqs1vfMZAfETX2Cqh1ZWeq8HMsAX15NGYoY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/CHANGELOG.md
+++ b/packages/examples/packages/transaction-insights/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+
 ## [0.38.0-flask.1]
 ### Changed
 - Update example to the new configuration format ([#1632](https://github.com/MetaMask/snaps/pull/1632))
@@ -17,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@0.38.0-flask.1...@metamask/insights-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@0.37.2-flask.1...@metamask/insights-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/insights-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/transaction-insights/CHANGELOG.md
+++ b/packages/examples/packages/transaction-insights/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
-- Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+### Changed
+- Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
+
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
 ### Changed

--- a/packages/examples/packages/transaction-insights/package.json
+++ b/packages/examples/packages/transaction-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/insights-example-snap",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of the Transaction Insights API.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of the Transaction Insights API.",
   "proposedName": "Insights Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7GvuWK7PaCWGnZx9MCrE2xttCOFsDzzIV2B4SPYCSDQ=",
+    "shasum": "9leaWB2VbcMzyGfUSwOlBRnz0m94AwAE74011uLthfY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/CHANGELOG.md
+++ b/packages/examples/packages/wasm/CHANGELOG.md
@@ -6,11 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.3-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+
 ## [0.37.2-flask.1]
 ### Changed
 - Release package independently ([#1600](https://github.com/MetaMask/snaps/pull/1600))
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@0.37.2-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@0.37.3-flask.1...HEAD
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@0.37.2-flask.1...@metamask/wasm-example-snap@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/wasm-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/wasm/CHANGELOG.md
+++ b/packages/examples/packages/wasm/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.37.3-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.37.2-flask.1]
 ### Changed

--- a/packages/examples/packages/wasm/package.json
+++ b/packages/examples/packages/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/wasm-example-snap",
-  "version": "0.37.2-flask.1",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating the use of WebAssembly and the `endowment:webassembly` permission.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.2-flask.1",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating the use of WebAssembly and the `endowment:webassembly` permission.",
   "proposedName": "WebAssembly Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "I3d7noxypEv9Szc1/MD7AIAmrgcX9YEpx1EtFoTCoWM=",
+    "shasum": "mYgoreKol2M0vXCADK74P5y76F2ik5+/6WNiuYUmTug=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/CHANGELOG.md
+++ b/packages/examples/packages/webpack-plugin/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.37.3-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.37.2-flask.1]
 ### Changed

--- a/packages/examples/packages/webpack-plugin/CHANGELOG.md
+++ b/packages/examples/packages/webpack-plugin/CHANGELOG.md
@@ -6,11 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.3-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+
 ## [0.37.2-flask.1]
 ### Changed
 - Release package independently ([#1600](https://github.com/MetaMask/snaps/pull/1600))
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@0.37.2-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@0.37.3-flask.1...HEAD
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@0.37.2-flask.1...@metamask/webpack-plugin-example-snap@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/webpack-plugin-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/webpack-plugin/package.json
+++ b/packages/examples/packages/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/webpack-plugin-example-snap",
-  "version": "0.37.2-flask.1",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating how to use the Webpack plugin to bundle a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.2-flask.1",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating how to use the Webpack plugin to bundle a snap.",
   "proposedName": "Webpack Plugin Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "aD0os62YMEOGXFoRtwrT8tCJQYEW+hoWDPe9rVR+Tvo=",
+    "shasum": "S2CsOBMneFGlsYQuUUhTVe09AUVq7d7ddwBfRBTT/hk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/rpc-methods/CHANGELOG.md
+++ b/packages/rpc-methods/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.1-flask.1]
-### Uncategorized
+### Fixed
 - Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
 
 ## [0.38.0-flask.1]

--- a/packages/rpc-methods/CHANGELOG.md
+++ b/packages/rpc-methods/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1-flask.1]
+### Uncategorized
+- Make `manageAccounts` arguments extend `RestrictedMethodParameters` ([#1687](https://github.com/MetaMask/snaps/pull/1687))
+
 ## [0.38.0-flask.1]
 ### Added
 - Add `snap_getLocale` JSON-RPC method ([#1557](https://github.com/MetaMask/snaps/pull/1557))
@@ -20,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.38.1-flask.1...HEAD
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.38.0-flask.1...@metamask/rpc-methods@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.37.2-flask.1...@metamask/rpc-methods@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/rpc-methods@0.37.2-flask.1

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/rpc-methods",
-  "version": "0.38.0-flask.1",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask Snap RPC method implementations.",
   "repository": {
     "type": "git",

--- a/packages/snaps-browserify-plugin/CHANGELOG.md
+++ b/packages/snaps-browserify-plugin/CHANGELOG.md
@@ -6,11 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.3-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+
 ## [0.37.2-flask.1]
 ### Changed
 - Release package independently ([#1600](https://github.com/MetaMask/snaps/pull/1600))
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@0.37.2-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@0.37.3-flask.1...HEAD
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@0.37.2-flask.1...@metamask/snaps-browserify-plugin@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-browserify-plugin@0.37.2-flask.1

--- a/packages/snaps-browserify-plugin/CHANGELOG.md
+++ b/packages/snaps-browserify-plugin/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.37.3-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.37.2-flask.1]
 ### Changed

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-browserify-plugin",
-  "version": "0.37.2-flask.1",
+  "version": "0.37.3-flask.1",
   "keywords": [
     "browserify-plugin"
   ],

--- a/packages/snaps-cli/CHANGELOG.md
+++ b/packages/snaps-cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.3-flask.1]
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.2-flask.1]
 ### Added

--- a/packages/snaps-cli/CHANGELOG.md
+++ b/packages/snaps-cli/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.3-flask.1]
+
 ## [0.38.2-flask.1]
 ### Added
 - Add `polyfills` option to Webpack configuration ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -35,7 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.2-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.3-flask.1...HEAD
+[0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.2-flask.1...@metamask/snaps-cli@0.38.3-flask.1
 [0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.1-flask.1...@metamask/snaps-cli@0.38.2-flask.1
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.0-flask.1...@metamask/snaps-cli@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-cli@0.38.0-flask.1

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-cli",
-  "version": "0.38.2-flask.1",
+  "version": "0.38.3-flask.1",
   "description": "A CLI for developing MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-controllers/CHANGELOG.md
+++ b/packages/snaps-controllers/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.2-flask.1]
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.1-flask.1]
 ### Fixed

--- a/packages/snaps-controllers/CHANGELOG.md
+++ b/packages/snaps-controllers/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.2-flask.1]
+
 ## [0.38.1-flask.1]
 ### Fixed
 - Fix parallel usage of registry ([#1669](https://github.com/MetaMask/snaps/pull/1669))
@@ -24,7 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.38.1-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.38.2-flask.1...HEAD
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.38.1-flask.1...@metamask/snaps-controllers@0.38.2-flask.1
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.38.0-flask.1...@metamask/snaps-controllers@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.37.2-flask.1...@metamask/snaps-controllers@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-controllers@0.37.2-flask.1

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-controllers",
-  "version": "0.38.1-flask.1",
+  "version": "0.38.2-flask.1",
   "description": "Controllers for MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-execution-environments/CHANGELOG.md
+++ b/packages/snaps-execution-environments/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.2-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Remove unused deps ([#1674](https://github.com/MetaMask/snaps/pull/1674))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
+- deps: ses@0.18.1->0.18.7 ([#1666](https://github.com/MetaMask/snaps/pull/1666))
+
 ## [0.38.1-flask.1]
 ### Changed
 - Update LavaMoat packages to latest versions ([#1657](https://github.com/MetaMask/snaps/pull/1657))
@@ -32,7 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.38.1-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.38.2-flask.1...HEAD
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.38.1-flask.1...@metamask/snaps-execution-environments@0.38.2-flask.1
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.38.0-flask.1...@metamask/snaps-execution-environments@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.37.3-flask.1...@metamask/snaps-execution-environments@0.38.0-flask.1
 [0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.37.2-flask.1...@metamask/snaps-execution-environments@0.37.3-flask.1

--- a/packages/snaps-execution-environments/CHANGELOG.md
+++ b/packages/snaps-execution-environments/CHANGELOG.md
@@ -7,12 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.2-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Remove unused deps ([#1674](https://github.com/MetaMask/snaps/pull/1674))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
-- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
-- deps: ses@0.18.1->0.18.7 ([#1666](https://github.com/MetaMask/snaps/pull/1666))
+### Changed
+- Bump `ses` to `0.18.7` ([#1666](https://github.com/MetaMask/snaps/pull/1666))
+
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-execution-environments",
-  "version": "0.38.1-flask.1",
+  "version": "0.38.2-flask.1",
   "description": "Snap sandbox environments for executing SES javascript",
   "repository": {
     "type": "git",

--- a/packages/snaps-jest/CHANGELOG.md
+++ b/packages/snaps-jest/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.4-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+
 ## [0.37.3-flask.1]
 ### Changed
 - Bump `semver` to `^7.5.4` ([#1631](https://github.com/MetaMask/snaps/pull/1631))
@@ -16,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.3-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.4-flask.1...HEAD
+[0.37.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.3-flask.1...@metamask/snaps-jest@0.37.4-flask.1
 [0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.2-flask.1...@metamask/snaps-jest@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-jest@0.37.2-flask.1

--- a/packages/snaps-jest/CHANGELOG.md
+++ b/packages/snaps-jest/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.37.4-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.37.3-flask.1]
 ### Changed

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-jest",
-  "version": "0.37.3-flask.1",
+  "version": "0.37.4-flask.1",
   "description": "A Jest preset for end-to-end testing MetaMask Snaps, including a Jest environment, and a set of Jest matchers.",
   "sideEffects": false,
   "main": "./dist/cjs/index.js",

--- a/packages/snaps-rollup-plugin/CHANGELOG.md
+++ b/packages/snaps-rollup-plugin/CHANGELOG.md
@@ -6,11 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.3-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+
 ## [0.37.2-flask.1]
 ### Changed
 - Release package independently ([#1600](https://github.com/MetaMask/snaps/pull/1600))
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@0.37.2-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@0.37.3-flask.1...HEAD
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@0.37.2-flask.1...@metamask/snaps-rollup-plugin@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-rollup-plugin@0.37.2-flask.1

--- a/packages/snaps-rollup-plugin/CHANGELOG.md
+++ b/packages/snaps-rollup-plugin/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.37.3-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.37.2-flask.1]
 ### Changed

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-rollup-plugin",
-  "version": "0.37.2-flask.1",
+  "version": "0.37.3-flask.1",
   "keywords": [
     "rollup",
     "rollup-plugin"

--- a/packages/snaps-simulator/CHANGELOG.md
+++ b/packages/snaps-simulator/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.0-flask.1]
-### Uncategorized
-- Add example snap for `snap_getLocale` ([#1684](https://github.com/MetaMask/snaps/pull/1684))
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
-- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
+### Added
+- Add support for `snap_getLocale` JSON-RPC method ([#1684](https://github.com/MetaMask/snaps/pull/1684))
+
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.37.2-flask.1]
 ### Changed

--- a/packages/snaps-simulator/CHANGELOG.md
+++ b/packages/snaps-simulator/CHANGELOG.md
@@ -6,11 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.0-flask.1]
+### Uncategorized
+- Add example snap for `snap_getLocale` ([#1684](https://github.com/MetaMask/snaps/pull/1684))
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+- Update core libs ([#1673](https://github.com/MetaMask/snaps/pull/1673))
+
 ## [0.37.2-flask.1]
 ### Changed
 - Release package independently ([#1600](https://github.com/MetaMask/snaps/pull/1600))
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@0.37.2-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@0.38.0-flask.1...HEAD
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@0.37.2-flask.1...@metamask/snaps-simulator@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-simulator@0.37.2-flask.1

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-simulator",
-  "version": "0.37.2-flask.1",
+  "version": "0.38.0-flask.1",
   "description": "A simulator for MetaMask Snaps, to be used for testing and development",
   "homepage": "https://github.com/MetaMask/snaps#readme",
   "bugs": {

--- a/packages/snaps-types/CHANGELOG.md
+++ b/packages/snaps-types/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.2-flask.1]
+
 ## [0.38.1-flask.1]
 ### Changed
 - Update transaction insights response and add severity level enum ([#1653](https://github.com/MetaMask/snaps/pull/1653))
@@ -23,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.1-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.2-flask.1...HEAD
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.1-flask.1...@metamask/snaps-types@0.38.2-flask.1
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.0-flask.1...@metamask/snaps-types@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.37.2-flask.1...@metamask/snaps-types@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-types@0.37.2-flask.1

--- a/packages/snaps-types/CHANGELOG.md
+++ b/packages/snaps-types/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.2-flask.1]
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/snaps-types/package.json
+++ b/packages/snaps-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-types",
-  "version": "0.38.1-flask.1",
+  "version": "0.38.2-flask.1",
   "description": "TypeScript types for developing MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-ui/CHANGELOG.md
+++ b/packages/snaps-ui/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.4-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+
 ## [0.37.3-flask.1]
 ### Changed
 - Bump `semver` to `^7.5.4` ([#1631](https://github.com/MetaMask/snaps/pull/1631))
@@ -16,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.3-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.4-flask.1...HEAD
+[0.37.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.3-flask.1...@metamask/snaps-ui@0.37.4-flask.1
 [0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.2-flask.1...@metamask/snaps-ui@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-ui@0.37.2-flask.1

--- a/packages/snaps-ui/CHANGELOG.md
+++ b/packages/snaps-ui/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.37.4-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.37.3-flask.1]
 ### Changed

--- a/packages/snaps-ui/package.json
+++ b/packages/snaps-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-ui",
-  "version": "0.37.3-flask.1",
+  "version": "0.37.4-flask.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-utils/CHANGELOG.md
+++ b/packages/snaps-utils/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.38.2-flask.1]
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/snaps-utils/CHANGELOG.md
+++ b/packages/snaps-utils/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.2-flask.1]
+
 ## [0.38.1-flask.1]
 ### Changed
 - Update transaction insights response and add severity level enum ([#1653](https://github.com/MetaMask/snaps/pull/1653))
@@ -26,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.1-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.2-flask.1...HEAD
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.1-flask.1...@metamask/snaps-utils@0.38.2-flask.1
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.0-flask.1...@metamask/snaps-utils@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.37.2-flask.1...@metamask/snaps-utils@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-utils@0.37.2-flask.1

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-utils",
-  "version": "0.38.1-flask.1",
+  "version": "0.38.2-flask.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-webpack-plugin/CHANGELOG.md
+++ b/packages/snaps-webpack-plugin/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.37.3-flask.1]
-### Uncategorized
-- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
-- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+### Fixed
+- Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.37.2-flask.1]
 ### Changed

--- a/packages/snaps-webpack-plugin/CHANGELOG.md
+++ b/packages/snaps-webpack-plugin/CHANGELOG.md
@@ -6,11 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.3-flask.1]
+### Uncategorized
+- Use depcheck to lint dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
+- Fix CLI usage of SWC ([#1677](https://github.com/MetaMask/snaps/pull/1677))
+
 ## [0.37.2-flask.1]
 ### Changed
 - Release package independently ([#1600](https://github.com/MetaMask/snaps/pull/1600))
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@0.37.2-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@0.37.3-flask.1...HEAD
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@0.37.2-flask.1...@metamask/snaps-webpack-plugin@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-webpack-plugin@0.37.2-flask.1

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-webpack-plugin",
-  "version": "0.37.2-flask.1",
+  "version": "0.37.3-flask.1",
   "keywords": [
     "webpack",
     "plugin"

--- a/packages/test-snaps/CHANGELOG.md
+++ b/packages/test-snaps/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.39.0-flask.1]
-### Uncategorized
-- Add example snap for `snap_getLocale` ([#1684](https://github.com/MetaMask/snaps/pull/1684))
+### Added
+- Add test snap for `snap_getLocale` ([#1684](https://github.com/MetaMask/snaps/pull/1684))
 
 ## [0.38.0-flask.1]
 ### Added

--- a/packages/test-snaps/CHANGELOG.md
+++ b/packages/test-snaps/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.0-flask.1]
+### Uncategorized
+- Add example snap for `snap_getLocale` ([#1684](https://github.com/MetaMask/snaps/pull/1684))
+
 ## [0.38.0-flask.1]
 ### Added
 - Add lifecycle hooks example snap ([#1645](https://github.com/MetaMask/snaps/pull/1645))
@@ -24,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix NPM package name of the network access snap ([#1621](https://github.com/MetaMask/snaps/pull/1621))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.38.0-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.39.0-flask.1...HEAD
+[0.39.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.38.0-flask.1...@metamask/test-snaps@0.39.0-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.37.3-flask.1...@metamask/test-snaps@0.38.0-flask.1
 [0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.37.2-flask.1...@metamask/test-snaps@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/test-snaps@0.37.2-flask.1

--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-snaps",
-  "version": "0.38.0-flask.1",
+  "version": "0.39.0-flask.1",
   "private": true,
   "description": "The test snaps website for MetaMask Snaps, used for end-to-end testing.",
   "repository": {


### PR DESCRIPTION
This release bumps most packages to:

- Update all the examples using the latest configuration.
- Add the `snap_getLocale` JSON-RPC method, so this can be E2E tested in the extension.
- Remove unused dependencies.
- And more.