### PR TITLE
Allow passing `undefined` parameters to `request()`

### DIFF
--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 79.72,
-  "functions": 91.85,
-  "lines": 91.02,
-  "statements": 90.74
+  "functions": 91.91,
+  "lines": 91.05,
+  "statements": 90.77
 }

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -820,6 +820,153 @@ describe('BaseSnapExecutor', () => {
     });
   });
 
+  it('allows passing undefined parameters to snap.request', async () => {
+    const CODE = `
+      module.exports.onRpcRequest = () => snap.request({ method: 'snap_getEntropy', params: { version: 1, salt: undefined } });
+    `;
+
+    const executor = new TestSnapExecutor();
+    await executor.executeSnap(1, MOCK_SNAP_ID, CODE, []);
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'OK',
+    });
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'snapRpc',
+      params: [
+        MOCK_SNAP_ID,
+        HandlerType.OnRpcRequest,
+        MOCK_ORIGIN,
+        { jsonrpc: '2.0', method: '', params: [] },
+      ],
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      method: 'OutboundRequest',
+    });
+
+    const request = await executor.readRpc();
+    expect(request).toStrictEqual({
+      name: 'metamask-provider',
+      data: {
+        id: expect.any(Number),
+        jsonrpc: '2.0',
+        method: 'snap_getEntropy',
+        params: {
+          version: 1,
+        },
+      },
+    });
+
+    // From getEntropy test vectors
+    const result =
+      '0x8bbb59ec55a4a8dd5429268e367ebbbe54eee7467c0090ca835c64d45c33a155';
+
+    await executor.writeRpc({
+      name: 'metamask-provider',
+      data: {
+        jsonrpc: '2.0',
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        id: request.data.id!,
+        result,
+      },
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      method: 'OutboundResponse',
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      id: 2,
+      jsonrpc: '2.0',
+      result,
+    });
+  });
+
+  it('allows passing undefined parameters to ethereum.request', async () => {
+    const CODE = `
+      module.exports.onRpcRequest = () => ethereum.request({ method: 'eth_call', params: [{
+        to: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        nonce: undefined,
+        gas: undefined,
+        data: '0x70a082310000000000000000000000004bbeeb066ed09b7aed07bf39eee0460dfa261520',
+      }] });
+    `;
+
+    const executor = new TestSnapExecutor();
+    await executor.executeSnap(1, MOCK_SNAP_ID, CODE, ['ethereum']);
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'OK',
+    });
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'snapRpc',
+      params: [
+        MOCK_SNAP_ID,
+        HandlerType.OnRpcRequest,
+        MOCK_ORIGIN,
+        { jsonrpc: '2.0', method: '', params: [] },
+      ],
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      method: 'OutboundRequest',
+    });
+
+    const request = await executor.readRpc();
+    expect(request).toStrictEqual({
+      name: 'metamask-provider',
+      data: {
+        id: expect.any(Number),
+        jsonrpc: '2.0',
+        method: 'eth_call',
+        params: [
+          {
+            to: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+            data: '0x70a082310000000000000000000000004bbeeb066ed09b7aed07bf39eee0460dfa261520',
+          },
+        ],
+      },
+    });
+
+    const result =
+      '0x00000000000000000000000000000000000000000000000000000010a7a512a9';
+
+    await executor.writeRpc({
+      name: 'metamask-provider',
+      data: {
+        jsonrpc: '2.0',
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        id: request.data.id!,
+        result,
+      },
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      method: 'OutboundResponse',
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      id: 2,
+      jsonrpc: '2.0',
+      result,
+    });
+  });
+
   it('notifies execution service of out of band errors via unhandledrejection', async () => {
     const CODE = `
       module.exports.onRpcRequest = async () => 'foo';

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -43,6 +43,7 @@ import {
   assertEthereumOutboundRequest,
   assertSnapOutboundRequest,
   constructError,
+  sanitizeRequestArguments,
   proxyStreamProvider,
   withTeardown,
 } from './utils';
@@ -421,7 +422,7 @@ export class BaseSnapExecutor {
     const originalRequest = provider.request.bind(provider);
 
     const request = async (args: RequestArguments) => {
-      const sanitizedArgs = getSafeJson(args) as RequestArguments;
+      const sanitizedArgs = sanitizeRequestArguments(args);
       assertSnapOutboundRequest(sanitizedArgs);
       this.notify({ method: 'OutboundRequest' });
       try {
@@ -462,7 +463,7 @@ export class BaseSnapExecutor {
     const originalRequest = provider.request.bind(provider);
 
     const request = async (args: RequestArguments) => {
-      const sanitizedArgs = getSafeJson(args) as RequestArguments;
+      const sanitizedArgs = sanitizeRequestArguments(args);
       assertEthereumOutboundRequest(sanitizedArgs);
       this.notify({ method: 'OutboundRequest' });
       try {

--- a/packages/snaps-execution-environments/src/common/utils.ts
+++ b/packages/snaps-execution-environments/src/common/utils.ts
@@ -1,6 +1,6 @@
 import type { StreamProvider } from '@metamask/providers';
 import type { RequestArguments } from '@metamask/providers/dist/BaseProvider';
-import { assert, assertStruct, JsonStruct } from '@metamask/utils';
+import { assert, assertStruct, getSafeJson, JsonStruct } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
 
 import { log } from '../logging';
@@ -169,4 +169,17 @@ export function assertEthereumOutboundRequest(args: RequestArguments) {
     }),
   );
   assertStruct(args, JsonStruct, 'Provided value is not JSON-RPC compatible');
+}
+
+/**
+ * Gets a sanitized value to be used for passing to the underlying MetaMask provider.
+ *
+ * @param value - An unsanitized value from a snap.
+ * @returns A sanitized value ready to be passed to a MetaMask provider.
+ */
+export function sanitizeRequestArguments(value: unknown): RequestArguments {
+  // Before passing to getSafeJson we run the value through JSON serialization.
+  // This lets request arguments contain undefined which is normally disallowed.
+  const json = JSON.parse(JSON.stringify(value));
+  return getSafeJson(json) as RequestArguments;
 }


### PR DESCRIPTION
This PR allows passing `undefined` parameters to `request()`. Previously this would fail as `getSafeJson` asserts that all input is valid according to the JSON spec. For compatibility's sake we now strip `undefined` values before passing to `getSafeJson`.