### PR TITLE
Fix `onNameLookup` types

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FzEv7I4+3tYNzM6dcEEaoq3J3aH6l8WCo0bFp56hI3k=",
+    "shasum": "G2rm2hO0v2s3s8+9TP60kn0vfCthv+2qA8hLocUrFRI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "jX8PaE9Oi1FWnJsW2Dm71crLo2uBEksCNeYPphmoy0Y=",
+    "shasum": "xtN2sSzBepDW1UGaC3uQJjDey3k8RvuonRhxa4YxGP8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7ryoRHayMjd7Ws8C+806kGR3OMNQFryMvIXPp6cDRw8=",
+    "shasum": "gJojnhtYc12yok+LwffrM92NKZScnEEwLuTMDA4EVuw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "txKgxLDTD0dBYL6WQgZxUqwHTcQcUUNNPU9/oWVK4Kg=",
+    "shasum": "Lb8wMUhb5JQ5jf10jql4PN5AKOppchdgdiJ1ORrsBwI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0T4dTLDl+8OxbagVuXQ+hgE81KlmdxpZYWSShfw6+Hc=",
+    "shasum": "7RWnbaxT2OS4oUIkQ6D+SWpGvuODrbP0gLZPsGMbyVg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AVvItsFeFROPIhuZLuxiNc6egWLhbhJQR9//daxg8qQ=",
+    "shasum": "mx7HBswlJDtlB9+wONEtF2QQYqFMfJ/3GviwC1CpbAM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Gw+1DNkjLVuQfJbrVA2sG+lIgek5oEuk0jRdsd44Ky8=",
+    "shasum": "ctv54QNzSPIGW07gGoKAZgQ488x0gknVDIjowURzsiA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cZdsqMkePYvSOaFyIkpn3WchgN4Dk/tDvVEHRyjdHeQ=",
+    "shasum": "PnmC24D4sbFqoEP0XvcYfwiLsv4ggz+HzkDh0LJqQyQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-types/src/types.ts
+++ b/packages/snaps-types/src/types.ts
@@ -17,9 +17,11 @@ export type {
   AccountId,
   ChainId,
   OnCronjobHandler,
+  OnNameLookupHandler,
   OnRpcRequestHandler,
   OnTransactionHandler,
   OnTransactionResponse,
+  OnNameLookupResponse,
   OnInstallHandler,
   OnUpdateHandler,
 } from '@metamask/snaps-utils';

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -2,5 +2,5 @@
   "branches": 95.02,
   "functions": 100,
   "lines": 98.65,
-  "statements": 95.69
+  "statements": 95.7
 }

--- a/packages/snaps-utils/src/handlers.ts
+++ b/packages/snaps-utils/src/handlers.ts
@@ -194,7 +194,7 @@ export type OnNameLookupResponse =
 
 export type OnNameLookupArgs = {
   chainId: Caip2ChainId;
-} & ({ domain: string } | { address: string });
+} & ({ domain: string; address?: never } | { address: string; domain?: never });
 
 /**
  * The `onNameLookup` handler. This is called whenever content is entered

--- a/packages/snaps-utils/src/handlers.ts
+++ b/packages/snaps-utils/src/handlers.ts
@@ -188,8 +188,9 @@ export type HandlerFunction<Type extends SnapHandler> =
 export type OnNameLookupResponse =
   | {
       resolvedAddress: AccountAddress;
+      resolvedDomain?: never;
     }
-  | { resolvedDomain: string }
+  | { resolvedDomain: string; resolvedAddress?: never }
   | null;
 
 export type OnNameLookupArgs = {

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -5,6 +5,7 @@ import {
   VersionStruct,
   isValidSemVerRange,
 } from '@metamask/utils';
+import { ChainIdStruct } from 'src/namespace';
 import type { Infer, Struct } from 'superstruct';
 import {
   array,
@@ -138,6 +139,8 @@ export const SnapIdsStruct = refine(
 
 export type SnapIds = Infer<typeof SnapIdsStruct>;
 
+export const ChainIdsStruct = array(ChainIdStruct);
+
 /* eslint-disable @typescript-eslint/naming-convention */
 export const PermissionsStruct = type({
   'endowment:long-running': optional(object({})),
@@ -152,7 +155,7 @@ export const PermissionsStruct = type({
     object({ jobs: CronjobSpecificationArrayStruct }),
   ),
   'endowment:rpc': optional(RpcOriginsStruct),
-  'endowment:name-lookup': optional(object({})),
+  'endowment:name-lookup': optional(ChainIdsStruct),
   snap_dialog: optional(object({})),
   // TODO: Remove
   snap_confirm: optional(object({})),

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -5,7 +5,6 @@ import {
   VersionStruct,
   isValidSemVerRange,
 } from '@metamask/utils';
-import { ChainIdStruct } from 'src/namespace';
 import type { Infer, Struct } from 'superstruct';
 import {
   array,
@@ -30,6 +29,7 @@ import { isEqual } from '../array';
 import { CronjobSpecificationArrayStruct } from '../cronjob';
 import { SIP_6_MAGIC_VALUE, STATE_ENCRYPTION_MAGIC_VALUE } from '../entropy';
 import { RpcOriginsStruct } from '../json-rpc';
+import { ChainIdStruct } from '../namespace';
 import { SnapIdStruct } from '../snaps';
 import { NameStruct, NpmSnapFileNames } from '../types';
 


### PR DESCRIPTION
The types previously merged in don't work with snap code as pointed out by @matthewwalsh0, we also weren't doing the correct validation for the manifest. Updated code with the correct types.