### PR TITLE
Release 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/create-snap/CHANGELOG.md
+++ b/packages/create-snap/CHANGELOG.md
@@ -22,8 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/create-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/create-snap@0.37.4-flask.1...@metamask/create-snap@1.0.0
-[0.37.4-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/create-snap@0.37.3-flask.1...@metamask/create-snap@0.37.4-flask.1
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/create-snap@0.37.2-flask.1...@metamask/create-snap@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/create-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@0.37.4-flask.1...@metamask/create-snap@1.0.0
+[0.37.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@0.37.3-flask.1...@metamask/create-snap@0.37.4-flask.1
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@0.37.2-flask.1...@metamask/create-snap@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/create-snap@0.37.2-flask.1

--- a/packages/create-snap/CHANGELOG.md
+++ b/packages/create-snap/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+
 ## [0.37.4-flask.1]
 ### Changed
 - Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738), [#1694](https://github.com/MetaMask/snaps/pull/1694))
@@ -20,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@0.37.4-flask.1...HEAD
-[0.37.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@0.37.3-flask.1...@metamask/create-snap@0.37.4-flask.1
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@0.37.2-flask.1...@metamask/create-snap@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/create-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/create-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/create-snap@0.37.4-flask.1...@metamask/create-snap@1.0.0
+[0.37.4-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/create-snap@0.37.3-flask.1...@metamask/create-snap@0.37.4-flask.1
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/create-snap@0.37.2-flask.1...@metamask/create-snap@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/create-snap@0.37.2-flask.1

--- a/packages/create-snap/CHANGELOG.md
+++ b/packages/create-snap/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.37.4-flask.1]
 ### Changed

--- a/packages/create-snap/CHANGELOG.md
+++ b/packages/create-snap/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
+### Changed
+- Initial stable release from main branch
 
 ## [0.37.4-flask.1]
 ### Changed

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/create-snap",
-  "version": "0.37.4-flask.1",
+  "version": "1.0.0",
   "description": "A CLI for creating MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/example-snaps",
-  "version": "0.38.2-flask.1",
+  "version": "1.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/examples/packages/bip32/CHANGELOG.md
+++ b/packages/examples/packages/bip32/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.37.3-flask.1]
 ### Changed

--- a/packages/examples/packages/bip32/CHANGELOG.md
+++ b/packages/examples/packages/bip32/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps-skunkworks.git/pull/1759))
+- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps-skunkworks.git/pull/1394))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
+- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps-skunkworks.git/pull/1725))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+
 ## [0.37.3-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -19,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@0.37.3-flask.1...HEAD
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@0.37.2-flask.1...@metamask/bip32-example-snap@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/bip32-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/bip32-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/bip32-example-snap@0.37.3-flask.1...@metamask/bip32-example-snap@1.0.0
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/bip32-example-snap@0.37.2-flask.1...@metamask/bip32-example-snap@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/bip32-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/bip32/CHANGELOG.md
+++ b/packages/examples/packages/bip32/CHANGELOG.md
@@ -7,14 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
-- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
-- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps/pull/1725))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
+### Changed
+- Initial stable release from main branch
 
 ## [0.37.3-flask.1]
 ### Changed

--- a/packages/examples/packages/bip32/CHANGELOG.md
+++ b/packages/examples/packages/bip32/CHANGELOG.md
@@ -8,13 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps-skunkworks.git/pull/1759))
-- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps-skunkworks.git/pull/1394))
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
-- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps-skunkworks.git/pull/1725))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
+- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
+- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps/pull/1725))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
 
 ## [0.37.3-flask.1]
 ### Changed
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/bip32-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/bip32-example-snap@0.37.3-flask.1...@metamask/bip32-example-snap@1.0.0
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/bip32-example-snap@0.37.2-flask.1...@metamask/bip32-example-snap@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/bip32-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@0.37.3-flask.1...@metamask/bip32-example-snap@1.0.0
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@0.37.2-flask.1...@metamask/bip32-example-snap@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/bip32-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/bip32/package.json
+++ b/packages/examples/packages/bip32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/bip32-example-snap",
-  "version": "0.37.3-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of `snap_getBip32Entropy`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.3-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of `snap_getBip32Entropy`.",
   "proposedName": "BIP-32 Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "G2rm2hO0v2s3s8+9TP60kn0vfCthv+2qA8hLocUrFRI=",
+    "shasum": "J3MpNxvOJdEwGq+zeIHh05yOsAoS8q2AqlTT5PLAkf8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/CHANGELOG.md
+++ b/packages/examples/packages/bip44/CHANGELOG.md
@@ -7,14 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
-- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
-- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps/pull/1725))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/bip44/CHANGELOG.md
+++ b/packages/examples/packages/bip44/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps-skunkworks.git/pull/1759))
+- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps-skunkworks.git/pull/1394))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
+- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps-skunkworks.git/pull/1725))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -24,7 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@0.38.1-flask.1...HEAD
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@0.38.0-flask.1...@metamask/bip44-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@0.37.2-flask.1...@metamask/bip44-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/bip44-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/bip44-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/bip44-example-snap@0.38.1-flask.1...@metamask/bip44-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/bip44-example-snap@0.38.0-flask.1...@metamask/bip44-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/bip44-example-snap@0.37.2-flask.1...@metamask/bip44-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/bip44-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/bip44/CHANGELOG.md
+++ b/packages/examples/packages/bip44/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/bip44/CHANGELOG.md
+++ b/packages/examples/packages/bip44/CHANGELOG.md
@@ -8,13 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps-skunkworks.git/pull/1759))
-- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps-skunkworks.git/pull/1394))
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
-- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps-skunkworks.git/pull/1725))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
+- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
+- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps/pull/1725))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
 
 ## [0.38.1-flask.1]
 ### Changed
@@ -34,8 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/bip44-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/bip44-example-snap@0.38.1-flask.1...@metamask/bip44-example-snap@1.0.0
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/bip44-example-snap@0.38.0-flask.1...@metamask/bip44-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/bip44-example-snap@0.37.2-flask.1...@metamask/bip44-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/bip44-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@0.38.1-flask.1...@metamask/bip44-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@0.38.0-flask.1...@metamask/bip44-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@0.37.2-flask.1...@metamask/bip44-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/bip44-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/bip44/package.json
+++ b/packages/examples/packages/bip44/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/bip44-example-snap",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of `snap_getBip44Entropy`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of `snap_getBip44Entropy`.",
   "proposedName": "BIP-44 Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xtN2sSzBepDW1UGaC3uQJjDey3k8RvuonRhxa4YxGP8=",
+    "shasum": "JKHoUebJ9c2urnFcUO06lKbtCcAOW3CaRGSImdpDG34=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/CHANGELOG.md
+++ b/packages/examples/packages/browserify-plugin/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+### Changed
+- Initial stable release from main branch
 
 ## [0.37.3-flask.1]
 ### Fixed

--- a/packages/examples/packages/browserify-plugin/CHANGELOG.md
+++ b/packages/examples/packages/browserify-plugin/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.37.3-flask.1]
 ### Fixed

--- a/packages/examples/packages/browserify-plugin/CHANGELOG.md
+++ b/packages/examples/packages/browserify-plugin/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
 
 ## [0.37.3-flask.1]
 ### Fixed
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/browserify-plugin-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/browserify-plugin-example-snap@0.37.3-flask.1...@metamask/browserify-plugin-example-snap@1.0.0
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/browserify-plugin-example-snap@0.37.2-flask.1...@metamask/browserify-plugin-example-snap@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/browserify-plugin-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@0.37.3-flask.1...@metamask/browserify-plugin-example-snap@1.0.0
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@0.37.2-flask.1...@metamask/browserify-plugin-example-snap@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/browserify-plugin-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/browserify-plugin/CHANGELOG.md
+++ b/packages/examples/packages/browserify-plugin/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+
 ## [0.37.3-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -16,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@0.37.3-flask.1...HEAD
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@0.37.2-flask.1...@metamask/browserify-plugin-example-snap@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/browserify-plugin-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/browserify-plugin-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/browserify-plugin-example-snap@0.37.3-flask.1...@metamask/browserify-plugin-example-snap@1.0.0
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/browserify-plugin-example-snap@0.37.2-flask.1...@metamask/browserify-plugin-example-snap@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/browserify-plugin-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/browserify-plugin/package.json
+++ b/packages/examples/packages/browserify-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/browserify-plugin-example-snap",
-  "version": "0.37.3-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating how to use the Browserify plugin to bundle a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.3-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating how to use the Browserify plugin to bundle a snap.",
   "proposedName": "Browserify Plugin Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xOODhSd8tm/DlFsi71Rg+zBBvna09C+4q5bGuQWcNC8=",
+    "shasum": "9Rwc+aO3oC1dHn3JIwXVlr6ONhV60NxZK//KDrt3mBk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/CHANGELOG.md
+++ b/packages/examples/packages/browserify/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+
 ## [0.38.1-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -15,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Browserify example snap ([#1632](https://github.com/MetaMask/snaps/pull/1632))
   - This snap demonstrates how to use the deprecated Browserify configuration format.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@0.38.1-flask.1...HEAD
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@0.38.0-flask.1...@metamask/browserify-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/browserify-example-snap@0.38.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/browserify-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/browserify-example-snap@0.38.1-flask.1...@metamask/browserify-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/browserify-example-snap@0.38.0-flask.1...@metamask/browserify-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/browserify-example-snap@0.38.0-flask.1

--- a/packages/examples/packages/browserify/CHANGELOG.md
+++ b/packages/examples/packages/browserify/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.1-flask.1]
 ### Fixed

--- a/packages/examples/packages/browserify/CHANGELOG.md
+++ b/packages/examples/packages/browserify/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
 
 ## [0.38.1-flask.1]
 ### Fixed
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Browserify example snap ([#1632](https://github.com/MetaMask/snaps/pull/1632))
   - This snap demonstrates how to use the deprecated Browserify configuration format.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/browserify-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/browserify-example-snap@0.38.1-flask.1...@metamask/browserify-example-snap@1.0.0
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/browserify-example-snap@0.38.0-flask.1...@metamask/browserify-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/browserify-example-snap@0.38.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@0.38.1-flask.1...@metamask/browserify-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@0.38.0-flask.1...@metamask/browserify-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/browserify-example-snap@0.38.0-flask.1

--- a/packages/examples/packages/browserify/CHANGELOG.md
+++ b/packages/examples/packages/browserify/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.1-flask.1]
 ### Fixed

--- a/packages/examples/packages/browserify/package.json
+++ b/packages/examples/packages/browserify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/browserify-example-snap",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating how to use Browserify to bundle a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating how to use the Browserify plugin to bundle a snap.",
   "proposedName": "Browserify Plugin Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "IhWWzU9xOVvn1C5t3VKdR2bdvuysJGTjdFlbRaGC8Bo=",
+    "shasum": "3mSghE7S6npYy/5vv/NFvnql9izqVeKSsIgmGES1Bwo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/CHANGELOG.md
+++ b/packages/examples/packages/cronjobs/CHANGELOG.md
@@ -7,11 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.1-flask.1]
 ### Fixed

