### PR TITLE
Add basic support for account RPC methods in snaps simulator

### DIFF
--- a/packages/snaps-simulator/src/features/simulation/middleware.ts
+++ b/packages/snaps-simulator/src/features/simulation/middleware.ts
@@ -1,3 +1,7 @@
+import {
+  BIP44CoinTypeNode,
+  getBIP44AddressKeyDeriver,
+} from '@metamask/key-tree';
 import { logError } from '@metamask/snaps-utils';
 import type {
   JsonRpcEngineEndCallback,
@@ -10,7 +14,47 @@ import type {
 export const methodHandlers = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   metamask_getProviderState: getProviderStateHandler,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  eth_requestAccounts: getAccountsHandler,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  eth_accounts: getAccountsHandler,
 };
+
+export type MiscMiddlewareHooks = {
+  getMnemonic: () => Promise<Uint8Array>;
+};
+
+/**
+ * A mock handler for account related methods that always returns the first address for the selected SRP.
+ *
+ * @param _request - Incoming JSON-RPC request, ignored for this specific handler.
+ * @param response - The outgoing JSON-RPC response, modified to return the result.
+ * @param _next - The json-rpc-engine middleware next handler.
+ * @param end - The json-rpc-engine middleware end handler.
+ * @param hooks - Any hooks required by this handler.
+ */
+async function getAccountsHandler(
+  _request: JsonRpcRequest<unknown>,
+  response: PendingJsonRpcResponse<unknown>,
+  _next: JsonRpcEngineNextCallback,
+  end: JsonRpcEngineEndCallback,
+  hooks: MiscMiddlewareHooks,
+) {
+  const { getMnemonic } = hooks;
+
+  const node = await BIP44CoinTypeNode.fromDerivationPath([
+    await getMnemonic(),
+    `bip32:44'`,
+    `bip32:60'`,
+  ]);
+
+  const deriveAddress = await getBIP44AddressKeyDeriver(node);
+
+  const { address } = await deriveAddress(0);
+
+  response.result = [address];
+  return end();
+}
 
 /**
  * A mock handler for metamask_getProviderState that always returns a specific hardcoded result.
@@ -39,12 +83,14 @@ async function getProviderStateHandler(
 /**
  * Creates a middleware for handling misc RPC methods normally handled internally by the MM client.
  *
+ * NOTE: This middleware provides all `hooks` to all handlers and should therefore NOT be used outside of the simulator.
+ *
+ * @param hooks - Any hooks used by the middleware handlers.
  * @returns Nothing.
  */
-export function createMiscMethodMiddleware(): JsonRpcMiddleware<
-  unknown,
-  unknown
-> {
+export function createMiscMethodMiddleware(
+  hooks: MiscMiddlewareHooks,
+): JsonRpcMiddleware<unknown, unknown> {
   // This should probably use createAsyncMiddleware
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async function methodMiddleware(request, response, next, end) {
@@ -53,7 +99,7 @@ export function createMiscMethodMiddleware(): JsonRpcMiddleware<
     if (handler) {
       try {
         // Implementations may or may not be async, so we must await them.
-        return await handler(request, response, next, end);
+        return await handler(request, response, next, end, hooks);
       } catch (error: any) {
         logError(error);
         return end(error);

--- a/packages/snaps-simulator/src/features/simulation/sagas.ts
+++ b/packages/snaps-simulator/src/features/simulation/sagas.ts
@@ -80,16 +80,20 @@ export function* initSaga({ payload }: PayloadAction<string>) {
 
   const srp: string = yield select(getSrp);
 
+  const sharedHooks = {
+    getMnemonic: async () => mnemonicPhraseToBytes(srp),
+  };
+
   const permissionSpecifications = {
     ...buildSnapEndowmentSpecifications(Object.keys(ExcludedSnapEndowments)),
     ...buildSnapRestrictedMethodSpecifications([], {
+      ...sharedHooks,
       // TODO: Add all the hooks required
       encrypt,
       decrypt,
       // TODO: Allow changing this?
       getLocale: async () => Promise.resolve('en'),
       getUnlockPromise: async () => Promise.resolve(true),
-      getMnemonic: async () => mnemonicPhraseToBytes(srp),
       showDialog: async (...args: Parameters<typeof showDialog>) =>
         await runSaga(showDialog, ...args).toPromise(),
       showNativeNotification: async (
@@ -137,7 +141,7 @@ export function* initSaga({ payload }: PayloadAction<string>) {
 
   const engine = new JsonRpcEngine();
 
-  engine.push(createMiscMethodMiddleware());
+  engine.push(createMiscMethodMiddleware(sharedHooks));
 
   engine.push(
     permissionController.createPermissionMiddleware({


### PR DESCRIPTION
This PR adds basic support for account RPC methods in the simulator by deriving the first address of the SRP and returning that when `eth_requestAccounts` or `eth_accounts` is requested. In the future, we should provide a permission flow that mirrors MetaMask clients, but for now this is useful.