### PR TITLE
Fix error when using single quotes in UI builder

### DIFF
--- a/packages/snaps-simulator/src/features/builder/utils.ts
+++ b/packages/snaps-simulator/src/features/builder/utils.ts
@@ -89,7 +89,7 @@ function getComponentArgs(component: Component): string {
     case NodeType.Text:
     case NodeType.Heading:
     case NodeType.Copyable:
-      return `'${component.value}'`;
+      return `'${component.value.replace(/'/gu, "\\'")}'`;
     case NodeType.Spinner:
     case NodeType.Divider:
     default:


### PR DESCRIPTION
Fixes #1427.

Previously the UI builder would crash if you inputted a quote, due to the code editor actually trying to interpret the code. This is fixed by escaping the quotes.