### PR TITLE
Fix fallback icon in snaps simulator

### DIFF
--- a/packages/snaps-simulator/src/components/SnapIcon.tsx
+++ b/packages/snaps-simulator/src/components/SnapIcon.tsx
@@ -28,7 +28,7 @@ export const SnapIcon: FunctionComponent<SnapIconProps> = ({ snapName }) => {
     <Box position="relative">
       <Avatar
         src={blobUrl as string}
-        name={snapName.slice(1, 2).toUpperCase()}
+        name={snapName.slice(0, 1).toUpperCase()}
         fontSize="md"
         background="background.alternative"
         color="text.alternative"


### PR DESCRIPTION
Fixes fallback icon in snaps simulator which was wrongly using the second char.