### PR TITLE
Use `require.resolve` for `swc-loader` to fix build issue

### DIFF
--- a/packages/snaps-cli/src/webpack/utils.ts
+++ b/packages/snaps-cli/src/webpack/utils.ts
@@ -95,7 +95,7 @@ export async function getDefaultLoader({
      * This is a Webpack loader that uses the `SWC` compiler, which is a much
      * faster alternative to Babel and TypeScript's own compiler.
      */
-    loader: 'swc-loader',
+    loader: require.resolve('swc-loader'),
 
     /**
      * The options for the `swc-loader`. These can be overridden in the

--- a/packages/snaps-webpack-plugin/src/plugin.ts
+++ b/packages/snaps-webpack-plugin/src/plugin.ts
@@ -2,6 +2,7 @@ import type { PostProcessOptions, SourceMap } from '@metamask/snaps-utils';
 import {
   checkManifest,
   evalBundle,
+  getErrorMessage,
   postProcessBundle,
   useTemporaryFile,
 } from '@metamask/snaps-utils';
@@ -107,9 +108,7 @@ export default class SnapsWebpackPlugin {
                 compilation.updateAsset(assetName, replacement as any);
               } catch (error) {
                 compilation.errors.push(
-                  new WebpackError(
-                    `Processing of the Snap bundle failed. This is likely a bug. Please report it to the MetaMask Snaps team at https://github.com/MetaMask/snaps/issues/new.\n${error.message}`,
-                  ),
+                  new WebpackError(getErrorMessage(error)),
                 );
               }
             });


### PR DESCRIPTION
Previously, the CLI would fail to build for certain projects when Webpack is enabled. I'm not sure why exactly this only breaks for some projects, but using `require.resolve` solves it. I've also added some better error handling to the Webpack plugin, to make errors more readable.

```
$ yarn build
✖ Compiled 0 files in 174ms with 2 errors.

  • Module not found: Error: Can't resolve 'swc-loader' in '[...]/Consensys/starknet-snap/packages/starknet-snap'
    resolve 'swc-loader' in '[...]/Consensys/starknet-snap/packages/starknet-snap'
      Parsed request is a module
      using description file: [...]/Consensys/starknet-snap/packages/starknet-snap/package.json (relative path: .)
        resolve as module
          [...]/Consensys/starknet-snap/packages/starknet-snap/node_modules doesn't exist or is not a directory
          [...]/Consensys/starknet-snap/packages/node_modules doesn't exist or is not a directory
          looking for modules in [...]/Consensys/starknet-snap/node_modules
            single file module
              using description file: [...]/Consensys/starknet-snap/package.json (relative path: ./node_modules/swc-loader)
                no extension
                  [...]/Consensys/starknet-snap/node_modules/swc-loader doesn't exist
                .js
                  [...]/Consensys/starknet-snap/node_modules/swc-loader.js doesn't exist
            [...]/Consensys/starknet-snap/node_modules/swc-loader doesn't exist
          [...]/Consensys/node_modules doesn't exist or is not a directory
          [...]

  • Failed to post process code:
    .inputSourceMap must be a boolean, object, or undefined
```