### PR TITLE
Use new yarn.lock for update pull request workflow

### DIFF
--- a/.github/workflows/update-pull-request.yml
+++ b/.github/workflows/update-pull-request.yml
@@ -100,7 +100,9 @@ jobs:
   regenerate-lavamoat-policies:
     name: Regenerate LavaMoat policies
     runs-on: ubuntu-latest
-    needs: prepare
+    needs:
+      - prepare
+      - dedupe-yarn-lock
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -109,6 +111,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PULL_REQUEST_UPDATE_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
+      - name: Restore yarn.lock
+        uses: actions/cache/restore@v3
+        with:
+          path: yarn.lock
+          key: cache-yarn-lock-${{ needs.prepare.outputs.COMMIT_SHA }}
+          fail-on-cache-miss: true
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
@@ -127,7 +135,9 @@ jobs:
   update-examples:
     name: Update examples
     runs-on: ubuntu-latest
-    needs: prepare
+    needs:
+      - prepare
+      - dedupe-yarn-lock
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -136,6 +146,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PULL_REQUEST_UPDATE_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
+      - name: Restore yarn.lock
+        uses: actions/cache/restore@v3
+        with:
+          path: yarn.lock
+          key: cache-yarn-lock-${{ needs.prepare.outputs.COMMIT_SHA }}
+          fail-on-cache-miss: true
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
`yarn dedupe` can change the lockfile, which can change the result of the other two jobs in the workflow. To solve this, the dedupe step is run first, and when that is finished, the other two jobs are run, using the new lockfile.