### PR TITLE
Add `getAllowedKeyringMethods` hook to be used by `invokeKeyring`

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cvECLsPKW1iv8uq4TW95cuWgCsBsUrvw2a/QlqnjE1A=",
+    "shasum": "RYHOFeY82uNI3egTzPcu4scZgZ2qJUzlSj93tY20qJ0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "NOR6OkMC96i6pL1nfqo4ur7OZxu0ozqoZc7ympM0Gjs=",
+    "shasum": "cvECLsPKW1iv8uq4TW95cuWgCsBsUrvw2a/QlqnjE1A=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "MJhQmSorfYhGXJMqXB+8E+1hhgQFXRVVRLvXJsXr8Ao=",
+    "shasum": "DOwNxEKGdxqfDy59TwzNDtCcfuGPt9eS0PojsIYfYaM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "DOwNxEKGdxqfDy59TwzNDtCcfuGPt9eS0PojsIYfYaM=",
+    "shasum": "vvf26WUqarQVXKpq0Cpms4P33bPg4a9bEDnRjpe7BPU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VIWwoadlScOzTWNNug2wXIOTcUG3LTR2jkclguYitAQ=",
+    "shasum": "MUqLTm5z9uwg6oo2o2J+ME3Uo7fSsZYmH3bI4Yoeer0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "MUqLTm5z9uwg6oo2o2J+ME3Uo7fSsZYmH3bI4Yoeer0=",
+    "shasum": "BTF3eAuMqO0+owCDSqJXbPDNwMKnzZCdmQvBQmnMIjs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8azu0ggwSpO8CKHw+Wh4PESRJXlTmEwF7PRvZsljsXI=",
+    "shasum": "JBbWxv01aboskhXDFpID58JBcmeZp/09quYgESQUeNs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "JBbWxv01aboskhXDFpID58JBcmeZp/09quYgESQUeNs=",
+    "shasum": "L5JpMUjAdHJRnlBnhBnyD8MYR9z8rMHq9Q8BVEOhFIw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1pMnIyEslx0I9fvxPTnqgE15gnCg9NCXkFb/Xxxx4sk=",
+    "shasum": "7yts99UNve2J47N8mHBTK/+XPlYrs5Bh+Ld4yaQ1AV4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "mv+L5dHEG+sQICA+p+07lloVRpXc7fcCWlUPVrCOBxI=",
+    "shasum": "1pMnIyEslx0I9fvxPTnqgE15gnCg9NCXkFb/Xxxx4sk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wyQzOLJV1Gx4Fq7G79gqi03CcsxcyEj73Jsh/cH0/68=",
+    "shasum": "xJfXGxkm4zn7ijyqOEynSDzjkJrFF3H4UaOolRz4KGw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Id8I3BtGeWYDK2dtkMwOXpf2wstbYPna7wynPLoD4KQ=",
+    "shasum": "wyQzOLJV1Gx4Fq7G79gqi03CcsxcyEj73Jsh/cH0/68=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3RyNa/1tEkdA7RYfiY/UvBKl5zJ2VYXdp1h17N9R7PA=",
+    "shasum": "i9qVJ7pADkWZ1oxE4PHHO5NoLpmyI6YUZbNHrvDdjVw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "i9qVJ7pADkWZ1oxE4PHHO5NoLpmyI6YUZbNHrvDdjVw=",
+    "shasum": "CgxqcCK1lxUdhcBg2pR1V56dTBmrlqAjjtYsE0Z0/jE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "gWQfey2nql08In8bZvZ9JEaLE40k0nmXoEJZBEgB1R8=",
+    "shasum": "aY28bl3jUxP+1Xfiwq6bwD9voabK9x56ty8ECy7meZ0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "J9El3MGPC+g5X5uPWMjt4kV4smFcXFGX+O2TWHuDtSw=",
+    "shasum": "gWQfey2nql08In8bZvZ9JEaLE40k0nmXoEJZBEgB1R8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -10,7 +10,7 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 87.17,
+      branches: 87.6,
       functions: 100,
       lines: 97.95,
       statements: 96.44,

