### PR TITLE
Try to match requested version with an allowlisted version

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 89.62,
-  "functions": 96.23,
-  "lines": 97.11,
-  "statements": 96.78
+  "branches": 89.95,
+  "functions": 96.24,
+  "lines": 97.15,
+  "statements": 96.82
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -726,6 +726,32 @@ describe('SnapController', () => {
     controller.destroy();
   });
 
+  it('throws an error if snap is not on allowlist and allowlisting is required but resolve succeeds', async () => {
+    const registry = new MockSnapsRegistry();
+    const rootMessenger = getControllerMessenger(registry);
+    const messenger = getSnapControllerMessenger(rootMessenger);
+    const controller = getSnapController(
+      getSnapControllerOptions({
+        featureFlags: { requireAllowlist: true },
+        messenger,
+        detectSnapLocation: loopbackDetect(),
+      }),
+    );
+
+    // Mock resolve to succeed, but registry.get() will fail later
+    registry.resolveVersion.mockReturnValue('1.0.0');
+
+    await expect(
+      controller.installSnaps(MOCK_ORIGIN, {
+        [MOCK_SNAP_ID]: { version: DEFAULT_REQUESTED_SNAP_VERSION },
+      }),
+    ).rejects.toThrow(
+      'Cannot install version "1.0.0" of snap "npm:@metamask/example-snap": The snap is not on the allow list.',
+    );
+
+    controller.destroy();
+  });
+
   it('throws an error if snap is not on allowlist and allowlisting is required', async () => {
     const controller = getSnapController(
       getSnapControllerOptions({

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -739,8 +739,45 @@ describe('SnapController', () => {
         [MOCK_SNAP_ID]: { version: DEFAULT_REQUESTED_SNAP_VERSION },
       }),
     ).rejects.toThrow(
-      'Cannot install version "1.0.0" of snap "npm:@metamask/example-snap": The snap is not on the allow list.',
+      'Cannot install version "*" of snap "npm:@metamask/example-snap": The snap is not on the allow list.',
     );
+
+    controller.destroy();
+  });
+
+  it('resolves to allowlisted version when allowlisting is required', async () => {
+    const registry = new MockSnapsRegistry();
+    const rootMessenger = getControllerMessenger(registry);
+    const messenger = getSnapControllerMessenger(rootMessenger);
+
+    const { manifest, sourceCode, svgIcon } = getSnapFiles({
+      manifest: getSnapManifest({
+        version: '1.1.0' as SemVerVersion,
+      }),
+    });
+
+    registry.get.mockResolvedValueOnce({
+      [MOCK_SNAP_ID]: { status: SnapsRegistryStatus.Verified },
+    });
+
+    registry.resolveVersion.mockReturnValue('1.1.0');
+
+    const controller = getSnapController(
+      getSnapControllerOptions({
+        messenger,
+        featureFlags: { requireAllowlist: true },
+        detectSnapLocation: loopbackDetect({
+          manifest,
+          files: [sourceCode, svgIcon as VirtualFile],
+        }),
+      }),
+    );
+
+    await controller.installSnaps(MOCK_ORIGIN, {
+      [MOCK_SNAP_ID]: { version: '^1.0.0' },
+    });
+
+    expect(controller.get(MOCK_SNAP_ID)?.version).toBe('1.1.0');
 
     controller.destroy();
   });

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -746,7 +746,7 @@ describe('SnapController', () => {
         [MOCK_SNAP_ID]: { version: DEFAULT_REQUESTED_SNAP_VERSION },
       }),
     ).rejects.toThrow(
-      'Cannot install version "1.0.0" of snap "npm:@metamask/example-snap": The snap is not on the allow list.',
+      'Cannot install version "1.0.0" of snap "npm:@metamask/example-snap": The snap is not on the allowlist.',
     );
 
     controller.destroy();
@@ -765,7 +765,7 @@ describe('SnapController', () => {
         [MOCK_SNAP_ID]: { version: DEFAULT_REQUESTED_SNAP_VERSION },
       }),
     ).rejects.toThrow(
-      'Cannot install version "*" of snap "npm:@metamask/example-snap": The snap is not on the allow list.',
+      'Cannot install snap "npm:@metamask/example-snap": The snap is not on the allowlist.',
     );
 
     controller.destroy();

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1092,7 +1092,7 @@ export class SnapController extends BaseController<
       result.status !== SnapsRegistryStatus.Verified
     ) {
       throw new Error(
-        `Cannot install version "${snapInfo.version}" of snap "${snapId}": The snap is not on the allow list.`,
+        `Cannot install version "${snapInfo.version}" of snap "${snapId}": The snap is not on the allowlist.`,
       );
     }
   }

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -102,6 +102,7 @@ import { processSnapPermissions } from './permissions';
 import type {
   GetMetadata,
   GetResult,
+  ResolveVersion,
   SnapsRegistryInfo,
   SnapsRegistryMetadata,
   SnapsRegistryRequest,
@@ -501,7 +502,8 @@ export type AllowedActions =
   | UpdateRequestState
   | GetResult
   | GetMetadata
-  | Update;
+  | Update
+  | ResolveVersion;
 
 export type AllowedEvents =
   | ExecutionServiceEvents
@@ -1681,13 +1683,18 @@ export class SnapController extends BaseController<
       )) {
         assertIsValidSnapId(snapId);
 
-        const [error, version] = resolveVersionRange(rawVersion);
+        const [error, resolvedVersion] = resolveVersionRange(rawVersion);
 
         if (error) {
           throw rpcErrors.invalidParams(
             `The "version" field must be a valid SemVer version range if specified. Received: "${rawVersion}".`,
           );
         }
+
+        // If we are running in allowlist mode, try to match the version with an allowlist version.
+        const version = this.#featureFlags.requireAllowlist
+          ? await this.#resolveAllowlistVersion(snapId, resolvedVersion)
+          : resolvedVersion;
 
         const location = this.#detectSnapLocation(snapId, {
           versionRange: version,
@@ -2063,6 +2070,17 @@ export class SnapController extends BaseController<
       });
       throw error;
     }