--- a/packages/examples/packages/cronjobs/CHANGELOG.md
+++ b/packages/examples/packages/cronjobs/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.1-flask.1]
 ### Fixed

--- a/packages/examples/packages/cronjobs/CHANGELOG.md
+++ b/packages/examples/packages/cronjobs/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
 
 ## [0.38.1-flask.1]
 ### Fixed
@@ -28,8 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/cronjob-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/cronjob-example-snap@0.38.1-flask.1...@metamask/cronjob-example-snap@1.0.0
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/cronjob-example-snap@0.38.0-flask.1...@metamask/cronjob-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/cronjob-example-snap@0.37.2-flask.1...@metamask/cronjob-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/cronjob-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@0.38.1-flask.1...@metamask/cronjob-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@0.38.0-flask.1...@metamask/cronjob-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@0.37.2-flask.1...@metamask/cronjob-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/cronjob-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/cronjobs/CHANGELOG.md
+++ b/packages/examples/packages/cronjobs/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+
 ## [0.38.1-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -21,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@0.38.1-flask.1...HEAD
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@0.38.0-flask.1...@metamask/cronjob-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@0.37.2-flask.1...@metamask/cronjob-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/cronjob-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/cronjob-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/cronjob-example-snap@0.38.1-flask.1...@metamask/cronjob-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/cronjob-example-snap@0.38.0-flask.1...@metamask/cronjob-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/cronjob-example-snap@0.37.2-flask.1...@metamask/cronjob-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/cronjob-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/cronjobs/package.json
+++ b/packages/examples/packages/cronjobs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/cronjob-example-snap",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of cronjobs in snaps.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of cronjobs in snaps.",
   "proposedName": "Cronjob Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "HIglMr0rqI8ddttm1udyvrjs8lfIw9z6B4dA/xvkmkc=",
+    "shasum": "rvezXlgNZfZl22VCm9paR8ZQBkEW6MMhsjHJsZ88mgU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/CHANGELOG.md
+++ b/packages/examples/packages/dialogs/CHANGELOG.md
@@ -8,13 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps-skunkworks.git/pull/1759))
-- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps-skunkworks.git/pull/1394))
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
-- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps-skunkworks.git/pull/1725))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
+- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
+- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps/pull/1725))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
 
 ## [0.38.1-flask.1]
 ### Changed
@@ -34,8 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/dialog-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/dialog-example-snap@0.38.1-flask.1...@metamask/dialog-example-snap@1.0.0
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/dialog-example-snap@0.38.0-flask.1...@metamask/dialog-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/dialog-example-snap@0.37.2-flask.1...@metamask/dialog-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/dialog-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@0.38.1-flask.1...@metamask/dialog-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@0.38.0-flask.1...@metamask/dialog-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@0.37.2-flask.1...@metamask/dialog-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/dialog-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/dialogs/CHANGELOG.md
+++ b/packages/examples/packages/dialogs/CHANGELOG.md
@@ -7,14 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
-- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
-- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps/pull/1725))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/dialogs/CHANGELOG.md
+++ b/packages/examples/packages/dialogs/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/dialogs/CHANGELOG.md
+++ b/packages/examples/packages/dialogs/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps-skunkworks.git/pull/1759))
+- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps-skunkworks.git/pull/1394))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
+- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps-skunkworks.git/pull/1725))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -24,7 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@0.38.1-flask.1...HEAD
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@0.38.0-flask.1...@metamask/dialog-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@0.37.2-flask.1...@metamask/dialog-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/dialog-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/dialog-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/dialog-example-snap@0.38.1-flask.1...@metamask/dialog-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/dialog-example-snap@0.38.0-flask.1...@metamask/dialog-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/dialog-example-snap@0.37.2-flask.1...@metamask/dialog-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/dialog-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/dialogs/package.json
+++ b/packages/examples/packages/dialogs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/dialog-example-snap",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of `snap_dialog`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of `snap_dialog`.",
   "proposedName": "Dialog Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "gJojnhtYc12yok+LwffrM92NKZScnEEwLuTMDA4EVuw=",
+    "shasum": "Tcm1oNE+DXYHjyz6Eeb1+SycfrpMQnEpJv+0++BoZss=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/errors/CHANGELOG.md
+++ b/packages/examples/packages/errors/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Changed
+- Initial stable release from main branch
+
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -24,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@0.38.1-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@0.38.1-flask.1...@metamask/error-example-snap@1.0.0
 [0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@0.38.0-flask.1...@metamask/error-example-snap@0.38.1-flask.1
 [0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@0.37.2-flask.1...@metamask/error-example-snap@0.38.0-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/error-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/errors/CHANGELOG.md
+++ b/packages/examples/packages/errors/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/errors/package.json
+++ b/packages/examples/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/error-example-snap",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of error handling in snaps.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/errors/snap.manifest.json
+++ b/packages/examples/packages/errors/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of error handling in snaps.",
   "proposedName": "Error Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "fRj3eRk7NIBp3Bd/Ji3rCIcMQy65psytCBFIQFo2G6s=",
+    "shasum": "Wa5LuPosJ5nAXu55PlzY9nk41VRuVmo3LcOdLaIbjq0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/CHANGELOG.md
+++ b/packages/examples/packages/ethereum-provider/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Add basic support for account RPC methods in snaps simulator ([#1710](https://github.com/MetaMask/snaps-skunkworks.git/pull/1710))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+
 ## [0.38.1-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -24,7 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@0.38.1-flask.1...HEAD
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@0.38.0-flask.1...@metamask/ethereum-provider-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@0.37.2-flask.1...@metamask/ethereum-provider-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/ethereum-provider-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/ethereum-provider-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/ethereum-provider-example-snap@0.38.1-flask.1...@metamask/ethereum-provider-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/ethereum-provider-example-snap@0.38.0-flask.1...@metamask/ethereum-provider-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/ethereum-provider-example-snap@0.37.2-flask.1...@metamask/ethereum-provider-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/ethereum-provider-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/ethereum-provider/CHANGELOG.md
+++ b/packages/examples/packages/ethereum-provider/CHANGELOG.md
@@ -7,12 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
-- Add basic support for account RPC methods in snaps simulator ([#1710](https://github.com/MetaMask/snaps/pull/1710))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.1-flask.1]
 ### Fixed

--- a/packages/examples/packages/ethereum-provider/CHANGELOG.md
+++ b/packages/examples/packages/ethereum-provider/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.1-flask.1]
 ### Fixed

--- a/packages/examples/packages/ethereum-provider/CHANGELOG.md
+++ b/packages/examples/packages/ethereum-provider/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
-- Add basic support for account RPC methods in snaps simulator ([#1710](https://github.com/MetaMask/snaps-skunkworks.git/pull/1710))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+- Add basic support for account RPC methods in snaps simulator ([#1710](https://github.com/MetaMask/snaps/pull/1710))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
 
 ## [0.38.1-flask.1]
 ### Fixed
@@ -32,8 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/ethereum-provider-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/ethereum-provider-example-snap@0.38.1-flask.1...@metamask/ethereum-provider-example-snap@1.0.0
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/ethereum-provider-example-snap@0.38.0-flask.1...@metamask/ethereum-provider-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/ethereum-provider-example-snap@0.37.2-flask.1...@metamask/ethereum-provider-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/ethereum-provider-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@0.38.1-flask.1...@metamask/ethereum-provider-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@0.38.0-flask.1...@metamask/ethereum-provider-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@0.37.2-flask.1...@metamask/ethereum-provider-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/ethereum-provider-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/ethereum-provider/package.json
+++ b/packages/examples/packages/ethereum-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ethereum-provider-example-snap",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of the Ethereum Provider API and `endowment:ethereum-provider` permission.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of the Ethereum Provider API and `endowment:ethereum-provider` permission.",
   "proposedName": "Ethereum Provider Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Ok99AlKnmOdPmD+tfDMFqErAncVG5thpFrt/G9J8IrI=",
+    "shasum": "CwJGR0Jll1DjOt3kpxD6l4utazQFokN95bqWCOToFKI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/CHANGELOG.md
+++ b/packages/examples/packages/ethers-js/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
 
 ## [0.38.1-flask.1]
 ### Changed
@@ -31,8 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/ethers-js-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/ethers-js-example-snap@0.38.1-flask.1...@metamask/ethers-js-example-snap@1.0.0
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/ethers-js-example-snap@0.38.0-flask.1...@metamask/ethers-js-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/ethers-js-example-snap@0.37.2-flask.1...@metamask/ethers-js-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/ethers-js-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@0.38.1-flask.1...@metamask/ethers-js-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@0.38.0-flask.1...@metamask/ethers-js-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@0.37.2-flask.1...@metamask/ethers-js-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/ethers-js-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/ethers-js/CHANGELOG.md
+++ b/packages/examples/packages/ethers-js/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/ethers-js/CHANGELOG.md
+++ b/packages/examples/packages/ethers-js/CHANGELOG.md
@@ -7,11 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/ethers-js/CHANGELOG.md
+++ b/packages/examples/packages/ethers-js/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -24,7 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@0.38.1-flask.1...HEAD
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@0.38.0-flask.1...@metamask/ethers-js-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@0.37.2-flask.1...@metamask/ethers-js-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/ethers-js-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/ethers-js-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/ethers-js-example-snap@0.38.1-flask.1...@metamask/ethers-js-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/ethers-js-example-snap@0.38.0-flask.1...@metamask/ethers-js-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/ethers-js-example-snap@0.37.2-flask.1...@metamask/ethers-js-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/ethers-js-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/ethers-js/package.json
+++ b/packages/examples/packages/ethers-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ethers-js-example-snap",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating how to use Ethers.js inside a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating how to use Ethers.js inside a snap.",
   "proposedName": "Ethers.js Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "yugwRyv+n2/Xap8CIftsrGljzb0y1Mid8sLtgqpgcC8=",
+    "shasum": "QY3seNbkU81kQ25hpBICjcMUK41iI0tYUlwqsiWbVCo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/CHANGELOG.md
+++ b/packages/examples/packages/get-entropy/CHANGELOG.md
@@ -8,13 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps-skunkworks.git/pull/1759))
-- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps-skunkworks.git/pull/1394))
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
-- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps-skunkworks.git/pull/1725))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
+- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
+- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps/pull/1725))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
 
 ## [0.38.1-flask.1]
 ### Changed
