### PR TITLE
Support `utf8` encoding for `snap_getFile`

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "EdwnuHKiqsIz4f+l6nKY0wZaq8bni4a5YEs4p6375/c=",
+    "shasum": "gp4XVXNWWi1Bnp32ui4kDeeAD2sa/fssO/PMnqkwLPA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "gp4XVXNWWi1Bnp32ui4kDeeAD2sa/fssO/PMnqkwLPA=",
+    "shasum": "AevK0LdcWtG890SssMLHsK8vI1NFlaZqjLrHiOAinX8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "MVUJZIRIG1QLd6ZhFftNn5pFGTzvnd2D39K9UABBfhU=",
+    "shasum": "cAlW0MBdkEiGzyvMADxeQ/IvW+PHTSNVEprQlogAfSI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cAlW0MBdkEiGzyvMADxeQ/IvW+PHTSNVEprQlogAfSI=",
+    "shasum": "13EWl1zMYnrGxMsJEK0JBvcUL2d8FoKlrB/9ugIg9g8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "co2jtMEwsAvgoeQJjq51RbqWbFramRLf/eVToZvetEo=",
+    "shasum": "ZcSIGt4pIKQDmH6EenAa/pH3Iy9PbxMlxpVSSfFpMPk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZcSIGt4pIKQDmH6EenAa/pH3Iy9PbxMlxpVSSfFpMPk=",
+    "shasum": "OGGoO4sXe19namsdmALoI5D5Gh9YgWtfZf4XujuggKQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7t1AQR2GJYVsKreUSkmEDUx2xHZNHkyHZ6IKexPyhWA=",
+    "shasum": "2D6z43N7y98AKwE4uoCrMW5xAD0ybrKWhgDm7Cjf/Hs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2D6z43N7y98AKwE4uoCrMW5xAD0ybrKWhgDm7Cjf/Hs=",
+    "shasum": "a5CI0z65D1RZM88OQ+5xOVCZ7RFjhr6pG6DgwBooD0Q=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/README.md
+++ b/packages/examples/packages/get-file/README.md
@@ -26,6 +26,7 @@ JSON-RPC methods:
 
 - `getFile`: Returns a static JSON file.
 - `getFileInBase64`: Returns the same static JSON file in Base64.
+- `getFileInHex`: Returns the same static JSON file in hexadecimal.
 
 For more information, you can refer to
 [the end-to-end tests](./src/index.test.ts).

--- a/packages/examples/packages/get-file/package.json
+++ b/packages/examples/packages/get-file/package.json
@@ -33,8 +33,7 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^5.1.1",
-    "@metamask/snaps-types": "workspace:^",
-    "@metamask/utils": "^8.1.0"
+    "@metamask/snaps-types": "workspace:^"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "O2nTSRhTbsRoF32bIN7m+RfHZgE3dqZJYMrhmZk4h5o=",
+    "shasum": "KeR2SaLL7hPmuTOW4n1Tz0VhgMEYqUTmjIMJHjdxBC8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "IsVfJYwK/RvI9RZKZyuhYfNCE+eVG2rL6/Hyjjt9hJw=",
+    "shasum": "O2nTSRhTbsRoF32bIN7m+RfHZgE3dqZJYMrhmZk4h5o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/src/index.test.ts
+++ b/packages/examples/packages/get-file/src/index.test.ts
@@ -50,4 +50,20 @@ describe('onRpcRequest', () => {
       await close();
     });
   });
+
+  describe('getFileInHex', () => {
+    it('returns the file in hex', async () => {
+      const { request, close } = await installSnap();
+
+      const response = request({
+        method: 'getFileInHex',
+      });
+
+      expect(await response).toRespondWith(
+        '0x7b0a202022666f6f223a2022626172220a7d0a',
+      );
+
+      await close();
+    });
+  });
 });

--- a/packages/examples/packages/get-file/src/index.ts
+++ b/packages/examples/packages/get-file/src/index.ts
@@ -24,7 +24,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     case 'getFile': {
       const fileInPlaintext = await snap.request({
         method: 'snap_getFile',
-        params: { path: './src/foo.json', encoding: 'plaintext' },
+        params: { path: './src/foo.json', encoding: 'utf8' },
       });
       return JSON.parse(fileInPlaintext);
     }

