### PR TITLE
Add Get File Snap to test-snaps page

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@metamask/eslint-config-jest": "^12.1.0",
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
+    "@metamask/snaps-cli": "workspace:^",
     "@metamask/utils": "^8.1.0",
     "@swc/cli": "^0.1.62",
     "@swc/core": "1.3.78",
@@ -117,7 +118,9 @@
       "geckodriver": true,
       "ts-node>@swc/core": true,
       "@swc/core": true,
-      "favicons>sharp": true
+      "favicons>sharp": true,
+      "@metamask/snaps-cli>@metamask/snaps-utils>@metamask/permission-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>keccak": false,
+      "@metamask/snaps-cli>@metamask/snaps-utils>@metamask/permission-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>secp256k1": false
     }
   },
   "packageManager": "yarn@3.6.0"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "@metamask/eslint-config-jest": "^12.1.0",
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
-    "@metamask/snaps-cli": "workspace:^",
     "@metamask/utils": "^8.1.0",
     "@swc/cli": "^0.1.62",
     "@swc/core": "1.3.78",
@@ -118,9 +117,7 @@
       "geckodriver": true,
       "ts-node>@swc/core": true,
       "@swc/core": true,
-      "favicons>sharp": true,
-      "@metamask/snaps-cli>@metamask/snaps-utils>@metamask/permission-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>keccak": false,
-      "@metamask/snaps-cli>@metamask/snaps-utils>@metamask/permission-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>secp256k1": false
+      "favicons>sharp": true
     }
   },
   "packageManager": "yarn@3.6.0"

--- a/packages/examples/packages/get-file/snap.config.ts
+++ b/packages/examples/packages/get-file/snap.config.ts
@@ -5,7 +5,7 @@ const config: SnapConfig = {
   bundler: 'webpack',
   input: resolve(__dirname, 'src/index.ts'),
   server: {
-    port: 8021,
+    port: 8024,
   },
   polyfills: {
     stream: true,

--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -37,6 +37,7 @@
     "@metamask/ethereum-provider-example-snap": "workspace:^",
     "@metamask/ethers-js-example-snap": "workspace:^",
     "@metamask/get-entropy-example-snap": "workspace:^",
+    "@metamask/get-file-example-snap": "workspace:^",
     "@metamask/get-locale-example-snap": "workspace:^",
     "@metamask/insights-example-snap": "workspace:^",
     "@metamask/json-rpc-example-snap": "workspace:^",

--- a/packages/test-snaps/src/features/snaps/get-file/GetFile.tsx
+++ b/packages/test-snaps/src/features/snaps/get-file/GetFile.tsx
@@ -1,0 +1,48 @@
+import { logError } from '@metamask/snaps-utils';
+import type { FunctionComponent } from 'react';
+import { Button, ButtonGroup } from 'react-bootstrap';
+
+import { useInvokeMutation } from '../../../api';
+import { Result, Snap } from '../../../components';
+import { getSnapId } from '../../../utils';
+import {
+  GET_FILE_SNAP_ID,
+  GET_FILE_SNAP_PORT,
+  GET_FILE_VERSION,
+} from './constants';
+
+export const GetFile: FunctionComponent = () => {
+  const [invokeSnap, { isLoading, data }] = useInvokeMutation();
+  const snapId = getSnapId(GET_FILE_SNAP_ID, GET_FILE_SNAP_PORT);
+
+  const handleSubmit = () => {
+    invokeSnap({
+      snapId,
+      method: 'getFile',
+    }).catch(logError);
+  };
+
+  return (
+    <Snap
+      name="Get File Snap"
+      snapId={GET_FILE_SNAP_ID}
+      port={GET_FILE_SNAP_PORT}
+      version={GET_FILE_VERSION}
+      testId="getfile"
+    >
+      <ButtonGroup className="mb-3">
+        <Button
+          id="sendGetFileHelloButton"
+          onClick={handleSubmit}
+          disabled={isLoading}
+        >
+          Submit
+        </Button>
+      </ButtonGroup>
+
+      <Result>
+        <span id="getFileResult">{JSON.stringify(data, null, 2)}</span>
+      </Result>
+    </Snap>
+  );
+};

--- a/packages/test-snaps/src/features/snaps/get-file/GetFile.tsx
+++ b/packages/test-snaps/src/features/snaps/get-file/GetFile.tsx
@@ -22,6 +22,20 @@ export const GetFile: FunctionComponent = () => {
     }).catch(logError);
   };
 