@@ -34,8 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/get-entropy-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/get-entropy-example-snap@0.38.1-flask.1...@metamask/get-entropy-example-snap@1.0.0
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/get-entropy-example-snap@0.38.0-flask.1...@metamask/get-entropy-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/get-entropy-example-snap@0.37.2-flask.1...@metamask/get-entropy-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/get-entropy-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@0.38.1-flask.1...@metamask/get-entropy-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@0.38.0-flask.1...@metamask/get-entropy-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@0.37.2-flask.1...@metamask/get-entropy-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/get-entropy-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/get-entropy/CHANGELOG.md
+++ b/packages/examples/packages/get-entropy/CHANGELOG.md
@@ -7,14 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
-- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
-- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps/pull/1725))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/get-entropy/CHANGELOG.md
+++ b/packages/examples/packages/get-entropy/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps-skunkworks.git/pull/1759))
+- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps-skunkworks.git/pull/1394))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
+- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps-skunkworks.git/pull/1725))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -24,7 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@0.38.1-flask.1...HEAD
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@0.38.0-flask.1...@metamask/get-entropy-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@0.37.2-flask.1...@metamask/get-entropy-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/get-entropy-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/get-entropy-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/get-entropy-example-snap@0.38.1-flask.1...@metamask/get-entropy-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/get-entropy-example-snap@0.38.0-flask.1...@metamask/get-entropy-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/get-entropy-example-snap@0.37.2-flask.1...@metamask/get-entropy-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/get-entropy-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/get-entropy/CHANGELOG.md
+++ b/packages/examples/packages/get-entropy/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/get-entropy/package.json
+++ b/packages/examples/packages/get-entropy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/get-entropy-example-snap",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of `snap_getEntropy`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of `snap_getEntropy`.",
   "proposedName": "Get Entropy Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Lb8wMUhb5JQ5jf10jql4PN5AKOppchdgdiJ1ORrsBwI=",
+    "shasum": "jz0qC13DGpmyhERi+4iQRk1EpogtRkOd5cE5T8uKb6I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/CHANGELOG.md
+++ b/packages/examples/packages/get-locale/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.1-flask.1]
 ### Added

--- a/packages/examples/packages/get-locale/CHANGELOG.md
+++ b/packages/examples/packages/get-locale/CHANGELOG.md
@@ -7,14 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
-- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
-- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps/pull/1725))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.1-flask.1]
 ### Added

--- a/packages/examples/packages/get-locale/CHANGELOG.md
+++ b/packages/examples/packages/get-locale/CHANGELOG.md
@@ -6,9 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps-skunkworks.git/pull/1759))
+- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps-skunkworks.git/pull/1394))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
+- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps-skunkworks.git/pull/1725))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+
 ## [0.38.1-flask.1]
 ### Added
 - Add example snap for `snap_getLocale` ([#1684](https://github.com/MetaMask/snaps/pull/1684))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/get-locale-example-snap@0.38.1-flask.1...HEAD
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/get-locale-example-snap@0.38.1-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/get-locale-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/get-locale-example-snap@0.38.1-flask.1...@metamask/get-locale-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/get-locale-example-snap@0.38.1-flask.1

--- a/packages/examples/packages/get-locale/CHANGELOG.md
+++ b/packages/examples/packages/get-locale/CHANGELOG.md
@@ -8,18 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps-skunkworks.git/pull/1759))
-- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps-skunkworks.git/pull/1394))
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
-- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps-skunkworks.git/pull/1725))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
+- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
+- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps/pull/1725))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
 
 ## [0.38.1-flask.1]
 ### Added
 - Add example snap for `snap_getLocale` ([#1684](https://github.com/MetaMask/snaps/pull/1684))
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/get-locale-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/get-locale-example-snap@0.38.1-flask.1...@metamask/get-locale-example-snap@1.0.0
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/get-locale-example-snap@0.38.1-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/get-locale-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/get-locale-example-snap@0.38.1-flask.1...@metamask/get-locale-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/get-locale-example-snap@0.38.1-flask.1

--- a/packages/examples/packages/get-locale/package.json
+++ b/packages/examples/packages/get-locale/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/get-locale-example-snap",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of `snap_getLocale`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of `snap_getLocale`.",
   "proposedName": "Get Locale Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7RWnbaxT2OS4oUIkQ6D+SWpGvuODrbP0gLZPsGMbyVg=",
+    "shasum": "XY2MC1SyQ2H5oBn47Tu9HSB/+pNFzYkNXVFSXY1jHco=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/package.json
+++ b/packages/examples/packages/invoke-snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/invoke-snap-example-snap",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "private": true,
   "description": "MetaMask example snaps demonstrating the use of `wallet_invokeSnap` to call a snap from another snap.",
   "repository": {

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/CHANGELOG.md
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -24,7 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@0.38.1-flask.1...HEAD
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@0.38.0-flask.1...@metamask/consumer-signer-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@0.37.2-flask.1...@metamask/consumer-signer-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/consumer-signer-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/consumer-signer-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/consumer-signer-example-snap@0.38.1-flask.1...@metamask/consumer-signer-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/consumer-signer-example-snap@0.38.0-flask.1...@metamask/consumer-signer-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/consumer-signer-example-snap@0.37.2-flask.1...@metamask/consumer-signer-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/consumer-signer-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/CHANGELOG.md
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
 
 ## [0.38.1-flask.1]
 ### Changed
@@ -31,8 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/consumer-signer-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/consumer-signer-example-snap@0.38.1-flask.1...@metamask/consumer-signer-example-snap@1.0.0
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/consumer-signer-example-snap@0.38.0-flask.1...@metamask/consumer-signer-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/consumer-signer-example-snap@0.37.2-flask.1...@metamask/consumer-signer-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/consumer-signer-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@0.38.1-flask.1...@metamask/consumer-signer-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@0.38.0-flask.1...@metamask/consumer-signer-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@0.37.2-flask.1...@metamask/consumer-signer-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/consumer-signer-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/CHANGELOG.md
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/CHANGELOG.md
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/CHANGELOG.md
@@ -7,11 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/consumer-signer-example-snap",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
   "proposedName": "Consumer Signer Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "dAsWBb5feUBTmia31pirj2mGicDQ6F2h9QMs91XGk/0=",
+    "shasum": "4h5TiQTb/0U11Eh6MSHVfIS+u4/jigOkK9vukcDhOUs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/CHANGELOG.md
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps-skunkworks.git/pull/1759))
+- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps-skunkworks.git/pull/1394))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
+- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps-skunkworks.git/pull/1725))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -24,7 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@0.38.1-flask.1...HEAD
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@0.38.0-flask.1...@metamask/core-signer-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@0.37.2-flask.1...@metamask/core-signer-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/core-signer-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/core-signer-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/core-signer-example-snap@0.38.1-flask.1...@metamask/core-signer-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/core-signer-example-snap@0.38.0-flask.1...@metamask/core-signer-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/core-signer-example-snap@0.37.2-flask.1...@metamask/core-signer-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/core-signer-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/invoke-snap/packages/core-signer/CHANGELOG.md
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/CHANGELOG.md
@@ -7,14 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
-- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
-- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps/pull/1725))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/invoke-snap/packages/core-signer/CHANGELOG.md
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/CHANGELOG.md
@@ -8,13 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps-skunkworks.git/pull/1759))
-- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps-skunkworks.git/pull/1394))
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
-- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps-skunkworks.git/pull/1725))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
+- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
+- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps/pull/1725))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
 
 ## [0.38.1-flask.1]
 ### Changed
@@ -34,8 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/core-signer-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/core-signer-example-snap@0.38.1-flask.1...@metamask/core-signer-example-snap@1.0.0
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/core-signer-example-snap@0.38.0-flask.1...@metamask/core-signer-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/core-signer-example-snap@0.37.2-flask.1...@metamask/core-signer-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/core-signer-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@0.38.1-flask.1...@metamask/core-signer-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@0.38.0-flask.1...@metamask/core-signer-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@0.37.2-flask.1...@metamask/core-signer-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/core-signer-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/invoke-snap/packages/core-signer/CHANGELOG.md
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/invoke-snap/packages/core-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-signer-example-snap",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
   "proposedName": "Core Signer Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "mx7HBswlJDtlB9+wONEtF2QQYqFMfJ/3GviwC1CpbAM=",
+    "shasum": "2NU8z5KfNVpKmOXojiY7l6SpbOLjXJua3nJ1cH6gdbo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/CHANGELOG.md
+++ b/packages/examples/packages/json-rpc/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+### Changed
+- Initial stable release from main branch
 
 ## [0.37.3-flask.1]
 ### Fixed

--- a/packages/examples/packages/json-rpc/CHANGELOG.md
+++ b/packages/examples/packages/json-rpc/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+
 ## [0.37.3-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -16,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@0.37.3-flask.1...HEAD
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@0.37.2-flask.1...@metamask/json-rpc-example-snap@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/json-rpc-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/json-rpc-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/json-rpc-example-snap@0.37.3-flask.1...@metamask/json-rpc-example-snap@1.0.0
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/json-rpc-example-snap@0.37.2-flask.1...@metamask/json-rpc-example-snap@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/json-rpc-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/json-rpc/CHANGELOG.md
+++ b/packages/examples/packages/json-rpc/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.37.3-flask.1]
 ### Fixed

--- a/packages/examples/packages/json-rpc/CHANGELOG.md
+++ b/packages/examples/packages/json-rpc/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
 
 ## [0.37.3-flask.1]
 ### Fixed
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/json-rpc-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/json-rpc-example-snap@0.37.3-flask.1...@metamask/json-rpc-example-snap@1.0.0
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/json-rpc-example-snap@0.37.2-flask.1...@metamask/json-rpc-example-snap@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/json-rpc-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@0.37.3-flask.1...@metamask/json-rpc-example-snap@1.0.0
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@0.37.2-flask.1...@metamask/json-rpc-example-snap@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/json-rpc-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/json-rpc/package.json
+++ b/packages/examples/packages/json-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/json-rpc-example-snap",
-  "version": "0.37.3-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of the `endowment:rpc` permission.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.3-flask.1",
+  "version": "1.0.0",
   "description": "An example snap to test JSON-RPC permissions.",
   "proposedName": "JSON-RPC Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+vsF1ik/wdawqBPTJHUSH18JWmQVkGSDQnGtQogppEg=",
