### PR TITLE
Add snap home page

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "IRszUKE17jyrodnG0pmG8LrHASWVWB0V2iecYJ6GLes=",
+    "shasum": "ZGBmn8PIXPqmtKWfCoMyxLRosjjz629J+o6Gmrx6lMo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "iBUiclCnj3KNLRmIMLOcQURQOqAVMPxv6A+opW8jX+w=",
+    "shasum": "oPPzWR+ovattZsQEVocqDAjgnhwC2yopyHDZxIlC958=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "iG9h3+e6fMyIIran1dm8ljFln/nwM/I3bKNeh8Nx6Qc=",
+    "shasum": "PR5Xz6lZURMLsnIM1Byarf47Wm/ykvk6g/s1tjIfozU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "crsrlV73iUKsTK0h2cHiYKJLSpdF8cU5isJnITEmFjQ=",
+    "shasum": "ksa1J8CleWZbLCzxBVwsiGjybbTOyEjTClo3X0ZiKJo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "C5l1eAO0LBeIGCrM4K58eG4tkDdJevIuhUB5oaIpXho=",
+    "shasum": "3PbK3jIVZ9xF03ZBZo48JnTC+UnrQG2LVdJd4nW/TnU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "XZZmkJJ+/xk9o3o18+bcEOg+YfBoJtSZLIQcSHkbK/w=",
+    "shasum": "g6DsM7o9494oIQR0hFeb5Y4Ks1r6PJqovf9+0aX+9B8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Yq4dOhW5EH3Imyz9aoICJ79C2dvGRWtul0M2fbAofRg=",
+    "shasum": "7RyNNJQrmEIhXN+nj1pN9yb+tDbHwhoca0sxRn+x41c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "deg0KqSp+LaqIwRteAl4IWW6i5y9OO6XF/RNismrhj4=",
+    "shasum": "wDb2iqyZup6awjLimDSZj960hcNPHl4OZa0m2pD5gTQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5tu0QJfgLM6JTisLSHD98rVw6NoRZBKqglHOPsYjLT8=",
+    "shasum": "T/gsezSAnsnfXY9ZOfyLxKguHLCv5V2sKmpxVyNDOao=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "T/gsezSAnsnfXY9ZOfyLxKguHLCv5V2sKmpxVyNDOao=",
+    "shasum": "5tu0QJfgLM6JTisLSHD98rVw6NoRZBKqglHOPsYjLT8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 90.04,
-  "functions": 96.28,
-  "lines": 97.17,
-  "statements": 96.85
+  "functions": 96.3,
+  "lines": 97.18,
+  "statements": 96.86
 }

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 90.04,
-  "functions": 96.3,
-  "lines": 97.18,
-  "statements": 96.86
+  "branches": 90.07,
+  "functions": 96.29,
+  "lines": 97.19,
+  "statements": 96.87
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2248,7 +2248,7 @@ describe('SnapController', () => {
     });
   });
 
