### PR TITLE
Speed up update PR workflow by only building dependencies

### DIFF
--- a/.github/workflows/update-pull-request.yml
+++ b/.github/workflows/update-pull-request.yml
@@ -143,8 +143,12 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies from cache
         run: yarn --immutable --immutable-cache
+      - name: Build dependencies
+        run: |
+          yarn build:source
+          yarn build:types
       - name: Update examples
-        run: yarn build
+        run: yarn build:examples
       - name: Cache examples
         uses: actions/cache/save@v3
         with:

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build:clean": "yarn clean && yarn build",
     "build:source": "yarn workspaces foreach --parallel --verbose run build:source",
     "build:types": "tsc --build tsconfig.build.json",
+    "build:examples": "yarn workspace @metamask/example-snaps build",
     "build:post-tsc": "yarn workspaces foreach --parallel --topological --topological-dev --verbose run build:post-tsc",
     "build:post-tsc:ci": "yarn workspaces foreach --parallel --topological --topological-dev --verbose --exclude root --exclude \"@metamask/snaps-simulator\" --exclude \"@metamask/snaps-execution-environments\" --exclude \"@metamask/snaps-jest\" --exclude \"@metamask/example-snaps\" --exclude \"@metamask/test-snaps\" run build:post-tsc",
     "clean": "yarn workspaces foreach --parallel --verbose run clean",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VurGsycbOqs1vfMZAfETX2Cqh1ZWeq8HMsAX15NGYoY=",
+    "shasum": "758j9nJmr/CN4SJBWxLYMZzK8Z3RHOd0UZ1V5jMYOlM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "758j9nJmr/CN4SJBWxLYMZzK8Z3RHOd0UZ1V5jMYOlM=",
+    "shasum": "VurGsycbOqs1vfMZAfETX2Cqh1ZWeq8HMsAX15NGYoY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
When running `yarn build`, everything in the repository is built, including the simulator, execution environments, test snaps, etc. This adds a lot of time to the build process, while those files are not used to build the examples.

By only building the source and types of the dependencies (of the examples), we can speed up the process significantly.