+  const handleSubmit2 = () => {
+    invokeSnap({
+      snapId,
+      method: 'getFileInBase64',
+    }).catch(logError);
+  };
+
+  const handleSubmit3 = () => {
+    invokeSnap({
+      snapId,
+      method: 'getFileInHex',
+    }).catch(logError);
+  };
+
   return (
     <Snap
       name="Get File Snap"
@@ -32,11 +46,25 @@ export const GetFile: FunctionComponent = () => {
     >
       <ButtonGroup className="mb-3">
         <Button
-          id="sendGetFileHelloButton"
+          id="sendGetFileTextButton"
           onClick={handleSubmit}
           disabled={isLoading}
         >
-          Submit
+          Get Text
+        </Button>
+        <Button
+          id="sendGetFileBase64Button"
+          onClick={handleSubmit2}
+          disabled={isLoading}
+        >
+          Get Base64
+        </Button>
+        <Button
+          id="sendGetFileHexButton"
+          onClick={handleSubmit3}
+          disabled={isLoading}
+        >
+          Get Hex
         </Button>
       </ButtonGroup>
 

--- a/packages/test-snaps/src/features/snaps/get-file/constants.ts
+++ b/packages/test-snaps/src/features/snaps/get-file/constants.ts
@@ -1,0 +1,5 @@
+import packageJson from '@metamask/get-file-example-snap/package.json';
+
+export const GET_FILE_SNAP_ID = 'npm:@metamask/get-file-example-snap';
+export const GET_FILE_SNAP_PORT = 8024;
+export const GET_FILE_VERSION = packageJson.version;

--- a/packages/test-snaps/src/features/snaps/get-file/index.ts
+++ b/packages/test-snaps/src/features/snaps/get-file/index.ts
@@ -1,0 +1,1 @@
+export * from './GetFile';

--- a/packages/test-snaps/src/features/snaps/index.ts
+++ b/packages/test-snaps/src/features/snaps/index.ts
@@ -6,6 +6,7 @@ export * from './errors';
 export * from './ethereum-provider';
 export * from './ethers-js';
 export * from './get-entropy';
+export * from './get-file';
 export * from './get-locale';
 export * from './json-rpc';
 export * from './lifecycle-hooks';

--- a/yarn.lock
+++ b/yarn.lock
@@ -20129,6 +20129,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
+    "@metamask/snaps-cli": "workspace:^"
     "@metamask/utils": ^8.1.0
     "@swc/cli": ^0.1.62
     "@swc/core": 1.3.78

--- a/yarn.lock
+++ b/yarn.lock
@@ -4458,7 +4458,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/get-file-example-snap@workspace:packages/examples/packages/get-file":
+"@metamask/get-file-example-snap@workspace:^, @metamask/get-file-example-snap@workspace:packages/examples/packages/get-file":
   version: 0.0.0-use.local
   resolution: "@metamask/get-file-example-snap@workspace:packages/examples/packages/get-file"
   dependencies:
@@ -5770,6 +5770,7 @@ __metadata:
     "@metamask/ethereum-provider-example-snap": "workspace:^"
     "@metamask/ethers-js-example-snap": "workspace:^"
     "@metamask/get-entropy-example-snap": "workspace:^"
+    "@metamask/get-file-example-snap": "workspace:^"
     "@metamask/get-locale-example-snap": "workspace:^"
     "@metamask/insights-example-snap": "workspace:^"
     "@metamask/json-rpc-example-snap": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20130,7 +20130,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/snaps-cli": "workspace:^"
     "@metamask/utils": ^8.1.0
     "@swc/cli": ^0.1.62
     "@swc/core": 1.3.78


### PR DESCRIPTION
This adds the Get File Snap to the test-snaps page.
This also addresses a port overlap and switches the get-file port to 8024.