### PR TITLE
Revert "Release 9.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "9.0.0",
+  "version": "8.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/create-snap/CHANGELOG.md
+++ b/packages/create-snap/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.37.4-flask.1]
 ### Changed
 - Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738), [#1694](https://github.com/MetaMask/snaps/pull/1694))
@@ -24,8 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@0.37.4-flask.1...@metamask/create-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@0.37.4-flask.1...HEAD
 [0.37.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@0.37.3-flask.1...@metamask/create-snap@0.37.4-flask.1
 [0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@0.37.2-flask.1...@metamask/create-snap@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/create-snap@0.37.2-flask.1

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/create-snap",
-  "version": "1.0.0",
+  "version": "0.37.4-flask.1",
   "description": "A CLI for creating MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/example-snaps",
-  "version": "1.0.0",
+  "version": "0.38.2-flask.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/examples/packages/bip32/CHANGELOG.md
+++ b/packages/examples/packages/bip32/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.37.3-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -23,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@0.37.3-flask.1...@metamask/bip32-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@0.37.3-flask.1...HEAD
 [0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@0.37.2-flask.1...@metamask/bip32-example-snap@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/bip32-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/bip32/package.json
+++ b/packages/examples/packages/bip32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/bip32-example-snap",
-  "version": "1.0.0",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_getBip32Entropy`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_getBip32Entropy`.",
   "proposedName": "BIP-32 Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "J3MpNxvOJdEwGq+zeIHh05yOsAoS8q2AqlTT5PLAkf8=",
+    "shasum": "G2rm2hO0v2s3s8+9TP60kn0vfCthv+2qA8hLocUrFRI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/CHANGELOG.md
+++ b/packages/examples/packages/bip44/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -28,8 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@0.38.1-flask.1...@metamask/bip44-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@0.38.1-flask.1...HEAD
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@0.38.0-flask.1...@metamask/bip44-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@0.37.2-flask.1...@metamask/bip44-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/bip44-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/bip44/package.json
+++ b/packages/examples/packages/bip44/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/bip44-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_getBip44Entropy`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_getBip44Entropy`.",
   "proposedName": "BIP-44 Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "JKHoUebJ9c2urnFcUO06lKbtCcAOW3CaRGSImdpDG34=",
+    "shasum": "xtN2sSzBepDW1UGaC3uQJjDey3k8RvuonRhxa4YxGP8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/CHANGELOG.md
+++ b/packages/examples/packages/browserify-plugin/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.37.3-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -20,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@0.37.3-flask.1...@metamask/browserify-plugin-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@0.37.3-flask.1...HEAD
 [0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@0.37.2-flask.1...@metamask/browserify-plugin-example-snap@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/browserify-plugin-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/browserify-plugin/package.json
+++ b/packages/examples/packages/browserify-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/browserify-plugin-example-snap",
-  "version": "1.0.0",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating how to use the Browserify plugin to bundle a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating how to use the Browserify plugin to bundle a snap.",
   "proposedName": "Browserify Plugin Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9Rwc+aO3oC1dHn3JIwXVlr6ONhV60NxZK//KDrt3mBk=",
+    "shasum": "xOODhSd8tm/DlFsi71Rg+zBBvna09C+4q5bGuQWcNC8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/CHANGELOG.md
+++ b/packages/examples/packages/browserify/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.1-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -19,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Browserify example snap ([#1632](https://github.com/MetaMask/snaps/pull/1632))
   - This snap demonstrates how to use the deprecated Browserify configuration format.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@0.38.1-flask.1...@metamask/browserify-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@0.38.1-flask.1...HEAD
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@0.38.0-flask.1...@metamask/browserify-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/browserify-example-snap@0.38.0-flask.1

--- a/packages/examples/packages/browserify/package.json
+++ b/packages/examples/packages/browserify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/browserify-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating how to use Browserify to bundle a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating how to use the Browserify plugin to bundle a snap.",
   "proposedName": "Browserify Plugin Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3mSghE7S6npYy/5vv/NFvnql9izqVeKSsIgmGES1Bwo=",
+    "shasum": "IhWWzU9xOVvn1C5t3VKdR2bdvuysJGTjdFlbRaGC8Bo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/CHANGELOG.md
+++ b/packages/examples/packages/cronjobs/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.1-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -25,8 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@0.38.1-flask.1...@metamask/cronjob-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@0.38.1-flask.1...HEAD
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@0.38.0-flask.1...@metamask/cronjob-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@0.37.2-flask.1...@metamask/cronjob-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/cronjob-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/cronjobs/package.json
+++ b/packages/examples/packages/cronjobs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/cronjob-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of cronjobs in snaps.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of cronjobs in snaps.",
   "proposedName": "Cronjob Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "rvezXlgNZfZl22VCm9paR8ZQBkEW6MMhsjHJsZ88mgU=",
+    "shasum": "HIglMr0rqI8ddttm1udyvrjs8lfIw9z6B4dA/xvkmkc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/CHANGELOG.md
+++ b/packages/examples/packages/dialogs/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -28,8 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@0.38.1-flask.1...@metamask/dialog-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@0.38.1-flask.1...HEAD
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@0.38.0-flask.1...@metamask/dialog-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@0.37.2-flask.1...@metamask/dialog-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/dialog-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/dialogs/package.json
+++ b/packages/examples/packages/dialogs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/dialog-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_dialog`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_dialog`.",
   "proposedName": "Dialog Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Tcm1oNE+DXYHjyz6Eeb1+SycfrpMQnEpJv+0++BoZss=",
+    "shasum": "gJojnhtYc12yok+LwffrM92NKZScnEEwLuTMDA4EVuw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/errors/CHANGELOG.md
+++ b/packages/examples/packages/errors/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -28,8 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@0.38.1-flask.1...@metamask/error-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@0.38.1-flask.1...HEAD
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@0.38.0-flask.1...@metamask/error-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@0.37.2-flask.1...@metamask/error-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/error-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/errors/package.json
+++ b/packages/examples/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/error-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of error handling in snaps.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/errors/snap.manifest.json
+++ b/packages/examples/packages/errors/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of error handling in snaps.",
   "proposedName": "Error Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Wa5LuPosJ5nAXu55PlzY9nk41VRuVmo3LcOdLaIbjq0=",
+    "shasum": "fRj3eRk7NIBp3Bd/Ji3rCIcMQy65psytCBFIQFo2G6s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/CHANGELOG.md
+++ b/packages/examples/packages/ethereum-provider/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.1-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -28,8 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@0.38.1-flask.1...@metamask/ethereum-provider-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@0.38.1-flask.1...HEAD
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@0.38.0-flask.1...@metamask/ethereum-provider-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@0.37.2-flask.1...@metamask/ethereum-provider-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/ethereum-provider-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/ethereum-provider/package.json
+++ b/packages/examples/packages/ethereum-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ethereum-provider-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of the Ethereum Provider API and `endowment:ethereum-provider` permission.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of the Ethereum Provider API and `endowment:ethereum-provider` permission.",
   "proposedName": "Ethereum Provider Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "CwJGR0Jll1DjOt3kpxD6l4utazQFokN95bqWCOToFKI=",
+    "shasum": "Ok99AlKnmOdPmD+tfDMFqErAncVG5thpFrt/G9J8IrI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/CHANGELOG.md
+++ b/packages/examples/packages/ethers-js/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -28,8 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@0.38.1-flask.1...@metamask/ethers-js-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@0.38.1-flask.1...HEAD
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@0.38.0-flask.1...@metamask/ethers-js-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@0.37.2-flask.1...@metamask/ethers-js-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/ethers-js-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/ethers-js/package.json
+++ b/packages/examples/packages/ethers-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ethers-js-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating how to use Ethers.js inside a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating how to use Ethers.js inside a snap.",
   "proposedName": "Ethers.js Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "QY3seNbkU81kQ25hpBICjcMUK41iI0tYUlwqsiWbVCo=",
+    "shasum": "yugwRyv+n2/Xap8CIftsrGljzb0y1Mid8sLtgqpgcC8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/CHANGELOG.md
+++ b/packages/examples/packages/get-entropy/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -28,8 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@0.38.1-flask.1...@metamask/get-entropy-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@0.38.1-flask.1...HEAD
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@0.38.0-flask.1...@metamask/get-entropy-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@0.37.2-flask.1...@metamask/get-entropy-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/get-entropy-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/get-entropy/package.json
+++ b/packages/examples/packages/get-entropy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/get-entropy-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_getEntropy`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_getEntropy`.",
   "proposedName": "Get Entropy Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "jz0qC13DGpmyhERi+4iQRk1EpogtRkOd5cE5T8uKb6I=",
+    "shasum": "Lb8wMUhb5JQ5jf10jql4PN5AKOppchdgdiJ1ORrsBwI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/CHANGELOG.md
+++ b/packages/examples/packages/get-locale/CHANGELOG.md
@@ -6,14 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.1-flask.1]
 ### Added
 - Add example snap for `snap_getLocale` ([#1684](https://github.com/MetaMask/snaps/pull/1684))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/get-locale-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/get-locale-example-snap@0.38.1-flask.1...@metamask/get-locale-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/get-locale-example-snap@0.38.1-flask.1...HEAD
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/get-locale-example-snap@0.38.1-flask.1

--- a/packages/examples/packages/get-locale/package.json
+++ b/packages/examples/packages/get-locale/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/get-locale-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_getLocale`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_getLocale`.",
   "proposedName": "Get Locale Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "XY2MC1SyQ2H5oBn47Tu9HSB/+pNFzYkNXVFSXY1jHco=",
+    "shasum": "7RWnbaxT2OS4oUIkQ6D+SWpGvuODrbP0gLZPsGMbyVg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/package.json
+++ b/packages/examples/packages/invoke-snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/invoke-snap-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "private": true,
   "description": "MetaMask example snaps demonstrating the use of `wallet_invokeSnap` to call a snap from another snap.",
   "repository": {

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/CHANGELOG.md
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -28,8 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@0.38.1-flask.1...@metamask/consumer-signer-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@0.38.1-flask.1...HEAD
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@0.38.0-flask.1...@metamask/consumer-signer-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@0.37.2-flask.1...@metamask/consumer-signer-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/consumer-signer-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/consumer-signer-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
   "proposedName": "Consumer Signer Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4h5TiQTb/0U11Eh6MSHVfIS+u4/jigOkK9vukcDhOUs=",
+    "shasum": "dAsWBb5feUBTmia31pirj2mGicDQ6F2h9QMs91XGk/0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/CHANGELOG.md
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -28,8 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@0.38.1-flask.1...@metamask/core-signer-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@0.38.1-flask.1...HEAD
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@0.38.0-flask.1...@metamask/core-signer-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@0.37.2-flask.1...@metamask/core-signer-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/core-signer-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/invoke-snap/packages/core-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-signer-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
   "proposedName": "Core Signer Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2NU8z5KfNVpKmOXojiY7l6SpbOLjXJua3nJ1cH6gdbo=",
+    "shasum": "mx7HBswlJDtlB9+wONEtF2QQYqFMfJ/3GviwC1CpbAM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/CHANGELOG.md
+++ b/packages/examples/packages/json-rpc/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.37.3-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -20,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@0.37.3-flask.1...@metamask/json-rpc-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@0.37.3-flask.1...HEAD
 [0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@0.37.2-flask.1...@metamask/json-rpc-example-snap@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/json-rpc-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/json-rpc/package.json
+++ b/packages/examples/packages/json-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/json-rpc-example-snap",
-  "version": "1.0.0",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating the use of the `endowment:rpc` permission.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.37.3-flask.1",
   "description": "An example snap to test JSON-RPC permissions.",
   "proposedName": "JSON-RPC Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "gKdBa0h+SZKNu6WFHFps5W1ly7WNTU2lrrOsyy7Z7VU=",
+    "shasum": "+vsF1ik/wdawqBPTJHUSH18JWmQVkGSDQnGtQogppEg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
+++ b/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
@@ -6,20 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.1-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
-### Added
+### Uncategorized
 - Add lifecycle hooks example snap ([#1645](https://github.com/MetaMask/snaps/pull/1645))
   - This snap demonstrates how to use the `onInstall` and `onUpdate` lifecycle hooks.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@0.38.1-flask.1...@metamask/lifecycle-hooks-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@0.38.1-flask.1...HEAD
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@0.38.0-flask.1...@metamask/lifecycle-hooks-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/lifecycle-hooks-example-snap@0.38.0-flask.1

--- a/packages/examples/packages/lifecycle-hooks/package.json
+++ b/packages/examples/packages/lifecycle-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/lifecycle-hooks-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of the `onInstall` and `onUpdate` lifecycle hooks.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of the `onInstall` and `onUpdate` lifecycle hooks.",
   "proposedName": "Lifecycle Hooks Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TszJ60KeknYWFD5tY/w/PMOk+cA5eeeaAkzyYbPqwYw=",
+    "shasum": "0QcTVXzV/zEAqp7Tffxy3hDvweMCSKfYp8GdESS84Dc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/CHANGELOG.md
+++ b/packages/examples/packages/manage-state/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -28,8 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@0.38.1-flask.1...@metamask/manage-state-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@0.38.1-flask.1...HEAD
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@0.38.0-flask.1...@metamask/manage-state-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@0.37.2-flask.1...@metamask/manage-state-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/manage-state-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/manage-state/package.json
+++ b/packages/examples/packages/manage-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/manage-state-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_manageState`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_manageState`.",
   "proposedName": "Manage State Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "56wgGzkHUCLNO3MxSciVCRIfy67gmEfBW6MeB0rMe5Q=",
+    "shasum": "ctv54QNzSPIGW07gGoKAZgQ488x0gknVDIjowURzsiA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/CHANGELOG.md
+++ b/packages/examples/packages/network-access/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.2-flask.1]
 ### Fixed
 - Fix network access example snap ([#1747](https://github.com/MetaMask/snaps/pull/1747))
@@ -32,8 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.38.2-flask.1...@metamask/network-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.38.2-flask.1...HEAD
 [0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.38.1-flask.1...@metamask/network-example-snap@0.38.2-flask.1
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.38.0-flask.1...@metamask/network-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.37.2-flask.1...@metamask/network-example-snap@0.38.0-flask.1

--- a/packages/examples/packages/network-access/package.json
+++ b/packages/examples/packages/network-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/network-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.2-flask.1",
   "description": "MetaMask example snap demonstrating the use of the `endowment:network-access` permission in snaps.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.38.2-flask.1",
   "description": "MetaMask example snap demonstrating the use of the `endowment:network-access` permission in snaps.",
   "proposedName": "Network Access Test Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6yhB3CDYFp1NILq/F8Y25mKCDRNdn1DjPYl8hUqd/Js=",
+    "shasum": "gietRn5VTciRfESWtWnTLKykNCZbTuIY7sRFhyTYkJI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/CHANGELOG.md
+++ b/packages/examples/packages/notifications/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -28,8 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@0.38.1-flask.1...@metamask/notification-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@0.38.1-flask.1...HEAD
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@0.38.0-flask.1...@metamask/notification-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@0.37.2-flask.1...@metamask/notification-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/notification-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/notifications/package.json
+++ b/packages/examples/packages/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/notification-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_notify`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of `snap_notify`.",
   "proposedName": "Notifications Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "uq9ZlrcyEVDZ3iAFoxI3j6Ocu4Pp6VVp7P+nMjVhE80=",
+    "shasum": "PnmC24D4sbFqoEP0XvcYfwiLsv4ggz+HzkDh0LJqQyQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/CHANGELOG.md
+++ b/packages/examples/packages/transaction-insights/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -28,8 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@0.38.1-flask.1...@metamask/insights-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@0.38.1-flask.1...HEAD
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@0.38.0-flask.1...@metamask/insights-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@0.37.2-flask.1...@metamask/insights-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/insights-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/transaction-insights/package.json
+++ b/packages/examples/packages/transaction-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/insights-example-snap",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of the Transaction Insights API.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "MetaMask example snap demonstrating the use of the Transaction Insights API.",
   "proposedName": "Insights Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8V8IDFAjnJro0x76n9qcAEHMQiWJXGEB33R8PzICy3E=",
+    "shasum": "xIGjReh51zxZwQa0KC47IMiWqvdKLp9b0o+WMxDqhR8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/CHANGELOG.md
+++ b/packages/examples/packages/wasm/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.37.3-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -20,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@0.37.3-flask.1...@metamask/wasm-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@0.37.3-flask.1...HEAD
 [0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@0.37.2-flask.1...@metamask/wasm-example-snap@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/wasm-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/wasm/package.json
+++ b/packages/examples/packages/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/wasm-example-snap",
-  "version": "1.0.0",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating the use of WebAssembly and the `endowment:webassembly` permission.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating the use of WebAssembly and the `endowment:webassembly` permission.",
   "proposedName": "WebAssembly Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "dbAcz7LgrYbcKyQ/mmLD6xFyfNTPCAeLiOXh9Yq922k=",
+    "shasum": "V7EPb/CWQjyOYgrHAYpabJByzSg9mpxuGFvzZnVMhaE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/CHANGELOG.md
+++ b/packages/examples/packages/webpack-plugin/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.37.3-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -20,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@0.37.3-flask.1...@metamask/webpack-plugin-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@0.37.3-flask.1...HEAD
 [0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@0.37.2-flask.1...@metamask/webpack-plugin-example-snap@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/webpack-plugin-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/webpack-plugin/package.json
+++ b/packages/examples/packages/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/webpack-plugin-example-snap",
-  "version": "1.0.0",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating how to use the Webpack plugin to bundle a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "0.37.3-flask.1",
   "description": "MetaMask example snap demonstrating how to use the Webpack plugin to bundle a snap.",
   "proposedName": "Webpack Plugin Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "QLJQP0A8+VtRdaJkwjbxy46olOzriIXteC8T4SCFczI=",
+    "shasum": "oj2ar7mKAfePJIJm3h0lm0dQ2JqX47I1K4SO1neLRk4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/rpc-methods/CHANGELOG.md
+++ b/packages/rpc-methods/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.3-flask.1]
 ### Changed
 - Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
@@ -37,8 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.38.3-flask.1...@metamask/rpc-methods@2.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.38.3-flask.1...HEAD
 [0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.38.2-flask.1...@metamask/rpc-methods@0.38.3-flask.1
 [0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.38.1-flask.1...@metamask/rpc-methods@0.38.2-flask.1
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.38.0-flask.1...@metamask/rpc-methods@0.38.1-flask.1

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/rpc-methods",
-  "version": "2.0.0",
+  "version": "0.38.3-flask.1",
   "description": "MetaMask Snap RPC method implementations.",
   "repository": {
     "type": "git",

--- a/packages/snaps-browserify-plugin/CHANGELOG.md
+++ b/packages/snaps-browserify-plugin/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.37.3-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -20,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@0.37.3-flask.1...@metamask/snaps-browserify-plugin@2.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@0.37.3-flask.1...HEAD
 [0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@0.37.2-flask.1...@metamask/snaps-browserify-plugin@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-browserify-plugin@0.37.2-flask.1

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-browserify-plugin",
-  "version": "2.0.0",
+  "version": "0.37.3-flask.1",
   "keywords": [
     "browserify-plugin"
   ],

--- a/packages/snaps-cli/CHANGELOG.md
+++ b/packages/snaps-cli/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.4-flask.1]
 ### Changed
 - Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738), [#1694](https://github.com/MetaMask/snaps/pull/1694))
@@ -47,8 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.4-flask.1...@metamask/snaps-cli@2.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.4-flask.1...HEAD
 [0.38.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.3-flask.1...@metamask/snaps-cli@0.38.4-flask.1
 [0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.2-flask.1...@metamask/snaps-cli@0.38.3-flask.1
 [0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.1-flask.1...@metamask/snaps-cli@0.38.2-flask.1

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-cli",
-  "version": "2.0.0",
+  "version": "0.38.4-flask.1",
   "description": "A CLI for developing MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-controllers/CHANGELOG.md
+++ b/packages/snaps-controllers/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.39.0-flask.1]
 ### Added
 - Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
@@ -51,8 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.39.0-flask.1...@metamask/snaps-controllers@2.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.39.0-flask.1...HEAD
 [0.39.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.38.3-flask.1...@metamask/snaps-controllers@0.39.0-flask.1
 [0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.38.2-flask.1...@metamask/snaps-controllers@0.38.3-flask.1
 [0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.38.1-flask.1...@metamask/snaps-controllers@0.38.2-flask.1

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-controllers",
-  "version": "2.0.0",
+  "version": "0.39.0-flask.1",
   "description": "Controllers for MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-execution-environments/CHANGELOG.md
+++ b/packages/snaps-execution-environments/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.39.0-flask.1]
 ### Added
 - Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
@@ -62,8 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.39.0-flask.1...@metamask/snaps-execution-environments@2.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.39.0-flask.1...HEAD
 [0.39.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.38.3-flask.1...@metamask/snaps-execution-environments@0.39.0-flask.1
 [0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.38.2-flask.1...@metamask/snaps-execution-environments@0.38.3-flask.1
 [0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.38.1-flask.1...@metamask/snaps-execution-environments@0.38.2-flask.1

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-execution-environments",
-  "version": "2.0.0",
+  "version": "0.39.0-flask.1",
   "description": "Snap sandbox environments for executing SES javascript",
   "repository": {
     "type": "git",

--- a/packages/snaps-jest/CHANGELOG.md
+++ b/packages/snaps-jest/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.37.5-flask.1]
 ### Changed
 - Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738), [#1694](https://github.com/MetaMask/snaps/pull/1694))
@@ -28,8 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.5-flask.1...@metamask/snaps-jest@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.5-flask.1...HEAD
 [0.37.5-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.4-flask.1...@metamask/snaps-jest@0.37.5-flask.1
 [0.37.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.3-flask.1...@metamask/snaps-jest@0.37.4-flask.1
 [0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.2-flask.1...@metamask/snaps-jest@0.37.3-flask.1

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-jest",
-  "version": "1.0.0",
+  "version": "0.37.5-flask.1",
   "description": "A Jest preset for end-to-end testing MetaMask Snaps, including a Jest environment, and a set of Jest matchers.",
   "sideEffects": false,
   "main": "./dist/cjs/index.js",

--- a/packages/snaps-rollup-plugin/CHANGELOG.md
+++ b/packages/snaps-rollup-plugin/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.37.3-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -20,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@0.37.3-flask.1...@metamask/snaps-rollup-plugin@2.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@0.37.3-flask.1...HEAD
 [0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@0.37.2-flask.1...@metamask/snaps-rollup-plugin@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-rollup-plugin@0.37.2-flask.1

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-rollup-plugin",
-  "version": "2.0.0",
+  "version": "0.37.3-flask.1",
   "keywords": [
     "rollup",
     "rollup-plugin"

--- a/packages/snaps-simulator/CHANGELOG.md
+++ b/packages/snaps-simulator/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.1-flask.1]
 ### Added
 - Add basic support for account RPC methods in snaps simulator ([#1710](https://github.com/MetaMask/snaps/pull/1710))
@@ -37,8 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@0.38.1-flask.1...@metamask/snaps-simulator@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@0.38.1-flask.1...HEAD
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@0.38.0-flask.1...@metamask/snaps-simulator@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@0.37.2-flask.1...@metamask/snaps-simulator@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-simulator@0.37.2-flask.1

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-simulator",
-  "version": "1.0.0",
+  "version": "0.38.1-flask.1",
   "description": "A simulator for MetaMask Snaps, to be used for testing and development",
   "homepage": "https://github.com/MetaMask/snaps#readme",
   "bugs": {

--- a/packages/snaps-types/CHANGELOG.md
+++ b/packages/snaps-types/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.3-flask.1]
 ### Added
 - Add `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
@@ -38,8 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.3-flask.1...@metamask/snaps-types@2.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.3-flask.1...HEAD
 [0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.2-flask.1...@metamask/snaps-types@0.38.3-flask.1
 [0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.1-flask.1...@metamask/snaps-types@0.38.2-flask.1
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.0-flask.1...@metamask/snaps-types@0.38.1-flask.1

--- a/packages/snaps-types/package.json
+++ b/packages/snaps-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-types",
-  "version": "2.0.0",
+  "version": "0.38.3-flask.1",
   "description": "TypeScript types for developing MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-ui/CHANGELOG.md
+++ b/packages/snaps-ui/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.37.5-flask.1]
 ### Changed
 - Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738), [#1694](https://github.com/MetaMask/snaps/pull/1694))
@@ -28,8 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.5-flask.1...@metamask/snaps-ui@2.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.5-flask.1...HEAD
 [0.37.5-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.4-flask.1...@metamask/snaps-ui@0.37.5-flask.1
 [0.37.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.3-flask.1...@metamask/snaps-ui@0.37.4-flask.1
 [0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.2-flask.1...@metamask/snaps-ui@0.37.3-flask.1

--- a/packages/snaps-ui/package.json
+++ b/packages/snaps-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-ui",
-  "version": "2.0.0",
+  "version": "0.37.5-flask.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-utils/CHANGELOG.md
+++ b/packages/snaps-utils/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.38.4-flask.1]
 ### Added
 - Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394), [#1759](https://github.com/MetaMask/snaps/pull/1759))
@@ -46,8 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.4-flask.1...@metamask/snaps-utils@2.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.4-flask.1...HEAD
 [0.38.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.3-flask.1...@metamask/snaps-utils@0.38.4-flask.1
 [0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.2-flask.1...@metamask/snaps-utils@0.38.3-flask.1
 [0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.1-flask.1...@metamask/snaps-utils@0.38.2-flask.1

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-utils",
-  "version": "2.0.0",
+  "version": "0.38.4-flask.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-webpack-plugin/CHANGELOG.md
+++ b/packages/snaps-webpack-plugin/CHANGELOG.md
@@ -6,13 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.37.4-flask.1]
-### Changed
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738), [#1694](https://github.com/MetaMask/snaps/pull/1694))
+### Uncategorized
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
 
 ## [0.37.3-flask.1]
 ### Fixed
@@ -24,8 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@0.37.4-flask.1...@metamask/snaps-webpack-plugin@2.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@0.37.4-flask.1...HEAD
 [0.37.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@0.37.3-flask.1...@metamask/snaps-webpack-plugin@0.37.4-flask.1
 [0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@0.37.2-flask.1...@metamask/snaps-webpack-plugin@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-webpack-plugin@0.37.2-flask.1

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-webpack-plugin",
-  "version": "2.0.0",
+  "version": "0.37.4-flask.1",
   "keywords": [
     "webpack",
     "plugin"

--- a/packages/test-snaps/CHANGELOG.md
+++ b/packages/test-snaps/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Changed
-- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
-
 ## [0.39.1-flask.1]
 ### Changed
 - Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
@@ -39,8 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix NPM package name of the network access snap ([#1621](https://github.com/MetaMask/snaps/pull/1621))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.39.1-flask.1...@metamask/test-snaps@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.39.1-flask.1...HEAD
 [0.39.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.39.0-flask.1...@metamask/test-snaps@0.39.1-flask.1
 [0.39.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.38.0-flask.1...@metamask/test-snaps@0.39.0-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.37.3-flask.1...@metamask/test-snaps@0.38.0-flask.1

--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-snaps",
-  "version": "1.0.0",
+  "version": "0.39.1-flask.1",
   "private": true,
   "description": "The test snaps website for MetaMask Snaps, used for end-to-end testing.",
   "repository": {


### PR DESCRIPTION
Reverts MetaMask/snaps#1767

Release failed because we forgot to change one version