### PR TITLE
Make `snaps-execution-environments` an optional peer dependency

### DIFF
--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -49,7 +49,6 @@
     "@metamask/permission-controller": "^4.1.2",
     "@metamask/post-message-stream": "^7.0.0",
     "@metamask/rpc-methods": "workspace:^",
-    "@metamask/snaps-execution-environments": "workspace:^",
     "@metamask/snaps-registry": "^2.0.0",
     "@metamask/snaps-utils": "workspace:^",
     "@metamask/utils": "^8.1.0",
@@ -121,6 +120,14 @@
     "wdio-chromedriver-service": "^8.1.1",
     "wdio-geckodriver-service": "^5.0.2",
     "webdriverio": "^8.15.9"
+  },
+  "peerDependencies": {
+    "@metamask/snaps-execution-environments": "workspace:^"
+  },
+  "peerDependenciesMeta": {
+    "@metamask/snaps-execution-environments": {
+      "optional": true
+    }
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5111,7 +5111,6 @@ __metadata:
     "@metamask/permission-controller": ^4.1.2
     "@metamask/post-message-stream": ^7.0.0
     "@metamask/rpc-methods": "workspace:^"
-    "@metamask/snaps-execution-environments": "workspace:^"
     "@metamask/snaps-registry": ^2.0.0
     "@metamask/snaps-utils": "workspace:^"
     "@metamask/template-snap": ^0.7.0
@@ -5173,6 +5172,11 @@ __metadata:
     wdio-chromedriver-service: ^8.1.1
     wdio-geckodriver-service: ^5.0.2
     webdriverio: ^8.15.9
+  peerDependencies:
+    "@metamask/snaps-execution-environments": "workspace:^"
+  peerDependenciesMeta:
+    "@metamask/snaps-execution-environments":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Makes `snaps-execution-environments` an optional peer dependency since you only need the dependency if you are trying to use the Node.js environments.

Fixes #1844 