--- a/packages/examples/packages/get-file/src/index.ts
+++ b/packages/examples/packages/get-file/src/index.ts
@@ -1,6 +1,5 @@
 import { rpcErrors } from '@metamask/rpc-errors';
 import type { OnRpcRequestHandler } from '@metamask/snaps-types';
-import { bytesToString, hexToBytes } from '@metamask/utils';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the
@@ -9,6 +8,8 @@ import { bytesToString, hexToBytes } from '@metamask/utils';
  * - `getFile`: Returns a statically defined JSON file. This uses the
  * `snap_getFile` JSON-RPC method to get this file and parses it before returning.
  * - `getFileInBase64`: Returns a statically defined JSON file in Base64.
+ * This uses the `snap_getFile` JSON-RPC method to get this file returns it directly.
+ * - `getFileInHex`: Returns a statically defined JSON file in hexadecimal.
  * This uses the `snap_getFile` JSON-RPC method to get this file returns it directly.
  *
  * @param params - The request parameters.
@@ -21,12 +22,11 @@ import { bytesToString, hexToBytes } from '@metamask/utils';
 export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   switch (request.method) {
     case 'getFile': {
-      const fileInHexadecimal = await snap.request({
+      const fileInPlaintext = await snap.request({
         method: 'snap_getFile',
-        params: { path: './src/foo.json', encoding: 'hex' },
+        params: { path: './src/foo.json', encoding: 'plaintext' },
       });
-      const bytes = hexToBytes(fileInHexadecimal);
-      return JSON.parse(bytesToString(bytes));
+      return JSON.parse(fileInPlaintext);
     }
 
     case 'getFileInBase64': {
@@ -34,6 +34,13 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
         method: 'snap_getFile',
         // Encoding is optional and defaults to base64
         params: { path: './src/foo.json' },
+      });
+    }
+
+    case 'getFileInHex': {
+      return await snap.request({
+        method: 'snap_getFile',
+        params: { path: './src/foo.json', encoding: 'hex' },
       });
     }
 

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "jKYiuKBqNaeeWsUi/TQp6OBh6UveiWiBb3NrL78L4V8=",
+    "shasum": "xF9GWygfjIPLjeSYBFO0RJ2O3hN6DtYt/v57Jzc0huU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xF9GWygfjIPLjeSYBFO0RJ2O3hN6DtYt/v57Jzc0huU=",
+    "shasum": "WHjV/BMEqShmPsz94ITTRZKqC80X1Iergou1FxRsBQI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Hh5M8dnbL4B3y4yPcILbdq9jz/2QS40rFJzQen/ek5g=",
+    "shasum": "ruYznsJRKMvZ2+hquwW9rvBqfVP8jPi0LbsDaeZFwaw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "dDhGT/5cpuAv+fsSIinTSg0vo+r1l4Xb4WfypWEjyyM=",
+    "shasum": "Hh5M8dnbL4B3y4yPcILbdq9jz/2QS40rFJzQen/ek5g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "mZqDsHNDaiCuYraPj7aVJKpswihyjfNSo9Jq5hD4BKM=",
+    "shasum": "jWOnAWbwW9vVmugnyT3Xax2tmkBR6MMOAuf0Gb4EVq4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TO6zLIG+k6OIa6iJ951A0R4kmQ28kT4A67Jaa87ElLY=",
+    "shasum": "mZqDsHNDaiCuYraPj7aVJKpswihyjfNSo9Jq5hD4BKM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1Hf1QF/WH3S6kjX7B0VDO0D8sj8WqcfvsK7NoeNrrFc=",
+    "shasum": "Od0ujiewFnZzr7savO+Rc/6kyN+wLTtRH1WkgwE9tpA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Od0ujiewFnZzr7savO+Rc/6kyN+wLTtRH1WkgwE9tpA=",
+    "shasum": "iI/GkZp/Ji9godApV9NAXyRzffAy9dDCr++2Ry3xrLk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/rpc-methods/src/permitted/getFile.ts
+++ b/packages/rpc-methods/src/permitted/getFile.ts
@@ -18,7 +18,7 @@ export const GetFileArgsStruct = object({
     union([
       enumValue(AuxiliaryFileEncoding.Base64),
       enumValue(AuxiliaryFileEncoding.Hex),
-      enumValue(AuxiliaryFileEncoding.Plaintext),
+      enumValue(AuxiliaryFileEncoding.Utf8),
     ]),
   ),
 });

