### PR TITLE
Refactor snap fetching slightly

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 89.28,
-  "functions": 95.6,
-  "lines": 96.97,
-  "statements": 96.64
+  "branches": 89.4,
+  "functions": 95.56,
+  "lines": 96.95,
+  "statements": 96.62
 }

--- a/packages/snaps-utils/src/snaps.ts
+++ b/packages/snaps-utils/src/snaps.ts
@@ -26,7 +26,7 @@ import validateNPMPackage from 'validate-npm-package-name';
 import { SnapCaveatType } from './caveats';
 import { checksumFiles } from './checksum';
 import type { SnapManifest, SnapPermissions } from './manifest/validation';
-import type { SnapFiles, SnapId, SnapsPermissionRequest } from './types';
+import type { FetchedSnapFiles, SnapId, SnapsPermissionRequest } from './types';
 import { SnapIdPrefixes, SnapValidationFailureReason, uri } from './types';
 import type { VirtualFile } from './virtual-file';
 
@@ -196,9 +196,7 @@ function getChecksummableManifest(
  * @param files - All required Snap files to be included in the checksum.
  * @returns The Base64-encoded SHA-256 digest of the source code.
  */
-export function getSnapChecksum(
-  files: Pick<SnapFiles, 'manifest' | 'sourceCode' | 'svgIcon'>,
-): string {
+export function getSnapChecksum(files: FetchedSnapFiles): string {
   const { manifest, sourceCode, svgIcon } = files;
   const all = [getChecksummableManifest(manifest), sourceCode, svgIcon].filter(
     (file) => file !== undefined,
@@ -214,7 +212,7 @@ export function getSnapChecksum(
  * @param errorMessage - The error message to throw if validation fails.
  */
 export function validateSnapShasum(
-  files: Pick<SnapFiles, 'manifest' | 'sourceCode' | 'svgIcon'>,
+  files: FetchedSnapFiles,
   errorMessage = 'Invalid Snap manifest: manifest shasum does not match computed shasum.',
 ): void {
   if (files.manifest.result.source.shasum !== getSnapChecksum(files)) {

--- a/packages/snaps-utils/src/types.ts
+++ b/packages/snaps-utils/src/types.ts
@@ -102,6 +102,14 @@ export type SnapFiles = {
 };
 
 /**
+ * A subset of snap files extracted from a fetched snap.
+ */
+export type FetchedSnapFiles = Pick<
+  SnapFiles,
+  'manifest' | 'sourceCode' | 'svgIcon'
+>;
+
+/**
  * The possible prefixes for snap ids.
  */
 /* eslint-disable @typescript-eslint/naming-convention */

--- a/packages/snaps-utils/src/validation.ts
+++ b/packages/snaps-utils/src/validation.ts
@@ -1,7 +1,7 @@
 import { assertIsSnapIcon } from './icon';
 import { assertIsSnapManifest } from './manifest/validation';
 import { validateSnapShasum } from './snaps';
-import type { SnapFiles } from './types';
+import type { FetchedSnapFiles } from './types';
 
 /**
  * Validates the files contained in a fetched snap.
@@ -9,9 +9,7 @@ import type { SnapFiles } from './types';
  * @param files - All potentially included files in a fetched snap.
  * @throws If any of the files are considered invalid.
  */
-export function validateFetchedSnap(
-  files: Pick<SnapFiles, 'manifest' | 'sourceCode' | 'svgIcon'>,
-): void {
+export function validateFetchedSnap(files: FetchedSnapFiles): void {
   assertIsSnapManifest(files.manifest.result);
   validateSnapShasum(files);
 


### PR DESCRIPTION
Refactors snap fetching slightly to remove the pattern of returning a list of files. Instead, we use another existing pattern where each type of file is defined within a strict set of keys.