--- a/packages/rpc-methods/src/permitted/invokeKeyring.test.ts
+++ b/packages/rpc-methods/src/permitted/invokeKeyring.test.ts
@@ -222,7 +222,7 @@ describe('wallet_invokeKeyring', () => {
 
       expect(response.error).toStrictEqual({
         ...ethErrors.rpc
-          .invalidRequest({ message: 'The request must specify a method.' })
+          .invalidRequest({ message: 'The request must have a method.' })
           .serialize(),
         stack: expect.any(String),
       });

--- a/packages/rpc-methods/src/permitted/invokeKeyring.test.ts
+++ b/packages/rpc-methods/src/permitted/invokeKeyring.test.ts
@@ -39,7 +39,7 @@ describe('wallet_invokeKeyring', () => {
         getSnap: jest.fn(),
         hasPermission: jest.fn(),
         handleSnapRpcRequest: jest.fn(),
-        getAllowedKeyringMethodsForOrigin: jest.fn(),
+        getAllowedKeyringMethods: jest.fn(),
       } as any);
 
     it('invokes the snap and returns the result', async () => {
@@ -50,7 +50,7 @@ describe('wallet_invokeKeyring', () => {
       hooks.hasPermission.mockImplementation(() => true);
       hooks.getSnap.mockImplementation(() => getSnapObject());
       hooks.handleSnapRpcRequest.mockImplementation(() => 'bar');
-      hooks.getAllowedKeyringMethodsForOrigin.mockImplementation(() => ['foo']);
+      hooks.getAllowedKeyringMethods.mockImplementation(() => ['foo']);
 
       const engine = new JsonRpcEngine();
       engine.push(createOriginMiddleware('metamask.io'));
@@ -97,7 +97,7 @@ describe('wallet_invokeKeyring', () => {
           message: 'Failed to start snap.',
         });
       });
-      hooks.getAllowedKeyringMethodsForOrigin.mockImplementation(() => ['foo']);
+      hooks.getAllowedKeyringMethods.mockImplementation(() => ['foo']);
 
       const engine = new JsonRpcEngine();
       engine.push(createOriginMiddleware('metamask.io'));
@@ -145,7 +145,7 @@ describe('wallet_invokeKeyring', () => {
           message: 'Failed to start snap.',
         });
       });
-      hooks.getAllowedKeyringMethodsForOrigin.mockImplementation(() => ['bar']);
+      hooks.getAllowedKeyringMethods.mockImplementation(() => ['bar']);
 
       const engine = new JsonRpcEngine();
       engine.push(createOriginMiddleware('metamask.io'));
@@ -194,7 +194,7 @@ describe('wallet_invokeKeyring', () => {
           message: 'Failed to start snap.',
         });
       });
-      hooks.getAllowedKeyringMethodsForOrigin.mockImplementation(() => ['foo']);
+      hooks.getAllowedKeyringMethods.mockImplementation(() => ['foo']);
 
       const engine = new JsonRpcEngine();
       engine.push(createOriginMiddleware('metamask.io'));

--- a/packages/rpc-methods/src/permitted/invokeKeyring.test.ts
+++ b/packages/rpc-methods/src/permitted/invokeKeyring.test.ts
@@ -39,6 +39,7 @@ describe('wallet_invokeKeyring', () => {
         getSnap: jest.fn(),
         hasPermission: jest.fn(),
         handleSnapRpcRequest: jest.fn(),
+        getAllowedKeyringMethodsForOrigin: jest.fn(),
       } as any);
 
     it('invokes the snap and returns the result', async () => {
@@ -49,6 +50,7 @@ describe('wallet_invokeKeyring', () => {
       hooks.hasPermission.mockImplementation(() => true);
       hooks.getSnap.mockImplementation(() => getSnapObject());
       hooks.handleSnapRpcRequest.mockImplementation(() => 'bar');
+      hooks.getAllowedKeyringMethodsForOrigin.mockImplementation(() => ['foo']);
 
       const engine = new JsonRpcEngine();
       engine.push(createOriginMiddleware('metamask.io'));
@@ -95,6 +97,7 @@ describe('wallet_invokeKeyring', () => {
           message: 'Failed to start snap.',
         });
       });
+      hooks.getAllowedKeyringMethodsForOrigin.mockImplementation(() => ['foo']);
 
       const engine = new JsonRpcEngine();
       engine.push(createOriginMiddleware('metamask.io'));
@@ -130,7 +133,102 @@ describe('wallet_invokeKeyring', () => {
       });
     });
 
