### PR TITLE
Bump node satisfied version in `create-snap`

### DIFF
--- a/packages/create-snap/src/cmds/init/initHandler.test.ts
+++ b/packages/create-snap/src/cmds/init/initHandler.test.ts
@@ -207,7 +207,7 @@ describe('initialize', () => {
       };
 
       await expect(initHandler({ ...getMockArgv() })).rejects.toThrow(
-        `Init Error: You are using an outdated version of Node (${process.version}). Please update to Node >=16.`,
+        `Init Error: You are using an outdated version of Node (${process.version}). Please update to Node >=18.6.0.`,
       );
     });
 

--- a/packages/create-snap/src/cmds/init/initHandler.ts
+++ b/packages/create-snap/src/cmds/init/initHandler.ts
@@ -22,7 +22,7 @@ import {
   yarnInstall,
 } from './initUtils';
 
-const SATISFIED_VERSION = '>=16' as SemVerRange;
+const SATISFIED_VERSION = '>=18.6.0' as SemVerRange;
 
 /**
  * Creates a new snap package, based on one of the provided templates. This


### PR DESCRIPTION
This bumps the node minimal version to use `create-snap` to `>=18.6.0`.