### PR TITLE
Fix unpacking zero byte files from NPM

### DIFF
--- a/packages/snaps-controllers/src/snaps/location/npm.test.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.test.ts
@@ -66,11 +66,11 @@ describe('NpmLocation', () => {
     const manifest = await location.manifest();
     const sourceCode = (
       await location.fetch(manifest.result.source.location.npm.filePath)
-    ).value.toString();
+    ).toString();
     assert(manifest.result.source.location.npm.iconPath);
     const svgIcon = (
       await location.fetch(manifest.result.source.location.npm.iconPath)
-    ).value.toString();
+    ).toString();
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenNthCalledWith(

--- a/packages/snaps-controllers/src/snaps/location/npm.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.ts
@@ -376,7 +376,7 @@ function createTarballStream(
       // The name is a path if the header type is "file".
       const path = headerName.replace(NPM_TARBALL_PATH_PREFIX, '');
       return entryStream.pipe(
-        concat((data) => {
+        concat({ encoding: 'uint8array' }, (data) => {
           try {
             totalSize += data.byteLength;
             // To prevent zip bombs, we set a safety limit for the total size of tarballs.


### PR DESCRIPTION
Fixes https://github.com/MetaMask/snaps/issues/1704

This is a fun one. If an NPM package included an empty file of length zero bytes, `concat-stream` would return it as an empty array instead of an `Uint8Array`. This meant that `data.byteLength` would be `undefined` which in turn would break our running counter of total tarball size, resulting in an error that the NPM tarball was too large:
```
number + undefined == NaN
NaN < TARBALL_SIZE_SAFETY_LIMIT == false
```

`concat-stream` supports providing an encoding argument that will convert any output to a given encoding and so the fix is simply providing the expected output type of `Uint8Array` as the specified encoding.

Previously `concat-stream` would try to infer the encoding by looking at the input, but the types did not take that into account causing this unexpected behaviour. 

https://www.npmjs.com/package/concat-stream