+  }
+
+  async #resolveAllowlistVersion(
+    snapId: ValidatedSnapId,
+    versionRange: SemVerRange,
+  ): Promise<SemVerRange> {
+    return await this.messagingSystem.call(
+      'SnapsRegistry:resolveVersion',
+      snapId,
+      versionRange,
+    );
   }
 
   /**

--- a/packages/snaps-controllers/src/snaps/registry/json.test.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.test.ts
@@ -355,7 +355,7 @@ describe('JsonSnapsRegistry', () => {
           '^1.0.0' as SemVerRange,
         ),
       ).rejects.toThrow(
-        'Cannot install version "^1.0.0" of snap "npm:@metamask/example-snap": The snap is not on the allow list.',
+        'Cannot install snap "npm:@metamask/example-snap": The snap is not on the allowlist.',
       );
     });
 
@@ -372,7 +372,7 @@ describe('JsonSnapsRegistry', () => {
           '^1.2.0' as SemVerRange,
         ),
       ).rejects.toThrow(
-        'Cannot install version "^1.2.0" of snap "npm:@metamask/example-snap": No matching versions of the snap are on the allow list.',
+        'Cannot install version "^1.2.0" of snap "npm:@metamask/example-snap": No matching versions of the snap are on the allowlist.',
       );
     });
 

--- a/packages/snaps-controllers/src/snaps/registry/json.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.ts
@@ -320,7 +320,7 @@ export class JsonSnapsRegistry extends BaseController<
 
     assert(
       targetVersion,
-      `Cannot install version "${targetVersion}" of snap "${snapId}": No matching versions of the snap are on the allow list.`,
+      `Cannot install version "${versionRange}" of snap "${snapId}": No matching versions of the snap are on the allow list.`,
     );
 
     // A semver version is technically also a valid semver range.

--- a/packages/snaps-controllers/src/snaps/registry/json.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.ts
@@ -6,6 +6,7 @@ import { getTargetVersion, type SnapId } from '@metamask/snaps-utils';
 import type { Hex, SemVerRange, SemVerVersion } from '@metamask/utils';
 import {
   assert,
+  assertIsSemVerRange,
   Duration,
   inMilliseconds,
   satisfiesVersionRange,
@@ -305,7 +306,7 @@ export class JsonSnapsRegistry extends BaseController<
 
     assert(
       versions,
-      `Cannot install version "${versionRange}" of snap "${snapId}": The snap is not on the allow list.`,
+      `Cannot install snap "${snapId}": The snap is not on the allowlist.`,
     );
 
     const targetVersion = getTargetVersion(
@@ -320,11 +321,12 @@ export class JsonSnapsRegistry extends BaseController<
 
     assert(
       targetVersion,
-      `Cannot install version "${versionRange}" of snap "${snapId}": No matching versions of the snap are on the allow list.`,
+      `Cannot install version "${versionRange}" of snap "${snapId}": No matching versions of the snap are on the allowlist.`,
     );
 
     // A semver version is technically also a valid semver range.
-    return targetVersion as unknown as SemVerRange;
+    assertIsSemVerRange(targetVersion);
+    return targetVersion;
   }
 
   /**

--- a/packages/snaps-controllers/src/snaps/registry/json.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.ts
@@ -2,8 +2,8 @@ import type { RestrictedControllerMessenger } from '@metamask/base-controller';
 import { BaseControllerV2 as BaseController } from '@metamask/base-controller';
 import type { SnapsRegistryDatabase } from '@metamask/snaps-registry';
 import { verify } from '@metamask/snaps-registry';
-import type { SnapId } from '@metamask/snaps-utils';
-import type { Hex } from '@metamask/utils';
+import { getTargetVersion, type SnapId } from '@metamask/snaps-utils';
+import type { Hex, SemVerRange, SemVerVersion } from '@metamask/utils';
 import {
   assert,
   Duration,
@@ -48,6 +48,11 @@ export type GetResult = {
   handler: SnapsRegistry['get'];
 };
 
+export type ResolveVersion = {
+  type: `${typeof controllerName}:resolveVersion`;
+  handler: SnapsRegistry['resolveVersion'];
+};
+
 export type GetMetadata = {
   type: `${typeof controllerName}:getMetadata`;
   handler: SnapsRegistry['getMetadata'];
@@ -58,7 +63,11 @@ export type Update = {
   handler: SnapsRegistry['update'];
 };
 
-export type SnapsRegistryActions = GetResult | GetMetadata | Update;
+export type SnapsRegistryActions =
+  | GetResult
+  | GetMetadata
+  | Update
+  | ResolveVersion;
 
 export type SnapsRegistryEvents = never;
 
@@ -138,9 +147,15 @@ export class JsonSnapsRegistry extends BaseController<
       'SnapsRegistry:get',
       async (...args) => this.#get(...args),
     );
+
     this.messagingSystem.registerActionHandler(
       'SnapsRegistry:getMetadata',
       async (...args) => this.#getMetadata(...args),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      'SnapsRegistry:resolveVersion',
+      async (...args) => this.#resolveVersion(...args),
     );
 
     this.messagingSystem.registerActionHandler(
@@ -264,6 +279,52 @@ export class JsonSnapsRegistry extends BaseController<
       acc[snapId] = result;
       return acc;
     }, Promise.resolve({}));
+  }
+
+  /**
+   * Find an allowlisted version within a specified version range.
+   *
+   * @param snapId - The ID of the snap we are trying to resolve a version for.
+   * @param versionRange - The version range.
+   * @param refetch - An optional flag used to determine if we are refetching the registry.
+   * @returns An allowlisted version within the specified version range.
+   * @throws If an allowlisted version does not exist within the version range.
+   */
+  async #resolveVersion(
+    snapId: SnapId,
+    versionRange: SemVerRange,
+    refetch = false,
+  ): Promise<SemVerRange> {
+    const database = await this.#getDatabase();
+    const versions = database?.verifiedSnaps[snapId]?.versions ?? null;
+
+    if (!versions && this.#refetchOnAllowlistMiss && !refetch) {
+      await this.#triggerUpdate();
+      return this.#resolveVersion(snapId, versionRange, true);
+    }
+
+    assert(
+      versions,
+      `Cannot install version "${versionRange}" of snap "${snapId}": The snap is not on the allow list.`,
+    );
+
+    const targetVersion = getTargetVersion(
+      Object.keys(versions) as SemVerVersion[],
+      versionRange,
+    );
+
+    if (!targetVersion && this.#refetchOnAllowlistMiss && !refetch) {
+      await this.#triggerUpdate();
+      return this.#resolveVersion(snapId, versionRange, true);
+    }
+
+    assert(
+      targetVersion,
+      `Cannot install version "${targetVersion}" of snap "${snapId}": No matching versions of the snap are on the allow list.`,
+    );
+
+    // A semver version is technically also a valid semver range.
+    return targetVersion as unknown as SemVerRange;
   }
 
   /**

--- a/packages/snaps-controllers/src/snaps/registry/registry.ts
+++ b/packages/snaps-controllers/src/snaps/registry/registry.ts
@@ -3,7 +3,7 @@ import type {
   SnapsRegistryDatabase,
 } from '@metamask/snaps-registry';
 import type { SnapId, ValidatedSnapId } from '@metamask/snaps-utils';
-import type { SemVerVersion } from '@metamask/utils';
+import type { SemVerRange, SemVerVersion } from '@metamask/utils';
 
 export type SnapsRegistryInfo = { version: SemVerVersion; checksum: string };
 export type SnapsRegistryRequest = Record<SnapId, SnapsRegistryInfo>;
@@ -28,6 +28,20 @@ export type SnapsRegistry = {
   ): Promise<Record<ValidatedSnapId, SnapsRegistryResult>>;
 
   update(): Promise<void>;
+
+  /**
+   * Find an allowlisted version within a specified version range.
+   *
+   * @param snapId - The ID of the snap we are trying to resolve a version for.
+   * @param versionRange - The version range.
+   * @param refetch - An optional flag used to determine if we are refetching the registry.
+   * @returns An allowlisted version within the specified version range.
+   * @throws If an allowlisted version does not exist within the version range.
+   */
+  resolveVersion(
+    snapId: SnapId,
+    versionRange: SemVerRange,
+  ): Promise<SemVerRange>;
 
   /**
    * Get metadata for the given snap ID.

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -348,7 +348,6 @@ export const getSnapControllerMessenger = (
       'SnapController:getAll',
       'SnapController:getPermitted',
       'SnapController:install',
-      'SnapController:removeSnapError',
       'SnapController:incrementActiveReferences',
       'SnapController:decrementActiveReferences',
       'SnapController:getRegistryMetadata',
@@ -359,6 +358,7 @@ export const getSnapControllerMessenger = (
       'SnapController:disconnectOrigin',
       'SnapController:revokeDynamicPermissions',
       'SnapController:getFile',
+      'SnapsRegistry:resolveVersion',
     ],
   });
 

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -282,6 +282,10 @@ export const getControllerMessenger = (registry = new MockSnapsRegistry()) => {
     'SnapsRegistry:getMetadata',
     registry.getMetadata.bind(registry),
   );
+  messenger.registerActionHandler(
+    'SnapsRegistry:resolveVersion',
+    registry.resolveVersion.bind(registry),
+  );
 
   messenger.registerActionHandler(
     'SnapsRegistry:update',
@@ -541,6 +545,7 @@ export const getRestrictedSnapsRegistryControllerMessenger = (
       'SnapsRegistry:get',
       'SnapsRegistry:getMetadata',
       'SnapsRegistry:update',
+      'SnapsRegistry:resolveVersion',
     ],
   });
 

--- a/packages/snaps-controllers/src/test-utils/registry.ts
+++ b/packages/snaps-controllers/src/test-utils/registry.ts
@@ -14,9 +14,9 @@ export class MockSnapsRegistry implements SnapsRegistry {
     );
   });
 
-  resolveVersion = jest.fn().mockImplementation((snapId, versionRange) => {
+  resolveVersion = jest.fn().mockImplementation((snapId) => {
     throw new Error(
-      `Cannot install version "${versionRange}" of snap "${snapId}": The snap is not on the allow list.`,
+      `Cannot install snap "${snapId}": The snap is not on the allowlist.`,
     );
   });
 

--- a/packages/snaps-controllers/src/test-utils/registry.ts
+++ b/packages/snaps-controllers/src/test-utils/registry.ts
@@ -14,6 +14,12 @@ export class MockSnapsRegistry implements SnapsRegistry {
     );
   });
 
+  resolveVersion = jest.fn().mockImplementation((snapId, versionRange) => {
+    throw new Error(
+      `Cannot install version "${versionRange}" of snap "${snapId}": The snap is not on the allow list.`,
+    );
+  });
+
   getMetadata = jest.fn().mockResolvedValue(null);
 
   update = jest.fn();


### PR DESCRIPTION
Adds a `resolveVersion` function to the registry implementation, this can be used to find the highest matching and allowlisted version for a given version range. This function will be used if the `requireAllowlist` feature flag is enabled and resolves to a specific version before hitting NPM.

This resolves an issue where you would get stuck trying to install a snap if you specified a broad version range that included un-allowlisted versions that were published to NPM.