### PR TITLE
Remove `--immutable-cache` from update PR workflow

### DIFF
--- a/.github/workflows/update-pull-request.yml
+++ b/.github/workflows/update-pull-request.yml
@@ -123,7 +123,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Install dependencies from cache
-        run: yarn --immutable --immutable-cache
+        run: yarn --immutable
       - name: Regenerate LavaMoat policies
         run: yarn build:lavamoat:policy
       - name: Cache LavaMoat policies
@@ -158,7 +158,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Install dependencies from cache
-        run: yarn --immutable --immutable-cache
+        run: yarn --immutable
       - name: Build dependencies
         run: |
           yarn build:source


### PR DESCRIPTION
After deduping, the cache may have stale packages. Removing `--immutable-cache` allows the installation to complete regardless.