-  it('throws if OnHomePage handler returns a phishing link', async () => {
+  it('throws if onHomePage handler returns a phishing link', async () => {
     const rootMessenger = getControllerMessenger();
     const messenger = getSnapControllerMessenger(rootMessenger);
     const snapController = getSnapController(
@@ -2311,7 +2311,7 @@ describe('SnapController', () => {
     snapController.destroy();
   });
 
-  it("doesn't throw if OnHomePage return value is valid", async () => {
+  it("doesn't throw if onHomePage return value is valid", async () => {
     const rootMessenger = getControllerMessenger();
     const messenger = getSnapControllerMessenger(rootMessenger);
     const snapController = getSnapController(

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2248,7 +2248,7 @@ describe('SnapController', () => {
     });
   });
 
-  it('throws if onSnapPage handler returns a phishing link', async () => {
+  it('throws if OnHomePage handler returns a phishing link', async () => {
     const rootMessenger = getControllerMessenger();
     const messenger = getSnapControllerMessenger(rootMessenger);
     const snapController = getSnapController(
@@ -2298,7 +2298,7 @@ describe('SnapController', () => {
       snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
         origin: 'foo.com',
-        handler: HandlerType.OnSnapPage,
+        handler: HandlerType.OnHomePage,
         request: {
           jsonrpc: '2.0',
           method: ' ',
@@ -2311,7 +2311,7 @@ describe('SnapController', () => {
     snapController.destroy();
   });
 
-  it("doesn't throw if onSnapPage return value is valid", async () => {
+  it("doesn't throw if OnHomePage return value is valid", async () => {
     const rootMessenger = getControllerMessenger();
     const messenger = getSnapControllerMessenger(rootMessenger);
     const snapController = getSnapController(
@@ -2351,7 +2351,7 @@ describe('SnapController', () => {
     const result = await snapController.handleRequest({
       snapId: MOCK_SNAP_ID,
       origin: 'foo.com',
-      handler: HandlerType.OnSnapPage,
+      handler: HandlerType.OnHomePage,
       request: {
         jsonrpc: '2.0',
         method: ' ',
@@ -3380,7 +3380,7 @@ describe('SnapController', () => {
           [MOCK_SNAP_ID]: {},
         }),
       ).rejects.toThrow(
-        'A snap must request at least one of the following permissions: endowment:rpc, endowment:transaction-insight, endowment:cronjob, endowment:name-lookup, endowment:lifecycle-hooks, endowment:keyring, endowment:home-page.',
+        'A snap must request at least one of the following permissions: endowment:rpc, endowment:transaction-insight, endowment:cronjob, endowment:name-lookup, endowment:lifecycle-hooks, endowment:keyring, endowment:page-home.',
       );
 
       controller.destroy();

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -3263,7 +3263,7 @@ describe('SnapController', () => {
           [MOCK_SNAP_ID]: {},
         }),
       ).rejects.toThrow(
-        'A snap must request at least one of the following permissions: endowment:rpc, endowment:transaction-insight, endowment:cronjob, endowment:name-lookup, endowment:lifecycle-hooks, endowment:keyring.',
+        'A snap must request at least one of the following permissions: endowment:rpc, endowment:transaction-insight, endowment:cronjob, endowment:name-lookup, endowment:lifecycle-hooks, endowment:keyring, endowment:home-page.',
       );
 
       controller.destroy();

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -68,7 +68,7 @@ import {
   SnapStatusEvents,
   validateFetchedSnap,
   unwrapError,
-  OnSnapPageResponseStruct,
+  OnHomePageResponseStruct,
 } from '@metamask/snaps-utils';
 import type { Json, NonEmptyArray, SemVerRange } from '@metamask/utils';
 import {
@@ -2684,8 +2684,8 @@ export class SnapController extends BaseController<
           this.#checkPhishingList.bind(this),
         );
         break;
-      case HandlerType.OnSnapPage:
-        assertStruct(result, OnSnapPageResponseStruct);
+      case HandlerType.OnHomePage:
+        assertStruct(result, OnHomePageResponseStruct);
 
         await this.#triggerPhishingListUpdate();
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -68,6 +68,7 @@ import {
   SnapStatusEvents,
   validateFetchedSnap,
   unwrapError,
+  OnSnapPageResponseStruct,
 } from '@metamask/snaps-utils';
 import type { Json, NonEmptyArray, SemVerRange } from '@metamask/utils';
 import {
@@ -2656,6 +2657,15 @@ export class SnapController extends BaseController<
     return rpcHandler;
   }
 
+  async #triggerPhishingListUpdate() {
+    return this.messagingSystem.call('PhishingController:maybeUpdateState');
+  }
+
+  #checkPhishingList(origin: string) {
+    return this.messagingSystem.call('PhishingController:testOrigin', origin)
+      .result;
+  }
+
   /**
    * Asserts that the returned result of a Snap RPC call is the expected shape.
    *
@@ -2667,13 +2677,21 @@ export class SnapController extends BaseController<
       case HandlerType.OnTransaction:
         assertStruct(result, OnTransactionResponseStruct);
 
-        await this.messagingSystem.call('PhishingController:maybeUpdateState');
+        await this.#triggerPhishingListUpdate();
 
-        await assertUILinksAreSafe(
+        assertUILinksAreSafe(
           result.content,
-          (url: string) =>
-            this.messagingSystem.call('PhishingController:testOrigin', url)
-              .result,
+          this.#checkPhishingList.bind(this),
+        );
+        break;
+      case HandlerType.OnSnapPage:
+        assertStruct(result, OnSnapPageResponseStruct);
+
+        await this.#triggerPhishingListUpdate();
+
+        assertUILinksAreSafe(
+          result.content,
+          this.#checkPhishingList.bind(this),
         );
         break;
       default:

--- a/packages/snaps-controllers/src/snaps/endowments/enum.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/enum.ts
@@ -8,4 +8,5 @@ export enum SnapEndowments {
   NameLookup = 'endowment:name-lookup',
   LifecycleHooks = 'endowment:lifecycle-hooks',
   Keyring = 'endowment:keyring',
+  SnapPages = 'endowment:snap-pages',
 }

--- a/packages/snaps-controllers/src/snaps/endowments/enum.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/enum.ts
@@ -8,5 +8,5 @@ export enum SnapEndowments {
   NameLookup = 'endowment:name-lookup',
   LifecycleHooks = 'endowment:lifecycle-hooks',
   Keyring = 'endowment:keyring',
-  SnapPages = 'endowment:snap-pages',
+  HomePage = 'endowment:home-page',
 }

--- a/packages/snaps-controllers/src/snaps/endowments/enum.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/enum.ts
@@ -8,5 +8,5 @@ export enum SnapEndowments {
   NameLookup = 'endowment:name-lookup',
   LifecycleHooks = 'endowment:lifecycle-hooks',
   Keyring = 'endowment:keyring',
-  HomePage = 'endowment:home-page',
+  HomePage = 'endowment:page-home',
 }

--- a/packages/snaps-controllers/src/snaps/endowments/home-page.test.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/home-page.test.ts
@@ -3,7 +3,7 @@ import { PermissionType, SubjectType } from '@metamask/permission-controller';
 import { SnapEndowments } from './enum';
 import { homePageEndowmentBuilder } from './home-page';
 
-describe('endowment:home-page', () => {
+describe('endowment:page-home', () => {
   it('builds the expected permission specification', () => {
     const specification = homePageEndowmentBuilder.specificationBuilder({});
     expect(specification).toStrictEqual({

--- a/packages/snaps-controllers/src/snaps/endowments/home-page.test.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/home-page.test.ts
@@ -1,0 +1,19 @@
+import { PermissionType, SubjectType } from '@metamask/permission-controller';
+
+import { SnapEndowments } from './enum';
+import { homePageEndowmentBuilder } from './home-page';
+
+describe('endowment:home-page', () => {
+  it('builds the expected permission specification', () => {
+    const specification = homePageEndowmentBuilder.specificationBuilder({});
+    expect(specification).toStrictEqual({
+      permissionType: PermissionType.Endowment,
+      targetName: SnapEndowments.HomePage,
+      endowmentGetter: expect.any(Function),
+      allowedCaveats: null,
+      subjectTypes: [SubjectType.Snap],
+    });
+
+    expect(specification.endowmentGetter()).toBeUndefined();
+  });
+});

--- a/packages/snaps-controllers/src/snaps/endowments/home-page.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/home-page.ts
@@ -18,7 +18,7 @@ type HomePageEndowmentSpecification = ValidPermissionSpecification<{
 }>;
 
 /**
- * `endowment:home-page` returns nothing; it is intended to be used as a
+ * `endowment:page-home` returns nothing; it is intended to be used as a
  * flag by the snap controller to detect whether the snap has the capability to
  * use the snap home page feature.
  *

--- a/packages/snaps-controllers/src/snaps/endowments/home-page.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/home-page.ts
@@ -8,9 +8,9 @@ import type { NonEmptyArray } from '@metamask/utils';
 
 import { SnapEndowments } from './enum';
 
-const permissionName = SnapEndowments.SnapPages;
+const permissionName = SnapEndowments.HomePage;
 
-type SnapPagesEndowmentSpecification = ValidPermissionSpecification<{
+type HomePageEndowmentSpecification = ValidPermissionSpecification<{
   permissionType: PermissionType.Endowment;
   targetName: typeof permissionName;
   endowmentGetter: (_options?: EndowmentGetterParams) => undefined;
@@ -18,9 +18,9 @@ type SnapPagesEndowmentSpecification = ValidPermissionSpecification<{
 }>;
 
 /**
- * `endowment:snap-pages` returns nothing; it is intended to be used as a
+ * `endowment:home-page` returns nothing; it is intended to be used as a
  * flag by the snap controller to detect whether the snap has the capability to
- * use snap pages.
+ * use the snap home page feature.
  *
  * @param _builderOptions - Optional specification builder options.
  * @returns The specification for the `snap-pages` endowment.
@@ -28,7 +28,7 @@ type SnapPagesEndowmentSpecification = ValidPermissionSpecification<{
 const specificationBuilder: PermissionSpecificationBuilder<
   PermissionType.Endowment,
   any,
-  SnapPagesEndowmentSpecification
+  HomePageEndowmentSpecification
 > = (_builderOptions?: unknown) => {
   return {
     permissionType: PermissionType.Endowment,
@@ -39,7 +39,7 @@ const specificationBuilder: PermissionSpecificationBuilder<
   };
 };
 
-export const snapPagesEndowmentBuilder = Object.freeze({
+export const homePageEndowmentBuilder = Object.freeze({
   targetName: permissionName,
   specificationBuilder,
 } as const);

--- a/packages/snaps-controllers/src/snaps/endowments/index.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/index.ts
@@ -76,7 +76,7 @@ export const handlerEndowments: Record<HandlerType, string> = {
   [HandlerType.OnInstall]: lifecycleHooksEndowmentBuilder.targetName,
   [HandlerType.OnUpdate]: lifecycleHooksEndowmentBuilder.targetName,
   [HandlerType.OnKeyringRequest]: keyringEndowmentBuilder.targetName,
-  [HandlerType.OnSnapPage]: homePageEndowmentBuilder.targetName,
+  [HandlerType.OnHomePage]: homePageEndowmentBuilder.targetName,
 };
 
 export * from './enum';

--- a/packages/snaps-controllers/src/snaps/endowments/index.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/index.ts
@@ -8,6 +8,7 @@ import {
   getCronjobCaveatMapper,
 } from './cronjob';
 import { ethereumProviderEndowmentBuilder } from './ethereum-provider';
+import { homePageEndowmentBuilder } from './home-page';
 import {
   getKeyringCaveatMapper,
   keyringCaveatSpecifications,
@@ -25,7 +26,6 @@ import {
   rpcCaveatSpecifications,
   rpcEndowmentBuilder,
 } from './rpc';
-import { snapPagesEndowmentBuilder } from './snap-pages';
 import {
   getTransactionInsightCaveatMapper,
   transactionInsightCaveatSpecifications,
@@ -45,7 +45,7 @@ export const endowmentPermissionBuilders = {
   [nameLookupEndowmentBuilder.targetName]: nameLookupEndowmentBuilder,
   [lifecycleHooksEndowmentBuilder.targetName]: lifecycleHooksEndowmentBuilder,
   [keyringEndowmentBuilder.targetName]: keyringEndowmentBuilder,
-  [snapPagesEndowmentBuilder.targetName]: snapPagesEndowmentBuilder,
+  [homePageEndowmentBuilder.targetName]: homePageEndowmentBuilder,
 } as const;
 
 export const endowmentCaveatSpecifications = {

--- a/packages/snaps-controllers/src/snaps/endowments/index.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/index.ts
@@ -25,6 +25,7 @@ import {
   rpcCaveatSpecifications,
   rpcEndowmentBuilder,
 } from './rpc';
+import { snapPagesEndowmentBuilder } from './snap-pages';
 import {
   getTransactionInsightCaveatMapper,
   transactionInsightCaveatSpecifications,
@@ -44,6 +45,7 @@ export const endowmentPermissionBuilders = {
   [nameLookupEndowmentBuilder.targetName]: nameLookupEndowmentBuilder,
   [lifecycleHooksEndowmentBuilder.targetName]: lifecycleHooksEndowmentBuilder,
   [keyringEndowmentBuilder.targetName]: keyringEndowmentBuilder,
+  [snapPagesEndowmentBuilder.targetName]: snapPagesEndowmentBuilder,
 } as const;
 
 export const endowmentCaveatSpecifications = {
@@ -74,6 +76,7 @@ export const handlerEndowments: Record<HandlerType, string> = {
   [HandlerType.OnInstall]: lifecycleHooksEndowmentBuilder.targetName,
   [HandlerType.OnUpdate]: lifecycleHooksEndowmentBuilder.targetName,
   [HandlerType.OnKeyringRequest]: keyringEndowmentBuilder.targetName,
+  [HandlerType.OnSnapPage]: snapPagesEndowmentBuilder.targetName,
 };
 
 export * from './enum';

--- a/packages/snaps-controllers/src/snaps/endowments/index.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/index.ts
@@ -76,7 +76,7 @@ export const handlerEndowments: Record<HandlerType, string> = {
   [HandlerType.OnInstall]: lifecycleHooksEndowmentBuilder.targetName,
   [HandlerType.OnUpdate]: lifecycleHooksEndowmentBuilder.targetName,
   [HandlerType.OnKeyringRequest]: keyringEndowmentBuilder.targetName,
-  [HandlerType.OnSnapPage]: snapPagesEndowmentBuilder.targetName,
+  [HandlerType.OnSnapPage]: homePageEndowmentBuilder.targetName,
 };
 
 export * from './enum';

--- a/packages/snaps-controllers/src/snaps/endowments/snap-pages.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/snap-pages.ts
@@ -1,0 +1,45 @@
+import type {
+  PermissionSpecificationBuilder,
+  EndowmentGetterParams,
+  ValidPermissionSpecification,
+} from '@metamask/permission-controller';
+import { PermissionType, SubjectType } from '@metamask/permission-controller';
+import type { NonEmptyArray } from '@metamask/utils';
+
+import { SnapEndowments } from './enum';
+
+const permissionName = SnapEndowments.SnapPages;
+
+type SnapPagesEndowmentSpecification = ValidPermissionSpecification<{
+  permissionType: PermissionType.Endowment;
+  targetName: typeof permissionName;
+  endowmentGetter: (_options?: EndowmentGetterParams) => undefined;
+  allowedCaveats: Readonly<NonEmptyArray<string>> | null;
+}>;
+
+/**
+ * `endowment:snap-pages` returns nothing; it is intended to be used as a
+ * flag by the snap controller to detect whether the snap has the capability to
+ * use snap pages.
+ *
+ * @param _builderOptions - Optional specification builder options.
+ * @returns The specification for the `snap-pages` endowment.
+ */
+const specificationBuilder: PermissionSpecificationBuilder<
+  PermissionType.Endowment,
+  any,
+  SnapPagesEndowmentSpecification
+> = (_builderOptions?: unknown) => {
+  return {
+    permissionType: PermissionType.Endowment,
+    targetName: permissionName,
+    allowedCaveats: null,
+    endowmentGetter: (_getterOptions?: EndowmentGetterParams) => undefined,
+    subjectTypes: [SubjectType.Snap],
+  };
+};
+
+export const snapPagesEndowmentBuilder = Object.freeze({
+  targetName: permissionName,
+  specificationBuilder,
+} as const);

--- a/packages/snaps-controllers/src/snaps/permission.test.ts
+++ b/packages/snaps-controllers/src/snaps/permission.test.ts
@@ -28,15 +28,6 @@ describe('buildSnapEndowmentSpecifications', () => {
           ],
           "targetName": "endowment:ethereum-provider",
         },
-        "endowment:page-home": {
-          "allowedCaveats": null,
-          "endowmentGetter": [Function],
-          "permissionType": "Endowment",
-          "subjectTypes": [
-            "snap",
-          ],
-          "targetName": "endowment:page-home",
-        },
         "endowment:keyring": {
           "allowedCaveats": [
             "keyringOrigin",
@@ -78,6 +69,15 @@ describe('buildSnapEndowmentSpecifications', () => {
             "snap",
           ],
           "targetName": "endowment:network-access",
+        },
+        "endowment:page-home": {
+          "allowedCaveats": null,
+          "endowmentGetter": [Function],
+          "permissionType": "Endowment",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetName": "endowment:page-home",
         },
         "endowment:rpc": {
           "allowedCaveats": [

--- a/packages/snaps-controllers/src/snaps/permission.test.ts
+++ b/packages/snaps-controllers/src/snaps/permission.test.ts
@@ -28,14 +28,14 @@ describe('buildSnapEndowmentSpecifications', () => {
           ],
           "targetName": "endowment:ethereum-provider",
         },
-        "endowment:home-page": {
+        "endowment:page-home": {
           "allowedCaveats": null,
           "endowmentGetter": [Function],
           "permissionType": "Endowment",
           "subjectTypes": [
             "snap",
           ],
-          "targetName": "endowment:home-page",
+          "targetName": "endowment:page-home",
         },
         "endowment:keyring": {
           "allowedCaveats": [

--- a/packages/snaps-controllers/src/snaps/permission.test.ts
+++ b/packages/snaps-controllers/src/snaps/permission.test.ts
@@ -28,6 +28,15 @@ describe('buildSnapEndowmentSpecifications', () => {
           ],
           "targetName": "endowment:ethereum-provider",
         },
+        "endowment:home-page": {
+          "allowedCaveats": null,
+          "endowmentGetter": [Function],
+          "permissionType": "Endowment",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetName": "endowment:home-page",
+        },
         "endowment:keyring": {
           "allowedCaveats": [
             "keyringOrigin",

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 81.15,
+  "branches": 81.29,
   "functions": 92.59,
-  "lines": 92.02,
-  "statements": 91.7
+  "lines": 92.03,
+  "statements": 91.71
 }

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1352,9 +1352,9 @@ describe('BaseSnapExecutor', () => {
     });
   });
 
-  it('supports onSnapPage export', async () => {
+  it('supports OnHomePage export', async () => {
     const CODE = `
-      module.exports.onSnapPage = () => ({ content: { type: 'panel', children: [] }});
+      module.exports.OnHomePage = () => ({ content: { type: 'panel', children: [] }});
     `;
 
     const executor = new TestSnapExecutor();
@@ -1372,7 +1372,7 @@ describe('BaseSnapExecutor', () => {
       method: 'snapRpc',
       params: [
         MOCK_SNAP_ID,
-        HandlerType.OnSnapPage,
+        HandlerType.OnHomePage,
         MOCK_ORIGIN,
         { jsonrpc: '2.0', method: '' },
       ],

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1352,9 +1352,9 @@ describe('BaseSnapExecutor', () => {
     });
   });
 
-  it('supports OnHomePage export', async () => {
+  it('supports onHomePage export', async () => {
     const CODE = `
-      module.exports.OnHomePage = () => ({ content: { type: 'panel', children: [] }});
+      module.exports.onHomePage = () => ({ content: { type: 'panel', children: [] }});
     `;
 
     const executor = new TestSnapExecutor();

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1352,6 +1352,39 @@ describe('BaseSnapExecutor', () => {
     });
   });
 
+  it('supports onSnapPage export', async () => {
+    const CODE = `
+      module.exports.onSnapPage = () => ({ content: { type: 'panel', children: [] }});
+    `;
+
+    const executor = new TestSnapExecutor();
+    await executor.executeSnap(1, MOCK_SNAP_ID, CODE, []);
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'OK',
+    });
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'snapRpc',
+      params: [
+        MOCK_SNAP_ID,
+        HandlerType.OnSnapPage,
+        MOCK_ORIGIN,
+        { jsonrpc: '2.0', method: '' },
+      ],
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      id: 2,
+      jsonrpc: '2.0',
+      result: { content: { type: 'panel', children: [] } },
+    });
+  });
+
   describe('lifecycle hooks', () => {
     const LIFECYCLE_HOOKS = [HandlerType.OnInstall, HandlerType.OnUpdate];
 

--- a/packages/snaps-execution-environments/src/common/commands.ts
+++ b/packages/snaps-execution-environments/src/common/commands.ts
@@ -75,7 +75,7 @@ export function getHandlerArguments(
     case HandlerType.OnUpdate:
       return { request };
 
-    case HandlerType.OnSnapPage:
+    case HandlerType.OnHomePage:
       return {};
 
     default:

--- a/packages/snaps-execution-environments/src/common/commands.ts
+++ b/packages/snaps-execution-environments/src/common/commands.ts
@@ -75,6 +75,9 @@ export function getHandlerArguments(
     case HandlerType.OnUpdate:
       return { request };
 
+    case HandlerType.OnSnapPage:
+      return {};
+
     default:
       return assertExhaustive(handler);
   }

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 96.02,
-  "functions": 97.95,
-  "lines": 98.36,
-  "statements": 95.63
+  "functions": 97.96,
+  "lines": 98.37,
+  "statements": 95.64
 }

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -2,5 +2,5 @@
   "branches": 96.02,
   "functions": 97.96,
   "lines": 98.37,
-  "statements": 95.64
+  "statements": 95.55
 }

--- a/packages/snaps-utils/src/handler-types.ts
+++ b/packages/snaps-utils/src/handler-types.ts
@@ -6,7 +6,7 @@ export enum HandlerType {
   OnUpdate = 'onUpdate',
   OnNameLookup = 'onNameLookup',
   OnKeyringRequest = 'onKeyringRequest',
-  OnSnapPage = 'onSnapPage',
+  OnHomePage = 'onHomePage',
 }
 
 export type SnapHandler = {

--- a/packages/snaps-utils/src/handler-types.ts
+++ b/packages/snaps-utils/src/handler-types.ts
@@ -6,6 +6,7 @@ export enum HandlerType {
   OnUpdate = 'onUpdate',
   OnNameLookup = 'onNameLookup',
   OnKeyringRequest = 'onKeyringRequest',
+  OnSnapPage = 'onSnapPage',
 }
 
 export type SnapHandler = {

--- a/packages/snaps-utils/src/handlers.ts
+++ b/packages/snaps-utils/src/handlers.ts
@@ -63,10 +63,10 @@ export const SNAP_EXPORTS = {
       return typeof snapExport === 'function';
     },
   },
-  [HandlerType.OnSnapPage]: {
-    type: HandlerType.OnSnapPage,
+  [HandlerType.OnHomePage]: {
+    type: HandlerType.OnHomePage,
     required: true,
-    validator: (snapExport: unknown): snapExport is OnSnapPageHandler => {
+    validator: (snapExport: unknown): snapExport is OnHomePageHandler => {
       return typeof snapExport === 'function';
     },
   },
@@ -176,13 +176,13 @@ export type OnKeyringRequestHandler<
   request: JsonRpcRequest<Params>;
 }) => Promise<unknown>;
 
-export type OnSnapPageHandler = () => Promise<OnSnapPageResponse>;
+export type OnHomePageHandler = () => Promise<OnHomePageResponse>;
 
-export const OnSnapPageResponseStruct = object({
+export const OnHomePageResponseStruct = object({
   content: ComponentStruct,
 });
 
-export type OnSnapPageResponse = Infer<typeof OnSnapPageResponseStruct>;
+export type OnHomePageResponse = Infer<typeof OnHomePageResponseStruct>;
 
 /**
  * Utility type for getting the handler function type from a handler type.

--- a/packages/snaps-utils/src/handlers.ts
+++ b/packages/snaps-utils/src/handlers.ts
@@ -1,3 +1,4 @@
+import type { Component } from '@metamask/snaps-ui';
 import { ComponentStruct } from '@metamask/snaps-ui';
 import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
 import type { Infer } from 'superstruct';
@@ -58,6 +59,13 @@ export const SNAP_EXPORTS = {
   },
   [HandlerType.OnKeyringRequest]: {
     type: HandlerType.OnKeyringRequest,
+    required: true,
+    validator: (snapExport: unknown): snapExport is OnKeyringRequestHandler => {
+      return typeof snapExport === 'function';
+    },
+  },
+  [HandlerType.OnSnapPage]: {
+    type: HandlerType.OnSnapPage,
     required: true,
     validator: (snapExport: unknown): snapExport is OnKeyringRequestHandler => {
       return typeof snapExport === 'function';
@@ -168,6 +176,12 @@ export type OnKeyringRequestHandler<
   origin: string;
   request: JsonRpcRequest<Params>;
 }) => Promise<unknown>;
+
+export type OnSnapPageHandler = () => Promise<OnSnapPageResponse>;
+
+export type OnSnapPageResponse = {
+  content: Component | null;
+};
 
 /**
  * Utility type for getting the handler function type from a handler type.

--- a/packages/snaps-utils/src/handlers.ts
+++ b/packages/snaps-utils/src/handlers.ts
@@ -67,7 +67,7 @@ export const SNAP_EXPORTS = {
   [HandlerType.OnSnapPage]: {
     type: HandlerType.OnSnapPage,
     required: true,
-    validator: (snapExport: unknown): snapExport is OnKeyringRequestHandler => {
+    validator: (snapExport: unknown): snapExport is OnSnapPageHandler => {
       return typeof snapExport === 'function';
     },
   },

--- a/packages/snaps-utils/src/handlers.ts
+++ b/packages/snaps-utils/src/handlers.ts
@@ -1,4 +1,3 @@
-import type { Component } from '@metamask/snaps-ui';
 import { ComponentStruct } from '@metamask/snaps-ui';
 import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
 import type { Infer } from 'superstruct';
@@ -179,9 +178,11 @@ export type OnKeyringRequestHandler<
 
 export type OnSnapPageHandler = () => Promise<OnSnapPageResponse>;
 
-export type OnSnapPageResponse = {
-  content: Component | null;
-};
+export const OnSnapPageResponseStruct = object({
+  content: ComponentStruct,
+});
+
+export type OnSnapPageResponse = Infer<typeof OnSnapPageResponseStruct>;
 
 /**
  * Utility type for getting the handler function type from a handler type.


### PR DESCRIPTION
Adds an `onHomePage` export and an endowment called `endowment:page-home`. Both of these are to be used for the new snaps home page feature.

Reference: https://metamask.github.io/SIPs/SIPS/sip-15

Progresses https://github.com/MetaMask/MetaMask-planning/issues/1384