### PR TITLE
Implement `SnapError`

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "O0Ncs/BuMYDj6nUxHCvIn1rO5BkQi5o7bFSs9Yw3lH8=",
+    "shasum": "eDkqoXIIvf+iTIyGzzm9OqITB1yn0EBBpZD5U4mMMW8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AO5ucwgLGZEMl4VFFmNGchd2e4PCo118EGfXU0Ltnfs=",
+    "shasum": "sbuK7gPHnaij+5TKchJ/otquOV6HjZjYFDiBN5gXc1o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "sbuK7gPHnaij+5TKchJ/otquOV6HjZjYFDiBN5gXc1o=",
+    "shasum": "mxQ/gwTrfMlcJ7vE9Dy5re4ysXghAv7P//FxWlCnRjU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "mxQ/gwTrfMlcJ7vE9Dy5re4ysXghAv7P//FxWlCnRjU=",
+    "shasum": "QbIeP2qWOCUL23DriGKPaAJBCtWiFOAsYhJJOkmTPHk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "eDkqoXIIvf+iTIyGzzm9OqITB1yn0EBBpZD5U4mMMW8=",
+    "shasum": "RUTdDLav0ICsDe2T3raTS/KhpItxG1GmKqnypQR1fAk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "RUTdDLav0ICsDe2T3raTS/KhpItxG1GmKqnypQR1fAk=",
+    "shasum": "AO5ucwgLGZEMl4VFFmNGchd2e4PCo118EGfXU0Ltnfs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/src/index.test.ts
+++ b/packages/examples/packages/bip32/src/index.test.ts
@@ -12,13 +12,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 
@@ -75,15 +74,10 @@ describe('onRpcRequest', () => {
       });
 
       expect(response).toRespondWithError({
-        code: -32603,
-        message: 'Internal JSON-RPC error.',
-        data: {
-          cause: {
-            message:
-              'The requested path is not permitted. Allowed paths must be specified in the snap manifest.',
-            stack: expect.any(String),
-          },
-        },
+        code: 4100,
+        message:
+          'The requested path is not permitted. Allowed paths must be specified in the snap manifest.',
+        stack: expect.any(String),
       });
 
       await close();
@@ -101,15 +95,10 @@ describe('onRpcRequest', () => {
       });
 
       expect(response).toRespondWithError({
-        code: -32603,
-        message: 'Internal JSON-RPC error.',
-        data: {
-          cause: {
-            message:
-              'The requested path is not permitted. Allowed paths must be specified in the snap manifest.',
-            stack: expect.any(String),
-          },
-        },
+        code: 4100,
+        message:
+          'The requested path is not permitted. Allowed paths must be specified in the snap manifest.',
+        stack: expect.any(String),
       });
 
       await close();
@@ -202,14 +191,9 @@ describe('onRpcRequest', () => {
       await ui.cancel();
 
       expect(await response).toRespondWithError({
-        code: -32603,
-        message: 'Internal JSON-RPC error.',
-        data: {
-          cause: {
-            message: 'User rejected the request.',
-            stack: expect.any(String),
-          },
-        },
+        code: 4001,
+        message: 'User rejected the request.',
+        stack: expect.any(String),
       });
 
       await close();

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Slvr0dg8/FoYzp4nmAbnaxzEwpsmGiaEZKXp77iOdbE=",
+    "shasum": "GC/e7FR0SIgXVH2QsObDG3c0VadVsGEdEytpp6WldfQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AzUqyDpEctSJaZwSiTVJjT9nLeUOdB5lHfrvJ4Gi62w=",
+    "shasum": "LkxO3exV5wCPIEMSwO0NKB+ZRE2ojmilbvXOavv0DzA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7loBSreAfg+v58nSmd+eh2+p/jDkOhC+btvqC8w14Dk=",
+    "shasum": "jWcfzY4mlKuy+U0U5xNfKyrG0idGPeOaTNPl4Ua6uGw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LkxO3exV5wCPIEMSwO0NKB+ZRE2ojmilbvXOavv0DzA=",
+    "shasum": "Slvr0dg8/FoYzp4nmAbnaxzEwpsmGiaEZKXp77iOdbE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "GC/e7FR0SIgXVH2QsObDG3c0VadVsGEdEytpp6WldfQ=",
+    "shasum": "7loBSreAfg+v58nSmd+eh2+p/jDkOhC+btvqC8w14Dk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "MgSpx86WLoY6ebo+Ta3qcCO9yiuIdp5mY8FlooDZJZg=",
+    "shasum": "AzUqyDpEctSJaZwSiTVJjT9nLeUOdB5lHfrvJ4Gi62w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/src/index.test.ts
+++ b/packages/examples/packages/bip44/src/index.test.ts
@@ -12,13 +12,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 
@@ -69,15 +68,10 @@ describe('onRpcRequest', () => {
       });
 
       expect(response).toRespondWithError({
-        code: -32603,
-        message: 'Internal JSON-RPC error.',
-        data: {
-          cause: {
-            message:
-              'The requested coin type is not permitted. Allowed coin types must be specified in the snap manifest.',
-            stack: expect.any(String),
-          },
-        },
+        code: 4100,
+        message:
+          'The requested coin type is not permitted. Allowed coin types must be specified in the snap manifest.',
+        stack: expect.any(String),
       });
 
       await close();
@@ -166,14 +160,9 @@ describe('onRpcRequest', () => {
       await ui.cancel();
 
       expect(await response).toRespondWithError({
-        code: -32603,
-        message: 'Internal JSON-RPC error.',
-        data: {
-          cause: {
-            message: 'User rejected the request.',
-            stack: expect.any(String),
-          },
-        },
+        code: 4001,
+        message: 'User rejected the request.',
+        stack: expect.any(String),
       });
 
       await close();

--- a/packages/examples/packages/browserify-plugin/src/index.test.ts
+++ b/packages/examples/packages/browserify-plugin/src/index.test.ts
@@ -10,13 +10,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/examples/packages/browserify/src/index.test.ts
+++ b/packages/examples/packages/browserify/src/index.test.ts
@@ -10,13 +10,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wiSeDD+wRoVABnpSZ8B4Rp26hTVcjGy8y2V/uCnPnUw=",
+    "shasum": "EEbh1VsNq7DPpi0TK67wvrc7FpASE+iIjFP0FU//lLQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "oW8TYppYMGKnWuIt9eDIn0pDTZpOLuKF55MK3BVxVRo=",
+    "shasum": "vKOUZtO0CdtaQLKLSoPFYCk8pJDYPzj/Ra2IVS25t/4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "a1d6VlQhOdFB2FQIMf9F5L0Z24/EABo7On4pg9UOVWs=",
+    "shasum": "oW8TYppYMGKnWuIt9eDIn0pDTZpOLuKF55MK3BVxVRo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vKOUZtO0CdtaQLKLSoPFYCk8pJDYPzj/Ra2IVS25t/4=",
+    "shasum": "5088QO3qlZ8bJEDRjmeQaQX58F0WOX/us8kjdCuVNBc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "EEbh1VsNq7DPpi0TK67wvrc7FpASE+iIjFP0FU//lLQ=",
+    "shasum": "a1d6VlQhOdFB2FQIMf9F5L0Z24/EABo7On4pg9UOVWs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "49Ki82EdQq7D43dfQc6FSZ9BOs0gDniYJC6n5KxvoVo=",
+    "shasum": "wiSeDD+wRoVABnpSZ8B4Rp26hTVcjGy8y2V/uCnPnUw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/src/index.test.ts
+++ b/packages/examples/packages/dialogs/src/index.test.ts
@@ -12,13 +12,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/examples/packages/ethereum-provider/src/index.test.ts
+++ b/packages/examples/packages/ethereum-provider/src/index.test.ts
@@ -10,13 +10,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/examples/packages/ethers-js/src/index.test.ts
+++ b/packages/examples/packages/ethers-js/src/index.test.ts
@@ -12,13 +12,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/examples/packages/ethers-js/src/index.test.ts
+++ b/packages/examples/packages/ethers-js/src/index.test.ts
@@ -84,14 +84,9 @@ describe('onRpcRequest', () => {
       await ui.cancel();
 
       expect(await response).toRespondWithError({
-        code: -32603,
-        message: 'Internal JSON-RPC error.',
-        data: {
-          cause: {
-            message: 'User rejected the request.',
-            stack: expect.any(String),
-          },
-        },
+        code: 4001,
+        message: 'User rejected the request.',
+        stack: expect.any(String),
       });
 
       await close();

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OZywJzSBM/UwkdpeXQ7t99vyGXOoQRtRq1h5a3Fzaas=",
+    "shasum": "svb40XCaun3rgf6ba2UYVtdRwRLBokeHm5r91E9cgws=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "nqdRr28NmCqz4gJRdHPSetrZtzQTdEjdyitOhlBkb18=",
+    "shasum": "QoWAUabV1xnRzNqb9YBmPLnAuDkq36g9Plnsn1Lau00=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "QoWAUabV1xnRzNqb9YBmPLnAuDkq36g9Plnsn1Lau00=",
+    "shasum": "Xtivd+RVJPyxKkyr4pC4pnMVj3bsWAGvi5XCw+jWwU4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Xtivd+RVJPyxKkyr4pC4pnMVj3bsWAGvi5XCw+jWwU4=",
+    "shasum": "/ZF7EV0bS0qjAC9hZIp3guh02izXRxluYTxaMyo401I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "/vHSKNUGmy1NiS/YgXRopAXAhh5ziQuN4/G+tu8kNfQ=",
+    "shasum": "OZywJzSBM/UwkdpeXQ7t99vyGXOoQRtRq1h5a3Fzaas=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "svb40XCaun3rgf6ba2UYVtdRwRLBokeHm5r91E9cgws=",
+    "shasum": "nqdRr28NmCqz4gJRdHPSetrZtzQTdEjdyitOhlBkb18=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/src/index.test.ts
+++ b/packages/examples/packages/get-entropy/src/index.test.ts
@@ -11,13 +11,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/examples/packages/get-file/package.json
+++ b/packages/examples/packages/get-file/package.json
@@ -32,7 +32,7 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^5.1.1",
+    "@metamask/rpc-errors": "^6.1.0",
     "@metamask/snaps-types": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AC9lKxpF32Lg5eUx+cl46l9hWzB940tYCWkxsCZNcIs=",
+    "shasum": "Ho7x2FWfVaRdRFNlgkleDb/qb/JyxlRiMfF02NU5BrM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/src/index.test.ts
+++ b/packages/examples/packages/get-file/src/index.test.ts
@@ -10,13 +10,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VDLdN2iWLu1ishmLKq0ylxJbSTaVgpMVawinDjgDNOo=",
+    "shasum": "DyDsDP1zwx/VpG4w1dDupwqG+gQVic95+MJzEmZPVkU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "nCOYvMfzeI8xom4WvtMR2uz2RvcpwoqT7S8yYcNe2wU=",
+    "shasum": "U7WJVtTjSSXviIV01u0CFE9CCgtqs0lS5CRFbvvoKOc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AYtXPDcnwRAYzdvgLzipFJag8PDw3Sji0UGxgO1qmP8=",
+    "shasum": "31bvJw6IyhNbSkqW22Ow5nI4NVcobrBvQ24qN3Gz+vI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "31bvJw6IyhNbSkqW22Ow5nI4NVcobrBvQ24qN3Gz+vI=",
+    "shasum": "2QfwCIrEzDTNhxaArUJS0XFKmZGqsZpRhR0X7ntKnNM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "DyDsDP1zwx/VpG4w1dDupwqG+gQVic95+MJzEmZPVkU=",
+    "shasum": "nCOYvMfzeI8xom4WvtMR2uz2RvcpwoqT7S8yYcNe2wU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "U7WJVtTjSSXviIV01u0CFE9CCgtqs0lS5CRFbvvoKOc=",
+    "shasum": "AYtXPDcnwRAYzdvgLzipFJag8PDw3Sji0UGxgO1qmP8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/src/index.test.ts
+++ b/packages/examples/packages/get-locale/src/index.test.ts
@@ -11,13 +11,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/src/index.test.ts
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/src/index.test.ts
@@ -14,13 +14,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "W61H0BCPfcrBJ7pBGjsFB+YYiSf09FumRFXcuRzn2zI=",
+    "shasum": "X4jrJWjRQQtyV3GSeYCufATAIN47hIiOc8u6rvrtUz4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "X4jrJWjRQQtyV3GSeYCufATAIN47hIiOc8u6rvrtUz4=",
+    "shasum": "K5ci9Vb/DYABLSK5JjxV/kKqwjjdDj07TGoBdm3HK4k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7eoQVjy43iBLByj9iYPD6VWPybret4NQeIQXjomeZC8=",
+    "shasum": "W61H0BCPfcrBJ7pBGjsFB+YYiSf09FumRFXcuRzn2zI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "afA87jJTY3/ZGsX4QkrIZchrq+Zs05RSom1unZjyEvo=",
+    "shasum": "mQhJLcp7NAe1WjSsDHOH/xUyhn0LFr1Zh91g+mbhOkM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "K5ci9Vb/DYABLSK5JjxV/kKqwjjdDj07TGoBdm3HK4k=",
+    "shasum": "sSc+88tT48EyJovR7a1+W4J2bbjbjj5YTQ57yco2F7c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "sSc+88tT48EyJovR7a1+W4J2bbjbjj5YTQ57yco2F7c=",
+    "shasum": "afA87jJTY3/ZGsX4QkrIZchrq+Zs05RSom1unZjyEvo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/src/index.test.ts
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/src/index.test.ts
@@ -13,13 +13,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/examples/packages/json-rpc/src/index.test.ts
+++ b/packages/examples/packages/json-rpc/src/index.test.ts
@@ -14,13 +14,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AZl20QbBhbRe7A1wV16HivUmfihThBkCgbIDhec7gOY=",
+    "shasum": "rDSQTF0uXaZkRooMgrg40d+S5d2X8M4x4j7j+xnYy2U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OGmcoozWOgIrP/NOhtsXhD17TQfrXii7M7DNFbBDHhA=",
+    "shasum": "AZl20QbBhbRe7A1wV16HivUmfihThBkCgbIDhec7gOY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vMEGNkcwLlouAhfVl9jd3DmFnJolrSHZxqASfdCs08M=",
+    "shasum": "FVfkuYuUjhWbfYFw90jdiTT6wFC+epEjKn9iPuMCpZw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FVfkuYuUjhWbfYFw90jdiTT6wFC+epEjKn9iPuMCpZw=",
+    "shasum": "cgy2smj9RdoJxmVEF//EvORjB1zxvr7mZN3w9cva0Hk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cgy2smj9RdoJxmVEF//EvORjB1zxvr7mZN3w9cva0Hk=",
+    "shasum": "6NBKJ/JyEqP99JoLyUMBPQtWnxBuPchuOKe3TH4t028=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "rDSQTF0uXaZkRooMgrg40d+S5d2X8M4x4j7j+xnYy2U=",
+    "shasum": "vMEGNkcwLlouAhfVl9jd3DmFnJolrSHZxqASfdCs08M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/src/index.test.ts
+++ b/packages/examples/packages/manage-state/src/index.test.ts
@@ -10,13 +10,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/examples/packages/name-lookup/src/index.test.ts
+++ b/packages/examples/packages/name-lookup/src/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from '@jest/globals';
+import type { OnNameLookupArgs } from '@metamask/snaps-utils';
 
 import { onNameLookup } from '.';
-import type { OnNameLookupArgs } from '../../../../snaps-utils/src';
 
 const DOMAIN_MOCK = 'test.domain';
 const ADDRESS_MOCK = '0xc0ffee254729296a45a3885639AC7E10F9d54979';

--- a/packages/examples/packages/name-lookup/src/index.test.ts
+++ b/packages/examples/packages/name-lookup/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from '@jest/globals';
-import type { OnNameLookupArgs } from '@metamask/snaps-utils';
+import type { OnNameLookupArgs } from '@metamask/snaps-types';
 
 import { onNameLookup } from '.';
 

--- a/packages/examples/packages/network-access/src/index.test.ts
+++ b/packages/examples/packages/network-access/src/index.test.ts
@@ -10,13 +10,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8ua0qIjaOY43fvfFebCyheOPne5heObgWZhpJa1Nzqs=",
+    "shasum": "EreMy849JVhYXzo1J7iMBh0QdzEyoV3OhYMpAIbZxGs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "q+QnuVlN8NlXrFTeoTlcNhYzxNhZ9e3RX0baOsN8aL4=",
+    "shasum": "8ua0qIjaOY43fvfFebCyheOPne5heObgWZhpJa1Nzqs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Rv25Qb8W2S0jX45gczcRgA4rqriU2AFKd6/NzkmtEx8=",
+    "shasum": "q+QnuVlN8NlXrFTeoTlcNhYzxNhZ9e3RX0baOsN8aL4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Wq3Vq6PFu9EAV2OfqGcwiJ5B2kCm7nJ9l0TNsTNXfxQ=",
+    "shasum": "Rv25Qb8W2S0jX45gczcRgA4rqriU2AFKd6/NzkmtEx8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "YIohXGCij4G2m+j3Gsg+sCaiJj2bvtyEVNDHcqpEO7w=",
+    "shasum": "Wq3Vq6PFu9EAV2OfqGcwiJ5B2kCm7nJ9l0TNsTNXfxQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TZW+CtPEHAya0jED3VY90IvX8vCMIba1kd/zGVm/KBs=",
+    "shasum": "YIohXGCij4G2m+j3Gsg+sCaiJj2bvtyEVNDHcqpEO7w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/src/index.test.ts
+++ b/packages/examples/packages/notifications/src/index.test.ts
@@ -11,13 +11,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/examples/packages/rollup-plugin/src/index.test.ts
+++ b/packages/examples/packages/rollup-plugin/src/index.test.ts
@@ -10,13 +10,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "G6jLmVw81D5Y2tzvcbwBgxkOrcYn/hFMoruaZavY6P4=",
+    "shasum": "Xkej3ZcUlhETrR/jKYufasko3mFmJ4Ifq9KHAzLCJ3k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/src/index.test.ts
+++ b/packages/examples/packages/wasm/src/index.test.ts
@@ -10,13 +10,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/examples/packages/wasm/src/index.ts
+++ b/packages/examples/packages/wasm/src/index.ts
@@ -80,5 +80,5 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     return wasm[method](...params);
   }
 
-  throw rpcErrors.methodNotFound({ data: { request } });
+  throw rpcErrors.methodNotFound({ data: { method } });
 };

--- a/packages/examples/packages/webpack-plugin/src/index.test.ts
+++ b/packages/examples/packages/webpack-plugin/src/index.test.ts
@@ -10,13 +10,12 @@ describe('onRpcRequest', () => {
     });
 
     expect(response).toRespondWithError({
-      code: -32603,
-      message: 'Internal JSON-RPC error.',
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
       data: {
-        cause: {
-          message: 'The method does not exist / is not available.',
-          stack: expect.any(String),
-        },
+        method: 'foo',
+        cause: null,
       },
     });
 

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -2,5 +2,5 @@
   "branches": 89.54,
   "functions": 96.2,
   "lines": 97.1,
-  "statements": 96.76
+  "statements": 96.77
 }

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 89.62,
+  "branches": 89.54,
   "functions": 96.2,
   "lines": 97.1,
-  "statements": 96.77
+  "statements": 96.76
 }

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "test:prepare": "yarn mkdirp test/fixtures && ./scripts/generate-fixtures.sh",
-    "test": "rimraf coverage && yarn test:prepare && jest --detectOpenHandles && yarn test:browser && yarn posttest",
+    "test": "rimraf coverage && yarn test:prepare && jest && yarn test:browser && yarn posttest",
     "posttest": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",
     "test:browser": "wdio run wdio.config.js",
     "test:ci": "yarn test",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -136,17 +136,5 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
-  },
-  "lavamoat": {
-    "allowScripts": {
-      "@metamask/permission-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>keccak": false,
-      "@metamask/permission-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>secp256k1": false,
-      "@swc/core": false,
-      "@wdio/browser-runner>@originjs/vite-plugin-commonjs>esbuild": false,
-      "@wdio/cli>@wdio/utils>edgedriver": false,
-      "esbuild": false,
-      "wdio-chromedriver-service>chromedriver": false,
-      "wdio-geckodriver-service>geckodriver": false
-    }
   }
 }

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "test:prepare": "yarn mkdirp test/fixtures && ./scripts/generate-fixtures.sh",
-    "test": "rimraf coverage && yarn test:prepare && jest && yarn test:browser && yarn posttest",
+    "test": "rimraf coverage && yarn test:prepare && jest --detectOpenHandles && yarn test:browser && yarn posttest",
     "posttest": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",
     "test:browser": "wdio run wdio.config.js",
     "test:ci": "yarn test",

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.ts
@@ -48,10 +48,6 @@ export type Job<WorkerType> = {
   worker: WorkerType;
 };
 