--- a/packages/rpc-methods/src/permitted/getFile.ts
+++ b/packages/rpc-methods/src/permitted/getFile.ts
@@ -18,6 +18,7 @@ export const GetFileArgsStruct = object({
     union([
       enumValue(AuxiliaryFileEncoding.Base64),
       enumValue(AuxiliaryFileEncoding.Hex),
+      enumValue(AuxiliaryFileEncoding.Plaintext),
     ]),
   ),
 });

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 95.5,
+  "branches": 95.52,
   "functions": 100,
   "lines": 98.72,
-  "statements": 95.81
+  "statements": 95.82
 }

--- a/packages/snaps-utils/src/auxiliary-files.test.ts
+++ b/packages/snaps-utils/src/auxiliary-files.test.ts
@@ -18,4 +18,12 @@ describe('encodeAuxiliaryFile', () => {
       bytesToHex(bytes),
     );
   });
+
+  it('returns plaintext when requested', () => {
+    const bytes = stringToBytes('foo');
+    const value = base64.encode(bytes);
+    expect(encodeAuxiliaryFile(value, AuxiliaryFileEncoding.Plaintext)).toBe(
+      'foo',
+    );
+  });
 });

--- a/packages/snaps-utils/src/auxiliary-files.test.ts
+++ b/packages/snaps-utils/src/auxiliary-files.test.ts
@@ -22,8 +22,6 @@ describe('encodeAuxiliaryFile', () => {
   it('returns plaintext when requested', () => {
     const bytes = stringToBytes('foo');
     const value = base64.encode(bytes);
-    expect(encodeAuxiliaryFile(value, AuxiliaryFileEncoding.Plaintext)).toBe(
-      'foo',
-    );
+    expect(encodeAuxiliaryFile(value, AuxiliaryFileEncoding.Utf8)).toBe('foo');
   });
 });

--- a/packages/snaps-utils/src/auxiliary-files.ts
+++ b/packages/snaps-utils/src/auxiliary-files.ts
@@ -4,7 +4,7 @@ import { base64 } from '@scure/base';
 export enum AuxiliaryFileEncoding {
   Base64 = 'base64',
   Hex = 'hex',
-  Plaintext = 'plaintext',
+  Utf8 = 'utf8',
 }
 
 /**
@@ -25,7 +25,7 @@ export function encodeAuxiliaryFile(
 
   // TODO: Use @metamask/utils for this
   const decoded = base64.decode(value);
-  if (encoding === AuxiliaryFileEncoding.Plaintext) {
+  if (encoding === AuxiliaryFileEncoding.Utf8) {
     return bytesToString(decoded);
   }
   return bytesToHex(decoded);

--- a/packages/snaps-utils/src/auxiliary-files.ts
+++ b/packages/snaps-utils/src/auxiliary-files.ts
@@ -1,9 +1,10 @@
-import { bytesToHex } from '@metamask/utils';
+import { bytesToHex, bytesToString } from '@metamask/utils';
 import { base64 } from '@scure/base';
 
 export enum AuxiliaryFileEncoding {
   Base64 = 'base64',
   Hex = 'hex',
+  Plaintext = 'plaintext',
 }
 
 /**
@@ -23,7 +24,9 @@ export function encodeAuxiliaryFile(
   }
 
   // TODO: Use @metamask/utils for this
-  // For now, the requested encoding here will always be hex.
   const decoded = base64.decode(value);
+  if (encoding === AuxiliaryFileEncoding.Plaintext) {
+    return bytesToString(decoded);
+  }
   return bytesToHex(decoded);
 }

--- a/packages/snaps-utils/src/auxiliary-files.ts
+++ b/packages/snaps-utils/src/auxiliary-files.ts
@@ -28,5 +28,6 @@ export function encodeAuxiliaryFile(
   if (encoding === AuxiliaryFileEncoding.Utf8) {
     return bytesToString(decoded);
   }
+
   return bytesToHex(decoded);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4444,7 +4444,6 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-types": "workspace:^"
-    "@metamask/utils": ^8.1.0
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1


### PR DESCRIPTION
Support `utf8` encoding for `snap_getFile`. This is useful for loading JSON or other text files.