### PR TITLE
Disable fullySpecified rule for `.js` imports in the default Webpack config

### DIFF
--- a/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
+++ b/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
@@ -32,6 +32,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
           },
         },
       },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
+      },
       false,
     ],
   },
@@ -166,6 +172,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "sync": false,
           },
         },
+      },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
       },
       false,
     ],
@@ -302,6 +314,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
           },
         },
       },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
+      },
       false,
     ],
   },
@@ -437,6 +455,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
           },
         },
       },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
+      },
       false,
     ],
   },
@@ -563,6 +587,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "sync": false,
           },
         },
+      },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
       },
       {
         "test": /\\\\\\.wasm\\$/u,
@@ -704,6 +734,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
           },
         },
       },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
+      },
       false,
     ],
   },
@@ -839,6 +875,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
           },
         },
       },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
+      },
       false,
     ],
   },
@@ -973,6 +1015,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "sync": false,
           },
         },
+      },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
       },
       false,
     ],
@@ -1117,6 +1165,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
           },
         },
       },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
+      },
       false,
     ],
   },
@@ -1259,6 +1313,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "sync": false,
           },
         },
+      },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
       },
       false,
     ],
@@ -1404,6 +1464,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
           },
         },
       },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
+      },
       false,
     ],
   },
@@ -1539,6 +1605,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
           },
         },
       },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
+      },
       false,
     ],
   },
@@ -1673,6 +1745,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "sync": false,
           },
         },
+      },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
       },
       false,
     ],
@@ -1817,6 +1895,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "sync": false,
           },
         },
+      },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
       },
       false,
     ],
@@ -1965,6 +2049,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
           },
         },
       },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
+      },
       false,
     ],
   },
@@ -2093,6 +2183,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
           },
         },
       },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
+      },
       false,
     ],
   },
@@ -2220,6 +2316,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "writeManifest": true,
           },
         },
+      },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/u,
       },
       false,
     ],

--- a/packages/snaps-cli/src/webpack/config.ts
+++ b/packages/snaps-cli/src/webpack/config.ts
@@ -179,6 +179,10 @@ export async function getDefaultConfiguration(
           exclude: /node_modules/u,
           use: await getDefaultLoader(config),
         },
+        /**
+         * This allows importing modules that uses .js and not .mjs on ES build.
+         * ref. https://webpack.js.org/configuration/module/#resolvefullyspecified
+         */
         {
           test: /\.m?js/u,
           resolve: {

--- a/packages/snaps-cli/src/webpack/config.ts
+++ b/packages/snaps-cli/src/webpack/config.ts
@@ -181,8 +181,10 @@ export async function getDefaultConfiguration(
         },
 
         /**
-         * This allows importing modules that uses .js and not .mjs on ES build.
-         * ref. https://webpack.js.org/configuration/module/#resolvefullyspecified
+         * This allows importing modules that uses `.js` and not `.mjs` for the
+         * ES build.
+         *
+         * @see https://webpack.js.org/configuration/module/#resolvefullyspecified
          */
         {
           test: /\.m?js/u,

--- a/packages/snaps-cli/src/webpack/config.ts
+++ b/packages/snaps-cli/src/webpack/config.ts
@@ -179,6 +179,7 @@ export async function getDefaultConfiguration(
           exclude: /node_modules/u,
           use: await getDefaultLoader(config),
         },
+
         /**
          * This allows importing modules that uses .js and not .mjs on ES build.
          * ref. https://webpack.js.org/configuration/module/#resolvefullyspecified

--- a/packages/snaps-cli/src/webpack/config.ts
+++ b/packages/snaps-cli/src/webpack/config.ts
@@ -179,6 +179,12 @@ export async function getDefaultConfiguration(
           exclude: /node_modules/u,
           use: await getDefaultLoader(config),
         },
+        {
+          test: /\.m?js/u,
+          resolve: {
+            fullySpecified: false,
+          },
+        },
 
         config.experimental.wasm && {
           test: /\.wasm$/u,


### PR DESCRIPTION
This PR adds the `fullySpecified` rule to `false` for `.js` imports in modules to the default Webpack config.

This will allow importing modules that uses .js and not .mjs for the ES build.