-export class ExecutionEnvironmentError extends Error {
-  cause?: Json;
-}
-
 export abstract class AbstractExecutionService<WorkerType>
   implements ExecutionService
 {

--- a/packages/snaps-controllers/src/services/browser.test.ts
+++ b/packages/snaps-controllers/src/services/browser.test.ts
@@ -8,7 +8,6 @@ describe('browser entrypoint', () => {
     'OffscreenExecutionService',
     'WebWorkerExecutionService',
     'ProxyPostMessageStream',
-    'ExecutionEnvironmentError',
   ];
 
   it('entrypoint has expected exports', () => {

--- a/packages/snaps-controllers/src/services/node/NodeThreadExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/node/NodeThreadExecutionService.test.ts
@@ -1,8 +1,8 @@
+import { JsonRpcError } from '@metamask/rpc-errors';
 import type { SnapId } from '@metamask/snaps-utils';
 import { HandlerType } from '@metamask/snaps-utils';
 
 import { createService, MOCK_BLOCK_NUMBER } from '../../test-utils';
-import { ExecutionEnvironmentError } from '../AbstractExecutionService';
 import type { SnapErrorJson } from '../ExecutionService';
 import { NodeThreadExecutionService } from './NodeThreadExecutionService';
 
@@ -72,13 +72,20 @@ describe('NodeThreadExecutionService', () => {
       })
       .catch((error) => error);
 
-    expect(result).toBeInstanceOf(ExecutionEnvironmentError);
+    expect(result).toBeInstanceOf(JsonRpcError);
 
+    // @ts-expect-error - This is a `JsonRpcError`.
     // eslint-disable-next-line jest/prefer-strict-equal
-    expect((result as ExecutionEnvironmentError).cause).toEqual({
-      // TODO: Unwrap errors, and change this to the actual error message.
-      message: 'foobar',
+    expect(result.serialize()).toEqual({
+      code: -31001,
+      message: 'Wrapped Snap Error',
       stack: expect.any(String),
+      data: {
+        cause: {
+          message: 'foobar',
+          stack: expect.any(String),
+        },
+      },
     });
 
     await service.terminateAllSnaps();
@@ -137,10 +144,12 @@ describe('NodeThreadExecutionService', () => {
       code: -32603,
       data: {
         snapId: 'TestSnap',
-        stack: expect.stringContaining('Error: random error inside'),
+        cause: {
+          message: 'random error inside',
+          stack: expect.any(String),
+        },
       },
-      // TODO: Unwrap errors, and change this to the actual error message.
-      message: 'Execution Environment Error',
+      message: 'Unhandled Snap Error',
     });
 
     await service.terminateAllSnaps();

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2169,7 +2169,6 @@ describe('SnapController', () => {
         }),
       );
 
-      // By installing we also indirectly test that the unpacking of the file works.
       await snapController.installSnaps(MOCK_ORIGIN, {
         [MOCK_SNAP_ID]: {},
       });
@@ -2227,7 +2226,6 @@ describe('SnapController', () => {
         }),
       );
 
-      // By installing we also indirectly test that the unpacking of the file works.
       await snapController.installSnaps(MOCK_ORIGIN, {
         [MOCK_SNAP_ID]: {},
       });
@@ -5889,6 +5887,7 @@ describe('SnapController', () => {
         }),
       );
 
+      // By installing we also indirectly test that the unpacking of the file works.
       await snapController.installSnaps(MOCK_ORIGIN, {
         [MOCK_SNAP_ID]: {},
       });
@@ -5926,6 +5925,7 @@ describe('SnapController', () => {
         }),
       );
 
+      // By installing we also indirectly test that the unpacking of the file works.
       await snapController.installSnaps(MOCK_ORIGIN, {
         [MOCK_SNAP_ID]: {},
       });

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2197,7 +2197,22 @@ describe('SnapController', () => {
         updateChecksum: true,
         sourceCode: `
           module.exports.onRpcRequest = () => {
-            throw new SnapError('foo');
+            class SnapError {
+              serialize() {
+                return {
+                  code: -31002,
+                  message: 'Snap Error',
+                  data: {
+                    cause: {
+                      code: -1,
+                      message: 'foo',
+                    },
+                  },
+                };
+              }
+            }
+
+            throw new SnapError();
           };
         `,
       });

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2160,7 +2160,7 @@ describe('SnapController', () => {
         `,
       });
 
-      const [snapController] = getSnapControllerWithEES(
+      const [snapController, service] = getSnapControllerWithEES(
         getSnapControllerWithEESOptions({
           detectSnapLocation: loopbackDetect({
             manifest,
@@ -2190,6 +2190,7 @@ describe('SnapController', () => {
       expect(snapController.state.snaps[MOCK_SNAP_ID].status).toBe('crashed');
 
       snapController.destroy();
+      await service.terminateAllSnaps();
     });
 
     it('does not crash the Snap on handled errors', async () => {
@@ -2217,7 +2218,7 @@ describe('SnapController', () => {
         `,
       });
 
-      const [snapController] = getSnapControllerWithEES(
+      const [snapController, service] = getSnapControllerWithEES(
         getSnapControllerWithEESOptions({
           detectSnapLocation: loopbackDetect({
             manifest,
@@ -2247,6 +2248,7 @@ describe('SnapController', () => {
       expect(snapController.state.snaps[MOCK_SNAP_ID].status).toBe('running');
 
       snapController.destroy();
+      await service.terminateAllSnaps();
     });
   });
 

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -5887,7 +5887,6 @@ describe('SnapController', () => {
         }),
       );
 
-      // By installing we also indirectly test that the unpacking of the file works.
       await snapController.installSnaps(MOCK_ORIGIN, {
         [MOCK_SNAP_ID]: {},
       });
@@ -5925,7 +5924,6 @@ describe('SnapController', () => {
         }),
       );
 
-      // By installing we also indirectly test that the unpacking of the file works.
       await snapController.installSnaps(MOCK_ORIGIN, {
         [MOCK_SNAP_ID]: {},
       });

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -45,6 +45,7 @@ import type {
   ValidatedSnapId,
 } from '@metamask/snaps-utils';
 import {
+  SnapError as ExecutionEnvironmentSnapError,
   assertIsSnapManifest,
   assertIsValidSnapId,
   AuxiliaryFileEncoding,
@@ -54,6 +55,7 @@ import {
   getErrorMessage,
   HandlerType,
   isOriginAllowed,
+  isSnapErrorWrapper,
   logError,
   normalizeRelative,
   resolveVersionRange,
@@ -61,6 +63,7 @@ import {
   SnapStatus,
   SnapStatusEvents,
   validateFetchedSnap,
+  UnhandledSnapError,
 } from '@metamask/snaps-utils';
 import type { Json, NonEmptyArray, SemVerRange } from '@metamask/utils';
 import {
@@ -71,6 +74,7 @@ import {
   gtVersion,
   hasProperty,
   inMilliseconds,
+  isJsonRpcError,
   isNonEmptyArray,
   isValidSemVerRange,
   satisfiesVersionRange,
@@ -2600,6 +2604,24 @@ export class SnapController extends BaseController<
         this.#recordSnapRpcRequestFinish(snapId, request.id);
         return result;
       } catch (error) {
+        // First we check if the error is a SnapErrorWrapper, which means that
+        // the error was thrown by the Snap itself.
+        if (isSnapErrorWrapper(error)) {
+          // If the error is a SnapErrorWrapper, we can check if it is a
+          // SnapError or JSON-RPC error, which means that the Snap threw an
+          // error in response to a request.
+          if (isJsonRpcError(error.data.cause)) {
+            throw new ExecutionEnvironmentSnapError(error.data.cause);
+          }
+
+          // Otherwise, the Snap threw an error outside of a request, so we
+          // need to crash the Snap.
+          await this.stopSnap(snapId, SnapStatusEvents.Crash);
+          throw new UnhandledSnapError(error.data.cause);
+        }
+
+        // If the error is not a SnapErrorWrapper, then it is an unknown error
+        // and we need to crash the Snap.
         await this.stopSnap(snapId, SnapStatusEvents.Crash);
         throw error;
       }

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2441,6 +2441,12 @@ export class SnapController extends BaseController<
       'ExecutionService:outboundResponse',
       this._onOutboundResponse,
     );
+
+    this.messagingSystem.clearEventSubscriptions(
+      'SnapController:snapInstalled',
+    );
+
+    this.messagingSystem.clearEventSubscriptions('SnapController:snapUpdated');
     /* eslint-enable @typescript-eslint/unbound-method */
   }
 

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 79.72,
-  "functions": 91.91,
-  "lines": 91.08,
-  "statements": 90.8
+  "branches": 81.15,
+  "functions": 91.85,
+  "lines": 91.51,
+  "statements": 91.21
 }

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 81.15,
-  "functions": 91.85,
-  "lines": 91.51,
-  "statements": 91.21
+  "functions": 92.59,
+  "lines": 92.02,
+  "statements": 91.7
 }

--- a/packages/snaps-execution-environments/lavamoat/browserify/iframe/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/iframe/policy.json
@@ -296,6 +296,7 @@
     },
     "external:../snaps-utils/src/errors.ts": {
       "packages": {
+        "@metamask/rpc-errors": true,
         "@metamask/utils": true
       }
     },

--- a/packages/snaps-execution-environments/lavamoat/browserify/node-process/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/node-process/policy.json
@@ -360,6 +360,7 @@
     },
     "external:../snaps-utils/src/errors.ts": {
       "packages": {
+        "@metamask/rpc-errors": true,
         "@metamask/utils": true
       }
     },

--- a/packages/snaps-execution-environments/lavamoat/browserify/node-thread/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/node-thread/policy.json
@@ -360,6 +360,7 @@
     },
     "external:../snaps-utils/src/errors.ts": {
       "packages": {
+        "@metamask/rpc-errors": true,
         "@metamask/utils": true
       }
     },

--- a/packages/snaps-execution-environments/lavamoat/browserify/offscreen/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/offscreen/policy.json
@@ -39,6 +39,12 @@
         "superstruct": true
       }
     },
