### PR TITLE
Fix network access example snap

### DIFF
--- a/packages/examples/packages/network-access/package.json
+++ b/packages/examples/packages/network-access/package.json
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^5.1.1",
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-types": "workspace:^",
+    "@metamask/utils": "^8.1.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wqf+7SaMQgrortuPpJIA9v/J0MIlpOePg0at8CWsRzU=",
+    "shasum": "IYhN5JtHz0Kg6pWY9rWt9K6R0+dDGBDlEZPKlBwlVCo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/src/constants.ts
+++ b/packages/examples/packages/network-access/src/constants.ts
@@ -1,3 +1,0 @@
-import { version } from '../package.json';
-
-export const DEFAULT_URL = `https://metamask.github.io/snaps/test-snaps/${version}/test-data.json`;

--- a/packages/examples/packages/network-access/src/index.test.ts
+++ b/packages/examples/packages/network-access/src/index.test.ts
@@ -1,8 +1,6 @@
 import { expect } from '@jest/globals';
 import { installSnap } from '@metamask/snaps-jest';
 
-import { DEFAULT_URL } from './constants';
-
 describe('onRpcRequest', () => {
   it('throws an error if the requested method does not exist', async () => {
     const { request, close } = await installSnap();
@@ -29,8 +27,10 @@ describe('onRpcRequest', () => {
     it('fetches a URL and returns the JSON response', async () => {
       const { request, close, mock } = await installSnap();
 
+      const url = 'https://example.com/';
+
       await mock({
-        url: DEFAULT_URL,
+        url,
         response: {
           contentType: 'application/json',
           body: JSON.stringify({
@@ -41,37 +41,13 @@ describe('onRpcRequest', () => {
 
       const response = await request({
         method: 'fetch',
+        params: {
+          url,
+        },
       });
 
       expect(response).toRespondWith({
         hello: 'world',
-      });
-
-      await close();
-    });
-
-    it('fetches a custom URL and returns the JSON response', async () => {
-      const { request, close, mock } = await installSnap();
-
-      await mock({
-        url: 'https://example.com/',
-        response: {
-          contentType: 'application/json',
-          body: JSON.stringify({
-            foo: 'bar',
-          }),
-        },
-      });
-
-      const response = await request({
-        method: 'fetch',
-        params: {
-          url: 'https://example.com/',
-        },
-      });
-
-      expect(response).toRespondWith({
-        foo: 'bar',
       });
 
       await close();

--- a/packages/examples/packages/network-access/src/index.ts
+++ b/packages/examples/packages/network-access/src/index.ts
@@ -1,7 +1,7 @@
 import { rpcErrors } from '@metamask/rpc-errors';
 import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import { assert } from '@metamask/utils';
 
-import { DEFAULT_URL } from './constants';
 import type { FetchParams } from './types';
 
 /**
@@ -13,12 +13,11 @@ import type { FetchParams } from './types';
  * permission.
  *
  * @param url - The URL to fetch the data from. This function assumes that the
- * provided URL is a JSON document. Defaults to
- * `https://metamask.github.io/snaps/test-snaps/latest/test-data.json`.
+ * provided URL is a JSON document.
  * @returns There response as JSON.
  * @throws If the provided URL is not a JSON document.
  */
-async function getJson(url = DEFAULT_URL) {
+async function getJson(url: string) {
   const response = await fetch(url);
   return await response.json();
 }
@@ -42,7 +41,8 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   switch (request.method) {
     case 'fetch': {
       const params = request.params as FetchParams | undefined;
-      return await getJson(params?.url);
+      assert(params?.url, 'Required url parameter was not specified.');
+      return await getJson(params.url);
     }
 
     default:

--- a/packages/examples/packages/network-access/src/types.ts
+++ b/packages/examples/packages/network-access/src/types.ts
@@ -3,8 +3,7 @@
  */
 export type FetchParams = {
   /**
-   * The URL to fetch. Defaults to
-   * `https://metamask.github.io/snaps/test-snaps/latest/test-data.json`.
+   * The URL to fetch.
    */
-  url?: string;
+  url: string;
 };

--- a/packages/test-snaps/src/features/snaps/network-access/NetworkAccess.tsx
+++ b/packages/test-snaps/src/features/snaps/network-access/NetworkAccess.tsx
@@ -1,6 +1,7 @@
 import { logError } from '@metamask/snaps-utils';
-import type { FunctionComponent } from 'react';
-import { Button } from 'react-bootstrap';
+import type { ChangeEvent, FunctionComponent } from 'react';
+import { useState } from 'react';
+import { Button, Form } from 'react-bootstrap';
 
 import { useInvokeMutation } from '../../../api';
 import { Result, Snap } from '../../../components';
@@ -12,12 +13,18 @@ import {
 } from './constants';
 
 export const NetworkAccess: FunctionComponent = () => {
+  const [url, setUrl] = useState(`${window.location.href}test-data.json`);
   const [invokeSnap, { isLoading, data, error }] = useInvokeMutation();
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setUrl(event.target.value);
+  };
 
   const handleSubmit = () => {
     invokeSnap({
       snapId: getSnapId(NETWORK_ACCESS_SNAP_ID, NETWORK_ACCESS_PORT),
       method: 'fetch',
+      params: { url },
     }).catch(logError);
   };
 
@@ -29,6 +36,14 @@ export const NetworkAccess: FunctionComponent = () => {
       version={NETWORK_ACCESS_VERSION}
       testId="network-access"
     >
+      <Form.Control
+        type="text"
+        placeholder="URL"
+        value={url}
+        onChange={handleChange}
+        id="fetchUrl"
+        className="mb-3"
+      />
       <Button
         variant="primary"
         id="sendNetworkAccessTest"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4655,6 +4655,7 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
+    "@metamask/utils": ^8.1.0
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1


### PR DESCRIPTION
Fixes an issue with the hardcoded path in the network access example snap. From now on, an URL parameter is expected to be passed. This PR also changes `test-snaps` to add an input field for passing this URL.