+    "shasum": "gKdBa0h+SZKNu6WFHFps5W1ly7WNTU2lrrOsyy7Z7VU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
+++ b/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+
 ## [0.38.1-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -15,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add lifecycle hooks example snap ([#1645](https://github.com/MetaMask/snaps/pull/1645))
   - This snap demonstrates how to use the `onInstall` and `onUpdate` lifecycle hooks.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@0.38.1-flask.1...HEAD
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@0.38.0-flask.1...@metamask/lifecycle-hooks-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/lifecycle-hooks-example-snap@0.38.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/lifecycle-hooks-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/lifecycle-hooks-example-snap@0.38.1-flask.1...@metamask/lifecycle-hooks-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/lifecycle-hooks-example-snap@0.38.0-flask.1...@metamask/lifecycle-hooks-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/lifecycle-hooks-example-snap@0.38.0-flask.1

--- a/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
+++ b/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
@@ -7,11 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.1-flask.1]
 ### Fixed

--- a/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
+++ b/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.1-flask.1]
 ### Fixed

--- a/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
+++ b/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
 
 ## [0.38.1-flask.1]
 ### Fixed
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add lifecycle hooks example snap ([#1645](https://github.com/MetaMask/snaps/pull/1645))
   - This snap demonstrates how to use the `onInstall` and `onUpdate` lifecycle hooks.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/lifecycle-hooks-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/lifecycle-hooks-example-snap@0.38.1-flask.1...@metamask/lifecycle-hooks-example-snap@1.0.0
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/lifecycle-hooks-example-snap@0.38.0-flask.1...@metamask/lifecycle-hooks-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/lifecycle-hooks-example-snap@0.38.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@0.38.1-flask.1...@metamask/lifecycle-hooks-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@0.38.0-flask.1...@metamask/lifecycle-hooks-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/lifecycle-hooks-example-snap@0.38.0-flask.1

--- a/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
+++ b/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
 
 ## [0.38.0-flask.1]
-### Uncategorized
+### Added
 - Add lifecycle hooks example snap ([#1645](https://github.com/MetaMask/snaps/pull/1645))
   - This snap demonstrates how to use the `onInstall` and `onUpdate` lifecycle hooks.
 

--- a/packages/examples/packages/lifecycle-hooks/package.json
+++ b/packages/examples/packages/lifecycle-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/lifecycle-hooks-example-snap",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of the `onInstall` and `onUpdate` lifecycle hooks.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of the `onInstall` and `onUpdate` lifecycle hooks.",
   "proposedName": "Lifecycle Hooks Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0QcTVXzV/zEAqp7Tffxy3hDvweMCSKfYp8GdESS84Dc=",
+    "shasum": "TszJ60KeknYWFD5tY/w/PMOk+cA5eeeaAkzyYbPqwYw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/CHANGELOG.md
+++ b/packages/examples/packages/manage-state/CHANGELOG.md
@@ -8,13 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps-skunkworks.git/pull/1759))
-- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps-skunkworks.git/pull/1394))
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
-- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps-skunkworks.git/pull/1725))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
+- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
+- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps/pull/1725))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
 
 ## [0.38.1-flask.1]
 ### Changed
@@ -34,8 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/manage-state-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/manage-state-example-snap@0.38.1-flask.1...@metamask/manage-state-example-snap@1.0.0
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/manage-state-example-snap@0.38.0-flask.1...@metamask/manage-state-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/manage-state-example-snap@0.37.2-flask.1...@metamask/manage-state-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/manage-state-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@0.38.1-flask.1...@metamask/manage-state-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@0.38.0-flask.1...@metamask/manage-state-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@0.37.2-flask.1...@metamask/manage-state-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/manage-state-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/manage-state/CHANGELOG.md
+++ b/packages/examples/packages/manage-state/CHANGELOG.md
@@ -7,14 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
-- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
-- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps/pull/1725))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/manage-state/CHANGELOG.md
+++ b/packages/examples/packages/manage-state/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/manage-state/CHANGELOG.md
+++ b/packages/examples/packages/manage-state/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps-skunkworks.git/pull/1759))
+- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps-skunkworks.git/pull/1394))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
+- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps-skunkworks.git/pull/1725))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -24,7 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@0.38.1-flask.1...HEAD
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@0.38.0-flask.1...@metamask/manage-state-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@0.37.2-flask.1...@metamask/manage-state-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/manage-state-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/manage-state-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/manage-state-example-snap@0.38.1-flask.1...@metamask/manage-state-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/manage-state-example-snap@0.38.0-flask.1...@metamask/manage-state-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/manage-state-example-snap@0.37.2-flask.1...@metamask/manage-state-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/manage-state-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/manage-state/package.json
+++ b/packages/examples/packages/manage-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/manage-state-example-snap",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of `snap_manageState`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of `snap_manageState`.",
   "proposedName": "Manage State Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ctv54QNzSPIGW07gGoKAZgQ488x0gknVDIjowURzsiA=",
+    "shasum": "56wgGzkHUCLNO3MxSciVCRIfy67gmEfBW6MeB0rMe5Q=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/CHANGELOG.md
+++ b/packages/examples/packages/network-access/CHANGELOG.md
@@ -30,9 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/network-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/network-example-snap@0.38.2-flask.1...@metamask/network-example-snap@1.0.0
-[0.38.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/network-example-snap@0.38.1-flask.1...@metamask/network-example-snap@0.38.2-flask.1
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/network-example-snap@0.38.0-flask.1...@metamask/network-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/network-example-snap@0.37.2-flask.1...@metamask/network-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/network-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.38.2-flask.1...@metamask/network-example-snap@1.0.0
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.38.1-flask.1...@metamask/network-example-snap@0.38.2-flask.1
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.38.0-flask.1...@metamask/network-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.37.2-flask.1...@metamask/network-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/network-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/network-access/CHANGELOG.md
+++ b/packages/examples/packages/network-access/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.2-flask.1]
 ### Fixed

--- a/packages/examples/packages/network-access/CHANGELOG.md
+++ b/packages/examples/packages/network-access/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.2-flask.1]
 ### Fixed

--- a/packages/examples/packages/network-access/CHANGELOG.md
+++ b/packages/examples/packages/network-access/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+
 ## [0.38.2-flask.1]
 ### Fixed
 - Fix network access example snap ([#1747](https://github.com/MetaMask/snaps/pull/1747))
@@ -28,8 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.38.2-flask.1...HEAD
-[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.38.1-flask.1...@metamask/network-example-snap@0.38.2-flask.1
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.38.0-flask.1...@metamask/network-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@0.37.2-flask.1...@metamask/network-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/network-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/network-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/network-example-snap@0.38.2-flask.1...@metamask/network-example-snap@1.0.0
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/network-example-snap@0.38.1-flask.1...@metamask/network-example-snap@0.38.2-flask.1
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/network-example-snap@0.38.0-flask.1...@metamask/network-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/network-example-snap@0.37.2-flask.1...@metamask/network-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/network-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/network-access/package.json
+++ b/packages/examples/packages/network-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/network-example-snap",
-  "version": "0.38.2-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of the `endowment:network-access` permission in snaps.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.2-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of the `endowment:network-access` permission in snaps.",
   "proposedName": "Network Access Test Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "gietRn5VTciRfESWtWnTLKykNCZbTuIY7sRFhyTYkJI=",
+    "shasum": "6yhB3CDYFp1NILq/F8Y25mKCDRNdn1DjPYl8hUqd/Js=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/CHANGELOG.md
+++ b/packages/examples/packages/notifications/CHANGELOG.md
@@ -8,13 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps-skunkworks.git/pull/1759))
-- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps-skunkworks.git/pull/1394))
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
-- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps-skunkworks.git/pull/1725))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
+- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
+- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps/pull/1725))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
 
 ## [0.38.1-flask.1]
 ### Changed
