### PR TITLE
Remove business-logic callbacks from `manageAccounts`

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "m77hc11RCuij1HByEtWIUYQx8GKmmUfLb4OL1UfrXdQ=",
+    "shasum": "xjRVmkQCtdD4PgLGREmKDLUnVbGFjQgGQHtOxPD/ElI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xjRVmkQCtdD4PgLGREmKDLUnVbGFjQgGQHtOxPD/ElI=",
+    "shasum": "3PwxV0pwRoE2K5SPMsBo8RVMEXTYxlsYloOkDriLKjc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3PwxV0pwRoE2K5SPMsBo8RVMEXTYxlsYloOkDriLKjc=",
+    "shasum": "oJq4dTUnhjIDFP/LKPHdwJMYAz+TRuWkIh+uqBVrtIU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FbOYrckc4pOhhCaiINA+MtFo2LGCpKje1IC2QGFZvFI=",
+    "shasum": "7clBghu5JsAhQju0vSQZO+o2sxiYYdR8+wWeZ/jt+fU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7clBghu5JsAhQju0vSQZO+o2sxiYYdR8+wWeZ/jt+fU=",
+    "shasum": "G6QuA+CkWmBawAJMIIlF5KuKlnVk1lxtiGLYHOLgvEk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "QWyksoWhazupKReQW6PsaDKG4H1X2TCEjer6Rfo8TF4=",
+    "shasum": "FbOYrckc4pOhhCaiINA+MtFo2LGCpKje1IC2QGFZvFI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4XT42VAN28h0ze+O9kNXEcWStTM6C50mzjAaW9x9kgI=",
+    "shasum": "InnTC/vTGN1Ghn2U9ZDTK9fYceka/3eGmiZ2upW+74k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "UA6KsZBappEBFP08HSCeispvyOLsTjXrv6tnAPZbVdM=",
+    "shasum": "4XT42VAN28h0ze+O9kNXEcWStTM6C50mzjAaW9x9kgI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "IqvWoXypOYaQZ9mVLTjI7nPC/dh6XhHNy5RNV04NEhA=",
+    "shasum": "UA6KsZBappEBFP08HSCeispvyOLsTjXrv6tnAPZbVdM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "miir6kZ9eC2WKC6R6W7pk1dz7DH6QEHL20HTi8cuul0=",
+    "shasum": "iamUGGzL/8u0LKQwA2Z63U7als3rz7gp7FTnRLHHaVA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+SB5dTh3M4raHJ5C/5zZwezRFasAgFoBOtmMZtTFMRQ=",
+    "shasum": "miir6kZ9eC2WKC6R6W7pk1dz7DH6QEHL20HTi8cuul0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "iamUGGzL/8u0LKQwA2Z63U7als3rz7gp7FTnRLHHaVA=",
+    "shasum": "UwfGDy4xTMJXLNzZLX0nEOm/YX+iW99xEExTK/+JTlw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "pd2zKqjA6P/AqLiK4M5R58h4IF8hKA/ArtCW7NbVKB0=",
+    "shasum": "rR/duPvEkqeqwJsSeUPvwKn1CDhlrWLSOdKi0HEU0nY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2xxJIVBgF3i0x+/CP4kxAaWaHH1DNO/z6lgnBv0UmZI=",
+    "shasum": "pd2zKqjA6P/AqLiK4M5R58h4IF8hKA/ArtCW7NbVKB0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "rR/duPvEkqeqwJsSeUPvwKn1CDhlrWLSOdKi0HEU0nY=",
+    "shasum": "64K4M1Oyj1pOsZ6pk5SU+j0uwsuoEXIXskG6xhR41s0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "clKfF4oqRxjrEmTNqwET2wcUQLARwlNlA+I4RswcnZE=",
+    "shasum": "cWWvmznt00GG+fr96xlgf3ZUG06+Acs0S8IvxIJ5oJA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cWWvmznt00GG+fr96xlgf3ZUG06+Acs0S8IvxIJ5oJA=",
+    "shasum": "h79VsSKMBuAbVko9dS99Y8PHHLsjnoe8S43bfoD0YO0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "eLC0h2fl+3ZB55WQu+o+nA3T/b6qp9yXnN5kUMcuSAw=",
+    "shasum": "clKfF4oqRxjrEmTNqwET2wcUQLARwlNlA+I4RswcnZE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "yGmev0n2RGdMyzc1m38N8/8/Fml6d8uM7V5tkmgihXE=",
+    "shasum": "DbigG996kHckROpQPCBfWEQSoXEp30r/yVclgLAJoqA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hUdj80bq9ZKm0Fx9FJY2ZKLwsVymg11G0yP78FxSEvY=",
+    "shasum": "yGmev0n2RGdMyzc1m38N8/8/Fml6d8uM7V5tkmgihXE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Bv3hrlo9drMd+ROGooNXCSDeP8jPFeka+g/GNFZt8lg=",
+    "shasum": "hUdj80bq9ZKm0Fx9FJY2ZKLwsVymg11G0yP78FxSEvY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OrgKsrZcakvsVk+9uBmI9yOsyKMG4fBszRCymS183fw=",
+    "shasum": "REluobJdl08B+RZeZe3NiCZBS08p7UKu+kiGLQpc+uM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "lhYQye/v9vWcNBHCoP98IaDEzpOMwB+oM3Kk5AZfgwQ=",
+    "shasum": "cgqaNTnIQHqb+/PLUkyq/mc6XnN4SFMrDAiqzfxCPr0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cgqaNTnIQHqb+/PLUkyq/mc6XnN4SFMrDAiqzfxCPr0=",
+    "shasum": "OrgKsrZcakvsVk+9uBmI9yOsyKMG4fBszRCymS183fw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -10,7 +10,7 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 86.84,
+      branches: 86.72,
       functions: 100,
       lines: 97.95,
       statements: 96.44,

