### PR TITLE
Add origin parameter to `snapInstalled` and `snapUpdated` events

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -507,10 +507,14 @@ describe('SnapController', () => {
         });
       }),
       new Promise<void>((resolve) => {
-        messenger.subscribe('SnapController:snapInstalled', (truncatedSnap) => {
-          expect(truncatedSnap).toStrictEqual(getTruncatedSnap());
-          resolve();
-        });
+        messenger.subscribe(
+          'SnapController:snapInstalled',
+          (truncatedSnap, origin) => {
+            expect(truncatedSnap).toStrictEqual(getTruncatedSnap());
+            expect(origin).toStrictEqual(MOCK_ORIGIN);
+            resolve();
+          },
+        );
       }),
     ]);
 
@@ -3912,6 +3916,11 @@ describe('SnapController', () => {
       );
 
       expect(onSnapUpdated).toHaveBeenCalledTimes(1);
+      expect(onSnapUpdated).toHaveBeenCalledWith(
+        newSnapTruncated,
+        '1.0.0',
+        MOCK_ORIGIN,
+      );
       expect(onSnapAdded).toHaveBeenCalledTimes(1);
 
       controller.destroy();
@@ -5993,6 +6002,7 @@ describe('SnapController', () => {
         'SnapController:snapUpdated',
         getTruncatedSnap(),
         '0.9.0',
+        MOCK_ORIGIN,
       );
 
       await new Promise((resolve) => setTimeout(resolve, 10));
@@ -6045,7 +6055,11 @@ describe('SnapController', () => {
         () => false,
       );
 
-      messenger.publish('SnapController:snapInstalled', getTruncatedSnap());
+      messenger.publish(
+        'SnapController:snapInstalled',
+        getTruncatedSnap(),
+        MOCK_ORIGIN,
+      );
 
       await new Promise((resolve) => setTimeout(resolve, 10));
 
@@ -6093,6 +6107,7 @@ describe('SnapController', () => {
         'SnapController:snapUpdated',
         getTruncatedSnap(),
         '0.9.0',
+        MOCK_ORIGIN,
       );
       await new Promise((resolve) => setTimeout(resolve, 10));
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -396,7 +396,7 @@ export type SnapBlocked = {
  */
 export type SnapInstalled = {
   type: `${typeof controllerName}:snapInstalled`;
-  payload: [snap: TruncatedSnap];
+  payload: [snap: TruncatedSnap, origin: string];
 };
 
 /**
@@ -429,7 +429,7 @@ export type SnapUnblocked = {
  */
 export type SnapUpdated = {
   type: `${typeof controllerName}:snapUpdated`;
-  payload: [snap: TruncatedSnap, oldVersion: string];
+  payload: [snap: TruncatedSnap, oldVersion: string, origin: string];
 };
 
 /**
@@ -1720,6 +1720,7 @@ export class SnapController extends BaseController<
         this.messagingSystem.publish(
           `SnapController:snapInstalled`,
           this.getTruncatedExpect(snapId),
+          origin,
         ),
       );
 
@@ -1728,6 +1729,7 @@ export class SnapController extends BaseController<
           `SnapController:snapUpdated`,
           this.getTruncatedExpect(snapId),
           oldVersion,
+          origin,
         ),
       );
 
@@ -2035,6 +2037,7 @@ export class SnapController extends BaseController<
           'SnapController:snapUpdated',
           truncatedSnap,
           snap.version,
+          origin,
         );
       }
 


### PR DESCRIPTION
Adds an origin parameter to the emitted `snapInstalled` and `snapUpdated` events.