### PR TITLE
Check minimum Node version in CLI

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8g+RyiujKTblt/Lcetra+JaTWWS45Imi9rVtAdymplA=",
+    "shasum": "h/XCImkjwpGbhE99Y1L+rRDq8SWoJ3PotkIZbUJmwUQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "h/XCImkjwpGbhE99Y1L+rRDq8SWoJ3PotkIZbUJmwUQ=",
+    "shasum": "8g+RyiujKTblt/Lcetra+JaTWWS45Imi9rVtAdymplA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -79,6 +79,7 @@
     "punycode": "^2.3.0",
     "querystring-es3": "^0.2.1",
     "readable-stream": "^3.6.2",
+    "semver": "^7.5.4",
     "serve-handler": "^6.1.5",
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0",

--- a/packages/snaps-cli/src/cli.test.ts
+++ b/packages/snaps-cli/src/cli.test.ts
@@ -1,6 +1,6 @@
 import type yargs from 'yargs';
 
-import { cli } from './cli';
+import { checkNodeVersion, cli } from './cli';
 import commands from './commands';
 
 jest.mock('./config');
@@ -26,6 +26,56 @@ const getMockArgv = (...args: string[]) => {
 // In Jest, that's sometimes "childProcess.js", sometimes other things.
 // In practice, it should always be "mm-snap".
 const HELP_TEXT_REGEX = /^\s*Usage: .+ <command> \[options\]/u;
+
+describe('checkNodeVersion', () => {
+  it.each(['16.17.0', '16.18.0', '18.6.0', '18.7.0', '20.0.0'])(
+    'does not exit if the Node version is %s',
+    (version) => {
+      const spy = jest.spyOn(process, 'exit').mockImplementation();
+      checkNodeVersion(version);
+
+      expect(spy).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['14.0.0', '16.0.0', '16.16.1'])(
+    'logs a message and exists if the Node version is %s',
+    (version) => {
+      const spy = jest.spyOn(process, 'exit').mockImplementation();
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      checkNodeVersion(version);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Node version ${version} is not supported. Please use Node 16.17.0 or later.`,
+        ),
+      );
+    },
+  );
+
+  it.each(['18.0.0', '18.5.0'])(
+    'logs a message and exists if the Node version is %s',
+    (version) => {
+      const spy = jest.spyOn(process, 'exit').mockImplementation();
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      checkNodeVersion(version);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Node version ${version} is not supported. Please use Node 18.6.0 or later.`,
+        ),
+      );
+    },
+  );
+});
 
 describe('cli', () => {
   it('exits if no argument was provided', async () => {

--- a/packages/snaps-cli/src/cli.ts
+++ b/packages/snaps-cli/src/cli.ts
@@ -1,9 +1,48 @@
+import semver from 'semver';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import builders from './builders';
 import { getConfigByArgv } from './config';
 import { error, getYargsErrorMessage, sanitizeInputs } from './utils';
+
+const MINIMUM_NODE_16_VERSION = '16.17.0';
+const MINIMUM_NODE_18_VERSION = '18.6.0';
+
+/**
+ * Check the Node version. If the Node version is less than the minimum required
+ * version, this logs an error and exits the process.
+ *
+ * @param nodeVersion - The Node version to check.
+ */
+export function checkNodeVersion(
+  nodeVersion: string = process.version.slice(1),
+) {
+  const majorVersion = semver.major(nodeVersion);
+  const message = `Node version ${nodeVersion} is not supported. Please use Node ${MINIMUM_NODE_16_VERSION} or later.`;
+
+  if (majorVersion < 16) {
+    error(message);
+    // eslint-disable-next-line n/no-process-exit
+    process.exit(1);
+  }
+
+  // Node 16 and 18 have a different minimum version requirement, so we need to
+  // check for both.
+  if (majorVersion === 16 && semver.lt(nodeVersion, MINIMUM_NODE_16_VERSION)) {
+    error(message);
+    // eslint-disable-next-line n/no-process-exit
+    process.exit(1);
+  }
+
+  if (majorVersion === 18 && semver.lt(nodeVersion, MINIMUM_NODE_18_VERSION)) {
+    error(
+      `Node version ${nodeVersion} is not supported. Please use Node ${MINIMUM_NODE_18_VERSION} or later.`,
+    );
+    // eslint-disable-next-line n/no-process-exit
+    process.exit(1);
+  }
+}
 
 /**
  * The main CLI entry point function. This processes the command line args, and
@@ -13,6 +52,8 @@ import { error, getYargsErrorMessage, sanitizeInputs } from './utils';
  * @param commands - The list of commands to use.
  */
 export async function cli(argv: string[], commands: any) {
+  checkNodeVersion();
+
   await yargs(hideBin(argv))
     .scriptName('mm-snap')
     .usage('Usage: $0 <command> [options]')

--- a/yarn.lock
+++ b/yarn.lock
@@ -5068,6 +5068,7 @@ __metadata:
     querystring-es3: ^0.2.1
     readable-stream: ^3.6.2
     rimraf: ^4.1.2
+    semver: ^7.5.4
     serve-handler: ^6.1.5
     stream-browserify: ^3.0.0
     stream-http: ^3.2.0


### PR DESCRIPTION
We got several reports about the CLI not working, which was caused by an outdated Node.js version. Some functionality we use requires at least Node.js 16.17.0 or Node.js 18.6.0. Node.js <16 is not support at all.

To prevent this, I've added a check to the CLI, to make sure that the user knows what the problem is.