--- a/packages/rpc-methods/src/restricted/manageAccounts.test.ts
+++ b/packages/rpc-methods/src/restricted/manageAccounts.test.ts
@@ -104,7 +104,7 @@ describe('manageAccountsImplementation', () => {
         params: {},
       }),
     ).rejects.toThrow(
-      'Expected the value to satisfy a union of `object | object`, but received: [object Object]',
+      'At path: method -- Expected a string, but received: undefined',
     );
   });
 
@@ -128,7 +128,7 @@ describe('manageAccountsImplementation', () => {
         params: { method: 123, params: {} },
       }),
     ).rejects.toThrow(
-      'Expected the value to satisfy a union of `object | object`, but received: [object Object]',
+      'At path: method -- Expected a string, but received: 123',
     );
   });
 
@@ -158,10 +158,14 @@ describe('manageAccountsImplementation', () => {
     });
 
     expect(createAccountSpy).toHaveBeenCalledTimes(1);
-    expect(createAccountSpy).toHaveBeenCalledWith(MOCK_SNAP_ID, {
-      method: 'deleteAccount',
-      params: { accountId: MOCK_CAIP_10_ACCOUNT },
-    });
+    expect(createAccountSpy).toHaveBeenCalledWith(
+      MOCK_SNAP_ID,
+      {
+        method: 'deleteAccount',
+        params: { accountId: MOCK_CAIP_10_ACCOUNT },
+      },
+      saveSnapKeyring,
+    );
     expect(requestResponse).toBe(true);
     createAccountSpy.mockClear();
   });

