### PR TITLE
Move allowlist version resolving to the `SnapLocation` implementations

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 89.95,
-  "functions": 96.24,
+  "branches": 90,
+  "functions": 96.27,
   "lines": 97.15,
-  "statements": 96.82
+  "statements": 96.83
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -769,7 +769,7 @@ describe('SnapController', () => {
         [MOCK_SNAP_ID]: { version: DEFAULT_REQUESTED_SNAP_VERSION },
       }),
     ).rejects.toThrow(
-      'Failed to fetch snap "npm:@metamask/example-snap": Cannot install snap "npm:@metamask/example-snap": The snap is not on the allowlist.',
+      'Failed to fetch snap "npm:@metamask/example-snap": The snap is not on the allowlist.',
     );
 
     controller.destroy();

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1683,7 +1683,7 @@ export class SnapController extends BaseController<
       )) {
         assertIsValidSnapId(snapId);
 
-        const [error, resolvedVersion] = resolveVersionRange(rawVersion);
+        const [error, version] = resolveVersionRange(rawVersion);
 
         if (error) {
           throw rpcErrors.invalidParams(
@@ -1691,15 +1691,14 @@ export class SnapController extends BaseController<
           );
         }
 
-        // If we are running in allowlist mode, try to match the version with an allowlist version.
-        const version = this.#featureFlags.requireAllowlist
-          ? await this.#resolveAllowlistVersion(snapId, resolvedVersion)
-          : resolvedVersion;
-
         const location = this.#detectSnapLocation(snapId, {
           versionRange: version,
           fetch: this.#fetchFunction,
           allowLocal: this.#featureFlags.allowLocalSnaps,
+          resolveVersion: async (range) =>
+            this.#featureFlags.requireAllowlist
+              ? await this.#resolveAllowlistVersion(snapId, range)
+              : range,
         });
 
         // Existing snaps may need to be updated, unless they should be re-installed (e.g. local snaps)

--- a/packages/snaps-controllers/src/snaps/location/location.ts
+++ b/packages/snaps-controllers/src/snaps/location/location.ts
@@ -1,4 +1,5 @@
 import type { SnapManifest, VirtualFile } from '@metamask/snaps-utils';
+import type { SemVerRange } from '@metamask/utils';
 import { assert } from '@metamask/utils';
 
 import { HttpLocation } from './http';
@@ -40,6 +41,8 @@ export type DetectSnapLocationOptions = NpmOptions & {
    * @default false
    */
   allowLocal?: boolean;
+
+  resolveVersion?: (range: SemVerRange) => Promise<SemVerRange>;
 };
 
 /**

--- a/packages/snaps-controllers/src/snaps/registry/json.test.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.test.ts
@@ -354,9 +354,7 @@ describe('JsonSnapsRegistry', () => {
           MOCK_SNAP_ID,
           '^1.0.0' as SemVerRange,
         ),
-      ).rejects.toThrow(
-        'Cannot install snap "npm:@metamask/example-snap": The snap is not on the allowlist.',
-      );
+      ).rejects.toThrow('The snap is not on the allowlist');
     });
 
     it('throws if resolved version is not on the allowlist', async () => {
@@ -372,7 +370,7 @@ describe('JsonSnapsRegistry', () => {
           '^1.2.0' as SemVerRange,
         ),
       ).rejects.toThrow(
-        'Cannot install version "^1.2.0" of snap "npm:@metamask/example-snap": No matching versions of the snap are on the allowlist.',
+        'No matching versions of the snap are on the allowlist',
       );
     });
 

--- a/packages/snaps-controllers/src/snaps/registry/json.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.ts
@@ -304,10 +304,7 @@ export class JsonSnapsRegistry extends BaseController<
       return this.#resolveVersion(snapId, versionRange, true);
     }
 
-    assert(
-      versions,
-      `Cannot install snap "${snapId}": The snap is not on the allowlist.`,
-    );
+    assert(versions, 'The snap is not on the allowlist');
 
     const targetVersion = getTargetVersion(
       Object.keys(versions) as SemVerVersion[],
@@ -321,7 +318,7 @@ export class JsonSnapsRegistry extends BaseController<
 
     assert(
       targetVersion,
-      `Cannot install version "${versionRange}" of snap "${snapId}": No matching versions of the snap are on the allowlist.`,
+      'No matching versions of the snap are on the allowlist',
     );
 
     // A semver version is technically also a valid semver range.

--- a/packages/snaps-controllers/src/test-utils/registry.ts
+++ b/packages/snaps-controllers/src/test-utils/registry.ts
@@ -14,10 +14,8 @@ export class MockSnapsRegistry implements SnapsRegistry {
     );
   });
 
-  resolveVersion = jest.fn().mockImplementation((snapId) => {
-    throw new Error(
-      `Cannot install snap "${snapId}": The snap is not on the allowlist.`,
-    );
+  resolveVersion = jest.fn().mockImplementation(() => {
+    throw new Error('The snap is not on the allowlist.');
   });
 
   getMetadata = jest.fn().mockResolvedValue(null);


### PR DESCRIPTION
Move allowlist version resolving to the `SnapLocation` implementations. This fixes an issue with the installation flow not triggering the popup in time.