### PR TITLE
Feature/account creation dialog

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FzEv7I4+3tYNzM6dcEEaoq3J3aH6l8WCo0bFp56hI3k=",
+    "shasum": "XpSs36O8CyJnY/h/ZmtCxPxg6ATrYp+lEBuEYOHdbX8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -37,6 +37,7 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
+    "@metamask/approval-controller": "^3.5.1",
     "@metamask/key-tree": "^9.0.0",
     "@metamask/permission-controller": "^4.1.0",
     "@metamask/snaps-ui": "workspace:^",

--- a/packages/rpc-methods/src/restricted/manageAccounts.test.ts
+++ b/packages/rpc-methods/src/restricted/manageAccounts.test.ts
@@ -98,7 +98,7 @@ describe('manageAccountsImplementation', () => {
         params: {},
       }),
     ).rejects.toThrow(
-      'Expected the value to satisfy a union of `object | object`, but received: [object Object]',
+      'At path: method -- Expected a string, but received: undefined',
     );
   });
 
@@ -120,7 +120,7 @@ describe('manageAccountsImplementation', () => {
         params: { method: 123, params: {} },
       }),
     ).rejects.toThrow(
-      'Expected the value to satisfy a union of `object | object`, but received: [object Object]',
+      'At path: method -- Expected a string, but received: 123',
     );
   });
 
@@ -148,10 +148,14 @@ describe('manageAccountsImplementation', () => {
     });
 
     expect(createAccountSpy).toHaveBeenCalledTimes(1);
-    expect(createAccountSpy).toHaveBeenCalledWith(MOCK_SNAP_ID, {
-      method: 'deleteAccount',
-      params: { accountId: MOCK_CAIP_10_ACCOUNT },
-    });
+    expect(createAccountSpy).toHaveBeenCalledWith(
+      MOCK_SNAP_ID,
+      {
+        method: 'deleteAccount',
+        params: { accountId: MOCK_CAIP_10_ACCOUNT },
+      },
+      saveSnapKeyring,
+    );
     expect(requestResponse).toBe(true);
     createAccountSpy.mockClear();
   });

--- a/packages/rpc-methods/src/restricted/manageAccounts.test.ts
+++ b/packages/rpc-methods/src/restricted/manageAccounts.test.ts
@@ -98,7 +98,7 @@ describe('manageAccountsImplementation', () => {
         params: {},
       }),
     ).rejects.toThrow(
-      'At path: method -- Expected a string, but received: undefined',
+      'Expected the value to satisfy a union of `object | object`, but received: [object Object]',
     );
   });
 
@@ -120,7 +120,7 @@ describe('manageAccountsImplementation', () => {
         params: { method: 123, params: {} },
       }),
     ).rejects.toThrow(
-      'At path: method -- Expected a string, but received: 123',
+      'Expected the value to satisfy a union of `object | object`, but received: [object Object]',
     );
   });
 
@@ -148,14 +148,10 @@ describe('manageAccountsImplementation', () => {
     });
 
     expect(createAccountSpy).toHaveBeenCalledTimes(1);
-    expect(createAccountSpy).toHaveBeenCalledWith(
-      MOCK_SNAP_ID,
-      {
-        method: 'deleteAccount',
-        params: { accountId: MOCK_CAIP_10_ACCOUNT },
-      },
-      saveSnapKeyring,
-    );
+    expect(createAccountSpy).toHaveBeenCalledWith(MOCK_SNAP_ID, {
+      method: 'deleteAccount',
+      params: { accountId: MOCK_CAIP_10_ACCOUNT },
+    });
     expect(requestResponse).toBe(true);
     createAccountSpy.mockClear();
   });

--- a/packages/rpc-methods/src/restricted/manageAccounts.ts
+++ b/packages/rpc-methods/src/restricted/manageAccounts.ts
@@ -7,17 +7,20 @@ import { SubjectType, PermissionType } from '@metamask/permission-controller';
 import type { Json, NonEmptyArray } from '@metamask/utils';
 import { JsonStruct } from '@metamask/utils';
 import type { Infer } from 'superstruct';
-import { assert, string, object, union, array, record } from 'superstruct';
+import {
+  assert,
+  string,
+  object,
+  union,
+  array,
+  record,
+  optional,
+} from 'superstruct';
 
-const SnapMessageStruct = union([
-  object({
-    method: string(),
-  }),
-  object({
-    method: string(),
-    params: union([array(JsonStruct), record(string(), JsonStruct)]),
-  }),
-]);
+const SnapMessageStruct = object({
+  method: string(),
+  params: optional(union([array(JsonStruct), record(string(), JsonStruct)])),
+});
 
 type Message = Infer<typeof SnapMessageStruct>;
 

--- a/packages/rpc-methods/src/restricted/manageAccounts.ts
+++ b/packages/rpc-methods/src/restricted/manageAccounts.ts
@@ -142,6 +142,7 @@ export function manageAccountsImplementation({
         await endApprovalFlow({ id: addAccountApprovalId });
       }
     }
+    await endApprovalFlow({ id: addAccountApprovalId });
     throw new Error('User denied account addition');
   };
 }

--- a/packages/rpc-methods/src/restricted/manageAccounts.ts
+++ b/packages/rpc-methods/src/restricted/manageAccounts.ts
@@ -144,6 +144,7 @@ export function manageAccountsImplementation({
       origin,
       type: 'snap_manageAccounts:confirmation',
     });