--- a/packages/rpc-methods/src/restricted/manageAccounts.test.ts
+++ b/packages/rpc-methods/src/restricted/manageAccounts.test.ts
@@ -19,7 +19,6 @@ class SnapKeyringMock {
   handleKeyringSnapMessage = async (
     _origin: string,
     _params: any,
-    _saveSnapKeyring: () => void,
   ): Promise<any> => {
     return true;
   };
@@ -29,7 +28,6 @@ describe('specification', () => {
   it('builds specification', () => {
     const methodHooks = {
       getSnapKeyring: jest.fn(),
-      saveSnapKeyring: jest.fn(),
     };
 
     expect(
@@ -54,7 +52,6 @@ describe('builder', () => {
       specificationBuilder: expect.any(Function),
       methodHooks: {
         getSnapKeyring: true,
-        saveSnapKeyring: true,
       },
     });
   });
@@ -64,7 +61,6 @@ describe('builder', () => {
       manageAccountsBuilder.specificationBuilder({
         methodHooks: {
           getSnapKeyring: jest.fn(),
-          saveSnapKeyring: jest.fn(),
         },
       }),
     ).toMatchObject({
@@ -87,11 +83,9 @@ describe('manageAccountsImplementation', () => {
   it('should throw params are not set', async () => {
     const mockKeyring = new SnapKeyringMock();
     const getSnapKeyring = jest.fn().mockResolvedValue(mockKeyring);
-    const saveSnapKeyring = jest.fn().mockResolvedValue(undefined);
 
     const manageAccounts = manageAccountsImplementation({
       getSnapKeyring,
-      saveSnapKeyring,
     });
 
     await expect(
@@ -111,11 +105,9 @@ describe('manageAccountsImplementation', () => {
   it('should throw params accountId is not set', async () => {
     const mockKeyring = new SnapKeyringMock();
     const getSnapKeyring = jest.fn().mockResolvedValue(mockKeyring);
-    const saveSnapKeyring = jest.fn().mockResolvedValue(undefined);
 
     const manageAccounts = manageAccountsImplementation({
       getSnapKeyring,
-      saveSnapKeyring,
     });
 
     await expect(
@@ -135,7 +127,6 @@ describe('manageAccountsImplementation', () => {
   it('should route request to snap keyring', async () => {
     const mockKeyring = new SnapKeyringMock();
     const getSnapKeyring = jest.fn().mockResolvedValue(mockKeyring);
-    const saveSnapKeyring = jest.fn().mockResolvedValue(undefined);
 
     const createAccountSpy = jest
       .spyOn(mockKeyring, 'handleKeyringSnapMessage')
@@ -143,7 +134,6 @@ describe('manageAccountsImplementation', () => {
 
     const manageAccounts = manageAccountsImplementation({
       getSnapKeyring,
-      saveSnapKeyring,
     });
 
     const requestResponse = await manageAccounts({
@@ -158,14 +148,10 @@ describe('manageAccountsImplementation', () => {
     });
 
     expect(createAccountSpy).toHaveBeenCalledTimes(1);
-    expect(createAccountSpy).toHaveBeenCalledWith(
-      MOCK_SNAP_ID,
-      {
-        method: 'deleteAccount',
-        params: { accountId: MOCK_CAIP_10_ACCOUNT },
-      },
-      saveSnapKeyring,
-    );
+    expect(createAccountSpy).toHaveBeenCalledWith(MOCK_SNAP_ID, {
+      method: 'deleteAccount',
+      params: { accountId: MOCK_CAIP_10_ACCOUNT },
+    });
     expect(requestResponse).toBe(true);
     createAccountSpy.mockClear();
   });

--- a/packages/rpc-methods/src/restricted/manageAccounts.test.ts
+++ b/packages/rpc-methods/src/restricted/manageAccounts.test.ts
@@ -98,7 +98,7 @@ describe('manageAccountsImplementation', () => {
         params: {},
       }),
     ).rejects.toThrow(
-      'At path: method -- Expected a string, but received: undefined',
+      'Expected the value to satisfy a union of `object | object`, but received: [object Object]',
     );
   });
 
@@ -120,7 +120,7 @@ describe('manageAccountsImplementation', () => {
         params: { method: 123, params: {} },
       }),
     ).rejects.toThrow(
-      'At path: method -- Expected a string, but received: 123',
+      'Expected the value to satisfy a union of `object | object`, but received: [object Object]',
     );
   });
 

--- a/packages/rpc-methods/src/restricted/manageAccounts.ts
+++ b/packages/rpc-methods/src/restricted/manageAccounts.ts
@@ -34,14 +34,8 @@ export type ManageAccountsMethodHooks = {
     handleKeyringSnapMessage: (
       snapId: string,
       message: Message,
-      saveCallback: () => Promise<void>,
     ) => Promise<Json>;
   }>;
-
-  /**
-   * Saves the snap keyring, should be called after mutable operations.
-   */
-  saveSnapKeyring: () => Promise<void>;
 };
 
 type ManageAccountsSpecificationBuilderOptions = {
@@ -87,14 +81,12 @@ export const specificationBuilder: PermissionSpecificationBuilder<
  *
  * @param hooks - The RPC method hooks.
  * @param hooks.getSnapKeyring - A function to get the snap keyring.
- * @param hooks.saveSnapKeyring - A function to save the snap keyring.
  * @returns The method implementation which either returns `null` for a
  * successful state update/deletion or returns the decrypted state.
  * @throws If the params are invalid.
  */
 export function manageAccountsImplementation({
   getSnapKeyring,
-  saveSnapKeyring,
 }: ManageAccountsMethodHooks) {
   return async function manageAccounts(
     options: RestrictedMethodOptions<Message>,
@@ -106,11 +98,7 @@ export function manageAccountsImplementation({
 
     assert(params, SnapMessageStruct);
     const keyring = await getSnapKeyring(origin);
-    return await keyring.handleKeyringSnapMessage(
-      origin,
-      params,
-      saveSnapKeyring,
-    );
+    return await keyring.handleKeyringSnapMessage(origin, params);
   };
 }
 
@@ -119,6 +107,5 @@ export const manageAccountsBuilder = Object.freeze({
   specificationBuilder,
   methodHooks: {
     getSnapKeyring: true,
-    saveSnapKeyring: true,
   },
 } as const);

--- a/packages/rpc-methods/src/restricted/manageAccounts.ts
+++ b/packages/rpc-methods/src/restricted/manageAccounts.ts
@@ -7,17 +7,20 @@ import { SubjectType, PermissionType } from '@metamask/permission-controller';
 import type { Json, NonEmptyArray } from '@metamask/utils';
 import { JsonStruct } from '@metamask/utils';
 import type { Infer } from 'superstruct';
-import { assert, string, object, union, array, record } from 'superstruct';
+import {
+  assert,
+  string,
+  object,
+  union,
+  array,
+  record,
+  optional,
+} from 'superstruct';
 
-const SnapMessageStruct = union([
-  object({
-    method: string(),
-  }),
-  object({
-    method: string(),
-    params: union([array(JsonStruct), record(string(), JsonStruct)]),
-  }),
-]);
+const SnapMessageStruct = object({
+  method: string(),
+  params: optional(union([array(JsonStruct), record(string(), JsonStruct)])),
+});
 
 type Message = Infer<typeof SnapMessageStruct>;
 
@@ -31,6 +34,7 @@ export type ManageAccountsMethodHooks = {
     handleKeyringSnapMessage: (
       snapId: string,
       message: Message,
+      saveCallback: () => Promise<void>,
     ) => Promise<Json>;
   }>;
 
@@ -102,14 +106,11 @@ export function manageAccountsImplementation({
 
     assert(params, SnapMessageStruct);
     const keyring = await getSnapKeyring(origin);
-    const result = await keyring.handleKeyringSnapMessage(origin, params);
-
-    const { method } = params;
-    if (['updateAccount', 'createAccount', 'deleteAccount'].includes(method)) {
-      await saveSnapKeyring();
-    }
-
-    return result;
+    return await keyring.handleKeyringSnapMessage(
+      origin,
+      params,
+      saveSnapKeyring,
+    );
   };
 }
 

--- a/packages/rpc-methods/src/restricted/manageAccounts.ts
+++ b/packages/rpc-methods/src/restricted/manageAccounts.ts
@@ -7,20 +7,17 @@ import { SubjectType, PermissionType } from '@metamask/permission-controller';
 import type { Json, NonEmptyArray } from '@metamask/utils';
 import { JsonStruct } from '@metamask/utils';
 import type { Infer } from 'superstruct';
-import {
-  assert,
-  string,
-  object,
-  union,
-  array,
-  record,
-  optional,
-} from 'superstruct';
+import { assert, string, object, union, array, record } from 'superstruct';
 
-const SnapMessageStruct = object({
-  method: string(),
-  params: optional(union([array(JsonStruct), record(string(), JsonStruct)])),
-});
+const SnapMessageStruct = union([
+  object({
+    method: string(),
+  }),
+  object({
+    method: string(),
+    params: union([array(JsonStruct), record(string(), JsonStruct)]),
+  }),
+]);
 
 type Message = Infer<typeof SnapMessageStruct>;
 


### PR DESCRIPTION
The `rpc-methods` repo should not have knowledge about the logic behind the `SnapKeyring` nor decide when its state needs to be saved.

This PR removes the **business-logic** callbacks from the `manageAccounts` implementation.

Note: The `manageAccounts` method is still 100% covered, but since some code was removed, the global coverage threshold decreased.