### PR TITLE
Add `allowedOrigins` field to `endowment:rpc`

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "MPZ9ur9CDq3vW/16po2PcMSAE/0wWl4sPgjGBwqCW7g=",
+    "shasum": "1WHTdqXAYxUf+ch4hGe3JbYok0XAxFKUMcBVB5o5lmc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1WHTdqXAYxUf+ch4hGe3JbYok0XAxFKUMcBVB5o5lmc=",
+    "shasum": "35n/r+4qoZLl+N5q0ACMTEU2ROspQP9GTMeqsuJ99gQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "H7vpcjHBrK0/AdGj9SAxC4gnp9l6zxDYtP+V/vFX9IU=",
+    "shasum": "V+l9lTrSHSqpWhriDF1ru8BrrEQx1+dVCDO4S/FXK4s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -18,7 +18,12 @@
   },
   "initialPermissions": {
     "endowment:rpc": {
-      "dapps": true
+      "dapps": true,
+      "snaps": {
+        "allowedOrigins": [
+          "npm:@metamask/json-rpc-example-snap"
+        ]
+      }
     },
     "snap_dialog": {},
     "snap_getBip44Entropy": [

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "V+l9lTrSHSqpWhriDF1ru8BrrEQx1+dVCDO4S/FXK4s=",
+    "shasum": "bYcRMl7jxVJlMwW9+U5IiivNK/4T/VsX+k1pGPlp9ik=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -19,11 +19,9 @@
   "initialPermissions": {
     "endowment:rpc": {
       "dapps": true,
-      "snaps": {
-        "allowedOrigins": [
-          "npm:@metamask/json-rpc-example-snap"
-        ]
-      }
+      "allowedOrigins": [
+        "npm:@metamask/json-rpc-example-snap"
+      ]
     },
     "snap_dialog": {},
     "snap_getBip44Entropy": [

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vI/KljQNJOA64un4kaXLrBIdTmoloIWnzydhrQFC0OY=",
+    "shasum": "zTD155x2TSEe8zsnJRo7J+CT47RsgOgh44JsB1WuVfU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "PiQKZ+XJWHflCsFTqI+bfOC2lv51ReaYh55NBKV7sqY=",
+    "shasum": "vI/KljQNJOA64un4kaXLrBIdTmoloIWnzydhrQFC0OY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "WvilWKhHZPbr31IFi6GP5yw77sFlJpFELjvS5qN0QvM=",
+    "shasum": "vYc7jb42Pj9kduadAZXDDQ7i524pFQZvrCtHL0ru12c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vYc7jb42Pj9kduadAZXDDQ7i524pFQZvrCtHL0ru12c=",
+    "shasum": "QFQgPo75m1aVfrlsAvtkdoPZ7PfTS6koFPpwCLJxgr0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Gp4DmjKNDQIpVkOJLRvThP/p1eRRjeViRoVeelkovPw=",
+    "shasum": "z7DohohSRqLwkXWEiINCgaEAW9IntR9Vjhdunt4wsmY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "BYde5IQ3I0Y6sCow1IGm4mAyksC5fdP3DHnOXZFzxDw=",
+    "shasum": "Gp4DmjKNDQIpVkOJLRvThP/p1eRRjeViRoVeelkovPw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "qQMuTp5zbcAAVNMENTQCvo5Rj825ohur3Uwld8Nxgs0=",
+    "shasum": "QU0XLyiD8WqL3MdYowPNb88EcdlpeE76nBvb/qOKqSk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "QU0XLyiD8WqL3MdYowPNb88EcdlpeE76nBvb/qOKqSk=",
+    "shasum": "SvREdi8XCfnwdJycaa/k7rrKnYJNSdXmrDJ0+cjQ2zo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "gKdBa0h+SZKNu6WFHFps5W1ly7WNTU2lrrOsyy7Z7VU=",
+    "shasum": "y2QayHgWDbm8Ax1NGQRO4885HVHviFlbus1Z7uVfOXk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/src/index.ts
+++ b/packages/examples/packages/json-rpc/src/index.ts
@@ -3,7 +3,7 @@ import type { OnRpcRequestHandler } from '@metamask/snaps-types';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the
- * `wallet_invokeSnap` method. This handler handles a single method:
+ * `wallet_invokeSnap` method. This handler handles two methods:
  *
  * - `invokeSnap`: Call the `getPublicKey` method of the
  * `@metamask/bip32-example-snap`, and return the response. This demonstrates
@@ -12,12 +12,16 @@ import type { OnRpcRequestHandler } from '@metamask/snaps-types';
  * extension, and it must have the `endowment:rpc` permission, with the "snaps"
  * option enabled.
  *
+ * - `invokeOtherSnap`: Call the `getPublicKey` method of the
+ * `@metamask/bip44-example-snap`, and return the response. This demonstrates
+ * that snaps can specify a list of `allowedOrigins` in their manifest, which
+ * restricts which snaps can invoke them through the `wallet_invokeSnap` method.
+ *
  * @param params - The request parameters.
  * @param params.request - The JSON-RPC request object.
  * @returns The JSON-RPC response.
  * @see https://docs.metamask.io/snaps/reference/exports/#onrpcrequest
  * @see https://docs.metamask.io/snaps/reference/rpc-api/#wallet_invokesnap
- * @see https://docs.metamask.io/snaps/reference/rpc-api/#snap_getentropy
  */
 export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   switch (request.method) {
@@ -32,6 +36,22 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
               path: ['m', "44'", "0'"],
               curve: 'secp256k1',
               compressed: true,
+            },
+          },
+        },
+      });
+    }
+
+    case 'invokeOtherSnap': {
+      return snap.request({
+        method: 'wallet_invokeSnap',
+        params: {
+          snapId: 'npm:@metamask/bip44-example-snap',
+          request: {
+            method: 'getPublicKey',
+            params: {
+              coinType: 1,
+              addressIndex: 0,
             },
           },
         },

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3l7IqA82IUC9I+tMEwQSSRKZKoTtQ3pgRwX8kyLz+MM=",
+    "shasum": "gi8JGBecyBA/9R0SuGPCaqeGAEuTUteA65ujvBSc+Ms=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "gi8JGBecyBA/9R0SuGPCaqeGAEuTUteA65ujvBSc+Ms=",
+    "shasum": "whwrc1YPP3PsAJzrXY2M/2akaG8pFvQhHcV62qO68M8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "z6nWAwVjLuw07zNx1RrFLPChIrr7U/UlJSFo7JXx4pM=",
+    "shasum": "vlD7grX9bqeqKMhtOudoXmOILBGS19bLBSe7FHTbjSo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vlD7grX9bqeqKMhtOudoXmOILBGS19bLBSe7FHTbjSo=",
+    "shasum": "StQFabni9psFzkxMGGPYiaXXugO1ewvMHcPXHnisCJ4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 89.06,
+  "branches": 88.74,
   "functions": 95.84,
   "lines": 96.98,
-  "statements": 96.64
+  "statements": 96.63
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -51,6 +51,7 @@ import {
   DEFAULT_REQUESTED_SNAP_VERSION,
   getErrorMessage,
   HandlerType,
+  isOriginAllowed,
   logError,
   normalizeRelative,
   resolveVersionRange,
@@ -2501,7 +2502,6 @@ export class SnapController extends BaseController<
         'SubjectMetadataController:getSubjectMetadata',
         origin,
       );
-      const isSnap = subject?.subjectType === SubjectType.Snap;
 
       const permissions = this.messagingSystem.call(
         'PermissionController:getPermissions',
@@ -2514,7 +2514,13 @@ export class SnapController extends BaseController<
       const origins = getRpcCaveatOrigins(rpcPermission);
       assert(origins);
 
-      if ((isSnap && !origins.snaps) || (!isSnap && !origins.dapps)) {
+      if (
+        !isOriginAllowed(
+          origins,
+          subject?.subjectType ?? SubjectType.Website,
+          origin,
+        )
+      ) {
         throw new Error(
           `Snap "${snapId}" is not permitted to handle JSON-RPC requests from "${origin}".`,
         );

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 95.12,
+  "branches": 95.21,
   "functions": 100,
-  "lines": 98.68,
-  "statements": 95.77
+  "lines": 98.67,
+  "statements": 95.74
 }

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 95.02,
+  "branches": 95.12,
   "functions": 100,
-  "lines": 98.65,
-  "statements": 95.7
+  "lines": 98.68,
+  "statements": 95.77
 }

--- a/packages/snaps-utils/src/json-rpc.test.ts
+++ b/packages/snaps-utils/src/json-rpc.test.ts
@@ -1,43 +1,11 @@
 import { SubjectType } from '@metamask/permission-controller';
-import { is } from 'superstruct';
 
 import type { RpcOrigins } from './json-rpc';
 import {
-  AllowedOriginsStruct,
   assertIsJsonRpcSuccess,
   assertIsRpcOrigins,
   isOriginAllowed,
 } from './json-rpc';
-
-describe('AllowedOriginsStruct', () => {
-  it.each([
-    { allowedOrigins: [] },
-    { allowedOrigins: ['foo'] },
-    { allowedOrigins: ['foo', 'bar'] },
-  ])('returns `true` for %p', (value) => {
-    expect(is(value, AllowedOriginsStruct)).toBe(true);
-  });
-
-  it.each([
-    {},
-    { allowedOrigins: null },
-    { allowedOrigins: undefined },
-    { allowedOrigins: 0 },
-    { allowedOrigins: 1 },
-    { allowedOrigins: '' },
-    { allowedOrigins: 'foo' },
-    { allowedOrigins: ['foo', null] },
-    { allowedOrigins: ['foo', undefined] },
-    { allowedOrigins: ['foo', 0] },
-    { allowedOrigins: ['foo', 1] },
-    { allowedOrigins: ['foo', 'bar', null] },
-    { allowedOrigins: ['foo', 'bar', undefined] },
-    { allowedOrigins: ['foo', 'bar', 0] },
-    { allowedOrigins: ['foo', 'bar', 1] },
-  ])('returns `false` for %p', (value) => {
-    expect(is(value, AllowedOriginsStruct)).toBe(false);
-  });
-});
 
 describe('assertIsRpcOrigins', () => {
   it.each([
@@ -45,16 +13,21 @@ describe('assertIsRpcOrigins', () => {
     { snaps: true },
     { dapps: true, snaps: true },
     {
-      dapps: { allowedOrigins: ['foo'] },
-      snaps: { allowedOrigins: ['bar'] },
+      dapps: true,
+      snaps: true,
+      allowedOrigins: ['foo', 'bar'],
     },
     {
-      dapps: { allowedOrigins: ['foo'] },
+      dapps: false,
       snaps: true,
+      allowedOrigins: ['foo', 'bar'],
     },
     {
       dapps: true,
-      snaps: { allowedOrigins: ['bar'] },
+      allowedOrigins: ['foo', 'bar'],
+    },
+    {
+      allowedOrigins: ['foo', 'bar'],
     },
   ])('does not throw for %p', (origins) => {
     expect(() => assertIsRpcOrigins(origins)).not.toThrow();
@@ -81,10 +54,11 @@ describe('assertIsRpcOrigins', () => {
   });
 
   it.each([
-    { dapps: { allowedOrigins: [] }, snaps: false },
-    { dapps: false, snaps: { allowedOrigins: [] } },
-    { dapps: { allowedOrigins: [] }, snaps: { allowedOrigins: [] } },
+    { dapps: false },
+    { snaps: false },
+    { allowedOrigins: [] },
     { dapps: false, snaps: false },
+    { dapps: false, snaps: false, allowedOrigins: [] },
   ])('throws if no origins are allowed', (value) => {
     expect(() => assertIsRpcOrigins(value)).toThrow(
       'Invalid JSON-RPC origins: Must specify at least one JSON-RPC origin.',
@@ -115,8 +89,7 @@ describe('isOriginAllowed', () => {
 
   it('returns `true` if the origin is allowed', () => {
     const origins: RpcOrigins = {
-      dapps: { allowedOrigins: ['foo'] },
-      snaps: { allowedOrigins: ['bar'] },
+      allowedOrigins: ['foo', 'bar'],
     };
 
     expect(isOriginAllowed(origins, SubjectType.Snap, 'bar')).toBe(true);
@@ -125,8 +98,7 @@ describe('isOriginAllowed', () => {
 
   it('returns `false` if the origin is not allowed', () => {
     const origins: RpcOrigins = {
-      dapps: { allowedOrigins: ['foo'] },
-      snaps: { allowedOrigins: ['bar'] },
+      allowedOrigins: [],
     };
 
     expect(isOriginAllowed(origins, SubjectType.Snap, 'foo')).toBe(false);


### PR DESCRIPTION
This adds an optional `allowedOrigins` field to `endowment:rpc`. For example, a Snap can now specify this:

```json
{
  "initialPermissions": {
    "endowment:rpc": {
      "allowedOrigins": [
        "example.com"
      ]
    }
  }
}
```

Which would then only allow requests from "example.com" to the Snap.