### PR TITLE
Fix Shell command injection in `create-snap`

### DIFF
--- a/packages/create-snap/src/cli.ts
+++ b/packages/create-snap/src/cli.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 
 import builders from './builders';
 import { init } from './cmds';
@@ -14,8 +15,7 @@ export async function cli(
   argv: string[],
   initCommand: typeof init = init,
 ): Promise<void> {
-  const rawArgv = argv.slice(2);
-  await yargs(rawArgv)
+  await yargs(hideBin(argv))
     .scriptName('create-snap')
     .usage('Usage: $0 [directory-name]')
 

--- a/packages/create-snap/src/cmds/init/initUtils.test.ts
+++ b/packages/create-snap/src/cmds/init/initUtils.test.ts
@@ -22,7 +22,7 @@ jest.mock('process', () => ({
 }));
 
 jest.mock('child_process', () => ({
-  execSync: jest.fn(),
+  spawnSync: jest.fn(),
 }));
 
 describe('initUtils', () => {
@@ -66,22 +66,22 @@ describe('initUtils', () => {
   });
 
   describe('buildSnap', () => {
-    it('calls execSync', () => {
-      const execSyncMock = jest
-        .spyOn(childProcess, 'execSync')
+    it('calls spawnSync', () => {
+      const spawnSyncMock = jest
+        .spyOn(childProcess, 'spawnSync')
         .mockImplementation();
 
       buildSnap('foo');
 
-      expect(execSyncMock).toHaveBeenCalledTimes(1);
-      expect(execSyncMock).toHaveBeenCalledWith('yarn build', {
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+      expect(spawnSyncMock).toHaveBeenCalledWith('yarn', ['build'], {
         stdio: [0, 1, 2],
         cwd: pathUtils.resolve(__dirname, 'foo'),
       });
     });
 
     it('throws an error when execution fails', () => {
-      jest.spyOn(childProcess, 'execSync').mockImplementation(() => {
+      jest.spyOn(childProcess, 'spawnSync').mockImplementation(() => {
         throw new Error('failed');
       });
 
@@ -93,15 +93,23 @@ describe('initUtils', () => {
 
   describe('cloneTemplate', () => {
     it('passes if the command is ran successfully', () => {
-      const execSyncMock = jest
-        .spyOn(childProcess, 'execSync')
-        .mockImplementation(() => Buffer.from([]));
+      const spawnSyncMock = jest
+        .spyOn(childProcess, 'spawnSync')
+        .mockImplementation(() => ({
+          pid: 1,
+          output: [],
+          stdout: '',
+          stderr: '',
+          status: null,
+          signal: null,
+        }));
 
       cloneTemplate('foo');
 
-      expect(execSyncMock).toHaveBeenCalledTimes(1);
-      expect(execSyncMock).toHaveBeenCalledWith(
-        `git clone --depth=1 ${TEMPLATE_GIT_URL} foo`,
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+      expect(spawnSyncMock).toHaveBeenCalledWith(
+        'git',
+        ['clone', '--depth=1', TEMPLATE_GIT_URL, 'foo'],
         {
           stdio: [2],
         },
@@ -109,8 +117,8 @@ describe('initUtils', () => {
     });
 
     it('throws if the command fails', () => {
-      const execSyncMock = jest
-        .spyOn(childProcess, 'execSync')
+      const spawnSyncMock = jest
+        .spyOn(childProcess, 'spawnSync')
         .mockImplementation(() => {
           throw new Error('error message');
         });
@@ -118,28 +126,35 @@ describe('initUtils', () => {
       expect(() => cloneTemplate('foo')).toThrow(
         'Init Error: Failed to clone the template.',
       );
-      expect(execSyncMock).toHaveBeenCalledTimes(1);
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('isGitInstalled', () => {
     it('returns true if git is installed', () => {
-      const execSyncMock = jest
-        .spyOn(childProcess, 'execSync')
-        .mockImplementation(() => Buffer.from([]));
+      const spawnSyncMock = jest
+        .spyOn(childProcess, 'spawnSync')
+        .mockImplementation(() => ({
+          pid: 1,
+          output: [],
+          stdout: '',
+          stderr: '',
+          status: null,
+          signal: null,
+        }));
 
       const result = isGitInstalled();
 
       expect(result).toBe(true);
-      expect(execSyncMock).toHaveBeenCalledTimes(1);
-      expect(execSyncMock).toHaveBeenCalledWith('git --version', {
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+      expect(spawnSyncMock).toHaveBeenCalledWith('git', ['--version'], {
         stdio: 'ignore',
       });
     });
 
     it('returns false if git is not installed', () => {
-      const execSyncMock = jest
-        .spyOn(childProcess, 'execSync')
+      const spawnSyncMock = jest
+        .spyOn(childProcess, 'spawnSync')
         .mockImplementation(() => {
           throw new Error('error message');
         });
@@ -147,22 +162,30 @@ describe('initUtils', () => {
       const result = isGitInstalled();
 
       expect(result).toBe(false);
-      expect(execSyncMock).toHaveBeenCalledTimes(1);
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('isInGitRepository', () => {
     it('returns true if the directory is a git repository', () => {
-      const execSyncMock = jest
-        .spyOn(childProcess, 'execSync')
-        .mockImplementation(() => Buffer.from([]));
+      const spawnSyncMock = jest
+        .spyOn(childProcess, 'spawnSync')
+        .mockImplementation(() => ({
+          pid: 1,
+          output: [],
+          stdout: '',
+          stderr: '',
+          status: null,
+          signal: null,
+        }));
 
       const result = isInGitRepository('foo');
 
       expect(result).toBe(true);
-      expect(execSyncMock).toHaveBeenCalledTimes(1);
-      expect(execSyncMock).toHaveBeenCalledWith(
-        'git rev-parse --is-inside-work-tree',
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+      expect(spawnSyncMock).toHaveBeenCalledWith(
+        'git',
+        ['rev-parse', '--is-inside-work-tree'],
         {
           stdio: 'ignore',
           cwd: pathUtils.resolve(__dirname, 'foo'),
@@ -171,8 +194,8 @@ describe('initUtils', () => {
     });
 
     it('returns false if the directory is not a git repository', () => {
-      const execSyncMock = jest
-        .spyOn(childProcess, 'execSync')
+      const spawnSyncMock = jest
+        .spyOn(childProcess, 'spawnSync')
         .mockImplementation(() => {
           throw new Error('error message');
         });
@@ -180,28 +203,35 @@ describe('initUtils', () => {
       const result = isInGitRepository('foo');
 
       expect(result).toBe(false);
-      expect(execSyncMock).toHaveBeenCalledTimes(1);
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('gitInit', () => {
     it('init a new repository', () => {
-      const execSyncMock = jest
-        .spyOn(childProcess, 'execSync')
-        .mockImplementation(() => Buffer.from([]));
+      const spawnSyncMock = jest
+        .spyOn(childProcess, 'spawnSync')
+        .mockImplementation(() => ({
+          pid: 1,
+          output: [],
+          stdout: '',
+          stderr: '',
+          status: null,
+          signal: null,
+        }));
 
       gitInit('foo');
 
-      expect(execSyncMock).toHaveBeenCalledTimes(1);
-      expect(execSyncMock).toHaveBeenCalledWith('git init', {
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+      expect(spawnSyncMock).toHaveBeenCalledWith('git', ['init'], {
         stdio: 'ignore',
         cwd: pathUtils.resolve(__dirname, 'foo'),
       });
     });
 
     it('throws an error if it fails to init a new repository', () => {
-      const execSyncMock = jest
-        .spyOn(childProcess, 'execSync')
+      const spawnSyncMock = jest
+        .spyOn(childProcess, 'spawnSync')
         .mockImplementation(() => {
           throw new Error('error message');
         });
@@ -209,28 +239,35 @@ describe('initUtils', () => {
       expect(() => gitInit('foo')).toThrow(
         'Init Error: Failed to init a new git repository.',
       );
-      expect(execSyncMock).toHaveBeenCalledTimes(1);
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('yarnInstall', () => {
     it('run yarn and yarn install commands', () => {
-      const execSyncMock = jest
-        .spyOn(childProcess, 'execSync')
-        .mockImplementation(() => Buffer.from([]));
+      const spawnSyncMock = jest
+        .spyOn(childProcess, 'spawnSync')
+        .mockImplementation(() => ({
+          pid: 1,
+          output: [],
+          stdout: '',
+          stderr: '',
+          status: null,
+          signal: null,
+        }));
 
       yarnInstall('foo');
 
-      expect(execSyncMock).toHaveBeenCalledTimes(1);
-      expect(execSyncMock).toHaveBeenCalledWith('yarn install', {
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+      expect(spawnSyncMock).toHaveBeenCalledWith('yarn', ['install'], {
         stdio: [0, 1, 2],
         cwd: 'foo',
       });
     });
 
     it('throws an error if it fails to run a command', () => {
-      const execSyncMock = jest
-        .spyOn(childProcess, 'execSync')
+      const spawnSyncMock = jest
+        .spyOn(childProcess, 'spawnSync')
         .mockImplementation(() => {
           throw new Error('error message');
         });
@@ -238,7 +275,7 @@ describe('initUtils', () => {
       expect(() => yarnInstall('foo')).toThrow(
         'Init Error: Failed to install dependencies.',
       );
-      expect(execSyncMock).toHaveBeenCalledTimes(1);
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/create-snap/src/cmds/init/initUtils.ts
+++ b/packages/create-snap/src/cmds/init/initUtils.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import { promises as fs } from 'fs';
 import pathUtils from 'path';
 
@@ -45,7 +45,7 @@ export async function prepareWorkingDirectory(
  */
 export function cloneTemplate(directory: string) {
   try {
-    execSync(`git clone --depth=1 ${TEMPLATE_GIT_URL} ${directory}`, {
+    spawnSync('git', ['clone', '--depth=1', TEMPLATE_GIT_URL, directory], {
       stdio: [2],
     });
   } catch (error) {
@@ -60,7 +60,7 @@ export function cloneTemplate(directory: string) {
  */
 export function isGitInstalled() {
   try {
-    execSync('git --version', { stdio: 'ignore' });
+    spawnSync('git', ['--version'], { stdio: 'ignore' });
     return true;
   } catch (error) {
     return false;
@@ -75,7 +75,7 @@ export function isGitInstalled() {
  */
 export function isInGitRepository(directory: string) {
   try {
-    execSync('git rev-parse --is-inside-work-tree', {
+    spawnSync('git', ['rev-parse', '--is-inside-work-tree'], {
       stdio: 'ignore',
       cwd: pathUtils.resolve(__dirname, directory),
     });
@@ -92,7 +92,7 @@ export function isInGitRepository(directory: string) {
  */
 export function gitInit(directory: string) {
   try {
-    execSync('git init', {
+    spawnSync('git', ['init'], {
       stdio: 'ignore',
       cwd: pathUtils.resolve(__dirname, directory),
     });
@@ -108,7 +108,7 @@ export function gitInit(directory: string) {
  */
 export function yarnInstall(directory: string) {
   try {
-    execSync('yarn install', {
+    spawnSync('yarn', ['install'], {
       stdio: [0, 1, 2],
       cwd: directory,
     });
@@ -124,7 +124,7 @@ export function yarnInstall(directory: string) {
  */
 export function buildSnap(snapDirectory: string) {
   try {
-    execSync('yarn build', {
+    spawnSync('yarn', ['build'], {
       stdio: [0, 1, 2],
       cwd: pathUtils.resolve(__dirname, snapDirectory),
     });


### PR DESCRIPTION
This changes `execSync` to `spawnSync` so we directly invoque the command and pass individual arguments to it.


https://github.com/MetaMask/snaps/assets/13910212/e5bd0656-c794-42ce-a6d6-de5541d752ce

