### PR TITLE
Pause timer on fetch

### DIFF
--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 80.71,
-  "functions": 92.02,
-  "lines": 91.66,
-  "statements": 91.36
+  "branches": 80.28,
+  "functions": 90.41,
+  "lines": 91.06,
+  "statements": 90.65
 }

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1059,6 +1059,16 @@ describe('BaseSnapExecutor', () => {
     });
 
     expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      method: 'OutboundRequest',
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      method: 'OutboundResponse',
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
       id: 2,
       jsonrpc: '2.0',
       result: 'foo',

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -191,6 +191,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundRequest',
+      params: { source: 'ethereum.request' },
     });
 
     const blockNumRequest = await executor.readRpc();
@@ -217,6 +218,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundResponse',
+      params: { source: 'ethereum.request' },
     });
 
     expect(await executor.readCommand()).toStrictEqual({
@@ -255,6 +257,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundRequest',
+      params: { source: 'snap.request' },
     });
 
     const walletRequest = await executor.readRpc();
@@ -281,6 +284,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundResponse',
+      params: { source: 'snap.request' },
     });
 
     expect(await executor.readCommand()).toStrictEqual({
@@ -416,6 +420,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundRequest',
+      params: { source: 'ethereum.request' },
     });
 
     const blockNumRequest = await executor.readRpc();
@@ -442,6 +447,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundResponse',
+      params: { source: 'ethereum.request' },
     });
 
     expect(await executor.readCommand()).toStrictEqual({
@@ -482,6 +488,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundRequest',
+      params: { source: 'snap.request' },
     });
 
     const getSnapsRequest = await executor.readRpc();
@@ -516,6 +523,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundResponse',
+      params: { source: 'snap.request' },
     });
 
     expect(await executor.readCommand()).toStrictEqual({
@@ -898,6 +906,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundRequest',
+      params: { source: 'snap.request' },
     });
 
     const request = await executor.readRpc();
@@ -930,6 +939,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundResponse',
+      params: { source: 'snap.request' },
     });
 
     expect(await executor.readCommand()).toStrictEqual({
@@ -973,6 +983,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundRequest',
+      params: { source: 'ethereum.request' },
     });
 
     const request = await executor.readRpc();
@@ -1007,6 +1018,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundResponse',
+      params: { source: 'ethereum.request' },
     });
 
     expect(await executor.readCommand()).toStrictEqual({
@@ -1051,21 +1063,25 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundRequest',
+      params: { source: 'fetch' },
     });
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundResponse',
+      params: { source: 'fetch' },
     });
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundRequest',
+      params: { source: 'fetch' },
     });
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundResponse',
+      params: { source: 'fetch' },
     });
 
     expect(await executor.readCommand()).toStrictEqual({
@@ -1624,6 +1640,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundRequest',
+      params: { source: 'ethereum.request' },
     });
 
     const blockNumRequest = await executor.readRpc();
@@ -1731,6 +1748,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundRequest',
+      params: { source: 'ethereum.request' },
     });
 
     const blockNumRequest = await executor.readRpc();
@@ -1823,6 +1841,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundRequest',
+      params: { source: 'ethereum.request' },
     });
 
     const blockNumRequest = await executor.readRpc();
