### PR TITLE
Fix cronjob running on disabled snaps

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 89,
   "functions": 95.13,
-  "lines": 96.77,
-  "statements": 96.44
+  "lines": 96.78,
+  "statements": 96.45
 }

--- a/packages/snaps-controllers/src/cronjob/CronjobController.test.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.test.ts
@@ -196,8 +196,46 @@ describe('CronjobController', () => {
       initialPermissions: {},
       version: MOCK_VERSION,
     };
-    // @ts-expect-error Accessing private property
-    cronjobController._handleEventSnapInstalled(snapInfo);
+
+    rootMessenger.publish('SnapController:snapInstalled', snapInfo);
+
+    jest.advanceTimersByTime(inMilliseconds(1, Duration.Minute));
+
+    expect(rootMessenger.call).toHaveBeenNthCalledWith(
+      4,
+      'SnapController:handleRequest',
+      {
+        snapId: MOCK_SNAP_ID,
+        origin: '',
+        handler: HandlerType.OnCronjob,
+        request: {
+          method: 'exampleMethodOne',
+          params: ['p1'],
+        },
+      },
+    );
+
+    cronjobController.destroy();
+  });
+
+  it('handles SnapEnabled event', () => {
+    const rootMessenger = getRootCronjobControllerMessenger();
+    const controllerMessenger =
+      getRestrictedCronjobControllerMessenger(rootMessenger);
+
+    const cronjobController = new CronjobController({
+      messenger: controllerMessenger,
+    });
+
+    const snapInfo: TruncatedSnap = {
+      blocked: false,
+      enabled: true,
+      id: MOCK_SNAP_ID,
+      initialPermissions: {},
+      version: MOCK_VERSION,
+    };
+
+    rootMessenger.publish('SnapController:snapEnabled', snapInfo);
 
     jest.advanceTimersByTime(inMilliseconds(1, Duration.Minute));
 
@@ -227,7 +265,43 @@ describe('CronjobController', () => {
       messenger: controllerMessenger,
     });
 
-    cronjobController.register(MOCK_SNAP_ID);
+    const snapInfo: TruncatedSnap = {
+      blocked: false,
+      enabled: true,
+      id: MOCK_SNAP_ID,
+      initialPermissions: {},
+      version: MOCK_VERSION,
+    };
+
+    rootMessenger.publish('SnapController:snapInstalled', snapInfo);
+    rootMessenger.publish('SnapController:snapRemoved', snapInfo);
+
+    jest.advanceTimersByTime(inMilliseconds(1, Duration.Minute));
+
+    expect(rootMessenger.call).not.toHaveBeenCalledWith(
+      'SnapController:handleRequest',
+      {
+        snapId: MOCK_SNAP_ID,
+        origin: '',
+        handler: HandlerType.OnCronjob,
+        request: {
+          method: 'exampleMethodOne',
+          params: ['p1'],
+        },
+      },
+    );
+
+    cronjobController.destroy();
+  });
+
+  it('handles SnapDisabled event', () => {
+    const rootMessenger = getRootCronjobControllerMessenger();
+    const controllerMessenger =
+      getRestrictedCronjobControllerMessenger(rootMessenger);
+
+    const cronjobController = new CronjobController({
+      messenger: controllerMessenger,
+    });
 
     const snapInfo: TruncatedSnap = {
       blocked: false,
@@ -237,8 +311,8 @@ describe('CronjobController', () => {
       version: MOCK_VERSION,
     };
 
-    // @ts-expect-error Accessing private property
-    cronjobController._handleEventSnapRemoved(snapInfo);
+    rootMessenger.publish('SnapController:snapInstalled', snapInfo);
+    rootMessenger.publish('SnapController:snapDisabled', snapInfo);
 
     jest.advanceTimersByTime(inMilliseconds(1, Duration.Minute));
 
@@ -267,8 +341,6 @@ describe('CronjobController', () => {
       messenger: controllerMessenger,
     });
 
-    cronjobController.register(MOCK_SNAP_ID);
-
     const snapInfo: TruncatedSnap = {
       blocked: false,
       enabled: true,
@@ -277,8 +349,12 @@ describe('CronjobController', () => {
       version: MOCK_VERSION,
     };
 
-    // @ts-expect-error Accessing private property
-    cronjobController._handleEventSnapUpdated(snapInfo);
+    rootMessenger.publish('SnapController:snapInstalled', snapInfo);
+    rootMessenger.publish(
+      'SnapController:snapUpdated',
+      snapInfo,
+      snapInfo.version,
+    );
 
     jest.advanceTimersByTime(inMilliseconds(15, Duration.Minute));
 

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -4501,6 +4501,7 @@ describe('SnapController', () => {
 
   describe('enableSnap', () => {
     it('enables a disabled snap', () => {
+      const messenger = getSnapControllerMessenger();
       const snapController = getSnapController(
         getSnapControllerOptions({
           state: {
@@ -4508,6 +4509,7 @@ describe('SnapController', () => {
               getPersistedSnapObject({ enabled: false }),
             ),
           },
+          messenger,
         }),
       );
 
@@ -4515,6 +4517,10 @@ describe('SnapController', () => {
 
       snapController.enableSnap(MOCK_SNAP_ID);
       expect(snapController.get(MOCK_SNAP_ID)?.enabled).toBe(true);
+      expect(messenger.publish).toHaveBeenCalledWith(
+        'SnapController:snapEnabled',
+        getTruncatedSnap(),
+      );
 
       snapController.destroy();
     });
@@ -4549,11 +4555,13 @@ describe('SnapController', () => {
 
   describe('disableSnap', () => {
     it('disables a snap', async () => {
+      const messenger = getSnapControllerMessenger();
       const snapController = getSnapController(
         getSnapControllerOptions({
           state: {
             snaps: getPersistedSnapsState(),
           },
+          messenger,
         }),
       );
 
@@ -4561,6 +4569,10 @@ describe('SnapController', () => {
 
       await snapController.disableSnap(MOCK_SNAP_ID);
       expect(snapController.get(MOCK_SNAP_ID)?.enabled).toBe(false);
+      expect(messenger.publish).toHaveBeenCalledWith(
+        'SnapController:snapDisabled',
+        getTruncatedSnap({ enabled: false }),
+      );
 
       snapController.destroy();
     });

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -436,12 +436,30 @@ export type SnapRolledback = {
   type: `${typeof controllerName}:snapRolledback`;
   payload: [snap: TruncatedSnap, failedVersion: string];
 };
+
 /**
  * Emitted when a Snap is terminated. This is different from the snap being
  * stopped as it can also be triggered when a snap fails initialization.
  */
 export type SnapTerminated = {
   type: `${typeof controllerName}:snapTerminated`;
+  payload: [snap: TruncatedSnap];
+};
+
+/**
+ * Emitted when a Snap is enabled by a user.
+ * This is not emitted by default when installing a snap.
+ */
+export type SnapEnabled = {
+  type: `${typeof controllerName}:snapEnabled`;
+  payload: [snap: TruncatedSnap];
+};
+
+/**
+ * Emitted when a Snap is disabled by a user.
+ */
+export type SnapDisabled = {
+  type: `${typeof controllerName}:snapDisabled`;
   payload: [snap: TruncatedSnap];
 };
 
@@ -454,7 +472,9 @@ export type SnapControllerEvents =
   | SnapUnblocked
   | SnapUpdated
   | SnapRolledback
-  | SnapTerminated;
+  | SnapTerminated
+  | SnapEnabled
+  | SnapDisabled;
 
 export type AllowedActions =
   | GetEndowments
@@ -1183,6 +1203,11 @@ export class SnapController extends BaseController<
     this.update((state: any) => {
       state.snaps[snapId].enabled = true;
     });
+
+    this.messagingSystem.publish(
+      'SnapController:snapEnabled',
+      this.getTruncatedExpect(snapId),
+    );
   }
 
   /**
@@ -1203,6 +1228,11 @@ export class SnapController extends BaseController<
     if (this.isRunning(snapId)) {
       return this.stopSnap(snapId, SnapStatusEvents.Stop);
     }
+
+    this.messagingSystem.publish(
+      'SnapController:snapDisabled',
+      this.getTruncatedExpect(snapId),
+    );
 
     return Promise.resolve();
   }

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1226,15 +1226,13 @@ export class SnapController extends BaseController<
     });
 
     if (this.isRunning(snapId)) {
-      return this.stopSnap(snapId, SnapStatusEvents.Stop);
+      await this.stopSnap(snapId, SnapStatusEvents.Stop);
     }
 
     this.messagingSystem.publish(
       'SnapController:snapDisabled',
       this.getTruncatedExpect(snapId),
     );
-
-    return Promise.resolve();
   }
 
   /**

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -469,6 +469,8 @@ export const getRestrictedCronjobControllerMessenger = (
       'SnapController:snapInstalled',
       'SnapController:snapUpdated',
       'SnapController:snapRemoved',
+      'SnapController:snapEnabled',
+      'SnapController:snapDisabled',
     ],
     allowedActions: [
       'PermissionController:hasPermission',

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -354,6 +354,7 @@ export const getSnapControllerMessenger = (
   });
 
   jest.spyOn(snapControllerMessenger, 'call');
+  jest.spyOn(snapControllerMessenger, 'publish');
 
   return snapControllerMessenger;
 };


### PR DESCRIPTION
Fixes an issue where cronjobs would still fire on disabled snaps. The cronjob wouldn't succeed as the snap was not allowed to run, but the CronjobController would try to run the cronjob regardless.

Fixes https://github.com/MetaMask/snaps/issues/1720