### PR TITLE
Preparations for releasing from `main`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - rc/1.0.0
   pull_request:
 
 jobs:
@@ -29,8 +28,6 @@ jobs:
   publish-staging-simulator:
     name: Publish Snaps Simulator to `staging` folder
     needs: lint-build-test
-    # The `rc/1.0.0` branch does not have the `snaps-simulator` package, so we
-    # only run this job on the `main` branch.
     if: ${{ github.ref_name == 'main' }}
     permissions:
       contents: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -232,9 +232,7 @@ jobs:
   publish-test-snaps:
     name: Publish test snaps
     needs: is-test-snaps-release
-    # The `rc/1.0.0` branch does not have `test-snaps` package, so we only run
-    # this job on the `main` branch.
-    if: ${{ github.ref_name == 'main' && needs.is-test-snaps-release.outputs.IS_TEST_SNAPS_RELEASE == 'true' }}
+    if: ${{ needs.is-test-snaps-release.outputs.IS_TEST_SNAPS_RELEASE == 'true' }}
     permissions:
       contents: write
     uses: ./.github/workflows/publish-github-pages.yml
@@ -271,9 +269,7 @@ jobs:
   publish-simulator-versioned:
     name: Publish Snaps Simulator to `${{ needs.is-simulator-release.outputs.SIMULATOR_VERSION }}` folder
     needs: is-simulator-release
-    # The `rc/1.0.0` branch does not have the `snaps-simulator` package, so we
-    # only run this job on the `main` branch.
-    if: ${{ github.ref_name == 'main' && needs.is-simulator-release.outputs.IS_SIMULATOR_RELEASE == 'true' }}
+    if: ${{ needs.is-simulator-release.outputs.IS_SIMULATOR_RELEASE == 'true' }}
     permissions:
       contents: write
     uses: ./.github/workflows/publish-github-pages.yml
@@ -287,9 +283,7 @@ jobs:
   publish-simulator-latest:
     name: Publish Snaps Simulator to `latest` folder
     needs: is-simulator-release
-    # The `rc/1.0.0` branch does not have the `snaps-simulator` package, so we
-    # only run this job on the `main` branch.
-    if: ${{ github.ref_name == 'main' && needs.is-simulator-release.outputs.IS_SIMULATOR_RELEASE == 'true' }}
+    if: ${{ needs.is-simulator-release.outputs.IS_SIMULATOR_RELEASE == 'true' }}
     permissions:
       contents: write
     uses: ./.github/workflows/publish-github-pages.yml

--- a/scripts/get-release-tag.ts
+++ b/scripts/get-release-tag.ts
@@ -9,7 +9,7 @@ enum Tag {
 }
 
 /**
- * Get the release tag from the`package.json` version.
+ * Get the release tag from the `package.json` version.
  *
  * - If the version is a prerelease, the tag is `next`.
  * - Otherwise, the tag is `latest`.

--- a/scripts/get-release-tag.ts
+++ b/scripts/get-release-tag.ts
@@ -4,31 +4,22 @@ import { prerelease } from 'semver';
 import packageJson from '../package.json';
 
 enum Tag {
-  Flask = 'flask',
   Next = 'next',
   Latest = 'latest',
 }
 
 /**
- * Get the release tag from the current branch name and `package.json` version.
+ * Get the release tag from the`package.json` version.
  *
- * - If the branch name is `main`, the tag is `flask`.
- * - Otherwise, if the version is a prerelease, the tag is `next`.
+ * - If the version is a prerelease, the tag is `next`.
  * - Otherwise, the tag is `latest`.
  *
  * @returns The release tag.
  */
 export function main(): Tag {
-  const branchName = process.env.GITHUB_REF_NAME;
   const { version } = packageJson;
 
-  assert(branchName, 'GITHUB_REF_NAME must be set.');
   assert(version, '`package.json` must have a version.');
-
-  // Currently, Flask releases are deployed from the `main` branch.
-  if (branchName === 'main') {
-    return Tag.Flask;
-  }
 
   // Otherwise, we're on a stable branch, which may or may not be a prerelease.
   const prereleaseTag = prerelease(version);


### PR DESCRIPTION
Removes the notion of the RC branch from the CI workflows and the `get-release-tag` script.