@@ -1852,6 +1871,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundResponse',
+      params: { source: 'ethereum.request' },
     });
 
     expect(await executor.readCommand()).toStrictEqual({

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1685,6 +1685,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundResponse',
+      params: { source: 'ethereum.request' },
     });
 
     expect(await executor.readCommand()).toStrictEqual({
@@ -1796,6 +1797,7 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       method: 'OutboundResponse',
+      params: { source: 'ethereum.request' },
     });
 
     expect(await executor.readCommand()).toStrictEqual({

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -110,7 +110,7 @@ const EXECUTION_ENVIRONMENT_METHODS = {
 
 type Methods = typeof EXECUTION_ENVIRONMENT_METHODS;
 
-export type NotifyFunction = BaseSnapExecutor['notify'];
+export type NotifyFunction = (notification:  Omit<JsonRpcNotification, 'jsonrpc'>) => Promise<void>;
 
 export class BaseSnapExecutor {
   private readonly snapData: Map<string, SnapData>;
@@ -366,7 +366,7 @@ export class BaseSnapExecutor {
         ethereum,
         snapId,
         endowments: _endowments,
-        notify: this.notify.bind(this),
+        notify: this.#notify.bind(this),
       });
 
       // !!! Ensure that this is the only place the data is being set.

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -110,7 +110,9 @@ const EXECUTION_ENVIRONMENT_METHODS = {
 
 type Methods = typeof EXECUTION_ENVIRONMENT_METHODS;
 
-export type NotifyFunction = (notification:  Omit<JsonRpcNotification, 'jsonrpc'>) => Promise<void>;
+export type NotifyFunction = (
+  notification: Omit<JsonRpcNotification, 'jsonrpc'>,
+) => Promise<void>;
 
 export class BaseSnapExecutor {
   private readonly snapData: Map<string, SnapData>;
@@ -457,11 +459,17 @@ export class BaseSnapExecutor {
       assertSnapOutboundRequest(sanitizedArgs);
       return await withTeardown(
         (async () => {
-          await this.#notify({ method: 'OutboundRequest' });
+          await this.#notify({
+            method: 'OutboundRequest',
+            params: { source: 'snap.request' },
+          });
           try {
             return await originalRequest(sanitizedArgs);
           } finally {
-            await this.#notify({ method: 'OutboundResponse' });
+            await this.#notify({
+              method: 'OutboundResponse',
+              params: { source: 'snap.request' },
+            });
           }
         })(),
         this as any,
@@ -503,11 +511,17 @@ export class BaseSnapExecutor {
       assertEthereumOutboundRequest(sanitizedArgs);
       return await withTeardown(
         (async () => {
-          await this.#notify({ method: 'OutboundRequest' });
+          await this.#notify({
+            method: 'OutboundRequest',
+            params: { source: 'ethereum.request' },
+          });
           try {
             return await originalRequest(sanitizedArgs);
           } finally {
-            await this.#notify({ method: 'OutboundResponse' });
+            await this.#notify({
+              method: 'OutboundResponse',
+              params: { source: 'ethereum.request' },
+            });
           }
         })(),
         this as any,

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -110,6 +110,8 @@ const EXECUTION_ENVIRONMENT_METHODS = {
 
 type Methods = typeof EXECUTION_ENVIRONMENT_METHODS;
 
+export type NotifyFunction = BaseSnapExecutor['notify'];
+
 export class BaseSnapExecutor {
   private readonly snapData: Map<string, SnapData>;
 
@@ -325,7 +327,7 @@ export class BaseSnapExecutor {
   protected async startSnap(
     snapId: string,
     sourceCode: string,
-    _endowments?: string[],
+    _endowments: string[],
   ): Promise<void> {
     log(`Starting snap '${snapId}' in worker.`);
     if (this.snapPromiseErrorHandler) {
@@ -359,12 +361,13 @@ export class BaseSnapExecutor {
     const snapModule: any = { exports: {} };
 
     try {
-      const { endowments, teardown: endowmentTeardown } = createEndowments(
+      const { endowments, teardown: endowmentTeardown } = createEndowments({
         snap,
         ethereum,
         snapId,
-        _endowments,
-      );
+        endowments: _endowments,
+        notify: this.notify.bind(this),
+      });
 
       // !!! Ensure that this is the only place the data is being set.
       // Other methods access the object value and mutate its properties.

--- a/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
@@ -1,3 +1,4 @@
+import { NotifyFunction } from '../BaseSnapExecutor';
 import { rootRealmGlobal } from '../globalObject';
 import consoleEndowment from './console';
 import crypto from './crypto';
@@ -11,6 +12,7 @@ import timeout from './timeout';
 
 export type EndowmentFactoryOptions = {
   snapId?: string;
+  notify?: NotifyFunction;
 };
 
 export type EndowmentFactory = {

--- a/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
@@ -1,4 +1,4 @@
-import { NotifyFunction } from '../BaseSnapExecutor';
+import type { NotifyFunction } from '../BaseSnapExecutor';
 import { rootRealmGlobal } from '../globalObject';
 import consoleEndowment from './console';
 import crypto from './crypto';

--- a/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
@@ -33,10 +33,16 @@ lockdown({
 globalThis.atob = harden(originalAtob);
 globalThis.btoa = harden(originalBtoa);
 
+const mockNotify = () => {
+  // no-op
+};
+
 describe('endowments', () => {
   describe('hardening', () => {
     const modules = buildCommonEndowments();
-    modules.forEach((endowment) => endowment.factory({ snapId: MOCK_SNAP_ID }));
+    modules.forEach((endowment) =>
+      endowment.factory({ snapId: MOCK_SNAP_ID, notify: mockNotify }),
+    );
 
     // Specially attenuated endowments or endowments that require
     // to be imported in a different way
@@ -57,9 +63,7 @@ describe('endowments', () => {
       Headers: HeadersHardened,
       Response: ResponseHardened,
     } = network.factory({
-      notify: () => {
-        // no-op
-      },
+      notify: mockNotify,
     });
     const { Date: DateAttenuated } = date.factory();
     const { console: consoleAttenuated } = consoleEndowment.factory({

--- a/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
@@ -56,7 +56,11 @@ describe('endowments', () => {
       Request: RequestHardened,
       Headers: HeadersHardened,
       Response: ResponseHardened,
-    } = network.factory();
+    } = network.factory({
+      notify: () => {
+        // no-op
+      },
+    });
     const { Date: DateAttenuated } = date.factory();
     const { console: consoleAttenuated } = consoleEndowment.factory({
       snapId: MOCK_SNAP_ID,

--- a/packages/snaps-execution-environments/src/common/endowments/index.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.ts
@@ -58,7 +58,7 @@ export function createEndowments({
   snap,
   ethereum,
   snapId,
-  endowments = [],
+  endowments,
   notify,
 }: {
   snap: SnapsProvider;

--- a/packages/snaps-execution-environments/src/common/endowments/network.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/network.test.ts
@@ -7,9 +7,12 @@ describe('Network endowments', () => {
     globalThis.harden = (value) => value;
   });
 
+  const factoryOptions = { notify: jest.fn() };
+
   describe('fetch', () => {
     beforeEach(() => {
       fetchMock.enableMocks();
+      factoryOptions.notify.mockClear();
     });
 
     afterEach(() => {
@@ -19,9 +22,24 @@ describe('Network endowments', () => {
     it('fetches and reads body', async () => {
       const RESULT = 'OK';
       fetchMock.mockOnce(async () => Promise.resolve(RESULT));
-      const { fetch } = network.factory();
+      const { fetch } = network.factory(factoryOptions);
       const result = await (await fetch('foo.com')).text();
       expect(result).toStrictEqual(RESULT);
+    });
+
+    it('send notification about outbound request and response', async () => {
+      const RESULT = 'OK';
+      fetchMock.mockOnce(async () => Promise.resolve(RESULT));
+      const { fetch } = network.factory(factoryOptions);
+      const result = await (await fetch('foo.com')).text();
+      expect(result).toStrictEqual(RESULT);
+      expect(factoryOptions.notify).toHaveBeenCalledWith({
+        method: 'OutboundRequest',
+      });
+      expect(factoryOptions.notify).toHaveBeenCalledWith({
+        method: 'OutboundResponse',
+      });
+      expect(factoryOptions.notify).toHaveBeenCalledTimes(2);
     });
 
     it('can use AbortController normally', async () => {
@@ -33,7 +51,7 @@ describe('Network endowments', () => {
           }),
       );
 
-      const { fetch } = network.factory();
+      const { fetch } = network.factory(factoryOptions);
 
       const controller = new AbortController();
 
@@ -63,7 +81,7 @@ describe('Network endowments', () => {
         async () => new Promise((resolve) => (fetchResolve = resolve)),
       );
 
-      const { fetch, teardownFunction } = network.factory();
+      const { fetch, teardownFunction } = network.factory(factoryOptions);
       const ErrorProxy = jest
         .fn()
         .mockImplementation((reason) => Error(reason));
@@ -90,7 +108,7 @@ describe('Network endowments', () => {
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
       fetchMock.mockReject(new Error('Failed to fetch.'));
 
-      const { fetch, teardownFunction } = network.factory();
+      const { fetch, teardownFunction } = network.factory(factoryOptions);
 
       // eslint-disable-next-line jest/valid-expect-in-promise
       fetch('foo.com').catch(() => {
@@ -116,7 +134,7 @@ describe('Network endowments', () => {
       const RESULT = 'OK';
       fetchMock.mockOnce(async () => Promise.resolve(RESULT));
 
-      const { fetch } = network.factory();
+      const { fetch } = network.factory(factoryOptions);
       const result = await fetch('foo.com');
 
       expect(result).toBeDefined();
@@ -139,7 +157,7 @@ describe('Network endowments', () => {
       const RESULT = 'OK';
       fetchMock.mockOnce(async () => Promise.resolve(RESULT));
 
-      const { fetch } = network.factory();
+      const { fetch } = network.factory(factoryOptions);
       const result = await fetch('foo.com');
 
       expect(result.bodyUsed).toBe(false);
@@ -150,7 +168,7 @@ describe('Network endowments', () => {
       const RESULT = 'OK';
       fetchMock.mockOnce(async () => Promise.resolve(RESULT));
 
-      const { fetch } = network.factory();
+      const { fetch } = network.factory(factoryOptions);
       const result = await fetch('foo.com');
 
       expect(result.bodyUsed).toBe(false);
@@ -163,7 +181,7 @@ describe('Network endowments', () => {
       const RESULT = 'OK';
       fetchMock.mockOnce(async () => Promise.resolve(RESULT));
 
-      const { fetch } = network.factory();
+      const { fetch } = network.factory(factoryOptions);
       const result = await fetch('foo.com');
 
       expect(result.bodyUsed).toBe(false);
@@ -177,7 +195,7 @@ describe('Network endowments', () => {
       const RESULT = '{}';
       fetchMock.mockOnce(async () => Promise.resolve(RESULT));
 
-      const { fetch } = network.factory();
+      const { fetch } = network.factory(factoryOptions);
       const result = await fetch('foo.com');
 
       expect(result.bodyUsed).toBe(false);

--- a/packages/snaps-execution-environments/src/common/endowments/network.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/network.test.ts
@@ -53,13 +53,7 @@ describe('Network endowments', () => {
     });
 
     it('can use AbortController normally', async () => {
-      let resolve: ((result: string) => void) | null = null;
-      fetchMock.mockOnce(
-        async () =>
-          new Promise((_resolve) => {
-            resolve = _resolve;
-          }),
-      );
+      fetchMock.mockOnce(async () => 'FAIL');
 
       const { fetch } = network.factory(factoryOptions);
 
@@ -67,7 +61,6 @@ describe('Network endowments', () => {
 
       const fetchPromise = fetch('foo.com', { signal: controller.signal });
       controller.abort();
-      (resolve as any)('FAIL');
       await expect(fetchPromise).rejects.toThrow('The operation was aborted');
     });
 
@@ -86,10 +79,7 @@ describe('Network endowments', () => {
     it.todo('reason from AbortController.abort() is passed down');
 
     it('should not expose then or catch after teardown has been called', async () => {
-      let fetchResolve: ((result: string) => void) | null = null;
-      fetchMock.mockOnce(
-        async () => new Promise((resolve) => (fetchResolve = resolve)),
-      );
+      fetchMock.mockOnce(async () => 'Resolved');
 
       const { fetch, teardownFunction } = network.factory(factoryOptions);
       const ErrorProxy = jest
@@ -107,7 +97,6 @@ describe('Network endowments', () => {
         .catch((error) => console.log(error));
 
       const teardownPromise = teardownFunction();
-      (fetchResolve as any)('Resolved');
       await teardownPromise;
       await new Promise((resolve) => setTimeout(() => resolve('Resolved'), 0));
 

--- a/packages/snaps-execution-environments/src/common/endowments/network.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/network.test.ts
@@ -39,7 +39,7 @@ describe('Network endowments', () => {
       expect(factoryOptions.notify).toHaveBeenCalledWith({
         method: 'OutboundResponse',
       });
-      expect(factoryOptions.notify).toHaveBeenCalledTimes(2);
+      expect(factoryOptions.notify).toHaveBeenCalledTimes(4);
     });
 
     it('can use AbortController normally', async () => {

--- a/packages/snaps-execution-environments/src/common/endowments/network.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/network.test.ts
@@ -33,11 +33,21 @@ describe('Network endowments', () => {
       const { fetch } = network.factory({ notify });
       const result = await (await fetch('foo.com')).text();
       expect(result).toStrictEqual(RESULT);
-      expect(notify).toHaveBeenCalledWith({
+      expect(notify).toHaveBeenNthCalledWith(1, {
         method: 'OutboundRequest',
+        params: { source: 'fetch' },
       });
-      expect(notify).toHaveBeenCalledWith({
+      expect(notify).toHaveBeenNthCalledWith(2, {
         method: 'OutboundResponse',
+        params: { source: 'fetch' },
+      });
+      expect(notify).toHaveBeenNthCalledWith(3, {
+        method: 'OutboundRequest',
+        params: { source: 'fetch' },
+      });
+      expect(notify).toHaveBeenNthCalledWith(4, {
+        method: 'OutboundResponse',
+        params: { source: 'fetch' },
       });
       expect(notify).toHaveBeenCalledTimes(4);
     });

--- a/packages/snaps-execution-environments/src/common/endowments/network.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/network.test.ts
@@ -12,7 +12,6 @@ describe('Network endowments', () => {
   describe('fetch', () => {
     beforeEach(() => {
       fetchMock.enableMocks();
-      factoryOptions.notify.mockClear();
     });
 
     afterEach(() => {
@@ -28,18 +27,19 @@ describe('Network endowments', () => {
     });
 
     it('send notification about outbound request and response', async () => {
+      const notify = jest.fn();
       const RESULT = 'OK';
       fetchMock.mockOnce(async () => Promise.resolve(RESULT));
-      const { fetch } = network.factory(factoryOptions);
+      const { fetch } = network.factory({ notify });
       const result = await (await fetch('foo.com')).text();
       expect(result).toStrictEqual(RESULT);
-      expect(factoryOptions.notify).toHaveBeenCalledWith({
+      expect(notify).toHaveBeenCalledWith({
         method: 'OutboundRequest',
       });
-      expect(factoryOptions.notify).toHaveBeenCalledWith({
+      expect(notify).toHaveBeenCalledWith({
         method: 'OutboundResponse',
       });
-      expect(factoryOptions.notify).toHaveBeenCalledTimes(4);
+      expect(notify).toHaveBeenCalledTimes(4);
     });
 
     it('can use AbortController normally', async () => {

--- a/packages/snaps-execution-environments/src/common/validation.ts
+++ b/packages/snaps-execution-environments/src/common/validation.ts
@@ -73,7 +73,7 @@ export const TerminateRequestArgumentsStruct = union([
 export const ExecuteSnapRequestArgumentsStruct = tuple([
   string(),
   string(),
-  optional(array(EndowmentStruct)),
+  array(EndowmentStruct),
 ]);
 
 export const SnapRpcRequestArgumentsStruct = tuple([


### PR DESCRIPTION
This PR adds notifications from the network access endowment that are sent during fetch. Calling `fetch` will result in `OutboundRequest` upfront and `OutboundResponse` once the promise resolves. Furthermore, once per response object, triggering an async action, e.g. `json()` will also trigger `OutboundRequest` upfront and `OutboundResponse` once the promise resolves. The notifications pause the request processing timer in the same way that requests via `snap.request` and `ethereum.request` pause the timer.

This PR also refactors the endowment creation slightly to make it take an options bag and always require an endowment array.

Closes https://github.com/MetaMask/snaps/issues/1755