### PR TITLE
Fix some issues with SnapController events

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 89,
-  "functions": 95.8,
-  "lines": 96.89,
-  "statements": 96.55
+  "branches": 89.06,
+  "functions": 95.84,
+  "lines": 96.98,
+  "statements": 96.64
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -835,6 +835,15 @@ describe('SnapController', () => {
     );
 
     expect(controller.get(MOCK_SNAP_ID)).toBeUndefined();
+    expect(messenger.publish).toHaveBeenCalledWith(
+      'SnapController:snapRemoved',
+      getTruncatedSnap(),
+    );
+
+    expect(messenger.publish).not.toHaveBeenCalledWith(
+      'SnapController:snapUninstalled',
+      getTruncatedSnap(),
+    );
 
     controller.destroy();
   });
@@ -895,6 +904,16 @@ describe('SnapController', () => {
     );
 
     await eventSubscriptionPromise;
+
+    expect(messenger.publish).toHaveBeenCalledWith(
+      'SnapController:snapRemoved',
+      getTruncatedSnap(),
+    );
+
+    expect(messenger.publish).not.toHaveBeenCalledWith(
+      'SnapController:snapUninstalled',
+      getTruncatedSnap(),
+    );
 
     snapController.destroy();
   });
@@ -1350,6 +1369,8 @@ describe('SnapController', () => {
       },
     });
 
+    const { messenger } = options;
+
     const [snapController, service] = getSnapControllerWithEES(
       options,
       new ExecutionEnvironmentStub(
@@ -1391,6 +1412,16 @@ describe('SnapController', () => {
     await snapController.removeSnap(snap.id);
 
     expect(snapController.state.snaps[snap.id]).toBeUndefined();
+
+    expect(messenger.publish).toHaveBeenCalledWith(
+      'SnapController:snapRemoved',
+      getTruncatedSnap(),
+    );
+
+    expect(messenger.publish).toHaveBeenCalledWith(
+      'SnapController:snapUninstalled',
+      getTruncatedSnap(),
+    );
 
     snapController.destroy();
     await service.terminateAllSnaps();

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1796,6 +1796,11 @@ export class SnapController extends BaseController<
         snapId,
         location,
         versionRange,
+        // Since we are requesting an update from within processRequestedSnap,
+        // we disable the emitting of the snapUpdated event and rely on the caller
+        // to publish this event after the update is complete.
+        // This is necesary as installSnaps may be installing multiple snaps
+        // and we don't want to emit events prematurely.
         false,
       );
     }

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -413,7 +413,8 @@ export type SnapUninstalled = {
 };
 
 /**
- * Emitted when a snap is removed.
+ * Emitted when a snap is removed from state, this may happen even
+ * if a snap has not fully completed installation.
  */
 export type SnapRemoved = {
   type: `${typeof controllerName}:snapRemoved`;

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -301,6 +301,7 @@ export const getSnapControllerMessenger = (
       'SnapController:snapAdded',
       'SnapController:snapBlocked',
       'SnapController:snapInstalled',
+      'SnapController:snapUninstalled',
       'SnapController:snapUnblocked',
       'SnapController:snapUpdated',
       'SnapController:snapRemoved',


### PR DESCRIPTION
Fixes a few issues with SnapController events being emitted prematurely when multiple snaps were being installed. Also adds a `SnapController:snapUninstalled` event which is more reliable than `SnapController:snapRemoved`.

This PR also removes an old feature flag `dappsCanUpdateSnaps`, this feature is now enabled by default.

Fixes https://github.com/MetaMask/MetaMask-planning/issues/1400