### PR TITLE
Bump `tar-stream` to the latest version

### DIFF
--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -61,7 +61,7 @@
     "json-rpc-middleware-stream": "^4.2.0",
     "nanoid": "^3.1.31",
     "readable-web-to-node-stream": "^3.0.2",
-    "tar-stream": "^2.2.0"
+    "tar-stream": "^3.1.6"
   },
   "devDependencies": {
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -83,7 +83,7 @@
     "@types/mocha": "^10.0.1",
     "@types/node": "18.14.2",
     "@types/readable-stream": "^2.3.15",
-    "@types/tar-stream": "^2.2.2",
+    "@types/tar-stream": "^3.1.1",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
     "@wdio/browser-runner": "^8.15.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5124,7 +5124,7 @@ __metadata:
     "@types/mocha": ^10.0.1
     "@types/node": 18.14.2
     "@types/readable-stream": ^2.3.15
-    "@types/tar-stream": ^2.2.2
+    "@types/tar-stream": ^3.1.1
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
     "@wdio/browser-runner": ^8.15.9
@@ -7475,12 +7475,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/tar-stream@npm:^2.2.2":
-  version: 2.2.2
-  resolution: "@types/tar-stream@npm:2.2.2"
+"@types/tar-stream@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@types/tar-stream@npm:3.1.1"
   dependencies:
     "@types/node": "*"
-  checksum: 4b33bc0d53770e952d6e2e8acb8889190510326a3e255d0c6edd94136d6027ecae939a7b49188d1d02d774328d9a3742ff633d505709d1a1200b3413c88d793d
+  checksum: ba9e5c3bc31a4eefe2c519d06bd9f563d1ddadb83ea272d23390276aeeda4766cb74ba5217a765994a65c86bdf0ba41fa731633c0b3dc63e6c4d959f4672cf86
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5163,7 +5163,7 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.11
     readable-web-to-node-stream: ^3.0.2
     rimraf: ^4.1.2
-    tar-stream: ^2.2.0
+    tar-stream: ^3.1.6
     ts-node: ^10.9.1
     typescript: ~4.8.4
     vite: ^4.3.9
@@ -21506,7 +21506,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-stream@npm:^3.1.5":
+"tar-stream@npm:^3.1.5, tar-stream@npm:^3.1.6":
   version: 3.1.6
   resolution: "tar-stream@npm:3.1.6"
   dependencies:


### PR DESCRIPTION
We were using a really old version, this brings us up to date with a more recent version.