+    "@metamask/rpc-errors": {
+      "packages": {
+        "@metamask/rpc-errors>fast-safe-stringify": true,
+        "@metamask/utils": true
+      }
+    },
     "@metamask/utils": {
       "globals": {
         "TextDecoder": true,
@@ -124,6 +130,7 @@
     },
     "external:../snaps-utils/src/errors.ts": {
       "packages": {
+        "@metamask/rpc-errors": true,
         "@metamask/utils": true
       }
     },

--- a/packages/snaps-execution-environments/lavamoat/browserify/worker-executor/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/worker-executor/policy.json
@@ -296,6 +296,7 @@
     },
     "external:../snaps-utils/src/errors.ts": {
       "packages": {
+        "@metamask/rpc-errors": true,
         "@metamask/utils": true
       }
     },

--- a/packages/snaps-execution-environments/lavamoat/browserify/worker-pool/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/worker-pool/policy.json
@@ -39,6 +39,12 @@
         "superstruct": true
       }
     },
+    "@metamask/rpc-errors": {
+      "packages": {
+        "@metamask/rpc-errors>fast-safe-stringify": true,
+        "@metamask/utils": true
+      }
+    },
     "@metamask/utils": {
       "globals": {
         "TextDecoder": true,
@@ -124,6 +130,7 @@
     },
     "external:../snaps-utils/src/errors.ts": {
       "packages": {
+        "@metamask/rpc-errors": true,
         "@metamask/utils": true
       }
     },

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1145,6 +1145,30 @@ describe('BaseSnapExecutor', () => {
     addEventListenerSpy.reset();
   });
 
+  it('throws an internal error if the Snap fails to start', async () => {
+    const CODE = `
+      throw new Error('Failed to start.');
+    `;
+
+    const executor = new TestSnapExecutor();
+    await executor.executeSnap(1, MOCK_SNAP_ID, CODE, ['ethereum']);
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      error: expect.objectContaining({
+        code: -32603,
+        message: `Error while running snap '${MOCK_SNAP_ID}': Failed to start.`,
+        data: {
+          cause: expect.objectContaining({
+            code: -32603,
+            message: 'Failed to start.',
+          }),
+        },
+      }),
+    });
+  });
+
   it('supports onTransaction export', async () => {
     const CODE = `
       module.exports.onTransaction = ({ transaction, chainId, transactionOrigin }) =>

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1795,7 +1795,7 @@ describe('BaseSnapExecutor', () => {
   it('handles `SnapError`s', async () => {
     const CODE = `
       module.exports.onRpcRequest = () => {
-        throw new SnapError('foo');
+        throw new SnapError('Snap error message.');
       };
     `;
 
@@ -1825,9 +1825,15 @@ describe('BaseSnapExecutor', () => {
       jsonrpc: '2.0',
       error: {
         code: -32603,
-        message: 'foo',
+        message: 'Handled Snap Error',
         data: {
-          originalError: {},
+          cause: {
+            code: -32603,
+            message: 'Snap error message.',
+            data: {
+              stack: expect.any(String),
+            },
+          },
         },
       },
     });

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -153,11 +153,10 @@ describe('BaseSnapExecutor', () => {
         code: -31001,
         message: 'Wrapped Snap Error',
         data: {
-          cause: {
+          cause: expect.objectContaining({
             code: -32603,
             message: `The snap "${MOCK_SNAP_ID}" has been terminated during execution.`,
-            stack: expect.anything(),
-          },
+          }),
         },
       },
     });
@@ -324,15 +323,14 @@ describe('BaseSnapExecutor', () => {
         code: -31001,
         message: 'Wrapped Snap Error',
         data: {
-          cause: {
+          cause: expect.objectContaining({
             code: -32601,
             message: 'The method does not exist / is not available.',
             data: {
               cause: null,
               method: 'snap_confirm',
             },
-            stack: expect.any(String),
-          },
+          }),
         },
       },
     });
@@ -371,15 +369,14 @@ describe('BaseSnapExecutor', () => {
         code: -31001,
         message: 'Wrapped Snap Error',
         data: {
-          cause: {
+          cause: expect.objectContaining({
             code: -32601,
             message: 'The method does not exist / is not available.',
             data: {
               cause: null,
               method: 'wallet_requestSnaps',
             },
-            stack: expect.any(String),
-          },
+          }),
         },
       },
     });
@@ -562,10 +559,11 @@ describe('BaseSnapExecutor', () => {
         code: -31001,
         message: 'Wrapped Snap Error',
         data: {
-          cause: {
-            message: "Cannot read properties of undefined (reading 'handle')",
-            stack: expect.any(String),
-          },
+          cause: expect.objectContaining({
+            message: expect.stringMatching(
+              /Cannot read properties of undefined \(reading 'handle'\)|ethereum\._rpcEngine is undefined/u,
+            ),
+          }),
         },
       },
     });
@@ -604,12 +602,11 @@ describe('BaseSnapExecutor', () => {
         code: -31001,
         message: 'Wrapped Snap Error',
         data: {
-          cause: {
+          cause: expect.objectContaining({
             code: -32004,
             message:
               'The global Snap API only allows RPC methods starting with `wallet_*` and `snap_*`.',
-            stack: expect.any(String),
-          },
+          }),
         },
       },
     });
@@ -648,12 +645,11 @@ describe('BaseSnapExecutor', () => {
         code: -31001,
         message: 'Wrapped Snap Error',
         data: {
-          cause: {
+          cause: expect.objectContaining({
             code: -32004,
             message:
               'The global Snap API only allows RPC methods starting with `wallet_*` and `snap_*`.',
-            stack: expect.any(String),
-          },
+          }),
         },
       },
     });
@@ -692,15 +688,14 @@ describe('BaseSnapExecutor', () => {
         code: -31001,
         message: 'Wrapped Snap Error',
         data: {
-          cause: {
+          cause: expect.objectContaining({
             code: -32601,
             message: 'The method does not exist / is not available.',
             data: {
               cause: null,
               method: 'wallet_requestSnaps',
             },
-            stack: expect.any(String),
-          },
+          }),
         },
       },
     });
@@ -739,15 +734,14 @@ describe('BaseSnapExecutor', () => {
         code: -31001,
         message: 'Wrapped Snap Error',
         data: {
-          cause: {
+          cause: expect.objectContaining({
             code: -32601,
             message: 'The method does not exist / is not available.',
             data: {
               cause: null,
               method: 'snap_dialog',
             },
-            stack: expect.anything(),
-          },
+          }),
         },
       },
     });
@@ -801,15 +795,14 @@ describe('BaseSnapExecutor', () => {
         code: -31001,
         message: 'Wrapped Snap Error',
         data: {
-          cause: {
+          cause: expect.objectContaining({
             code: -32601,
             message: 'The method does not exist / is not available.',
             data: {
               cause: null,
               method: 'wallet_requestSnaps',
             },
-            stack: expect.any(String),
-          },
+          }),
         },
       },
     });
@@ -862,15 +855,14 @@ describe('BaseSnapExecutor', () => {
         code: -31001,
         message: 'Wrapped Snap Error',
         data: {
-          cause: {
+          cause: expect.objectContaining({
             code: -32601,
             message: 'The method does not exist / is not available.',
             data: {
               cause: null,
               method: 'wallet_requestSnaps',
             },
-            stack: expect.any(String),
-          },
+          }),
         },
       },
       id: 2,
@@ -1079,10 +1071,9 @@ describe('BaseSnapExecutor', () => {
           code: -32603,
           data: {
             snapId: MOCK_SNAP_ID,
-            cause: {
+            cause: expect.objectContaining({
               message: 'Test error.',
-              stack: error.stack,
-            },
+            }),
           },
           message: 'Unhandled Snap Error',
         },
@@ -1142,10 +1133,9 @@ describe('BaseSnapExecutor', () => {
           code: -32603,
           data: {
             snapId: MOCK_SNAP_ID,
-            cause: {
+            cause: expect.objectContaining({
               message: 'Test error.',
-              stack: error.stack,
-            },
+            }),
           },
           message: 'Unhandled Snap Error',
         },
@@ -1453,11 +1443,11 @@ describe('BaseSnapExecutor', () => {
       error: {
         code: -31001,
         data: {
-          cause: {
-            message:
-              "Cannot read properties of undefined (reading 'startSnap')",
-            stack: expect.any(String),
-          },
+          cause: expect.objectContaining({
+            message: expect.stringMatching(
+              /Cannot read properties of undefined (reading 'startSnap')|this is undefined/u,
+            ),
+          }),
         },
         message: 'Wrapped Snap Error',
       },

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1445,7 +1445,7 @@ describe('BaseSnapExecutor', () => {
         data: {
           cause: expect.objectContaining({
             message: expect.stringMatching(
-              /Cannot read properties of undefined (reading 'startSnap')|this is undefined/u,
+              /Cannot read properties of undefined \(reading 'startSnap'\)|this is undefined/u,
             ),
           }),
         },

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -147,13 +147,19 @@ describe('BaseSnapExecutor', () => {
     });
 
     expect(await executor.readCommand()).toStrictEqual({
-      error: {
-        code: -32603,
-        message: `The snap "${MOCK_SNAP_ID}" has been terminated during execution.`,
-        stack: expect.anything(),
-      },
-      id: 2,
       jsonrpc: '2.0',
+      id: 2,
+      error: {
+        code: -31001,
+        message: 'Wrapped Snap Error',
+        data: {
+          cause: {
+            code: -32603,
+            message: `The snap "${MOCK_SNAP_ID}" has been terminated during execution.`,
+            stack: expect.anything(),
+          },
+        },
+      },
     });
   });
 
@@ -313,16 +319,22 @@ describe('BaseSnapExecutor', () => {
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
-      error: {
-        code: -32601,
-        message: 'The method does not exist / is not available.',
-        data: {
-          cause: null,
-          method: 'snap_confirm',
-        },
-        stack: expect.any(String),
-      },
       id: 2,
+      error: {
+        code: -31001,
+        message: 'Wrapped Snap Error',
+        data: {
+          cause: {
+            code: -32601,
+            message: 'The method does not exist / is not available.',
+            data: {
+              cause: null,
+              method: 'snap_confirm',
+            },
+            stack: expect.any(String),
+          },
+        },
+      },
     });
   });
 
@@ -354,16 +366,22 @@ describe('BaseSnapExecutor', () => {
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
-      error: {
-        code: -32601,
-        message: 'The method does not exist / is not available.',
-        data: {
-          cause: null,
-          method: 'wallet_requestSnaps',
-        },
-        stack: expect.any(String),
-      },
       id: 2,
+      error: {
+        code: -31001,
+        message: 'Wrapped Snap Error',
+        data: {
+          cause: {
+            code: -32601,
+            message: 'The method does not exist / is not available.',
+            data: {
+              cause: null,
+              method: 'wallet_requestSnaps',
+            },
+            stack: expect.any(String),
+          },
+        },
+      },
     });
   });
 
@@ -539,13 +557,17 @@ describe('BaseSnapExecutor', () => {
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
-      error: {
-        code: -32603,
-        // TODO: Unwrap errors, and change this to the actual error message.
-        message: 'Execution Environment Error',
-        data: expect.any(Object),
-      },
       id: 2,
+      error: {
+        code: -31001,
+        message: 'Wrapped Snap Error',
+        data: {
+          cause: {
+            message: "Cannot read properties of undefined (reading 'handle')",
+            stack: expect.any(String),
+          },
+        },
+      },
     });
   });
 
@@ -577,13 +599,19 @@ describe('BaseSnapExecutor', () => {
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
-      error: {
-        code: -32004,
-        message:
-          'The global Snap API only allows RPC methods starting with `wallet_*` and `snap_*`.',
-        stack: expect.any(String),
-      },
       id: 2,
+      error: {
+        code: -31001,
+        message: 'Wrapped Snap Error',
+        data: {
+          cause: {
+            code: -32004,
+            message:
+              'The global Snap API only allows RPC methods starting with `wallet_*` and `snap_*`.',
+            stack: expect.any(String),
+          },
+        },
+      },
     });
   });
 
@@ -615,13 +643,19 @@ describe('BaseSnapExecutor', () => {
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
-      error: {
-        code: -32004,
-        message:
-          'The global Snap API only allows RPC methods starting with `wallet_*` and `snap_*`.',
-        stack: expect.any(String),
-      },
       id: 2,
+      error: {
+        code: -31001,
+        message: 'Wrapped Snap Error',
+        data: {
+          cause: {
+            code: -32004,
+            message:
+              'The global Snap API only allows RPC methods starting with `wallet_*` and `snap_*`.',
+            stack: expect.any(String),
+          },
+        },
+      },
     });
   });
 
@@ -653,16 +687,22 @@ describe('BaseSnapExecutor', () => {
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
-      error: {
-        code: -32601,
-        message: 'The method does not exist / is not available.',
-        data: {
-          cause: null,
-          method: 'wallet_requestSnaps',
-        },
-        stack: expect.any(String),
-      },
       id: 2,
+      error: {
+        code: -31001,
+        message: 'Wrapped Snap Error',
+        data: {
+          cause: {
+            code: -32601,
+            message: 'The method does not exist / is not available.',
+            data: {
+              cause: null,
+              method: 'wallet_requestSnaps',
+            },
+            stack: expect.any(String),
+          },
+        },
+      },
     });
   });
 
@@ -694,16 +734,22 @@ describe('BaseSnapExecutor', () => {
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
-      error: {
-        code: -32601,
-        message: 'The method does not exist / is not available.',
-        data: {
-          cause: null,
-          method: 'snap_dialog',
-        },
-        stack: expect.anything(),
-      },
       id: 2,
+      error: {
+        code: -31001,
+        message: 'Wrapped Snap Error',
+        data: {
+          cause: {
+            code: -32601,
+            message: 'The method does not exist / is not available.',
+            data: {
+              cause: null,
+              method: 'snap_dialog',
+            },
+            stack: expect.anything(),
+          },
+        },
+      },
     });
   });
 
@@ -750,16 +796,22 @@ describe('BaseSnapExecutor', () => {
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
-      error: {
-        code: -32601,
-        message: 'The method does not exist / is not available.',
-        data: {
-          cause: null,
-          method: 'wallet_requestSnaps',
-        },
-        stack: expect.any(String),
-      },
       id: 2,
+      error: {
+        code: -31001,
+        message: 'Wrapped Snap Error',
+        data: {
+          cause: {
+            code: -32601,
+            message: 'The method does not exist / is not available.',
+            data: {
+              cause: null,
+              method: 'wallet_requestSnaps',
+            },
+            stack: expect.any(String),
+          },
+        },
+      },
     });
   });
 
@@ -807,13 +859,19 @@ describe('BaseSnapExecutor', () => {
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
       error: {
-        code: -32601,
-        message: 'The method does not exist / is not available.',
+        code: -31001,
+        message: 'Wrapped Snap Error',
         data: {
-          cause: null,
-          method: 'wallet_requestSnaps',
+          cause: {
+            code: -32601,
+            message: 'The method does not exist / is not available.',
+            data: {
+              cause: null,
+              method: 'wallet_requestSnaps',
+            },
+            stack: expect.any(String),
+          },
         },
-        stack: expect.any(String),
       },
       id: 2,
     });
@@ -1020,11 +1078,13 @@ describe('BaseSnapExecutor', () => {
         error: {
           code: -32603,
           data: {
-            stack: error.stack,
             snapId: MOCK_SNAP_ID,
+            cause: {
+              message: 'Test error.',
+              stack: error.stack,
+            },
           },
-          // TODO: Unwrap errors, and change this to the actual error message.
-          message: 'Execution Environment Error',
+          message: 'Unhandled Snap Error',
         },
       },
     });
@@ -1081,11 +1141,13 @@ describe('BaseSnapExecutor', () => {
         error: {
           code: -32603,
           data: {
-            stack: error.stack,
             snapId: MOCK_SNAP_ID,
+            cause: {
+              message: 'Test error.',
+              stack: error.stack,
+            },
           },
-          // TODO: Unwrap errors, and change this to the actual error message.
-          message: 'Execution Environment Error',
+          message: 'Unhandled Snap Error',
         },
       },
     });
@@ -1389,10 +1451,15 @@ describe('BaseSnapExecutor', () => {
       jsonrpc: '2.0',
       id: 2,
       error: {
-        code: -32603,
-        data: expect.anything(),
-        // TODO: Unwrap errors, and change this to the actual error message.
-        message: 'Execution Environment Error',
+        code: -31001,
+        data: {
+          cause: {
+            message:
+              "Cannot read properties of undefined (reading 'startSnap')",
+            stack: expect.any(String),
+          },
+        },
+        message: 'Wrapped Snap Error',
       },
     });
 
@@ -1716,44 +1783,6 @@ describe('BaseSnapExecutor', () => {
     });
   });
 
-  it('throws when trying to throw an unserializable value', async () => {
-    const CODE = `
-      module.exports.onRpcRequest = () => { const error = new Error("foo"); error.data = BigInt(0); throw error; };
-    `;
-
-    const executor = new TestSnapExecutor();
-    await executor.executeSnap(1, MOCK_SNAP_ID, CODE, []);
-
-    expect(await executor.readCommand()).toStrictEqual({
-      jsonrpc: '2.0',
-      id: 1,
-      result: 'OK',
-    });
-
-    await executor.writeCommand({
-      jsonrpc: '2.0',
-      id: 2,
-      method: 'snapRpc',
-      params: [
-        MOCK_SNAP_ID,
-        HandlerType.OnRpcRequest,
-        MOCK_ORIGIN,
-        { jsonrpc: '2.0', method: '', params: [] },
-      ],
-    });
-
-    expect(await executor.readCommand()).toStrictEqual({
-      jsonrpc: '2.0',
-      id: 2,
-      error: {
-        code: -32603,
-        data: expect.any(Object),
-        // TODO: Unwrap errors, and change this to the actual error message.
-        message: 'Execution Environment Error',
-      },
-    });
-  });
-
   it('contains the self-referential global scopes', async () => {
     const CODE = `
       module.exports.onRpcRequest = () => globalThis !== undefined &&
@@ -1795,12 +1824,27 @@ describe('BaseSnapExecutor', () => {
   it('handles `SnapError`s', async () => {
     const CODE = `
       module.exports.onRpcRequest = () => {
-        throw new SnapError('Snap error message.');
+        class SnapError {
+          serialize() {
+            return {
+              code: -31002,
+              message: 'Snap Error',
+              data: {
+                cause: {
+                  code: -1,
+                  message: 'Snap error message.',
+                },
+              },
+            };
+          }
+        }
+
+        throw new SnapError();
       };
     `;
 
     const executor = new TestSnapExecutor();
-    await executor.executeSnap(1, MOCK_SNAP_ID, CODE, ['SnapError']);
+    await executor.executeSnap(1, MOCK_SNAP_ID, CODE, []);
 
     expect(await executor.readCommand()).toStrictEqual({
       jsonrpc: '2.0',
@@ -1824,14 +1868,17 @@ describe('BaseSnapExecutor', () => {
       id: 2,
       jsonrpc: '2.0',
       error: {
-        code: -32603,
-        message: 'Handled Snap Error',
+        code: -31001,
+        message: 'Wrapped Snap Error',
         data: {
           cause: {
-            code: -32603,
-            message: 'Snap error message.',
+            code: -31002,
+            message: 'Snap Error',
             data: {
-              stack: expect.any(String),
+              cause: {
+                code: -1,
+                message: 'Snap error message.',
+              },
             },
           },
         },

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -70,9 +70,11 @@ const fallbackError = {
   message: 'Execution Environment Error',
 };
 
-const unhandledError = rpcErrors.internal<Json>({
-  message: 'Unhandled Snap Error',
-});
+const unhandledError = rpcErrors
+  .internal<Json>({
+    message: 'Unhandled Snap Error',
+  })
+  .serialize();
 
 export type InvokeSnapArgs = Omit<SnapExportsParameters[0], 'chainId'>;
 
@@ -183,7 +185,7 @@ export class BaseSnapExecutor {
 
   private errorHandler(error: unknown, data: Record<string, Json>) {
     const serializedError = serializeError(error, {
-      fallbackError: unhandledError.serialize(),
+      fallbackError: unhandledError,
       shouldIncludeStack: false,
     });
 

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -15,7 +15,7 @@ import {
   logError,
   SNAP_EXPORTS,
   getErrorMessage,
-  UnhandledSnapError,
+  WrappedSnapError,
 } from '@metamask/snaps-utils';
 import type {
   JsonRpcNotification,
@@ -178,7 +178,7 @@ export class BaseSnapExecutor {
             );
           }
         } catch (error) {
-          throw new UnhandledSnapError(error);
+          throw new WrappedSnapError(error);
         }
       },
       this.onTerminate.bind(this),

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -69,6 +69,10 @@ const fallbackError = {
   message: 'Execution Environment Error',
 };
 
+const unhandledError = ethErrors.rpc.internal({
+  message: 'Unhandled Snap Error',
+});
+
 export type InvokeSnapArgs = Omit<SnapExportsParameters[0], 'chainId'>;
 
 export type InvokeSnap = (
@@ -179,7 +183,7 @@ export class BaseSnapExecutor {
   private errorHandler(error: unknown, data: Record<string, Json>) {
     const constructedError = constructError(error);
     const serializedError = serializeError(constructedError, {
-      fallbackError,
+      fallbackError: unhandledError,
       shouldIncludeStack: false,
     });
 
@@ -358,6 +362,7 @@ export class BaseSnapExecutor {
         module: snapModule,
         exports: snapModule.exports,
       });
+
       // All of those are JavaScript runtime specific and self referential,
       // but we add them for compatibility sake with external libraries.
       //

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -17,6 +17,7 @@ import {
   getErrorMessage,
   WrappedSnapError,
   getErrorData,
+  unwrapError,
 } from '@metamask/snaps-utils';
 import type {
   JsonRpcNotification,
@@ -381,14 +382,14 @@ export class BaseSnapExecutor {
       });
     } catch (error) {
       this.removeSnap(snapId);
+
+      const [cause] = unwrapError(error);
       throw rpcErrors.internal({
         message: `Error while running snap '${snapId}': ${getErrorMessage(
           error,
         )}`,
         data: {
-          cause: serializeError(error, {
-            fallbackError,
-          }),
+          cause: cause.serialize(),
         },
       });
     }

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -14,7 +14,6 @@ import {
   SNAP_EXPORT_NAMES,
   logError,
   SNAP_EXPORTS,
-  getErrorMessage,
   WrappedSnapError,
   getErrorData,
   unwrapError,
@@ -385,9 +384,7 @@ export class BaseSnapExecutor {
 
       const [cause] = unwrapError(error);
       throw rpcErrors.internal({
-        message: `Error while running snap '${snapId}': ${getErrorMessage(
-          error,
-        )}`,
+        message: `Error while running snap '${snapId}': ${cause.message}`,
         data: {
           cause: cause.serialize(),
         },

--- a/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
@@ -1,4 +1,5 @@
 import type { SnapId } from '@metamask/snaps-utils';
+import { SnapError } from '@metamask/snaps-utils';
 
 import { rootRealmGlobal } from '../globalObject';
 import consoleEndowment from './console';
@@ -42,6 +43,7 @@ const commonEndowments: CommonEndowmentSpecification[] = [
   { endowment: Int8Array, name: 'Int8Array' },
   { endowment: Int16Array, name: 'Int16Array' },
   { endowment: Int32Array, name: 'Int32Array' },
+  { endowment: SnapError, name: 'SnapError' },
   { endowment: Uint8Array, name: 'Uint8Array' },
   { endowment: Uint8ClampedArray, name: 'Uint8ClampedArray' },
   { endowment: Uint16Array, name: 'Uint16Array' },

--- a/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
@@ -1,5 +1,4 @@
 import type { SnapId } from '@metamask/snaps-utils';
-import { SnapError } from '@metamask/snaps-utils';
 
 import { rootRealmGlobal } from '../globalObject';
 import consoleEndowment from './console';
@@ -43,7 +42,6 @@ const commonEndowments: CommonEndowmentSpecification[] = [
   { endowment: Int8Array, name: 'Int8Array' },
   { endowment: Int16Array, name: 'Int16Array' },
   { endowment: Int32Array, name: 'Int32Array' },
-  { endowment: SnapError, name: 'SnapError' },
   { endowment: Uint8Array, name: 'Uint8Array' },
   { endowment: Uint8ClampedArray, name: 'Uint8ClampedArray' },
   { endowment: Uint16Array, name: 'Uint16Array' },

--- a/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
@@ -25,6 +25,7 @@ lockdown({
   domainTaming: 'unsafe',
   errorTaming: 'unsafe',
   stackFiltering: 'verbose',
+  overrideTaming: 'severe',
 });
 
 // This is a hack to make `atob`, and `btoa` hardening work. This needs to be

--- a/packages/snaps-execution-environments/src/common/utils.test.ts
+++ b/packages/snaps-execution-environments/src/common/utils.test.ts
@@ -2,27 +2,7 @@ import {
   BLOCKED_RPC_METHODS,
   assertEthereumOutboundRequest,
   assertSnapOutboundRequest,
-  constructError,
 } from './utils';
-
-describe('Utils', () => {
-  describe('constructError', () => {
-    it('will return the original error if it is an error', () => {
-      const error = constructError(new Error('unhandledrejection'));
-      expect(error).toStrictEqual(new Error('unhandledrejection'));
-    });
-
-    it('will return undefined if it is not passed an Error or a string', () => {
-      const error = constructError(undefined);
-      expect(error).toBeUndefined();
-    });
-
-    it('will return an Error object with the message of the original error if it was a string', () => {
-      const error = constructError('some reason');
-      expect(error?.message).toBe('some reason');
-    });
-  });
-});
 
 describe('assertSnapOutboundRequest', () => {
   it('allows wallet_ and snap_ prefixed RPC methods', () => {

--- a/packages/snaps-execution-environments/src/common/utils.ts
+++ b/packages/snaps-execution-environments/src/common/utils.ts
@@ -4,27 +4,6 @@ import { rpcErrors } from '@metamask/rpc-errors';
 import { assert, assertStruct, getSafeJson, JsonStruct } from '@metamask/utils';
 
 import { log } from '../logging';
-
-/**
- * Takes an error that was thrown, determines if it is
- * an error object. If it is then it will return that. Otherwise,
- * an error object is created with the original error message.
- *
- * @param originalError - The error that was originally thrown.
- * @returns An error object.
- */
-export function constructError(originalError: unknown) {
-  let _originalError: Error | undefined;
-  if (originalError instanceof Error) {
-    _originalError = originalError;
-  } else if (typeof originalError === 'string') {
-    _originalError = new Error(originalError);
-    // The stack is useless in this case.
-    delete _originalError.stack;
-  }
-  return _originalError;
-}
-
 /**
  * Make proxy for Promise and handle the teardown process properly.
  * If the teardown is called in the meanwhile, Promise result will not be

--- a/packages/snaps-rpc-methods/src/permitted/getSnaps.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getSnaps.ts
@@ -1,9 +1,7 @@
+import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
+import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import type { InstallSnapsResult } from '@metamask/snaps-utils';
-import type {
-  PermittedHandlerExport,
-  PendingJsonRpcResponse,
-  JsonRpcEngineEndCallback,
-} from '@metamask/types';
+import type { JsonRpcParams, PendingJsonRpcResponse } from '@metamask/utils';
 
 import type { MethodHooksObject } from '../utils';
 
@@ -16,7 +14,7 @@ const hookNames: MethodHooksObject<GetSnapsHooks> = {
  */
 export const getSnapsHandler: PermittedHandlerExport<
   GetSnapsHooks,
-  void,
+  JsonRpcParams,
   InstallSnapsResult
 > = {
   methodNames: ['wallet_getSnaps'],

--- a/packages/snaps-rpc-methods/src/permitted/invokeKeyring.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/invokeKeyring.test.ts
@@ -4,10 +4,9 @@ import { HandlerType } from '@metamask/snaps-utils';
 import { MOCK_SNAP_ID, getSnapObject } from '@metamask/snaps-utils/test-utils';
 import type {
   JsonRpcRequest,
-  PendingJsonRpcResponse,
   JsonRpcFailure,
   JsonRpcSuccess,
-} from '@metamask/types';
+} from '@metamask/utils';
 
 import { invokeKeyringHandler } from './invokeKeyring';
 
@@ -56,8 +55,8 @@ describe('wallet_invokeKeyring', () => {
       engine.push(createOriginMiddleware('metamask.io'));
       engine.push((req, res, next, end) => {
         const result = implementation(
-          req as JsonRpcRequest<JsonRpcRequest<unknown>>,
-          res as PendingJsonRpcResponse<unknown>,
+          req as JsonRpcRequest<JsonRpcRequest>,
+          res,
           next,
           end,
           hooks,
@@ -103,8 +102,8 @@ describe('wallet_invokeKeyring', () => {
       engine.push(createOriginMiddleware('metamask.io'));
       engine.push((req, res, next, end) => {
         const result = implementation(
-          req as JsonRpcRequest<JsonRpcRequest<unknown>>,
-          res as PendingJsonRpcResponse<unknown>,
+          req as JsonRpcRequest<JsonRpcRequest>,
+          res,
           next,
           end,
           hooks,
@@ -151,8 +150,8 @@ describe('wallet_invokeKeyring', () => {
       engine.push(createOriginMiddleware('metamask.io'));
       engine.push((req, res, next, end) => {
         const result = implementation(
-          req as JsonRpcRequest<JsonRpcRequest<unknown>>,
-          res as PendingJsonRpcResponse<unknown>,
+          req as JsonRpcRequest<JsonRpcRequest>,
+          res,
           next,
           end,
           hooks,
@@ -200,8 +199,8 @@ describe('wallet_invokeKeyring', () => {
       engine.push(createOriginMiddleware('metamask.io'));
       engine.push((req, res, next, end) => {
         const result = implementation(
-          req as JsonRpcRequest<JsonRpcRequest<unknown>>,
-          res as PendingJsonRpcResponse<unknown>,
+          req as JsonRpcRequest<JsonRpcRequest>,
+          res,
           next,
           end,
           hooks,
@@ -239,8 +238,8 @@ describe('wallet_invokeKeyring', () => {
       engine.push(createOriginMiddleware('metamask.io'));
       engine.push((req, res, next, end) => {
         const result = implementation(
-          req as JsonRpcRequest<JsonRpcRequest<unknown>>,
-          res as PendingJsonRpcResponse<unknown>,
+          req as JsonRpcRequest<JsonRpcRequest>,
+          res,
           next,
           end,
           hooks,
@@ -281,8 +280,8 @@ describe('wallet_invokeKeyring', () => {
       engine.push(createOriginMiddleware('metamask.io'));
       engine.push((req, res, next, end) => {
         const result = implementation(
-          req as JsonRpcRequest<JsonRpcRequest<unknown>>,
-          res as PendingJsonRpcResponse<unknown>,
+          req as JsonRpcRequest<JsonRpcRequest>,
+          res,
           next,
           end,
           hooks,
@@ -319,8 +318,8 @@ describe('wallet_invokeKeyring', () => {
       const engine = new JsonRpcEngine();
       engine.push((req, res, next, end) => {
         const result = implementation(
-          req as JsonRpcRequest<JsonRpcRequest<unknown>>,
-          res as PendingJsonRpcResponse<unknown>,
+          req as JsonRpcRequest<JsonRpcRequest>,
+          res,
           next,
           end,
           hooks,

--- a/packages/snaps-rpc-methods/src/permitted/invokeKeyring.ts
+++ b/packages/snaps-rpc-methods/src/permitted/invokeKeyring.ts
@@ -1,3 +1,5 @@
+import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
+import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
 import type { Snap } from '@metamask/snaps-utils';
 import {
@@ -6,12 +8,7 @@ import {
   type SnapId,
   type SnapRpcHookArgs,
 } from '@metamask/snaps-utils';
-import type {
-  PermittedHandlerExport,
-  PendingJsonRpcResponse,
-  JsonRpcEngineEndCallback,
-  JsonRpcRequest,
-} from '@metamask/types';
+import type { PendingJsonRpcResponse, JsonRpcRequest } from '@metamask/utils';
 import { hasProperty, type Json } from '@metamask/utils';
 
 import type { MethodHooksObject } from '../utils';
@@ -30,8 +27,8 @@ const hookNames: MethodHooksObject<InvokeKeyringHooks> = {
  */
 export const invokeKeyringHandler: PermittedHandlerExport<
   InvokeKeyringHooks,
-  JsonRpcRequest<unknown>,
-  unknown
+  JsonRpcRequest,
+  Json
 > = {
   methodNames: ['wallet_invokeKeyring'],
   implementation: invokeKeyringImplementation,
@@ -71,8 +68,8 @@ export type InvokeKeyringHooks = {
  * @returns Nothing.
  */
 async function invokeKeyringImplementation(
-  req: JsonRpcRequest<unknown>,
-  res: PendingJsonRpcResponse<unknown>,
+  req: JsonRpcRequest,
+  res: PendingJsonRpcResponse<Json>,
   _next: unknown,
   end: JsonRpcEngineEndCallback,
   {
@@ -90,7 +87,7 @@ async function invokeKeyringImplementation(
   }
 
   // We expect the MM middleware stack to always add the origin to requests
-  const { origin } = req as JsonRpcRequest<unknown> & { origin: string };
+  const { origin } = req as JsonRpcRequest & { origin: string };
   const { snapId, request } = params;
 
   if (!origin || !hasPermission(origin, WALLET_SNAP_PERMISSION_KEY)) {

--- a/packages/snaps-rpc-methods/src/permitted/invokeSnapSugar.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/invokeSnapSugar.test.ts
@@ -1,16 +1,17 @@
-import { rpcErrors } from '@metamask/rpc-errors';
 import type {
   JsonRpcEngineEndCallback,
   JsonRpcEngineNextCallback,
-  JsonRpcRequest,
-} from '@metamask/types';
+} from '@metamask/json-rpc-engine';
+import { rpcErrors } from '@metamask/rpc-errors';
+import type { JsonRpcRequest } from '@metamask/utils';
 
+import type { InvokeSnapSugarArgs } from './invokeSnapSugar';
 import { getValidatedParams, invokeSnapSugar } from './invokeSnapSugar';
 
 describe('wallet_invokeSnap', () => {
   describe('invokeSnapSugar', () => {
     it('invokes snap with next()', () => {
-      const req: JsonRpcRequest<unknown> = {
+      const req: JsonRpcRequest<InvokeSnapSugarArgs> = {
         id: 'some-id',
         jsonrpc: '2.0',
         method: 'wallet_invokeSnap',
@@ -31,12 +32,15 @@ describe('wallet_invokeSnap', () => {
     });
 
     it('ends with an error if params are invalid', () => {
-      const req: JsonRpcRequest<unknown> = {
+      const req: JsonRpcRequest<InvokeSnapSugarArgs> = {
         id: 'some-id',
         jsonrpc: '2.0',
         method: 'wallet_invokeSnap',
         params: {
+          // @ts-expect-error - Invalid params.
           snapId: undefined,
+
+          // @ts-expect-error - Invalid params.
           request: [],
         },
       };

--- a/packages/snaps-rpc-methods/src/permitted/invokeSnapSugar.ts
+++ b/packages/snaps-rpc-methods/src/permitted/invokeSnapSugar.ts
@@ -1,15 +1,15 @@
-import { rpcErrors } from '@metamask/rpc-errors';
 import type {
-  PermittedHandlerExport,
-  JsonRpcRequest,
-  JsonRpcEngineNextCallback,
   JsonRpcEngineEndCallback,
-} from '@metamask/types';
+  JsonRpcEngineNextCallback,
+} from '@metamask/json-rpc-engine';
+import type { PermittedHandlerExport } from '@metamask/permission-controller';
+import { rpcErrors } from '@metamask/rpc-errors';
+import type { Json, JsonRpcRequest } from '@metamask/utils';
 import { isObject } from '@metamask/utils';
 
 export type InvokeSnapSugarArgs = {
   snapId: string;
-  request: Record<string, unknown>;
+  request: Record<string, Json>;
 };
 
 /**
@@ -17,8 +17,8 @@ export type InvokeSnapSugarArgs = {
  */
 export const invokeSnapSugarHandler: PermittedHandlerExport<
   void,
-  JsonRpcRequest<unknown>,
-  unknown
+  InvokeSnapSugarArgs,
+  Json
 > = {
   methodNames: ['wallet_invokeSnap'],
   implementation: invokeSnapSugar,
@@ -38,7 +38,7 @@ export const invokeSnapSugarHandler: PermittedHandlerExport<
  * @throws If the params are invalid.
  */
 export function invokeSnapSugar(
-  req: JsonRpcRequest<unknown>,
+  req: JsonRpcRequest<InvokeSnapSugarArgs>,
   _res: unknown,
   next: JsonRpcEngineNextCallback,
   end: JsonRpcEngineEndCallback,

--- a/packages/snaps-rpc-methods/src/permitted/requestSnaps.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/requestSnaps.test.ts
@@ -15,7 +15,7 @@ import type {
   JsonRpcRequest,
   JsonRpcSuccess,
   PendingJsonRpcResponse,
-} from '@metamask/types';
+} from '@metamask/utils';
 
 import { WALLET_SNAP_PERMISSION_KEY } from '../restricted/invokeSnap';
 import {

--- a/packages/snaps-rpc-methods/src/permitted/requestSnaps.ts
+++ b/packages/snaps-rpc-methods/src/permitted/requestSnaps.ts
@@ -1,7 +1,9 @@
+import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
 import type {
   PermissionConstraint,
   RequestedPermissions,
   Caveat,
+  PermittedHandlerExport,
 } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
 import type { SnapsPermissionRequest } from '@metamask/snaps-utils';
@@ -10,12 +12,10 @@ import {
   verifyRequestedSnapPermissions,
 } from '@metamask/snaps-utils';
 import type {
-  PermittedHandlerExport,
   JsonRpcRequest,
   PendingJsonRpcResponse,
-  JsonRpcEngineEndCallback,
-} from '@metamask/types';
-import type { Json } from '@metamask/utils';
+  Json,
+} from '@metamask/utils';
 import { hasProperty, isObject } from '@metamask/utils';
 
 import { WALLET_SNAP_PERMISSION_KEY } from '../restricted/invokeSnap';

--- a/packages/snaps-rpc-methods/src/request.ts
+++ b/packages/snaps-rpc-methods/src/request.ts
@@ -2,8 +2,8 @@ import type {
   PermissionSpecificationBuilder,
   PermissionType,
   RestrictedMethodOptions,
+  PermittedHandlerExport,
 } from '@metamask/permission-controller';
-import type { PermittedHandlerExport } from '@metamask/types';
 import type { JsonRpcParams } from '@metamask/utils';
 
 import type { methodHandlers } from './permitted';

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -58,7 +58,6 @@
     "@metamask/json-rpc-engine": "^7.1.1",
     "@metamask/key-tree": "^9.0.0",
     "@metamask/permission-controller": "^5.0.0",
-    "@metamask/rpc-errors": "^6.1.0",
     "@metamask/snaps-controllers": "workspace:^",
     "@metamask/snaps-execution-environments": "workspace:^",
     "@metamask/snaps-rpc-methods": "workspace:^",

--- a/packages/snaps-simulator/src/features/simulation/sagas.ts
+++ b/packages/snaps-simulator/src/features/simulation/sagas.ts
@@ -9,7 +9,6 @@ import {
   SubjectMetadataController,
   SubjectType,
 } from '@metamask/permission-controller';
-import { serializeError } from '@metamask/rpc-errors';
 import {
   IframeExecutionService,
   setupMultiplex,
@@ -28,7 +27,7 @@ import type {
   SnapRpcHookArgs,
   VirtualFile,
 } from '@metamask/snaps-utils';
-import { logError } from '@metamask/snaps-utils';
+import { logError, unwrapError } from '@metamask/snaps-utils';
 import { getSafeJson } from '@metamask/utils';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createEngineStream } from 'json-rpc-middleware-stream';
@@ -262,9 +261,13 @@ export function* requestSaga({ payload }: PayloadAction<SnapRpcHookArgs>) {
       },
     });
   } catch (error) {
+    const [unwrappedError] = unwrapError(error);
+
     yield put({
       type: `${payload.handler}/setResponse`,
-      payload: { error: serializeError(error) },
+      payload: {
+        error: unwrappedError.serialize(),
+      },
     });
   }
 }

--- a/packages/snaps-types/src/types.ts
+++ b/packages/snaps-types/src/types.ts
@@ -26,4 +26,4 @@ export type {
   OnUpdateHandler,
   OnKeyringRequestHandler,
 } from '@metamask/snaps-utils';
-export { SeverityLevel } from '@metamask/snaps-utils';
+export { SeverityLevel, SnapError } from '@metamask/snaps-utils';

--- a/packages/snaps-types/src/types.ts
+++ b/packages/snaps-types/src/types.ts
@@ -21,6 +21,7 @@ export type {
   OnRpcRequestHandler,
   OnTransactionHandler,
   OnTransactionResponse,
+  OnNameLookupArgs,
   OnNameLookupResponse,
   OnInstallHandler,
   OnUpdateHandler,

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 95.52,
-  "functions": 100,
-  "lines": 98.72,
-  "statements": 95.82
+  "branches": 95.73,
+  "functions": 97.94,
+  "lines": 98.35,
+  "statements": 95.71
 }

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 95.73,
+  "branches": 95.72,
   "functions": 97.94,
   "lines": 98.35,
   "statements": 95.71

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 95.72,
-  "functions": 97.94,
-  "lines": 98.35,
-  "statements": 95.71
+  "branches": 96.02,
+  "functions": 97.95,
+  "lines": 98.36,
+  "statements": 95.72
 }

--- a/packages/snaps-utils/src/default-endowments.ts
+++ b/packages/snaps-utils/src/default-endowments.ts
@@ -30,6 +30,7 @@ export const DEFAULT_ENDOWMENTS: readonly string[] = Object.freeze([
   'BigUint64Array',
   'DataView',
   'ArrayBuffer',
+  'SnapError',
   // Used by fetch, but also as API for some packages that don't do network connections
   // https://github.com/MetaMask/snaps-monorepo/issues/662
   // https://github.com/MetaMask/snaps-monorepo/discussions/678

--- a/packages/snaps-utils/src/default-endowments.ts
+++ b/packages/snaps-utils/src/default-endowments.ts
@@ -30,7 +30,6 @@ export const DEFAULT_ENDOWMENTS: readonly string[] = Object.freeze([
   'BigUint64Array',
   'DataView',
   'ArrayBuffer',
-  'SnapError',
   // Used by fetch, but also as API for some packages that don't do network connections
   // https://github.com/MetaMask/snaps-monorepo/issues/662
   // https://github.com/MetaMask/snaps-monorepo/discussions/678

--- a/packages/snaps-utils/src/errors.test.ts
+++ b/packages/snaps-utils/src/errors.test.ts
@@ -151,9 +151,8 @@ describe('WrappedSnapError', () => {
             cause: {
               code: -32603,
               message: 'foo',
-              data: {
-                stack: error.stack,
-              },
+              stack: error.stack,
+              data: {},
             },
           },
         },
@@ -177,9 +176,8 @@ describe('WrappedSnapError', () => {
               cause: {
                 code: -32603,
                 message: 'foo',
-                data: {
-                  stack: error.stack,
-                },
+                stack: error.stack,
+                data: {},
               },
             },
           },
@@ -206,9 +204,8 @@ describe('SnapError', () => {
         cause: {
           code: -32603,
           message: 'foo',
-          data: {
-            stack: error.stack,
-          },
+          stack: error.stack,
+          data: {},
         },
       },
     });
@@ -233,9 +230,8 @@ describe('SnapError', () => {
         cause: {
           code: -32000,
           message: 'foo',
-          data: {
-            stack: error.stack,
-          },
+          stack: error.stack,
+          data: {},
         },
       },
     });
@@ -274,9 +270,9 @@ describe('SnapError', () => {
         cause: {
           code: -32000,
           message: 'foo',
+          stack: error.stack,
           data: {
             foo: 'bar',
-            stack: error.stack,
           },
         },
       },
@@ -299,9 +295,8 @@ describe('SnapError', () => {
         cause: {
           code: -32603,
           message: 'foo',
-          data: {
-            stack: error.stack,
-          },
+          stack: error.stack,
+          data: {},
         },
       },
     });
@@ -323,9 +318,9 @@ describe('SnapError', () => {
         cause: {
           code: -32603,
           message: 'foo',
+          stack: error.stack,
           data: {
             foo: 'bar',
-            stack: error.stack,
           },
         },
       },
@@ -348,9 +343,8 @@ describe('SnapError', () => {
         cause: {
           code: -32602,
           message: 'foo',
-          data: {
-            stack: error.stack,
-          },
+          stack: error.stack,
+          data: {},
         },
       },
     });
@@ -374,9 +368,9 @@ describe('SnapError', () => {
         cause: {
           code: -32602,
           message: 'foo',
+          stack: error.stack,
           data: {
             foo: 'bar',
-            stack: error.stack,
           },
         },
       },
@@ -402,9 +396,8 @@ describe('SnapError', () => {
         cause: {
           code: 0,
           message: 'foo',
-          data: {
-            stack: error.stack,
-          },
+          stack: error.stack,
+          data: {},
         },
       },
     });
@@ -432,9 +425,9 @@ describe('SnapError', () => {
         cause: {
           code: 0,
           message: 'foo',
+          stack: error.stack,
           data: {
             foo: 'bar',
-            stack: error.stack,
           },
         },
       },
@@ -467,10 +460,10 @@ describe('SnapError', () => {
         cause: {
           code: 0,
           message: 'foo',
+          stack: error.stack,
           data: {
             foo: 'bar',
             bar: 'qux',
-            stack: error.stack,
           },
         },
       },
@@ -604,7 +597,6 @@ describe('unwrapError', () => {
     expect(unwrappedError.stack).toBeDefined();
     expect(unwrappedError.data).toStrictEqual({
       foo: 'bar',
-      stack: expect.any(String),
     });
     expect(handled).toBe(true);
   });

--- a/packages/snaps-utils/src/errors.test.ts
+++ b/packages/snaps-utils/src/errors.test.ts
@@ -1,6 +1,6 @@
 import { rpcErrors } from '@metamask/rpc-errors';
 
-import { getErrorMessage } from './errors';
+import { BaseSnapError, getErrorMessage, SnapError } from './errors';
 
 describe('getErrorMessage', () => {
   it('returns the error message if the error is an object with a message property', () => {
@@ -16,5 +16,245 @@ describe('getErrorMessage', () => {
     expect(getErrorMessage(null)).toBe('null');
     expect(getErrorMessage(undefined)).toBe('undefined');
     expect(getErrorMessage({ foo: 'bar' })).toBe('[object Object]');
+  });
+});
+
+describe('SnapError', () => {
+  it('creates an error from a message', () => {
+    const error = new SnapError('foo');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(BaseSnapError);
+    expect(error).toBeInstanceOf(SnapError);
+    expect(error.message).toBe('foo');
+    expect(error.code).toBe(-32603);
+    expect(error.data).toStrictEqual({});
+    expect(error.stack).toBeDefined();
+    expect(error.toJSON()).toStrictEqual({
+      code: -32603,
+      message: 'foo',
+      data: {
+        stack: error.stack,
+      },
+    });
+  });
+
+  it('creates an error from a message and code', () => {
+    const error = new SnapError({
+      message: 'foo',
+      code: -32000,
+    });
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(BaseSnapError);
+    expect(error).toBeInstanceOf(SnapError);
+    expect(error.message).toBe('foo');
+    expect(error.code).toBe(-32000);
+    expect(error.data).toStrictEqual({});
+    expect(error.stack).toBeDefined();
+    expect(error.toJSON()).toStrictEqual({
+      code: -32000,
+      message: 'foo',
+      data: {
+        stack: error.stack,
+      },
+    });
+  });
+
+  it('creates an error from a message and data', () => {
+    const error = new SnapError('foo', { foo: 'bar' });
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(BaseSnapError);
+    expect(error).toBeInstanceOf(SnapError);
+    expect(error.message).toBe('foo');
+    expect(error.code).toBe(-32603);
+    expect(error.data).toStrictEqual({ foo: 'bar' });
+    expect(error.stack).toBeDefined();
+  });
+
+  it('creates an error from a message, code, and data', () => {
+    const error = new SnapError(
+      {
+        message: 'foo',
+        code: -32000,
+      },
+      { foo: 'bar' },
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(BaseSnapError);
+    expect(error).toBeInstanceOf(SnapError);
+    expect(error.message).toBe('foo');
+    expect(error.code).toBe(-32000);
+    expect(error.data).toStrictEqual({ foo: 'bar' });
+    expect(error.stack).toBeDefined();
+    expect(error.toJSON()).toStrictEqual({
+      code: -32000,
+      message: 'foo',
+      data: {
+        foo: 'bar',
+        stack: error.stack,
+      },
+    });
+  });
+
+  it('creates an error from an error', () => {
+    const error = new SnapError(new Error('foo'));
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(BaseSnapError);
+    expect(error).toBeInstanceOf(SnapError);
+    expect(error.message).toBe('foo');
+    expect(error.code).toBe(-32603);
+    expect(error.data).toStrictEqual({});
+    expect(error.stack).toBeDefined();
+    expect(error.toJSON()).toStrictEqual({
+      code: -32603,
+      message: 'foo',
+      data: {
+        stack: error.stack,
+      },
+    });
+  });
+
+  it('creates an error from an error and data', () => {
+    const error = new SnapError(new Error('foo'), { foo: 'bar' });
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(BaseSnapError);
+    expect(error).toBeInstanceOf(SnapError);
+    expect(error.message).toBe('foo');
+    expect(error.code).toBe(-32603);
+    expect(error.data).toStrictEqual({ foo: 'bar' });
+    expect(error.stack).toBeDefined();
+    expect(error.toJSON()).toStrictEqual({
+      code: -32603,
+      message: 'foo',
+      data: {
+        foo: 'bar',
+        stack: error.stack,
+      },
+    });
+  });
+
+  it('creates an error from a JsonRpcError', () => {
+    const error = new SnapError(ethErrors.rpc.invalidParams('foo'));
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(BaseSnapError);
+    expect(error).toBeInstanceOf(SnapError);
+    expect(error.message).toBe('foo');
+    expect(error.code).toBe(-32602);
+    expect(error.data).toStrictEqual({});
+    expect(error.stack).toBeDefined();
+    expect(error.toJSON()).toStrictEqual({
+      code: -32602,
+      message: 'foo',
+      data: {
+        stack: error.stack,
+      },
+    });
+  });
+
+  it('creates an error from a JsonRpcError and data', () => {
+    const error = new SnapError(ethErrors.rpc.invalidParams('foo'), {
+      foo: 'bar',
+    });
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(BaseSnapError);
+    expect(error).toBeInstanceOf(SnapError);
+    expect(error.message).toBe('foo');
+    expect(error.code).toBe(-32602);
+    expect(error.data).toStrictEqual({ foo: 'bar' });
+    expect(error.stack).toBeDefined();
+    expect(error.toJSON()).toStrictEqual({
+      code: -32602,
+      message: 'foo',
+      data: {
+        foo: 'bar',
+        stack: error.stack,
+      },
+    });
+  });
+
+  it('creates an error from a JsonRpcError with a code of 0', () => {
+    const error = new SnapError({
+      message: 'foo',
+      code: 0,
+    });
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(BaseSnapError);
+    expect(error).toBeInstanceOf(SnapError);
+    expect(error.message).toBe('foo');
+    expect(error.code).toBe(0);
+    expect(error.data).toStrictEqual({});
+    expect(error.stack).toBeDefined();
+    expect(error.toJSON()).toStrictEqual({
+      code: 0,
+      message: 'foo',
+      data: {
+        stack: error.stack,
+      },
+    });
+  });
+
+  it('creates an error from a JsonRpcError with a code of 0 and data', () => {
+    const error = new SnapError(
+      {
+        message: 'foo',
+        code: 0,
+      },
+      { foo: 'bar' },
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(BaseSnapError);
+    expect(error).toBeInstanceOf(SnapError);
+    expect(error.message).toBe('foo');
+    expect(error.code).toBe(0);
+    expect(error.data).toStrictEqual({ foo: 'bar' });
+    expect(error.stack).toBeDefined();
+    expect(error.toJSON()).toStrictEqual({
+      code: 0,
+      message: 'foo',
+      data: {
+        foo: 'bar',
+        stack: error.stack,
+      },
+    });
+  });
+
+  it('creates an error from a JsonRpcError with a code of 0 and merges the data', () => {
+    const error = new SnapError(
+      {
+        message: 'foo',
+        code: 0,
+        data: {
+          foo: 'baz',
+          bar: 'qux',
+        },
+      },
+      { foo: 'bar' },
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(BaseSnapError);
+    expect(error).toBeInstanceOf(SnapError);
+    expect(error.message).toBe('foo');
+    expect(error.code).toBe(0);
+    expect(error.data).toStrictEqual({ foo: 'bar', bar: 'qux' });
+    expect(error.stack).toBeDefined();
+    expect(error.toJSON()).toStrictEqual({
+      code: 0,
+      message: 'foo',
+      data: {
+        foo: 'bar',
+        bar: 'qux',
+        stack: error.stack,
+      },
+    });
   });
 });

--- a/packages/snaps-utils/src/errors.test.ts
+++ b/packages/snaps-utils/src/errors.test.ts
@@ -547,7 +547,7 @@ describe('unwrapError', () => {
     expect(unwrappedError.code).toBe(-1);
     expect(unwrappedError.message).toBe('foo');
     expect(unwrappedError.stack).toBeDefined();
-    expect(handled).toBe(true);
+    expect(handled).toBe(false);
   });
 
   it('unwraps a wrapped Snap error with a `rpc-errors` error', () => {
@@ -560,7 +560,7 @@ describe('unwrapError', () => {
     expect(unwrappedError.code).toBe(errorCodes.rpc.invalidParams);
     expect(unwrappedError.message).toBe('foo');
     expect(unwrappedError.stack).toBeDefined();
-    expect(handled).toBe(true);
+    expect(handled).toBe(false);
   });
 
   it('unwraps a wrapped Snap error with a wrapped Snap error', () => {
@@ -607,6 +607,30 @@ describe('unwrapError', () => {
       stack: expect.any(String),
     });
     expect(handled).toBe(true);
+  });
+
+  it('unwraps an unwrapped JSON-RPC error', () => {
+    const error = new JsonRpcError(-1, 'foo');
+
+    const [unwrappedError, handled] = unwrapError(error);
+
+    expect(unwrappedError).toBeInstanceOf(Error);
+    expect(unwrappedError.code).toBe(-1);
+    expect(unwrappedError.message).toBe('foo');
+    expect(unwrappedError.stack).toBeDefined();
+    expect(handled).toBe(false);
+  });
+
+  it('unwraps an unwrapped `rpc-errors` error', () => {
+    const error = rpcErrors.invalidParams('foo');
+
+    const [unwrappedError, handled] = unwrapError(error);
+
+    expect(unwrappedError).toBeInstanceOf(Error);
+    expect(unwrappedError.code).toBe(errorCodes.rpc.invalidParams);
+    expect(unwrappedError.message).toBe('foo');
+    expect(unwrappedError.stack).toBeDefined();
+    expect(handled).toBe(false);
   });
 
   it('unwraps an unknown error', () => {

--- a/packages/snaps-utils/src/errors.test.ts
+++ b/packages/snaps-utils/src/errors.test.ts
@@ -1,4 +1,4 @@
-import { rpcErrors } from '@metamask/rpc-errors';
+import { errorCodes, JsonRpcError, rpcErrors } from '@metamask/rpc-errors';
 
 import {
   getErrorMessage,
@@ -7,7 +7,8 @@ import {
   SNAP_ERROR_WRAPPER_CODE,
   SNAP_ERROR_WRAPPER_MESSAGE,
   SnapError,
-  UnhandledSnapError,
+  unwrapError,
+  WrappedSnapError,
 } from './errors';
 
 describe('getErrorMessage', () => {
@@ -30,10 +31,10 @@ describe('getErrorMessage', () => {
 describe('SnapErrorWrapper', () => {
   it('wraps an error', () => {
     const error = new Error('foo');
-    const wrapped = new UnhandledSnapError(error);
+    const wrapped = new WrappedSnapError(error);
 
     expect(wrapped).toBeInstanceOf(Error);
-    expect(wrapped).toBeInstanceOf(UnhandledSnapError);
+    expect(wrapped).toBeInstanceOf(WrappedSnapError);
     expect(wrapped.message).toBe('foo');
     expect(wrapped.stack).toBeDefined();
     expect(wrapped.toJSON()).toStrictEqual({
@@ -48,12 +49,33 @@ describe('SnapErrorWrapper', () => {
     });
   });
 
-  it('wraps a Snap error', () => {
-    const error = new SnapError('foo');
-    const wrapped = new UnhandledSnapError(error);
+  it('wraps a JSON-RPC error', () => {
+    const error = new JsonRpcError(-1, 'foo');
+    const wrapped = new WrappedSnapError(error);
 
     expect(wrapped).toBeInstanceOf(Error);
-    expect(wrapped).toBeInstanceOf(UnhandledSnapError);
+    expect(wrapped).toBeInstanceOf(WrappedSnapError);
+    expect(wrapped.message).toBe('foo');
+    expect(wrapped.stack).toBeDefined();
+    expect(wrapped.toJSON()).toStrictEqual({
+      code: SNAP_ERROR_WRAPPER_CODE,
+      message: SNAP_ERROR_WRAPPER_MESSAGE,
+      data: {
+        cause: {
+          code: -1,
+          message: 'foo',
+          stack: error.stack,
+        },
+      },
+    });
+  });
+
+  it('wraps a Snap error', () => {
+    const error = new SnapError('foo');
+    const wrapped = new WrappedSnapError(error);
+
+    expect(wrapped).toBeInstanceOf(Error);
+    expect(wrapped).toBeInstanceOf(WrappedSnapError);
     expect(wrapped.message).toBe('foo');
     expect(wrapped.stack).toBeDefined();
     expect(wrapped.toJSON()).toStrictEqual({
@@ -89,10 +111,16 @@ describe('SnapError', () => {
     expect(error.data).toStrictEqual({});
     expect(error.stack).toBeDefined();
     expect(error.toJSON()).toStrictEqual({
-      code: -32603,
-      message: 'foo',
+      code: -31002,
+      message: 'Snap Error',
       data: {
-        stack: error.stack,
+        cause: {
+          code: -32603,
+          message: 'foo',
+          data: {
+            stack: error.stack,
+          },
+        },
       },
     });
   });
@@ -110,10 +138,16 @@ describe('SnapError', () => {
     expect(error.data).toStrictEqual({});
     expect(error.stack).toBeDefined();
     expect(error.toJSON()).toStrictEqual({
-      code: -32000,
-      message: 'foo',
+      code: -31002,
+      message: 'Snap Error',
       data: {
-        stack: error.stack,
+        cause: {
+          code: -32000,
+          message: 'foo',
+          data: {
+            stack: error.stack,
+          },
+        },
       },
     });
   });
@@ -145,11 +179,17 @@ describe('SnapError', () => {
     expect(error.data).toStrictEqual({ foo: 'bar' });
     expect(error.stack).toBeDefined();
     expect(error.toJSON()).toStrictEqual({
-      code: -32000,
-      message: 'foo',
+      code: -31002,
+      message: 'Snap Error',
       data: {
-        foo: 'bar',
-        stack: error.stack,
+        cause: {
+          code: -32000,
+          message: 'foo',
+          data: {
+            foo: 'bar',
+            stack: error.stack,
+          },
+        },
       },
     });
   });
@@ -164,10 +204,16 @@ describe('SnapError', () => {
     expect(error.data).toStrictEqual({});
     expect(error.stack).toBeDefined();
     expect(error.toJSON()).toStrictEqual({
-      code: -32603,
-      message: 'foo',
+      code: -31002,
+      message: 'Snap Error',
       data: {
-        stack: error.stack,
+        cause: {
+          code: -32603,
+          message: 'foo',
+          data: {
+            stack: error.stack,
+          },
+        },
       },
     });
   });
@@ -182,11 +228,17 @@ describe('SnapError', () => {
     expect(error.data).toStrictEqual({ foo: 'bar' });
     expect(error.stack).toBeDefined();
     expect(error.toJSON()).toStrictEqual({
-      code: -32603,
-      message: 'foo',
+      code: -31002,
+      message: 'Snap Error',
       data: {
-        foo: 'bar',
-        stack: error.stack,
+        cause: {
+          code: -32603,
+          message: 'foo',
+          data: {
+            foo: 'bar',
+            stack: error.stack,
+          },
+        },
       },
     });
   });
@@ -201,10 +253,16 @@ describe('SnapError', () => {
     expect(error.data).toStrictEqual({});
     expect(error.stack).toBeDefined();
     expect(error.toJSON()).toStrictEqual({
-      code: -32602,
-      message: 'foo',
+      code: -31002,
+      message: 'Snap Error',
       data: {
-        stack: error.stack,
+        cause: {
+          code: -32602,
+          message: 'foo',
+          data: {
+            stack: error.stack,
+          },
+        },
       },
     });
   });
@@ -221,11 +279,17 @@ describe('SnapError', () => {
     expect(error.data).toStrictEqual({ foo: 'bar' });
     expect(error.stack).toBeDefined();
     expect(error.toJSON()).toStrictEqual({
-      code: -32602,
-      message: 'foo',
+      code: -31002,
+      message: 'Snap Error',
       data: {
-        foo: 'bar',
-        stack: error.stack,
+        cause: {
+          code: -32602,
+          message: 'foo',
+          data: {
+            foo: 'bar',
+            stack: error.stack,
+          },
+        },
       },
     });
   });
@@ -243,10 +307,16 @@ describe('SnapError', () => {
     expect(error.data).toStrictEqual({});
     expect(error.stack).toBeDefined();
     expect(error.toJSON()).toStrictEqual({
-      code: 0,
-      message: 'foo',
+      code: -31002,
+      message: 'Snap Error',
       data: {
-        stack: error.stack,
+        cause: {
+          code: 0,
+          message: 'foo',
+          data: {
+            stack: error.stack,
+          },
+        },
       },
     });
   });
@@ -267,11 +337,17 @@ describe('SnapError', () => {
     expect(error.data).toStrictEqual({ foo: 'bar' });
     expect(error.stack).toBeDefined();
     expect(error.toJSON()).toStrictEqual({
-      code: 0,
-      message: 'foo',
+      code: -31002,
+      message: 'Snap Error',
       data: {
-        foo: 'bar',
-        stack: error.stack,
+        cause: {
+          code: 0,
+          message: 'foo',
+          data: {
+            foo: 'bar',
+            stack: error.stack,
+          },
+        },
       },
     });
   });
@@ -296,13 +372,93 @@ describe('SnapError', () => {
     expect(error.data).toStrictEqual({ foo: 'bar', bar: 'qux' });
     expect(error.stack).toBeDefined();
     expect(error.toJSON()).toStrictEqual({
-      code: 0,
-      message: 'foo',
+      code: -31002,
+      message: 'Snap Error',
       data: {
-        foo: 'bar',
-        bar: 'qux',
-        stack: error.stack,
+        cause: {
+          code: 0,
+          message: 'foo',
+          data: {
+            foo: 'bar',
+            bar: 'qux',
+            stack: error.stack,
+          },
+        },
       },
     });
+  });
+});
+
+describe('unwrapError', () => {
+  it('unwraps a wrapped Snap error with an unknown error', () => {
+    const error = new Error('foo');
+    const wrapped = new WrappedSnapError(error).toJSON();
+
+    const [unwrappedError, handled] = unwrapError(wrapped);
+
+    expect(unwrappedError).toBeInstanceOf(Error);
+    expect(unwrappedError.code).toBe(errorCodes.rpc.internal);
+    expect(unwrappedError.message).toBe('foo');
+    expect(unwrappedError.stack).toBeDefined();
+    expect(handled).toBe(false);
+  });
+
+  it('unwraps a wrapped Snap error with a JSON-RPC error', () => {
+    const error = new JsonRpcError(-1, 'foo');
+    const wrapped = new WrappedSnapError(error).toJSON();
+
+    const [unwrappedError, handled] = unwrapError(wrapped);
+
+    expect(unwrappedError).toBeInstanceOf(Error);
+    expect(unwrappedError.code).toBe(-1);
+    expect(unwrappedError.message).toBe('foo');
+    expect(unwrappedError.stack).toBeDefined();
+    expect(handled).toBe(true);
+  });
+
+  it('unwraps a wrapped Snap error with a wrapped Snap error', () => {
+    const error = new SnapError('foo');
+    const wrapped = new WrappedSnapError(error).toJSON();
+
+    const [unwrappedError, handled] = unwrapError(wrapped);
+
+    expect(unwrappedError).toBeInstanceOf(Error);
+    expect(unwrappedError.code).toBe(-32603);
+    expect(unwrappedError.message).toBe('foo');
+    expect(unwrappedError.stack).toBeDefined();
+    expect(handled).toBe(true);
+  });
+
+  it('unwraps a wrapped Snap error with a wrapped Snap error and code', () => {
+    const error = new SnapError({
+      message: 'foo',
+      code: -32000,
+    });
+
+    const wrapped = new WrappedSnapError(error).toJSON();
+    const [unwrappedError, handled] = unwrapError(wrapped);
+
+    expect(unwrappedError).toBeInstanceOf(Error);
+    expect(unwrappedError.code).toBe(-32000);
+    expect(unwrappedError.message).toBe('foo');
+    expect(unwrappedError.stack).toBeDefined();
+    expect(handled).toBe(true);
+  });
+
+  it('unwraps a wrapped Snap error with a wrapped Snap error and data', () => {
+    const error = new SnapError('foo', { foo: 'bar' });
+
+    const wrapped = new WrappedSnapError(error).toJSON();
+    const [unwrappedError, handled] = unwrapError(wrapped);
+
+    expect(unwrappedError).toBeInstanceOf(Error);
+    expect(unwrappedError.code).toBe(-32603);
+    expect(unwrappedError.message).toBe('foo');
+    expect(unwrappedError.stack).toBeDefined();
+    expect(unwrappedError.data).toStrictEqual({
+      foo: 'bar',
+      stack: expect.any(String),
+    });
+    expect(handled).toBe(true);
   });
 });

--- a/packages/snaps-utils/src/errors.test.ts
+++ b/packages/snaps-utils/src/errors.test.ts
@@ -550,6 +550,19 @@ describe('unwrapError', () => {
     expect(handled).toBe(true);
   });
 
+  it('unwraps a wrapped Snap error with a `rpc-errors` error', () => {
+    const error = rpcErrors.invalidParams('foo');
+    const wrapped = new WrappedSnapError(error).toJSON();
+
+    const [unwrappedError, handled] = unwrapError(wrapped);
+
+    expect(unwrappedError).toBeInstanceOf(Error);
+    expect(unwrappedError.code).toBe(errorCodes.rpc.invalidParams);
+    expect(unwrappedError.message).toBe('foo');
+    expect(unwrappedError.stack).toBeDefined();
+    expect(handled).toBe(true);
+  });
+
   it('unwraps a wrapped Snap error with a wrapped Snap error', () => {
     const error = new SnapError('foo');
     const wrapped = new WrappedSnapError(error).toJSON();

--- a/packages/snaps-utils/src/errors.test.ts
+++ b/packages/snaps-utils/src/errors.test.ts
@@ -1,6 +1,14 @@
 import { rpcErrors } from '@metamask/rpc-errors';
 
-import { BaseSnapError, getErrorMessage, SnapError } from './errors';
+import {
+  getErrorMessage,
+  SNAP_ERROR_CODE,
+  SNAP_ERROR_MESSAGE,
+  SNAP_ERROR_WRAPPER_CODE,
+  SNAP_ERROR_WRAPPER_MESSAGE,
+  SnapError,
+  UnhandledSnapError,
+} from './errors';
 
 describe('getErrorMessage', () => {
   it('returns the error message if the error is an object with a message property', () => {
@@ -19,12 +27,62 @@ describe('getErrorMessage', () => {
   });
 });
 
+describe('SnapErrorWrapper', () => {
+  it('wraps an error', () => {
+    const error = new Error('foo');
+    const wrapped = new UnhandledSnapError(error);
+
+    expect(wrapped).toBeInstanceOf(Error);
+    expect(wrapped).toBeInstanceOf(UnhandledSnapError);
+    expect(wrapped.message).toBe('foo');
+    expect(wrapped.stack).toBeDefined();
+    expect(wrapped.toJSON()).toStrictEqual({
+      code: SNAP_ERROR_WRAPPER_CODE,
+      message: SNAP_ERROR_WRAPPER_MESSAGE,
+      data: {
+        cause: {
+          message: 'foo',
+          stack: error.stack,
+        },
+      },
+    });
+  });
+
+  it('wraps a Snap error', () => {
+    const error = new SnapError('foo');
+    const wrapped = new UnhandledSnapError(error);
+
+    expect(wrapped).toBeInstanceOf(Error);
+    expect(wrapped).toBeInstanceOf(UnhandledSnapError);
+    expect(wrapped.message).toBe('foo');
+    expect(wrapped.stack).toBeDefined();
+    expect(wrapped.toJSON()).toStrictEqual({
+      code: SNAP_ERROR_WRAPPER_CODE,
+      message: SNAP_ERROR_WRAPPER_MESSAGE,
+      data: {
+        cause: {
+          code: SNAP_ERROR_CODE,
+          message: SNAP_ERROR_MESSAGE,
+          data: {
+            cause: {
+              code: -32603,
+              message: 'foo',
+              data: {
+                stack: error.stack,
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+});
+
 describe('SnapError', () => {
   it('creates an error from a message', () => {
     const error = new SnapError('foo');
 
     expect(error).toBeInstanceOf(Error);
-    expect(error).toBeInstanceOf(BaseSnapError);
     expect(error).toBeInstanceOf(SnapError);
     expect(error.message).toBe('foo');
     expect(error.code).toBe(-32603);
@@ -46,7 +104,6 @@ describe('SnapError', () => {
     });
 
     expect(error).toBeInstanceOf(Error);
-    expect(error).toBeInstanceOf(BaseSnapError);
     expect(error).toBeInstanceOf(SnapError);
     expect(error.message).toBe('foo');
     expect(error.code).toBe(-32000);
@@ -65,7 +122,6 @@ describe('SnapError', () => {
     const error = new SnapError('foo', { foo: 'bar' });
 
     expect(error).toBeInstanceOf(Error);
-    expect(error).toBeInstanceOf(BaseSnapError);
     expect(error).toBeInstanceOf(SnapError);
     expect(error.message).toBe('foo');
     expect(error.code).toBe(-32603);
@@ -83,7 +139,6 @@ describe('SnapError', () => {
     );
 
     expect(error).toBeInstanceOf(Error);
-    expect(error).toBeInstanceOf(BaseSnapError);
     expect(error).toBeInstanceOf(SnapError);
     expect(error.message).toBe('foo');
     expect(error.code).toBe(-32000);
@@ -103,7 +158,6 @@ describe('SnapError', () => {
     const error = new SnapError(new Error('foo'));
 
     expect(error).toBeInstanceOf(Error);
-    expect(error).toBeInstanceOf(BaseSnapError);
     expect(error).toBeInstanceOf(SnapError);
     expect(error.message).toBe('foo');
     expect(error.code).toBe(-32603);
@@ -122,7 +176,6 @@ describe('SnapError', () => {
     const error = new SnapError(new Error('foo'), { foo: 'bar' });
 
     expect(error).toBeInstanceOf(Error);
-    expect(error).toBeInstanceOf(BaseSnapError);
     expect(error).toBeInstanceOf(SnapError);
     expect(error.message).toBe('foo');
     expect(error.code).toBe(-32603);
@@ -139,10 +192,9 @@ describe('SnapError', () => {
   });
 
   it('creates an error from a JsonRpcError', () => {
-    const error = new SnapError(ethErrors.rpc.invalidParams('foo'));
+    const error = new SnapError(rpcErrors.invalidParams('foo'));
 
     expect(error).toBeInstanceOf(Error);
-    expect(error).toBeInstanceOf(BaseSnapError);
     expect(error).toBeInstanceOf(SnapError);
     expect(error.message).toBe('foo');
     expect(error.code).toBe(-32602);
@@ -158,12 +210,11 @@ describe('SnapError', () => {
   });
 
   it('creates an error from a JsonRpcError and data', () => {
-    const error = new SnapError(ethErrors.rpc.invalidParams('foo'), {
+    const error = new SnapError(rpcErrors.invalidParams('foo'), {
       foo: 'bar',
     });
 
     expect(error).toBeInstanceOf(Error);
-    expect(error).toBeInstanceOf(BaseSnapError);
     expect(error).toBeInstanceOf(SnapError);
     expect(error.message).toBe('foo');
     expect(error.code).toBe(-32602);
@@ -186,7 +237,6 @@ describe('SnapError', () => {
     });
 
     expect(error).toBeInstanceOf(Error);
-    expect(error).toBeInstanceOf(BaseSnapError);
     expect(error).toBeInstanceOf(SnapError);
     expect(error.message).toBe('foo');
     expect(error.code).toBe(0);
@@ -211,7 +261,6 @@ describe('SnapError', () => {
     );
 
     expect(error).toBeInstanceOf(Error);
-    expect(error).toBeInstanceOf(BaseSnapError);
     expect(error).toBeInstanceOf(SnapError);
     expect(error.message).toBe('foo');
     expect(error.code).toBe(0);
@@ -241,7 +290,6 @@ describe('SnapError', () => {
     );
 
     expect(error).toBeInstanceOf(Error);
-    expect(error).toBeInstanceOf(BaseSnapError);
     expect(error).toBeInstanceOf(SnapError);
     expect(error.message).toBe('foo');
     expect(error.code).toBe(0);

--- a/packages/snaps-utils/src/errors.ts
+++ b/packages/snaps-utils/src/errors.ts
@@ -68,7 +68,7 @@ export function getErrorCode(error: unknown) {
     return error.code;
   }
 
-  return -32603;
+  return errorCodes.rpc.internal;
 }
 
 /**
@@ -220,20 +220,11 @@ export class SnapError extends Error {
    * with the error data, if any.
    */
   constructor(
-    error: string | Error | JsonRpcError | SerializedSnapError,
+    error: string | Error | JsonRpcError,
     data: Record<string, Json> = {},
   ) {
     const message = getErrorMessage(error);
     super(message);
-
-    if (isJsonRpcError(error) && isSerializedSnapError(error)) {
-      this.#message = error.data.cause.message;
-      this.#code = error.data.cause.code;
-      this.#data = error.data.cause.data;
-      this.#stack = error.data.cause.stack;
-
-      return;
-    }
 
     this.#message = message;
     this.#code = getErrorCode(error);
@@ -364,7 +355,7 @@ export function isSerializedSnapError(
  * @param error - The object to check.
  * @returns Whether the object is a `WrappedSnapError`.
  */
-export function isSnapErrorWrapper(
+export function isWrappedSnapError(
   error: unknown,
 ): error is SerializedSnapErrorWrapper {
   return (
@@ -390,7 +381,7 @@ export function unwrapError(
   // different types of errors that can be thrown by a Snap.
 
   // If the error is a wrapped Snap error, unwrap it.
-  if (isSnapErrorWrapper(error)) {
+  if (isWrappedSnapError(error)) {
     // The wrapped error can be a JSON-RPC error, or an unknown error. If it's
     // a JSON-RPC error, we can unwrap it further.
     if (isJsonRpcError(error.data.cause)) {

--- a/packages/snaps-utils/src/errors.ts
+++ b/packages/snaps-utils/src/errors.ts
@@ -3,7 +3,7 @@ import {
   JsonRpcError as RpcError,
   serializeCause,
 } from '@metamask/rpc-errors';
-import type { OptionalDataWithOptionalCause } from '@metamask/rpc-errors/dist/utils';
+import type { DataWithOptionalCause } from '@metamask/rpc-errors';
 import type { Json, JsonRpcError } from '@metamask/utils';
 import {
   hasProperty,
@@ -116,7 +116,7 @@ export type SerializedSnapError = {
   };
 };
 
-export class UnhandledSnapError extends Error {
+export class WrappedSnapError extends Error {
   readonly #error: unknown;
 
   readonly #message: string;
@@ -124,9 +124,9 @@ export class UnhandledSnapError extends Error {
   readonly #stack?: string;
 
   /**
-   * Create a new `UnhandledSnapError`.
+   * Create a new `WrappedSnapError`.
    *
-   * @param error - The error to create the `UnhandledSnapError` from.
+   * @param error - The error to create the `WrappedSnapError` from.
    */
   constructor(error: unknown) {
     const message = getErrorMessage(error);
@@ -143,7 +143,7 @@ export class UnhandledSnapError extends Error {
    * @returns The error name.
    */
   get name() {
-    return 'UnhandledSnapError';
+    return 'WrappedSnapError';
   }
 
   /**
@@ -385,7 +385,7 @@ export function isSnapErrorWrapper(
  */
 export function unwrapError(
   error: unknown,
-): [error: RpcError<OptionalDataWithOptionalCause>, isHandled: boolean] {
+): [error: RpcError<DataWithOptionalCause>, isHandled: boolean] {
   // This logic is a bit complicated, but it's necessary to handle all the
   // different types of errors that can be thrown by a Snap.
 

--- a/packages/snaps-utils/src/errors.ts
+++ b/packages/snaps-utils/src/errors.ts
@@ -1,4 +1,5 @@
-import { hasProperty, isObject } from '@metamask/utils';
+import type { Json, JsonRpcError } from '@metamask/utils';
+import { hasProperty, isObject, isValidJson } from '@metamask/utils';
 
 /**
  * Get the error message from an unknown error type.
@@ -19,4 +20,161 @@ export function getErrorMessage(error: unknown) {
   }
 
   return String(error);
+}
+
+/**
+ * Get the error code from an unknown error type.
+ *
+ * @param error - The error to get the code from.
+ * @returns The error code, or `-32603` if the error does not have a valid code.
+ */
+export function getErrorCode(error: unknown) {
+  if (
+    isObject(error) &&
+    hasProperty(error, 'code') &&
+    typeof error.code === 'number' &&
+    Number.isInteger(error.code)
+  ) {
+    return error.code;
+  }
+
+  return -32603;
+}
+
+/**
+ * Get the error data from an unknown error type.
+ *
+ * @param error - The error to get the data from.
+ * @returns The error data, or null if the error does not have valid data.
+ */
+export function getErrorData(error: unknown) {
+  if (
+    isObject(error) &&
+    hasProperty(error, 'data') &&
+    typeof error.data === 'object' &&
+    error.data !== null &&
+    isValidJson(error.data) &&
+    !Array.isArray(error.data)
+  ) {
+    return error.data;
+  }
+
+  return {};
+}
+
+/**
+ * A base class for Snap errors. This should be used for errors which are
+ * expected to be thrown by a Snap, and which should not cause the Snap to
+ * crash.
+ */
+export abstract class BaseSnapError extends Error {}
+
+/**
+ * A generic error which can be thrown by a Snap, without it causing the Snap to
+ * crash.
+ */
+export class SnapError extends BaseSnapError {
+  readonly #code: number;
+
+  readonly #message: string;
+
+  readonly #data: Record<string, Json>;
+
+  readonly #stack?: string;
+
+  /**
+   * Create a new `SnapError`.
+   *
+   * @param error - The error to create the `SnapError` from. If this is a
+   * `string`, it will be used as the error message. If this is an `Error`, its
+   * `message` property will be used as the error message. If this is a
+   * `JsonRpcError`, its `message` property will be used as the error message
+   * and its `code` property will be used as the error code. Otherwise, the
+   * error will be converted to a string and used as the error message.
+   * @param data - Additional data to include in the error. This will be merged
+   * with the error data, if any.
+   */
+  constructor(
+    error: string | Error | JsonRpcError,
+    data: Record<string, Json> = {},
+  ) {
+    const message = getErrorMessage(error);
+    super(message);
+
+    this.#message = message;
+    this.#code = getErrorCode(error);
+    this.#data = { ...getErrorData(error), ...data };
+    this.#stack = super.stack;
+  }
+
+  /**
+   * The error name.
+   *
+   * @returns The error name.
+   */
+  get name() {
+    return 'SnapError';
+  }
+
+  /**
+   * The error code.
+   *
+   * @returns The error code.
+   */
+  get code() {
+    return this.#code;
+  }
+
+  /**
+   * The error message.
+   *
+   * @returns The error message.
+   */
+  get message() {
+    return this.#message;
+  }
+
+  /**
+   * Additional data for the error.
+   *
+   * @returns Additional data for the error.
+   */
+  get data() {
+    return this.#data;
+  }
+
+  /**
+   * The error stack.
+   *
+   * @returns The error stack.
+   */
+  get stack() {
+    return this.#stack;
+  }
+
+  /**
+   * Convert the error to a JSON object.
+   *
+   * @returns The JSON object.
+   */
+  toJSON() {
+    return {
+      code: this.code,
+      message: this.message,
+      data: {
+        ...this.data,
+        stack: this.stack,
+      },
+    };
+  }
+
+  /**
+   * Serialize the error to a JSON object. This is called by
+   * `@metamask/rpc-errors` when serializing the error.
+   *
+   * @returns The JSON object.
+   */
+  serialize() {
+    return this.toJSON();
+  }
 }

--- a/packages/snaps-utils/src/errors.ts
+++ b/packages/snaps-utils/src/errors.ts
@@ -393,7 +393,7 @@ export function unwrapError(
 
       // Otherwise, we use the original JSON-RPC error.
       const { code, message, data } = error.data.cause;
-      return [new RpcError(code, message, data), true];
+      return [new RpcError(code, message, data), false];
     }
 
     // Otherwise, we throw an internal error with the wrapped error as the
@@ -402,6 +402,11 @@ export function unwrapError(
       new RpcError(errorCodes.rpc.internal, getErrorMessage(error.data.cause)),
       false,
     ];
+  }
+
+  if (isJsonRpcError(error)) {
+    const { code, message, data } = error;
+    return [new RpcError(code, message, data), false];
   }
 
   // If the error is not a wrapped error, we don't know how to handle it, so we

--- a/packages/snaps-utils/src/errors.ts
+++ b/packages/snaps-utils/src/errors.ts
@@ -1,5 +1,11 @@
+import { serializeCause } from '@metamask/rpc-errors';
 import type { Json, JsonRpcError } from '@metamask/utils';
-import { hasProperty, isObject, isValidJson } from '@metamask/utils';
+import {
+  hasProperty,
+  isJsonRpcError,
+  isObject,
+  isValidJson,
+} from '@metamask/utils';
 
 /**
  * Get the error message from an unknown error type.
@@ -20,6 +26,25 @@ export function getErrorMessage(error: unknown) {
   }
 
   return String(error);
+}
+
+/**
+ * Get the error stack from an unknown error type.
+ *
+ * @param error - The error to get the stack from.
+ * @returns The error stack, or undefined if the error does not have a valid
+ * stack.
+ */
+export function getErrorStack(error: unknown) {
+  if (
+    isObject(error) &&
+    hasProperty(error, 'stack') &&
+    typeof error.stack === 'string'
+  ) {
+    return error.stack;
+  }
+
+  return undefined;
 }
 
 /**
@@ -62,18 +87,113 @@ export function getErrorData(error: unknown) {
   return {};
 }
 
-/**
- * A base class for Snap errors. This should be used for errors which are
- * expected to be thrown by a Snap, and which should not cause the Snap to
- * crash.
- */
-export abstract class BaseSnapError extends Error {}
+export const SNAP_ERROR_WRAPPER_CODE = -31001;
+export const SNAP_ERROR_WRAPPER_MESSAGE = 'Wrapped Snap Error';
+
+export const SNAP_ERROR_CODE = -31002;
+export const SNAP_ERROR_MESSAGE = 'Snap Error';
+
+export type SerializedSnapErrorWrapper = {
+  code: typeof SNAP_ERROR_WRAPPER_CODE;
+  message: typeof SNAP_ERROR_WRAPPER_MESSAGE;
+  data: {
+    cause: Json;
+  };
+};
+
+export type SerializedSnapError = {
+  code: typeof SNAP_ERROR_CODE;
+  message: typeof SNAP_ERROR_MESSAGE;
+  data: {
+    cause: JsonRpcError & {
+      data: Record<string, Json>;
+    };
+  };
+};
+
+export class UnhandledSnapError extends Error {
+  readonly #error: unknown;
+
+  readonly #message: string;
+
+  readonly #stack?: string;
+
+  /**
+   * Create a new `UnhandledSnapError`.
+   *
+   * @param error - The error to create the `UnhandledSnapError` from.
+   */
+  constructor(error: unknown) {
+    const message = getErrorMessage(error);
+    super(message);
+
+    this.#error = error;
+    this.#message = message;
+    this.#stack = getErrorStack(error);
+  }
+
+  /**
+   * The error name.
+   *
+   * @returns The error name.
+   */
+  get name() {
+    return 'UnhandledSnapError';
+  }
+
+  /**
+   * The error message.
+   *
+   * @returns The error message.
+   */
+  get message() {
+    return this.#message;
+  }
+
+  /**
+   * The error stack.
+   *
+   * @returns The error stack.
+   */
+  get stack() {
+    return this.#stack;
+  }
+
+  /**
+   * Convert the error to a JSON object.
+   *
+   * @returns The JSON object.
+   */
+  toJSON(): SerializedSnapErrorWrapper {
+    const cause = isSnapError(this.#error)
+      ? this.#error.serialize()
+      : serializeCause(this.#error);
+
+    return {
+      code: SNAP_ERROR_WRAPPER_CODE,
+      message: SNAP_ERROR_WRAPPER_MESSAGE,
+      data: {
+        cause,
+      },
+    };
+  }
+
+  /**
+   * Serialize the error to a JSON object. This is called by
+   * `@metamask/rpc-errors` when serializing the error.
+   *
+   * @returns The JSON object.
+   */
+  serialize() {
+    return this.toJSON();
+  }
+}
 
 /**
  * A generic error which can be thrown by a Snap, without it causing the Snap to
  * crash.
  */
-export class SnapError extends BaseSnapError {
+export class SnapError extends Error {
   readonly #code: number;
 
   readonly #message: string;
@@ -95,11 +215,20 @@ export class SnapError extends BaseSnapError {
    * with the error data, if any.
    */
   constructor(
-    error: string | Error | JsonRpcError,
+    error: string | Error | JsonRpcError | SerializedSnapError,
     data: Record<string, Json> = {},
   ) {
     const message = getErrorMessage(error);
     super(message);
+
+    if (isJsonRpcError(error) && isSerializedSnapError(error)) {
+      this.#message = error.data.cause.message;
+      this.#code = error.data.cause.code;
+      this.#data = error.data.cause.data;
+      this.#stack = error.data.cause.stack;
+
+      return;
+    }
 
     this.#message = message;
     this.#code = getErrorCode(error);
@@ -157,13 +286,23 @@ export class SnapError extends BaseSnapError {
    *
    * @returns The JSON object.
    */
-  toJSON() {
+  toJSON(): SerializedSnapError {
+    const data = this.stack
+      ? {
+          ...this.data,
+          stack: this.stack,
+        }
+      : this.data;
+
     return {
-      code: this.code,
-      message: this.message,
+      code: SNAP_ERROR_CODE,
+      message: SNAP_ERROR_MESSAGE,
       data: {
-        ...this.data,
-        stack: this.stack,
+        cause: {
+          code: this.code,
+          message: this.message,
+          data,
+        },
       },
     };
   }
@@ -177,4 +316,54 @@ export class SnapError extends BaseSnapError {
   serialize() {
     return this.toJSON();
   }
+}
+
+/**
+ * Check if an object is a `SnapError`.
+ *
+ * @param error - The object to check.
+ * @returns Whether the object is a `SnapError`.
+ */
+export function isSnapError(error: unknown): error is SnapError {
+  if (
+    isObject(error) &&
+    'serialize' in error &&
+    typeof error.serialize === 'function'
+  ) {
+    const serialized = error.serialize();
+    return (
+      isJsonRpcError(serialized) &&
+      serialized.code === SNAP_ERROR_CODE &&
+      serialized.message === SNAP_ERROR_MESSAGE
+    );
+  }
+
+  return false;
+}
+
+/**
+ * Check if a JSON-RPC error is a `SnapError`.
+ *
+ * @param error - The object to check.
+ * @returns Whether the object is a `SnapError`.
+ */
+export function isSerializedSnapError(
+  error: JsonRpcError,
+): error is SerializedSnapError {
+  return error.code === SNAP_ERROR_CODE && error.message === SNAP_ERROR_MESSAGE;
+}
+
+/**
+ * Check if a JSON-RPC error is a `WrappedSnapError`.
+ *
+ * @param error - The object to check.
+ * @returns Whether the object is a `WrappedSnapError`.
+ */
+export function isSnapErrorWrapper(
+  error: JsonRpcError,
+): error is SerializedSnapErrorWrapper {
+  return (
+    error.code === SNAP_ERROR_WRAPPER_CODE &&
+    error.message === SNAP_ERROR_WRAPPER_MESSAGE
+  );
 }

--- a/packages/snaps-utils/src/errors.ts
+++ b/packages/snaps-utils/src/errors.ts
@@ -75,7 +75,8 @@ export function getErrorCode(error: unknown) {
  * Get the error data from an unknown error type.
  *
  * @param error - The error to get the data from.
- * @returns The error data, or null if the error does not have valid data.
+ * @returns The error data, or an empty object if the error does not have valid
+ * data.
  */
 export function getErrorData(error: unknown) {
   if (
@@ -327,11 +328,7 @@ export function isSnapError(error: unknown): error is SnapError {
     typeof error.serialize === 'function'
   ) {
     const serialized = error.serialize();
-    return (
-      isJsonRpcError(serialized) &&
-      serialized.code === SNAP_ERROR_CODE &&
-      serialized.message === SNAP_ERROR_MESSAGE
-    );
+    return isJsonRpcError(serialized) && isSerializedSnapError(serialized);
   }
 
   return false;
@@ -404,6 +401,8 @@ export function unwrapError(
     ];
   }
 
+  // The error can be a non-wrapped JSON-RPC error, in which case we can just
+  // re-throw it with the same code, message, and data.
   if (isJsonRpcError(error)) {
     const { code, message, data } = error;
     return [new RpcError(code, message, data), false];

--- a/yarn.lock
+++ b/yarn.lock
@@ -5453,7 +5453,6 @@ __metadata:
     "@metamask/json-rpc-engine": ^7.1.1
     "@metamask/key-tree": ^9.0.0
     "@metamask/permission-controller": ^5.0.0
-    "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-controllers": "workspace:^"
     "@metamask/snaps-execution-environments": "workspace:^"
     "@metamask/snaps-rpc-methods": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4469,7 +4469,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^5.1.1
+    "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
@@ -4951,16 +4951,6 @@ __metadata:
     typescript: ~4.8.4
   languageName: unknown
   linkType: soft
-
-"@metamask/rpc-errors@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "@metamask/rpc-errors@npm:5.1.1"
-  dependencies:
-    "@metamask/utils": ^5.0.0
-    fast-safe-stringify: ^2.0.6
-  checksum: ccd1b24da66af3ae63960b79c04b86efb8b96acb89ca6f7e0bbfe636d23ba5cddeba533c0692eafb87c44ec6f840085372d0f21b39e05df9a80700ff61538a30
-  languageName: node
-  linkType: hard
 
 "@metamask/rpc-errors@npm:^6.0.0, @metamask/rpc-errors@npm:^6.1.0":
   version: 6.1.0


### PR DESCRIPTION
This implements the `SnapError` class, and wrapping/unwrapping of errors thrown from a Snap. `SnapError`s will not cause the Snap to crash, and can be used to respond to JSON-RPC requests for example.

Closes #1824.