### PR TITLE
Fix an issue with throwing snaps running long

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2521,6 +2521,8 @@ describe('SnapController', () => {
 
       const [snapController, service] = getSnapControllerWithEES(
         getSnapControllerWithEESOptions({
+          idleTimeCheckInterval: 10,
+          maxIdleTime: 50,
           detectSnapLocation: loopbackDetect({
             manifest,
             files: [sourceCode, svgIcon as VirtualFile],
@@ -2546,6 +2548,11 @@ describe('SnapController', () => {
       ).rejects.toThrow('foo');
 
       expect(snapController.state.snaps[MOCK_SNAP_ID].status).toBe('running');
+
+      await sleep(100);
+
+      // Should be terminated by idle timeout now
+      expect(snapController.state.snaps[MOCK_SNAP_ID].status).toBe('stopped');
 
       snapController.destroy();
       await service.terminateAllSnaps();

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2638,7 +2638,6 @@ export class SnapController extends BaseController<
 
         await this.#assertSnapRpcRequestResult(handlerType, result);
 
-        this.#recordSnapRpcRequestFinish(snapId, request.id);
         return result;
       } catch (error) {
         const [jsonRpcError, handled] = unwrapError(error);
@@ -2648,6 +2647,8 @@ export class SnapController extends BaseController<
         }
 
         throw jsonRpcError;
+      } finally {
+        this.#recordSnapRpcRequestFinish(snapId, request.id);
       }
     };
 


### PR DESCRIPTION
Fixes an issue where snaps throwing a `SnapError` would be allowed to run longer than expected.