### PR TITLE
Bump SES

### DIFF
--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -112,7 +112,7 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^4.1.2",
     "serve-handler": "^6.1.5",
-    "ses": "^0.18.7",
+    "ses": "^0.18.8",
     "terser": "^5.17.7",
     "ts-node": "^10.9.1",
     "typescript": "~4.8.4",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -84,7 +84,7 @@
     "is-svg": "^4.4.0",
     "rfdc": "^1.3.0",
     "semver": "^7.5.4",
-    "ses": "^0.18.7",
+    "ses": "^0.18.8",
     "superstruct": "^1.0.3",
     "validate-npm-package-name": "^5.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,10 +2812,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@endo/env-options@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "@endo/env-options@npm:0.1.3"
-  checksum: da8c66865d4d30b0053a00960657dc36f022975a888f0dd6a2f6bb37b9fe731f45a02a2cf263d93b1a40fcb37b25f8ba7076cb8af9e93fd95f496365d9382930
+"@endo/env-options@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "@endo/env-options@npm:0.1.4"
+  checksum: 6099f0a6b700a60bee7b226aa2a39bb5748e22f25e9606d70e5a66a8e62cbd8c972b0fe578735a658f80bf2ebece62e28c20aa3f16417cbfe6c19a8689966dd3
   languageName: node
   linkType: hard
 
@@ -5242,7 +5242,7 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^4.1.2
     serve-handler: ^6.1.5
-    ses: ^0.18.7
+    ses: ^0.18.8
     superstruct: ^1.0.3
     terser: ^5.17.7
     ts-node: ^10.9.1
@@ -5603,7 +5603,7 @@ __metadata:
     rfdc: ^1.3.0
     rimraf: ^4.1.2
     semver: ^7.5.4
-    ses: ^0.18.7
+    ses: ^0.18.8
     superstruct: ^1.0.3
     ts-node: ^10.9.1
     typescript: ~4.8.4
@@ -20490,12 +20490,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ses@npm:^0.18.7":
-  version: 0.18.7
-  resolution: "ses@npm:0.18.7"
+"ses@npm:^0.18.8":
+  version: 0.18.8
+  resolution: "ses@npm:0.18.8"
   dependencies:
-    "@endo/env-options": ^0.1.3
-  checksum: 75ac014771d9bc1f747193c6d0f9e7d2d7700a10311ba8d805d9bc78d4c20d4ef40537f0535b1ea6abf06babf67e70f8bd37b2ad68ad54992a0c5ce842181c87
+    "@endo/env-options": ^0.1.4
+  checksum: d7976d2ee218baec021c5cfdfb193d63b52bf2b6cbdbbb90c19d835915a1872b6924910f7fd42bc849eb2de78fc7bdd6e7b4667e1df3c79244cc92d4ede48aa6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bump SES to latest to fix incompatibilities with latest Chrome. This mostly was surfaced locally when running tests.