+
     // eslint-disable-next-line no-console
     console.log(
       'SNAPS/ manageAccountsImplementation/ confirmationResult',
@@ -154,11 +155,14 @@ export function manageAccountsImplementation({
         const account = await keyring.handleKeyringSnapMessage(origin, params);
         await showApprovalSuccess();
         await endApprovalFlow(addAccountApprovalId);
+
+        const accountName = confirmationResult.accountName ?? '[Empty]';
+
         await showApprovalSuccess({
           flowToEnd: addAccountApprovalId,
-          message: 'Account added',
+          message: `Added Account: **${accountName}**`,
         });
-        await endApprovalFlow({ id: addAccountApprovalId });
+
         return account;
       } catch (error) {
         await showApprovalError({ error: error.message });

--- a/packages/rpc-methods/src/restricted/manageAccounts.ts
+++ b/packages/rpc-methods/src/restricted/manageAccounts.ts
@@ -26,6 +26,11 @@ type Message = Infer<typeof SnapMessageStruct>;
 
 export const methodName = 'snap_manageAccounts';
 
+type AccountConfirmationResult = {
+  confirmed: boolean;
+  accountName?: string;
+};
+
 export type ManageAccountsMethodHooks = {
   /**
    * Gets the snap keyring implementation.

--- a/packages/rpc-methods/src/restricted/manageAccounts.ts
+++ b/packages/rpc-methods/src/restricted/manageAccounts.ts
@@ -1,4 +1,14 @@
 import type {
+  AddApprovalOptions,
+  SuccessOptions,
+  EndFlowOptions,
+  ApprovalFlowStartResult,
+  StartFlowOptions,
+  SuccessResult,
+  ErrorResult,
+  ErrorOptions,
+} from '@metamask/approval-controller';
+import type {
   RestrictedMethodOptions,
   ValidPermissionSpecification,
   PermissionSpecificationBuilder,
@@ -26,16 +36,6 @@ type Message = Infer<typeof SnapMessageStruct>;
 
 export const methodName = 'snap_manageAccounts';
 
-// from https://github.com/MetaMask/core/blob/main/packages/approval-controller/src/ApprovalController.ts#L157
-type AddApprovalOptions = {
-  id?: string;
-  origin: string;
-  type: string;
-  requestData?: Record<string, Json>;
-  requestState?: Record<string, Json>;
-  expectsResult?: boolean;
-};
-
 type AccountConfirmationResult = {
   confirmed: boolean;
   accountName?: string;
@@ -58,14 +58,14 @@ export type ManageAccountsMethodHooks = {
     content: any,
     placeholder: any,
   ) => Promise<AccountConfirmationResult>;
-  startApprovalFlow: () => string;
+  startApprovalFlow: (opts?: StartFlowOptions) => ApprovalFlowStartResult;
   requestUserApproval: (
     opts: AddApprovalOptions,
   ) => Promise<AccountConfirmationResult>;
-  endApprovalFlow: (id: string) => Promise<void>;
-  setApprovalFlowLoadingText: () => Promise<void>;
-  showApprovalSuccess: () => Promise<void>;
-  showApprovalError: () => Promise<void>;
+  endApprovalFlow: ({ id }: EndFlowOptions) => Promise<void>;
+  // setApprovalFlowLoadingText: () => Promise<void>;
+  showApprovalSuccess: (opts?: SuccessOptions) => Promise<SuccessResult>;
+  showApprovalError: (opts?: ErrorOptions) => Promise<ErrorResult>;
 };
 
 type ManageAccountsSpecificationBuilderOptions = {
@@ -138,7 +138,7 @@ export function manageAccountsImplementation({
 
     assert(params, SnapMessageStruct);
     const keyring = await getSnapKeyring(origin);
-    const addAccountApprovalId = startApprovalFlow();
+    const { id: addAccountApprovalId } = startApprovalFlow();
 
     const confirmationResult = await requestUserApproval({
       origin,
@@ -154,10 +154,15 @@ export function manageAccountsImplementation({
         const account = await keyring.handleKeyringSnapMessage(origin, params);
         await showApprovalSuccess();
         await endApprovalFlow(addAccountApprovalId);
+        await showApprovalSuccess({
+          flowToEnd: addAccountApprovalId,
+          message: 'Account added',
+        });
+        await endApprovalFlow({ id: addAccountApprovalId });
         return account;
       } catch (error) {
-        await showApprovalError();
-        await endApprovalFlow(addAccountApprovalId);
+        await showApprovalError({ error: error.message });
+        await endApprovalFlow({ id: addAccountApprovalId });
       }
     }
     throw new Error('User denied account addition');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4835,6 +4835,7 @@ __metadata:
   resolution: "@metamask/rpc-methods@workspace:packages/rpc-methods"
   dependencies:
     "@lavamoat/allow-scripts": ^2.3.1
+    "@metamask/approval-controller": ^3.5.1
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/browser-passworder": ^4.1.0
     "@metamask/eslint-config": ^12.1.0


### PR DESCRIPTION
Progresses: https://github.com/MetaMask/accounts-planning/issues/14
Works alongside this change: https://github.com/MetaMask/metamask-extension/pull/20684

See description of extension [companion PR](https://github.com/MetaMask/metamask-extension/pull/20684) for details on how to test.

### What did I change?
- I have added the approval controller methods as hooks to be passed into the manageAccountsImplementation in order to trigger an approval request from the user of the extension before an account is added.
1. I start the approval, this is used to keep the approval flow open until I explicit end it or show the success screen.
2. I requestApproval from the user
3. upon confirmation, I showSuccess with the message `Your account is ready!`, create the account and add it.
4. upon denial, I throw an error indicating the user denied the action and end the flow