### PR TITLE
Update Slack subteam and channel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
       contents: write
     uses: ./.github/workflows/publish-release.yml
     with:
-      slack-subteam: S042S7RE4AE # @metamask-npm-publishers
+      slack-subteam: S05RL9W7H54 # @metamask-snaps-publishers
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       PUBLISH_PAGES_TOKEN: ${{ secrets.PUBLISH_PAGES_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,7 +6,7 @@ on:
       slack-channel:
         required: false
         type: string
-        default: 'metamask-dev'
+        default: 'metamask-snaps'
       slack-icon-url:
         required: false
         type: string
@@ -96,6 +96,10 @@ jobs:
       - run: npm config set ignore-scripts true
       - name: Dry Run Publish
         uses: MetaMask/action-npm-publish@v4
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          subteam: ${{ inputs.slack-subteam }}
+          channel: metamask-snaps
 
   npm-publish:
     name: Publish to NPM


### PR DESCRIPTION
This updates the Slack subteam to `@metamask-snaps-publishers` and the channel to `metamask-snaps`.