@@ -34,8 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/notification-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/notification-example-snap@0.38.1-flask.1...@metamask/notification-example-snap@1.0.0
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/notification-example-snap@0.38.0-flask.1...@metamask/notification-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/notification-example-snap@0.37.2-flask.1...@metamask/notification-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/notification-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@0.38.1-flask.1...@metamask/notification-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@0.38.0-flask.1...@metamask/notification-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@0.37.2-flask.1...@metamask/notification-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/notification-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/notifications/CHANGELOG.md
+++ b/packages/examples/packages/notifications/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps-skunkworks.git/pull/1759))
+- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps-skunkworks.git/pull/1394))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
+- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps-skunkworks.git/pull/1725))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -24,7 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@0.38.1-flask.1...HEAD
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@0.38.0-flask.1...@metamask/notification-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@0.37.2-flask.1...@metamask/notification-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/notification-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/notification-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/notification-example-snap@0.38.1-flask.1...@metamask/notification-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/notification-example-snap@0.38.0-flask.1...@metamask/notification-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/notification-example-snap@0.37.2-flask.1...@metamask/notification-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/notification-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/notifications/CHANGELOG.md
+++ b/packages/examples/packages/notifications/CHANGELOG.md
@@ -7,14 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Fix `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
-- Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
-- Remove business-logic callbacks from `manageAccounts` ([#1725](https://github.com/MetaMask/snaps/pull/1725))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
+### Changed
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/notifications/package.json
+++ b/packages/examples/packages/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/notification-example-snap",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of `snap_notify`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of `snap_notify`.",
   "proposedName": "Notifications Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "PnmC24D4sbFqoEP0XvcYfwiLsv4ggz+HzkDh0LJqQyQ=",
+    "shasum": "uq9ZlrcyEVDZ3iAFoxI3j6Ocu4Pp6VVp7P+nMjVhE80=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/CHANGELOG.md
+++ b/packages/examples/packages/rollup-plugin/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Changed
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
+
 ## [0.37.3-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -16,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/rollup-plugin-example-snap@0.37.3-flask.1...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/rollup-plugin-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/rollup-plugin-example-snap@0.37.3-flask.1...@metamask/rollup-plugin-example-snap@1.0.0
 [0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/rollup-plugin-example-snap@0.37.2-flask.1...@metamask/rollup-plugin-example-snap@0.37.3-flask.1
 [0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/rollup-plugin-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/rollup-plugin/package.json
+++ b/packages/examples/packages/rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/rollup-plugin-example-snap",
-  "version": "0.37.3-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating how to use the Rollup plugin to bundle a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.3-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating how to use the Rollup plugin to bundle a snap.",
   "proposedName": "Rollup Plugin Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VurGsycbOqs1vfMZAfETX2Cqh1ZWeq8HMsAX15NGYoY=",
+    "shasum": "mTvk8AhVg/XsDgwHxadpcOQQiKiPtrKjcF5uY5f2Eac=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/CHANGELOG.md
+++ b/packages/examples/packages/transaction-insights/CHANGELOG.md
@@ -7,11 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
+### Changed
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.1-flask.1]
 ### Changed

--- a/packages/examples/packages/transaction-insights/CHANGELOG.md
+++ b/packages/examples/packages/transaction-insights/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+
 ## [0.38.1-flask.1]
 ### Changed
 - Use `polyfills` option for specifying Node.js polyfills ([#1650](https://github.com/MetaMask/snaps/pull/1650))
@@ -24,7 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@0.38.1-flask.1...HEAD
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@0.38.0-flask.1...@metamask/insights-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@0.37.2-flask.1...@metamask/insights-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/insights-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/insights-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/insights-example-snap@0.38.1-flask.1...@metamask/insights-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/insights-example-snap@0.38.0-flask.1...@metamask/insights-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/insights-example-snap@0.37.2-flask.1...@metamask/insights-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/insights-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/transaction-insights/CHANGELOG.md
+++ b/packages/examples/packages/transaction-insights/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps-skunkworks.git/pull/1739))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps-skunkworks.git/pull/1738))
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps-skunkworks.git/pull/1694))
+- Bump @metamask/eth-sig-util from 6.0.0 to 6.0.1 ([#1739](https://github.com/MetaMask/snaps/pull/1739))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
 
 ## [0.38.1-flask.1]
 ### Changed
@@ -31,8 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/insights-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/insights-example-snap@0.38.1-flask.1...@metamask/insights-example-snap@1.0.0
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/insights-example-snap@0.38.0-flask.1...@metamask/insights-example-snap@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/insights-example-snap@0.37.2-flask.1...@metamask/insights-example-snap@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/insights-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@0.38.1-flask.1...@metamask/insights-example-snap@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@0.38.0-flask.1...@metamask/insights-example-snap@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@0.37.2-flask.1...@metamask/insights-example-snap@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/insights-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/transaction-insights/package.json
+++ b/packages/examples/packages/transaction-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/insights-example-snap",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of the Transaction Insights API.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of the Transaction Insights API.",
   "proposedName": "Insights Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xIGjReh51zxZwQa0KC47IMiWqvdKLp9b0o+WMxDqhR8=",
+    "shasum": "8V8IDFAjnJro0x76n9qcAEHMQiWJXGEB33R8PzICy3E=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/CHANGELOG.md
+++ b/packages/examples/packages/wasm/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+
 ## [0.37.3-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -16,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@0.37.3-flask.1...HEAD
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@0.37.2-flask.1...@metamask/wasm-example-snap@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/wasm-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/wasm-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/wasm-example-snap@0.37.3-flask.1...@metamask/wasm-example-snap@1.0.0
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/wasm-example-snap@0.37.2-flask.1...@metamask/wasm-example-snap@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/wasm-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/wasm/CHANGELOG.md
+++ b/packages/examples/packages/wasm/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
 
 ## [0.37.3-flask.1]
 ### Fixed
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/wasm-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/wasm-example-snap@0.37.3-flask.1...@metamask/wasm-example-snap@1.0.0
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/wasm-example-snap@0.37.2-flask.1...@metamask/wasm-example-snap@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/wasm-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@0.37.3-flask.1...@metamask/wasm-example-snap@1.0.0
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@0.37.2-flask.1...@metamask/wasm-example-snap@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/wasm-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/wasm/CHANGELOG.md
+++ b/packages/examples/packages/wasm/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+### Changed
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.37.3-flask.1]
 ### Fixed

--- a/packages/examples/packages/wasm/package.json
+++ b/packages/examples/packages/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/wasm-example-snap",
-  "version": "0.37.3-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of WebAssembly and the `endowment:webassembly` permission.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.3-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating the use of WebAssembly and the `endowment:webassembly` permission.",
   "proposedName": "WebAssembly Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "V7EPb/CWQjyOYgrHAYpabJByzSg9mpxuGFvzZnVMhaE=",
+    "shasum": "dbAcz7LgrYbcKyQ/mmLD6xFyfNTPCAeLiOXh9Yq922k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/CHANGELOG.md
+++ b/packages/examples/packages/webpack-plugin/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Uncategorized
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
 
 ## [0.37.3-flask.1]
 ### Fixed
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/webpack-plugin-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/webpack-plugin-example-snap@0.37.3-flask.1...@metamask/webpack-plugin-example-snap@1.0.0
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/webpack-plugin-example-snap@0.37.2-flask.1...@metamask/webpack-plugin-example-snap@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/webpack-plugin-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@0.37.3-flask.1...@metamask/webpack-plugin-example-snap@1.0.0
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@0.37.2-flask.1...@metamask/webpack-plugin-example-snap@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/webpack-plugin-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/webpack-plugin/CHANGELOG.md
+++ b/packages/examples/packages/webpack-plugin/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+### Uncategorized
+- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps-skunkworks.git/pull/1702))
+
 ## [0.37.3-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -16,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@0.37.3-flask.1...HEAD
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@0.37.2-flask.1...@metamask/webpack-plugin-example-snap@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/webpack-plugin-example-snap@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/webpack-plugin-example-snap@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/webpack-plugin-example-snap@0.37.3-flask.1...@metamask/webpack-plugin-example-snap@1.0.0
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/webpack-plugin-example-snap@0.37.2-flask.1...@metamask/webpack-plugin-example-snap@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/webpack-plugin-example-snap@0.37.2-flask.1

--- a/packages/examples/packages/webpack-plugin/CHANGELOG.md
+++ b/packages/examples/packages/webpack-plugin/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- Bump WebdriverIO ([#1702](https://github.com/MetaMask/snaps/pull/1702))
+### Changed
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.37.3-flask.1]
 ### Fixed

--- a/packages/examples/packages/webpack-plugin/package.json
+++ b/packages/examples/packages/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/webpack-plugin-example-snap",
-  "version": "0.37.3-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating how to use the Webpack plugin to bundle a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.3-flask.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating how to use the Webpack plugin to bundle a snap.",
   "proposedName": "Webpack Plugin Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "oj2ar7mKAfePJIJm3h0lm0dQ2JqX47I1K4SO1neLRk4=",
+    "shasum": "QLJQP0A8+VtRdaJkwjbxy46olOzriIXteC8T4SCFczI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/rpc-methods/CHANGELOG.md
+++ b/packages/rpc-methods/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
 ## [0.38.3-flask.1]
 ### Changed
 - Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
@@ -33,9 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.38.3-flask.1...HEAD
-[0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.38.2-flask.1...@metamask/rpc-methods@0.38.3-flask.1
-[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.38.1-flask.1...@metamask/rpc-methods@0.38.2-flask.1
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.38.0-flask.1...@metamask/rpc-methods@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.37.2-flask.1...@metamask/rpc-methods@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/rpc-methods@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/rpc-methods@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/rpc-methods@0.38.3-flask.1...@metamask/rpc-methods@2.0.0
+[0.38.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/rpc-methods@0.38.2-flask.1...@metamask/rpc-methods@0.38.3-flask.1
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/rpc-methods@0.38.1-flask.1...@metamask/rpc-methods@0.38.2-flask.1
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/rpc-methods@0.38.0-flask.1...@metamask/rpc-methods@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/rpc-methods@0.37.2-flask.1...@metamask/rpc-methods@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/rpc-methods@0.37.2-flask.1

--- a/packages/rpc-methods/CHANGELOG.md
+++ b/packages/rpc-methods/CHANGELOG.md
@@ -35,10 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/rpc-methods@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/rpc-methods@0.38.3-flask.1...@metamask/rpc-methods@2.0.0
-[0.38.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/rpc-methods@0.38.2-flask.1...@metamask/rpc-methods@0.38.3-flask.1
-[0.38.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/rpc-methods@0.38.1-flask.1...@metamask/rpc-methods@0.38.2-flask.1
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/rpc-methods@0.38.0-flask.1...@metamask/rpc-methods@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/rpc-methods@0.37.2-flask.1...@metamask/rpc-methods@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/rpc-methods@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.38.3-flask.1...@metamask/rpc-methods@2.0.0
+[0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.38.2-flask.1...@metamask/rpc-methods@0.38.3-flask.1
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.38.1-flask.1...@metamask/rpc-methods@0.38.2-flask.1
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.38.0-flask.1...@metamask/rpc-methods@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/rpc-methods@0.37.2-flask.1...@metamask/rpc-methods@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/rpc-methods@0.37.2-flask.1

--- a/packages/rpc-methods/CHANGELOG.md
+++ b/packages/rpc-methods/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.0.0]
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.3-flask.1]
 ### Changed

--- a/packages/rpc-methods/CHANGELOG.md
+++ b/packages/rpc-methods/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.3-flask.1]
 ### Changed

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/rpc-methods",
-  "version": "0.38.3-flask.1",
+  "version": "2.0.0",
   "description": "MetaMask Snap RPC method implementations.",
   "repository": {
     "type": "git",

--- a/packages/snaps-browserify-plugin/CHANGELOG.md
+++ b/packages/snaps-browserify-plugin/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.37.3-flask.1]
 ### Fixed

--- a/packages/snaps-browserify-plugin/CHANGELOG.md
+++ b/packages/snaps-browserify-plugin/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.0.0]
+### Changed
+- Initial stable release from main branch
 
 ## [0.37.3-flask.1]
 ### Fixed

--- a/packages/snaps-browserify-plugin/CHANGELOG.md
+++ b/packages/snaps-browserify-plugin/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
 ## [0.37.3-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -16,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@0.37.3-flask.1...HEAD
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@0.37.2-flask.1...@metamask/snaps-browserify-plugin@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-browserify-plugin@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-browserify-plugin@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-browserify-plugin@0.37.3-flask.1...@metamask/snaps-browserify-plugin@2.0.0
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-browserify-plugin@0.37.2-flask.1...@metamask/snaps-browserify-plugin@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-browserify-plugin@0.37.2-flask.1

--- a/packages/snaps-browserify-plugin/CHANGELOG.md
+++ b/packages/snaps-browserify-plugin/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-browserify-plugin@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-browserify-plugin@0.37.3-flask.1...@metamask/snaps-browserify-plugin@2.0.0
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-browserify-plugin@0.37.2-flask.1...@metamask/snaps-browserify-plugin@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-browserify-plugin@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@0.37.3-flask.1...@metamask/snaps-browserify-plugin@2.0.0
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@0.37.2-flask.1...@metamask/snaps-browserify-plugin@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-browserify-plugin@0.37.2-flask.1

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-browserify-plugin",
-  "version": "0.37.3-flask.1",
+  "version": "2.0.0",
   "keywords": [
     "browserify-plugin"
   ],

--- a/packages/snaps-cli/CHANGELOG.md
+++ b/packages/snaps-cli/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.4-flask.1]
 ### Changed

--- a/packages/snaps-cli/CHANGELOG.md
+++ b/packages/snaps-cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.0.0]
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.4-flask.1]
 ### Changed

--- a/packages/snaps-cli/CHANGELOG.md
+++ b/packages/snaps-cli/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
 ## [0.38.4-flask.1]
 ### Changed
 - Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738), [#1694](https://github.com/MetaMask/snaps/pull/1694))
@@ -43,9 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.4-flask.1...HEAD
-[0.38.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.3-flask.1...@metamask/snaps-cli@0.38.4-flask.1
-[0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.2-flask.1...@metamask/snaps-cli@0.38.3-flask.1
-[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.1-flask.1...@metamask/snaps-cli@0.38.2-flask.1
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.0-flask.1...@metamask/snaps-cli@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-cli@0.38.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-cli@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-cli@0.38.4-flask.1...@metamask/snaps-cli@2.0.0
+[0.38.4-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-cli@0.38.3-flask.1...@metamask/snaps-cli@0.38.4-flask.1
+[0.38.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-cli@0.38.2-flask.1...@metamask/snaps-cli@0.38.3-flask.1
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-cli@0.38.1-flask.1...@metamask/snaps-cli@0.38.2-flask.1
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-cli@0.38.0-flask.1...@metamask/snaps-cli@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-cli@0.38.0-flask.1

--- a/packages/snaps-cli/CHANGELOG.md
+++ b/packages/snaps-cli/CHANGELOG.md
@@ -45,10 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-cli@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-cli@0.38.4-flask.1...@metamask/snaps-cli@2.0.0
-[0.38.4-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-cli@0.38.3-flask.1...@metamask/snaps-cli@0.38.4-flask.1
-[0.38.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-cli@0.38.2-flask.1...@metamask/snaps-cli@0.38.3-flask.1
-[0.38.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-cli@0.38.1-flask.1...@metamask/snaps-cli@0.38.2-flask.1
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-cli@0.38.0-flask.1...@metamask/snaps-cli@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-cli@0.38.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.4-flask.1...@metamask/snaps-cli@2.0.0
+[0.38.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.3-flask.1...@metamask/snaps-cli@0.38.4-flask.1
+[0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.2-flask.1...@metamask/snaps-cli@0.38.3-flask.1
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.1-flask.1...@metamask/snaps-cli@0.38.2-flask.1
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@0.38.0-flask.1...@metamask/snaps-cli@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-cli@0.38.0-flask.1

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-cli",
-  "version": "0.38.4-flask.1",
+  "version": "2.0.0",
   "description": "A CLI for developing MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-controllers/CHANGELOG.md
+++ b/packages/snaps-controllers/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.0.0]
+### Changed
+- Initial stable release from main branch
 
 ## [0.39.0-flask.1]
 ### Added

--- a/packages/snaps-controllers/CHANGELOG.md
+++ b/packages/snaps-controllers/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
 ## [0.39.0-flask.1]
 ### Added
 - Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
@@ -47,10 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.39.0-flask.1...HEAD
-[0.39.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.38.3-flask.1...@metamask/snaps-controllers@0.39.0-flask.1
-[0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.38.2-flask.1...@metamask/snaps-controllers@0.38.3-flask.1
-[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.38.1-flask.1...@metamask/snaps-controllers@0.38.2-flask.1
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.38.0-flask.1...@metamask/snaps-controllers@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.37.2-flask.1...@metamask/snaps-controllers@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-controllers@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-controllers@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-controllers@0.39.0-flask.1...@metamask/snaps-controllers@2.0.0
+[0.39.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-controllers@0.38.3-flask.1...@metamask/snaps-controllers@0.39.0-flask.1
+[0.38.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-controllers@0.38.2-flask.1...@metamask/snaps-controllers@0.38.3-flask.1
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-controllers@0.38.1-flask.1...@metamask/snaps-controllers@0.38.2-flask.1
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-controllers@0.38.0-flask.1...@metamask/snaps-controllers@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-controllers@0.37.2-flask.1...@metamask/snaps-controllers@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-controllers@0.37.2-flask.1

--- a/packages/snaps-controllers/CHANGELOG.md
+++ b/packages/snaps-controllers/CHANGELOG.md
@@ -49,11 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-controllers@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-controllers@0.39.0-flask.1...@metamask/snaps-controllers@2.0.0
-[0.39.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-controllers@0.38.3-flask.1...@metamask/snaps-controllers@0.39.0-flask.1
-[0.38.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-controllers@0.38.2-flask.1...@metamask/snaps-controllers@0.38.3-flask.1
-[0.38.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-controllers@0.38.1-flask.1...@metamask/snaps-controllers@0.38.2-flask.1
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-controllers@0.38.0-flask.1...@metamask/snaps-controllers@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-controllers@0.37.2-flask.1...@metamask/snaps-controllers@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-controllers@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.39.0-flask.1...@metamask/snaps-controllers@2.0.0
+[0.39.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.38.3-flask.1...@metamask/snaps-controllers@0.39.0-flask.1
+[0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.38.2-flask.1...@metamask/snaps-controllers@0.38.3-flask.1
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.38.1-flask.1...@metamask/snaps-controllers@0.38.2-flask.1
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.38.0-flask.1...@metamask/snaps-controllers@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@0.37.2-flask.1...@metamask/snaps-controllers@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-controllers@0.37.2-flask.1

--- a/packages/snaps-controllers/CHANGELOG.md
+++ b/packages/snaps-controllers/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.39.0-flask.1]
 ### Added

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-controllers",
-  "version": "0.39.0-flask.1",
+  "version": "2.0.0",
   "description": "Controllers for MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-execution-environments/CHANGELOG.md
+++ b/packages/snaps-execution-environments/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.0.0]
+### Changed
+- Initial stable release from main branch
 
 ## [0.39.0-flask.1]
 ### Added

--- a/packages/snaps-execution-environments/CHANGELOG.md
+++ b/packages/snaps-execution-environments/CHANGELOG.md
@@ -60,12 +60,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-execution-environments@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-execution-environments@0.39.0-flask.1...@metamask/snaps-execution-environments@2.0.0
-[0.39.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-execution-environments@0.38.3-flask.1...@metamask/snaps-execution-environments@0.39.0-flask.1
-[0.38.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-execution-environments@0.38.2-flask.1...@metamask/snaps-execution-environments@0.38.3-flask.1
-[0.38.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-execution-environments@0.38.1-flask.1...@metamask/snaps-execution-environments@0.38.2-flask.1
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-execution-environments@0.38.0-flask.1...@metamask/snaps-execution-environments@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-execution-environments@0.37.3-flask.1...@metamask/snaps-execution-environments@0.38.0-flask.1
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-execution-environments@0.37.2-flask.1...@metamask/snaps-execution-environments@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-execution-environments@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.39.0-flask.1...@metamask/snaps-execution-environments@2.0.0
+[0.39.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.38.3-flask.1...@metamask/snaps-execution-environments@0.39.0-flask.1
+[0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.38.2-flask.1...@metamask/snaps-execution-environments@0.38.3-flask.1
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.38.1-flask.1...@metamask/snaps-execution-environments@0.38.2-flask.1
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.38.0-flask.1...@metamask/snaps-execution-environments@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.37.3-flask.1...@metamask/snaps-execution-environments@0.38.0-flask.1
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.37.2-flask.1...@metamask/snaps-execution-environments@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-execution-environments@0.37.2-flask.1

--- a/packages/snaps-execution-environments/CHANGELOG.md
+++ b/packages/snaps-execution-environments/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.39.0-flask.1]
 ### Added

--- a/packages/snaps-execution-environments/CHANGELOG.md
+++ b/packages/snaps-execution-environments/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
 ## [0.39.0-flask.1]
 ### Added
 - Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394))
@@ -58,11 +60,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.39.0-flask.1...HEAD
-[0.39.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.38.3-flask.1...@metamask/snaps-execution-environments@0.39.0-flask.1
-[0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.38.2-flask.1...@metamask/snaps-execution-environments@0.38.3-flask.1
-[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.38.1-flask.1...@metamask/snaps-execution-environments@0.38.2-flask.1
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.38.0-flask.1...@metamask/snaps-execution-environments@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.37.3-flask.1...@metamask/snaps-execution-environments@0.38.0-flask.1
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@0.37.2-flask.1...@metamask/snaps-execution-environments@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-execution-environments@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-execution-environments@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-execution-environments@0.39.0-flask.1...@metamask/snaps-execution-environments@2.0.0
+[0.39.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-execution-environments@0.38.3-flask.1...@metamask/snaps-execution-environments@0.39.0-flask.1
+[0.38.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-execution-environments@0.38.2-flask.1...@metamask/snaps-execution-environments@0.38.3-flask.1
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-execution-environments@0.38.1-flask.1...@metamask/snaps-execution-environments@0.38.2-flask.1
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-execution-environments@0.38.0-flask.1...@metamask/snaps-execution-environments@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-execution-environments@0.37.3-flask.1...@metamask/snaps-execution-environments@0.38.0-flask.1
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-execution-environments@0.37.2-flask.1...@metamask/snaps-execution-environments@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-execution-environments@0.37.2-flask.1

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-execution-environments",
-  "version": "0.39.0-flask.1",
+  "version": "2.0.0",
   "description": "Snap sandbox environments for executing SES javascript",
   "repository": {
     "type": "git",

--- a/packages/snaps-jest/CHANGELOG.md
+++ b/packages/snaps-jest/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.37.5-flask.1]
 ### Changed

--- a/packages/snaps-jest/CHANGELOG.md
+++ b/packages/snaps-jest/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
+### Changed
+- Initial stable release from main branch
 
 ## [0.37.5-flask.1]
 ### Changed

--- a/packages/snaps-jest/CHANGELOG.md
+++ b/packages/snaps-jest/CHANGELOG.md
@@ -26,9 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-jest@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-jest@0.37.5-flask.1...@metamask/snaps-jest@1.0.0
-[0.37.5-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-jest@0.37.4-flask.1...@metamask/snaps-jest@0.37.5-flask.1
-[0.37.4-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-jest@0.37.3-flask.1...@metamask/snaps-jest@0.37.4-flask.1
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-jest@0.37.2-flask.1...@metamask/snaps-jest@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-jest@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.5-flask.1...@metamask/snaps-jest@1.0.0
+[0.37.5-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.4-flask.1...@metamask/snaps-jest@0.37.5-flask.1
+[0.37.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.3-flask.1...@metamask/snaps-jest@0.37.4-flask.1
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.2-flask.1...@metamask/snaps-jest@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-jest@0.37.2-flask.1

--- a/packages/snaps-jest/CHANGELOG.md
+++ b/packages/snaps-jest/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+
 ## [0.37.5-flask.1]
 ### Changed
 - Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738), [#1694](https://github.com/MetaMask/snaps/pull/1694))
@@ -24,8 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.5-flask.1...HEAD
-[0.37.5-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.4-flask.1...@metamask/snaps-jest@0.37.5-flask.1
-[0.37.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.3-flask.1...@metamask/snaps-jest@0.37.4-flask.1
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@0.37.2-flask.1...@metamask/snaps-jest@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-jest@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-jest@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-jest@0.37.5-flask.1...@metamask/snaps-jest@1.0.0
+[0.37.5-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-jest@0.37.4-flask.1...@metamask/snaps-jest@0.37.5-flask.1
+[0.37.4-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-jest@0.37.3-flask.1...@metamask/snaps-jest@0.37.4-flask.1
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-jest@0.37.2-flask.1...@metamask/snaps-jest@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-jest@0.37.2-flask.1

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-jest",
-  "version": "0.37.5-flask.1",
+  "version": "1.0.0",
   "description": "A Jest preset for end-to-end testing MetaMask Snaps, including a Jest environment, and a set of Jest matchers.",
   "sideEffects": false,
   "main": "./dist/cjs/index.js",

--- a/packages/snaps-rollup-plugin/CHANGELOG.md
+++ b/packages/snaps-rollup-plugin/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
 ## [0.37.3-flask.1]
 ### Fixed
 - Remove unused dependencies ([#1680](https://github.com/MetaMask/snaps/pull/1680))
@@ -16,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@0.37.3-flask.1...HEAD
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@0.37.2-flask.1...@metamask/snaps-rollup-plugin@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-rollup-plugin@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-rollup-plugin@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-rollup-plugin@0.37.3-flask.1...@metamask/snaps-rollup-plugin@2.0.0
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-rollup-plugin@0.37.2-flask.1...@metamask/snaps-rollup-plugin@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-rollup-plugin@0.37.2-flask.1

--- a/packages/snaps-rollup-plugin/CHANGELOG.md
+++ b/packages/snaps-rollup-plugin/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.37.3-flask.1]
 ### Fixed

--- a/packages/snaps-rollup-plugin/CHANGELOG.md
+++ b/packages/snaps-rollup-plugin/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.0.0]
+### Changed
+- Initial stable release from main branch
 
 ## [0.37.3-flask.1]
 ### Fixed

--- a/packages/snaps-rollup-plugin/CHANGELOG.md
+++ b/packages/snaps-rollup-plugin/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-rollup-plugin@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-rollup-plugin@0.37.3-flask.1...@metamask/snaps-rollup-plugin@2.0.0
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-rollup-plugin@0.37.2-flask.1...@metamask/snaps-rollup-plugin@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-rollup-plugin@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@0.37.3-flask.1...@metamask/snaps-rollup-plugin@2.0.0
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@0.37.2-flask.1...@metamask/snaps-rollup-plugin@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-rollup-plugin@0.37.2-flask.1

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-rollup-plugin",
-  "version": "0.37.3-flask.1",
+  "version": "2.0.0",
   "keywords": [
     "rollup",
     "rollup-plugin"

--- a/packages/snaps-simulator/CHANGELOG.md
+++ b/packages/snaps-simulator/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.1-flask.1]
 ### Added

--- a/packages/snaps-simulator/CHANGELOG.md
+++ b/packages/snaps-simulator/CHANGELOG.md
@@ -35,8 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-simulator@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-simulator@0.38.1-flask.1...@metamask/snaps-simulator@1.0.0
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-simulator@0.38.0-flask.1...@metamask/snaps-simulator@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-simulator@0.37.2-flask.1...@metamask/snaps-simulator@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-simulator@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@0.38.1-flask.1...@metamask/snaps-simulator@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@0.38.0-flask.1...@metamask/snaps-simulator@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@0.37.2-flask.1...@metamask/snaps-simulator@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-simulator@0.37.2-flask.1

--- a/packages/snaps-simulator/CHANGELOG.md
+++ b/packages/snaps-simulator/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.1-flask.1]
 ### Added

--- a/packages/snaps-simulator/CHANGELOG.md
+++ b/packages/snaps-simulator/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+
 ## [0.38.1-flask.1]
 ### Added
 - Add basic support for account RPC methods in snaps simulator ([#1710](https://github.com/MetaMask/snaps/pull/1710))
@@ -33,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@0.38.1-flask.1...HEAD
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@0.38.0-flask.1...@metamask/snaps-simulator@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@0.37.2-flask.1...@metamask/snaps-simulator@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-simulator@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-simulator@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-simulator@0.38.1-flask.1...@metamask/snaps-simulator@1.0.0
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-simulator@0.38.0-flask.1...@metamask/snaps-simulator@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-simulator@0.37.2-flask.1...@metamask/snaps-simulator@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-simulator@0.37.2-flask.1

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-simulator",
-  "version": "0.38.1-flask.1",
+  "version": "1.0.0",
   "description": "A simulator for MetaMask Snaps, to be used for testing and development",
   "homepage": "https://github.com/MetaMask/snaps#readme",
   "bugs": {

--- a/packages/snaps-types/CHANGELOG.md
+++ b/packages/snaps-types/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
 ## [0.38.3-flask.1]
 ### Added
 - Add `onNameLookup` types ([#1759](https://github.com/MetaMask/snaps/pull/1759))
@@ -34,9 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.3-flask.1...HEAD
-[0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.2-flask.1...@metamask/snaps-types@0.38.3-flask.1
-[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.1-flask.1...@metamask/snaps-types@0.38.2-flask.1
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.0-flask.1...@metamask/snaps-types@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.37.2-flask.1...@metamask/snaps-types@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-types@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-types@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-types@0.38.3-flask.1...@metamask/snaps-types@2.0.0
+[0.38.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-types@0.38.2-flask.1...@metamask/snaps-types@0.38.3-flask.1
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-types@0.38.1-flask.1...@metamask/snaps-types@0.38.2-flask.1
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-types@0.38.0-flask.1...@metamask/snaps-types@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-types@0.37.2-flask.1...@metamask/snaps-types@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-types@0.37.2-flask.1

--- a/packages/snaps-types/CHANGELOG.md
+++ b/packages/snaps-types/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.3-flask.1]
 ### Added

--- a/packages/snaps-types/CHANGELOG.md
+++ b/packages/snaps-types/CHANGELOG.md
@@ -36,10 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-types@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-types@0.38.3-flask.1...@metamask/snaps-types@2.0.0
-[0.38.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-types@0.38.2-flask.1...@metamask/snaps-types@0.38.3-flask.1
-[0.38.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-types@0.38.1-flask.1...@metamask/snaps-types@0.38.2-flask.1
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-types@0.38.0-flask.1...@metamask/snaps-types@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-types@0.37.2-flask.1...@metamask/snaps-types@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-types@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.3-flask.1...@metamask/snaps-types@2.0.0
+[0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.2-flask.1...@metamask/snaps-types@0.38.3-flask.1
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.1-flask.1...@metamask/snaps-types@0.38.2-flask.1
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.0-flask.1...@metamask/snaps-types@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.37.2-flask.1...@metamask/snaps-types@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-types@0.37.2-flask.1

--- a/packages/snaps-types/CHANGELOG.md
+++ b/packages/snaps-types/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.0.0]
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.3-flask.1]
 ### Added

--- a/packages/snaps-types/package.json
+++ b/packages/snaps-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-types",
-  "version": "0.38.3-flask.1",
+  "version": "2.0.0",
   "description": "TypeScript types for developing MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-ui/CHANGELOG.md
+++ b/packages/snaps-ui/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.37.5-flask.1]
 ### Changed

--- a/packages/snaps-ui/CHANGELOG.md
+++ b/packages/snaps-ui/CHANGELOG.md
@@ -26,9 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-ui@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-ui@0.37.5-flask.1...@metamask/snaps-ui@2.0.0
-[0.37.5-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-ui@0.37.4-flask.1...@metamask/snaps-ui@0.37.5-flask.1
-[0.37.4-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-ui@0.37.3-flask.1...@metamask/snaps-ui@0.37.4-flask.1
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-ui@0.37.2-flask.1...@metamask/snaps-ui@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-ui@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.5-flask.1...@metamask/snaps-ui@2.0.0
+[0.37.5-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.4-flask.1...@metamask/snaps-ui@0.37.5-flask.1
+[0.37.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.3-flask.1...@metamask/snaps-ui@0.37.4-flask.1
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.2-flask.1...@metamask/snaps-ui@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-ui@0.37.2-flask.1

--- a/packages/snaps-ui/CHANGELOG.md
+++ b/packages/snaps-ui/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
 ## [0.37.5-flask.1]
 ### Changed
 - Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738), [#1694](https://github.com/MetaMask/snaps/pull/1694))
@@ -24,8 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.5-flask.1...HEAD
-[0.37.5-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.4-flask.1...@metamask/snaps-ui@0.37.5-flask.1
-[0.37.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.3-flask.1...@metamask/snaps-ui@0.37.4-flask.1
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-ui@0.37.2-flask.1...@metamask/snaps-ui@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-ui@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-ui@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-ui@0.37.5-flask.1...@metamask/snaps-ui@2.0.0
+[0.37.5-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-ui@0.37.4-flask.1...@metamask/snaps-ui@0.37.5-flask.1
+[0.37.4-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-ui@0.37.3-flask.1...@metamask/snaps-ui@0.37.4-flask.1
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-ui@0.37.2-flask.1...@metamask/snaps-ui@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-ui@0.37.2-flask.1

--- a/packages/snaps-ui/CHANGELOG.md
+++ b/packages/snaps-ui/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.0.0]
+### Changed
+- Initial stable release from main branch
 
 ## [0.37.5-flask.1]
 ### Changed

--- a/packages/snaps-ui/package.json
+++ b/packages/snaps-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-ui",
-  "version": "0.37.5-flask.1",
+  "version": "2.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-utils/CHANGELOG.md
+++ b/packages/snaps-utils/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
 ## [0.38.4-flask.1]
 ### Added
 - Add `onNameLookup` export ([#1394](https://github.com/MetaMask/snaps/pull/1394), [#1759](https://github.com/MetaMask/snaps/pull/1759))
@@ -42,10 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.4-flask.1...HEAD
-[0.38.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.3-flask.1...@metamask/snaps-utils@0.38.4-flask.1
-[0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.2-flask.1...@metamask/snaps-utils@0.38.3-flask.1
-[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.1-flask.1...@metamask/snaps-utils@0.38.2-flask.1
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.0-flask.1...@metamask/snaps-utils@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.37.2-flask.1...@metamask/snaps-utils@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-utils@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-utils@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-utils@0.38.4-flask.1...@metamask/snaps-utils@2.0.0
+[0.38.4-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-utils@0.38.3-flask.1...@metamask/snaps-utils@0.38.4-flask.1
+[0.38.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-utils@0.38.2-flask.1...@metamask/snaps-utils@0.38.3-flask.1
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-utils@0.38.1-flask.1...@metamask/snaps-utils@0.38.2-flask.1
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-utils@0.38.0-flask.1...@metamask/snaps-utils@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-utils@0.37.2-flask.1...@metamask/snaps-utils@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-utils@0.37.2-flask.1

--- a/packages/snaps-utils/CHANGELOG.md
+++ b/packages/snaps-utils/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.0.0]
+### Changed
+- Initial stable release from main branch
 
 ## [0.38.4-flask.1]
 ### Added

--- a/packages/snaps-utils/CHANGELOG.md
+++ b/packages/snaps-utils/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.38.4-flask.1]
 ### Added

--- a/packages/snaps-utils/CHANGELOG.md
+++ b/packages/snaps-utils/CHANGELOG.md
@@ -44,11 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-utils@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-utils@0.38.4-flask.1...@metamask/snaps-utils@2.0.0
-[0.38.4-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-utils@0.38.3-flask.1...@metamask/snaps-utils@0.38.4-flask.1
-[0.38.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-utils@0.38.2-flask.1...@metamask/snaps-utils@0.38.3-flask.1
-[0.38.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-utils@0.38.1-flask.1...@metamask/snaps-utils@0.38.2-flask.1
-[0.38.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-utils@0.38.0-flask.1...@metamask/snaps-utils@0.38.1-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-utils@0.37.2-flask.1...@metamask/snaps-utils@0.38.0-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-utils@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.4-flask.1...@metamask/snaps-utils@2.0.0
+[0.38.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.3-flask.1...@metamask/snaps-utils@0.38.4-flask.1
+[0.38.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.2-flask.1...@metamask/snaps-utils@0.38.3-flask.1
+[0.38.2-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.1-flask.1...@metamask/snaps-utils@0.38.2-flask.1
+[0.38.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.38.0-flask.1...@metamask/snaps-utils@0.38.1-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@0.37.2-flask.1...@metamask/snaps-utils@0.38.0-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-utils@0.37.2-flask.1

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-utils",
-  "version": "0.38.4-flask.1",
+  "version": "2.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-webpack-plugin/CHANGELOG.md
+++ b/packages/snaps-webpack-plugin/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.0.0]
+### Changed
+- Initial stable release from main branch
 
 ## [0.37.4-flask.1]
 ### Uncategorized

--- a/packages/snaps-webpack-plugin/CHANGELOG.md
+++ b/packages/snaps-webpack-plugin/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
 ## [0.37.4-flask.1]
 ### Uncategorized
 - Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
@@ -21,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@0.37.4-flask.1...HEAD
-[0.37.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@0.37.3-flask.1...@metamask/snaps-webpack-plugin@0.37.4-flask.1
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@0.37.2-flask.1...@metamask/snaps-webpack-plugin@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-webpack-plugin@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-webpack-plugin@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-webpack-plugin@0.37.4-flask.1...@metamask/snaps-webpack-plugin@2.0.0
+[0.37.4-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-webpack-plugin@0.37.3-flask.1...@metamask/snaps-webpack-plugin@0.37.4-flask.1
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-webpack-plugin@0.37.2-flask.1...@metamask/snaps-webpack-plugin@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-webpack-plugin@0.37.2-flask.1

--- a/packages/snaps-webpack-plugin/CHANGELOG.md
+++ b/packages/snaps-webpack-plugin/CHANGELOG.md
@@ -23,8 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-webpack-plugin@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-webpack-plugin@0.37.4-flask.1...@metamask/snaps-webpack-plugin@2.0.0
-[0.37.4-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-webpack-plugin@0.37.3-flask.1...@metamask/snaps-webpack-plugin@0.37.4-flask.1
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/snaps-webpack-plugin@0.37.2-flask.1...@metamask/snaps-webpack-plugin@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/snaps-webpack-plugin@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@0.37.4-flask.1...@metamask/snaps-webpack-plugin@2.0.0
+[0.37.4-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@0.37.3-flask.1...@metamask/snaps-webpack-plugin@0.37.4-flask.1
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@0.37.2-flask.1...@metamask/snaps-webpack-plugin@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/snaps-webpack-plugin@0.37.2-flask.1

--- a/packages/snaps-webpack-plugin/CHANGELOG.md
+++ b/packages/snaps-webpack-plugin/CHANGELOG.md
@@ -11,9 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.37.4-flask.1]
-### Uncategorized
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
-- Bump `metamask/utils` and `metamask/snaps-registry` ([#1694](https://github.com/MetaMask/snaps/pull/1694))
+### Changed
+- Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738), [#1694](https://github.com/MetaMask/snaps/pull/1694))
 
 ## [0.37.3-flask.1]
 ### Fixed

--- a/packages/snaps-webpack-plugin/CHANGELOG.md
+++ b/packages/snaps-webpack-plugin/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.37.4-flask.1]
 ### Uncategorized

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-webpack-plugin",
-  "version": "0.37.4-flask.1",
+  "version": "2.0.0",
   "keywords": [
     "webpack",
     "plugin"

--- a/packages/test-snaps/CHANGELOG.md
+++ b/packages/test-snaps/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Changed
-- Initial stable release from main branch
+- Initial stable release from main branch ([#1757](https://github.com/MetaMask/snaps/pull/1757))
 
 ## [0.39.1-flask.1]
 ### Changed

--- a/packages/test-snaps/CHANGELOG.md
+++ b/packages/test-snaps/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+
 ## [0.39.1-flask.1]
 ### Changed
 - Bump `metamask/utils` and `metamask/snaps-registry` ([#1738](https://github.com/MetaMask/snaps/pull/1738))
@@ -35,9 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix NPM package name of the network access snap ([#1621](https://github.com/MetaMask/snaps/pull/1621))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.39.1-flask.1...HEAD
-[0.39.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.39.0-flask.1...@metamask/test-snaps@0.39.1-flask.1
-[0.39.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.38.0-flask.1...@metamask/test-snaps@0.39.0-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.37.3-flask.1...@metamask/test-snaps@0.38.0-flask.1
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.37.2-flask.1...@metamask/test-snaps@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/test-snaps@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/test-snaps@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/test-snaps@0.39.1-flask.1...@metamask/test-snaps@1.0.0
+[0.39.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/test-snaps@0.39.0-flask.1...@metamask/test-snaps@0.39.1-flask.1
+[0.39.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/test-snaps@0.38.0-flask.1...@metamask/test-snaps@0.39.0-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/test-snaps@0.37.3-flask.1...@metamask/test-snaps@0.38.0-flask.1
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/test-snaps@0.37.2-flask.1...@metamask/test-snaps@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/test-snaps@0.37.2-flask.1

--- a/packages/test-snaps/CHANGELOG.md
+++ b/packages/test-snaps/CHANGELOG.md
@@ -37,10 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix NPM package name of the network access snap ([#1621](https://github.com/MetaMask/snaps/pull/1621))
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/test-snaps@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/test-snaps@0.39.1-flask.1...@metamask/test-snaps@1.0.0
-[0.39.1-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/test-snaps@0.39.0-flask.1...@metamask/test-snaps@0.39.1-flask.1
-[0.39.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/test-snaps@0.38.0-flask.1...@metamask/test-snaps@0.39.0-flask.1
-[0.38.0-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/test-snaps@0.37.3-flask.1...@metamask/test-snaps@0.38.0-flask.1
-[0.37.3-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/compare/@metamask/test-snaps@0.37.2-flask.1...@metamask/test-snaps@0.37.3-flask.1
-[0.37.2-flask.1]: https://github.com/MetaMask/snaps-skunkworks.git/releases/tag/@metamask/test-snaps@0.37.2-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.39.1-flask.1...@metamask/test-snaps@1.0.0
+[0.39.1-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.39.0-flask.1...@metamask/test-snaps@0.39.1-flask.1
+[0.39.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.38.0-flask.1...@metamask/test-snaps@0.39.0-flask.1
+[0.38.0-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.37.3-flask.1...@metamask/test-snaps@0.38.0-flask.1
+[0.37.3-flask.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@0.37.2-flask.1...@metamask/test-snaps@0.37.3-flask.1
+[0.37.2-flask.1]: https://github.com/MetaMask/snaps/releases/tag/@metamask/test-snaps@0.37.2-flask.1

--- a/packages/test-snaps/CHANGELOG.md
+++ b/packages/test-snaps/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
+### Changed
+- Initial stable release from main branch
 
 ## [0.39.1-flask.1]
 ### Changed

--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-snaps",
-  "version": "0.39.1-flask.1",
+  "version": "1.0.0",
   "private": true,
   "description": "The test snaps website for MetaMask Snaps, used for end-to-end testing.",
   "repository": {


### PR DESCRIPTION
See the changelogs for details.

This is the first release of the combined RC and flask packages from `main` and therefore the retirement of the RC branch.

All packages currently already published as `1.x` are bumped to `2.0.0` because there is a difference in build output between the RC branch and `main`. The remaining packages are simply bumped to `1.0.0`.

Recreated version of #1767 because of a mistake that blocked release.