-    it('fails if the origin doesnt have the permission to invoke the snap', async () => {
+    it('fails if origin is not authorized to call the method', async () => {
+      const { implementation } = invokeKeyringHandler;
+
+      const hooks = getMockHooks();
+
+      hooks.hasPermission.mockImplementation(() => true);
+      hooks.getSnap.mockImplementation(() => getSnapObject());
+      hooks.handleSnapRpcRequest.mockImplementation(() => {
+        throw ethErrors.rpc.invalidRequest({
+          message: 'Failed to start snap.',
+        });
+      });
+      hooks.getAllowedKeyringMethodsForOrigin.mockImplementation(() => ['bar']);
+
+      const engine = new JsonRpcEngine();
+      engine.push(createOriginMiddleware('metamask.io'));
+      engine.push((req, res, next, end) => {
+        const result = implementation(
+          req as JsonRpcRequest<JsonRpcRequest<unknown>>,
+          res as PendingJsonRpcResponse<unknown>,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = (await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'wallet_invokeKeyring',
+        params: {
+          snapId: MOCK_SNAP_ID,
+          request: { method: 'foo' },
+        },
+      })) as JsonRpcFailure;
+
+      expect(response.error).toStrictEqual({
+        ...ethErrors.rpc
+          .invalidRequest({
+            message:
+              'The origin "metamask.io" is not allowed to invoke the method "foo".',
+          })
+          .serialize(),
+        stack: expect.any(String),
+      });
+    });
+
+    it("fails if the request doesn't have a method name", async () => {
+      const { implementation } = invokeKeyringHandler;
+
+      const hooks = getMockHooks();
+
+      hooks.hasPermission.mockImplementation(() => true);
+      hooks.getSnap.mockImplementation(() => getSnapObject());
+      hooks.handleSnapRpcRequest.mockImplementation(() => {
+        throw ethErrors.rpc.invalidRequest({
+          message: 'Failed to start snap.',
+        });
+      });
+      hooks.getAllowedKeyringMethodsForOrigin.mockImplementation(() => ['foo']);
+
+      const engine = new JsonRpcEngine();
+      engine.push(createOriginMiddleware('metamask.io'));
+      engine.push((req, res, next, end) => {
+        const result = implementation(
+          req as JsonRpcRequest<JsonRpcRequest<unknown>>,
+          res as PendingJsonRpcResponse<unknown>,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = (await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'wallet_invokeKeyring',
+        params: {
+          snapId: MOCK_SNAP_ID,
+          request: { something: 'foo' },
+        },
+      })) as JsonRpcFailure;
+
+      expect(response.error).toStrictEqual({
+        ...ethErrors.rpc
+          .invalidRequest({ message: 'The request must specify a method.' })
+          .serialize(),
+        stack: expect.any(String),
+      });
+    });
+
+    it("fails if the origin doesn't have the permission to invoke the snap", async () => {
       const { implementation } = invokeKeyringHandler;
 
       const hooks = getMockHooks();

--- a/packages/rpc-methods/src/permitted/invokeKeyring.ts
+++ b/packages/rpc-methods/src/permitted/invokeKeyring.ts
@@ -112,7 +112,7 @@ async function invokeKeyringImplementation(
   if (!hasProperty(request, 'method') || typeof request.method !== 'string') {
     return end(
       ethErrors.rpc.invalidRequest({
-        message: `The request must specify a method.`,
+        message: 'The request must have a method.',
       }),
     );
   }

--- a/packages/rpc-methods/src/permitted/invokeKeyring.ts
+++ b/packages/rpc-methods/src/permitted/invokeKeyring.ts
@@ -22,7 +22,7 @@ const hookNames: MethodHooksObject<InvokeKeyringHooks> = {
   hasPermission: true,
   handleSnapRpcRequest: true,
   getSnap: true,
-  getAllowedKeyringMethodsForOrigin: true,
+  getAllowedKeyringMethods: true,
 };
 
 /**
@@ -50,7 +50,7 @@ export type InvokeKeyringHooks = {
 
   getSnap: (snapId: SnapId) => Snap | undefined;
 
-  getAllowedKeyringMethodsForOrigin: (origin: string) => string[];
+  getAllowedKeyringMethods: (origin: string) => string[];
 };
 
 /**
@@ -66,8 +66,8 @@ export type InvokeKeyringHooks = {
  * @param hooks.handleSnapRpcRequest - Invokes a snap with a given RPC request.
  * @param hooks.hasPermission - Checks whether a given origin has a given permission.
  * @param hooks.getSnap - Gets information about a given snap.
- * @param hooks.getAllowedKeyringMethodsForOrigin - Get the list of allowed
- * Keyring methods for a given origin.
+ * @param hooks.getAllowedKeyringMethods - Get the list of allowed Keyring
+ * methods for a given origin.
  * @returns Nothing.
  */
 async function invokeKeyringImplementation(
@@ -79,7 +79,7 @@ async function invokeKeyringImplementation(
     handleSnapRpcRequest,
     hasPermission,
     getSnap,
-    getAllowedKeyringMethodsForOrigin,
+    getAllowedKeyringMethods,
   }: InvokeKeyringHooks,
 ): Promise<void> {
   let params: InvokeSnapSugarArgs;
@@ -117,7 +117,7 @@ async function invokeKeyringImplementation(
     );
   }
 
-  const allowedMethods = getAllowedKeyringMethodsForOrigin(origin);
+  const allowedMethods = getAllowedKeyringMethods(origin);
   if (!allowedMethods.includes(request.method)) {
     return end(
       ethErrors.rpc.invalidRequest({

--- a/packages/snaps-execution-environments/src/common/commands.ts
+++ b/packages/snaps-execution-environments/src/common/commands.ts
@@ -67,12 +67,12 @@ export function getHandlerArguments(
           };
     }
     case HandlerType.OnRpcRequest:
+    case HandlerType.OnKeyringRequest:
       return { origin, request };
 
     case HandlerType.OnCronjob:
     case HandlerType.OnInstall:
     case HandlerType.OnUpdate:
-    case HandlerType.OnKeyringRequest:
       return { request };
 
     default:


### PR DESCRIPTION
This PR replaces #1809 to use a branch from `MetaMask/snaps` instead of my personal repo.