### PR TITLE
Add support for unencrypted storage

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZGBmn8PIXPqmtKWfCoMyxLRosjjz629J+o6Gmrx6lMo=",
+    "shasum": "qN4CNYXZrb/QJrMPJCyIRUtHKxJtjr71C1MUHC/BWo0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "oPPzWR+ovattZsQEVocqDAjgnhwC2yopyHDZxIlC958=",
+    "shasum": "M17digZHs4dAkOCxsR1MUCQUS9BYZhM0liiG2jf9gWA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "PR5Xz6lZURMLsnIM1Byarf47Wm/ykvk6g/s1tjIfozU=",
+    "shasum": "sHlkhcOxphsQpmOXjKpgRU0ODqyybDwc7S4fEvAgtBQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ksa1J8CleWZbLCzxBVwsiGjybbTOyEjTClo3X0ZiKJo=",
+    "shasum": "9OaYSZkxosfqTODP7dai9t60vXeN/H+iMfdeZb/XJHw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3PbK3jIVZ9xF03ZBZo48JnTC+UnrQG2LVdJd4nW/TnU=",
+    "shasum": "yPe6Qq17okTMeteHzE3Ud/1nbgWpPO0KAZUPZf9ZDTw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "g6DsM7o9494oIQR0hFeb5Y4Ks1r6PJqovf9+0aX+9B8=",
+    "shasum": "nJi7n2ljX3rZ4vq5Jg6W6FS4ysRNXPnHXj0saNKDaYE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7RyNNJQrmEIhXN+nj1pN9yb+tDbHwhoca0sxRn+x41c=",
+    "shasum": "cbGV5hLqH9XM36yTNtuIT3p/vmcETr7S7Tf8K5Eou9k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wDb2iqyZup6awjLimDSZj960hcNPHl4OZa0m2pD5gTQ=",
+    "shasum": "MUX/xHZjMBc4U3mtZqb9ZWt6kx/8QCEjfz3L/pHO8sc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4nozpikFVi1Kl6pl3QMVKqBiqBCA2NLnW0SP7BhISXY=",
+    "shasum": "Ep5EYZTZ1sT+pzIlIrwv8HXVN0BW4yOwxrY7xuQmuk8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 90.07,
+  "branches": 90.21,
   "functions": 96.29,
-  "lines": 97.19,
-  "statements": 96.87
+  "lines": 97.2,
+  "statements": 96.88
 }

--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -10,7 +10,7 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 87.8,
+      branches: 88.88,
       functions: 100,
       lines: 98.18,
       statements: 96.57,

--- a/packages/snaps-rpc-methods/src/restricted/manageState.ts
+++ b/packages/snaps-rpc-methods/src/restricted/manageState.ts
@@ -283,7 +283,7 @@ export function getManageStateImplementation({
     const shouldEncrypt = encrypted ?? true;
 
     // We only need to prompt the user when the mnemonic is needed
-    // which it isnt for the clear operation or unencrypted storage.
+    // which it isn't for the clear operation or unencrypted storage.
     if (shouldEncrypt && operation !== ManageStateOperation.ClearState) {
       await getUnlockPromise(true);
     }

--- a/packages/snaps-rpc-methods/src/restricted/manageState.ts
+++ b/packages/snaps-rpc-methods/src/restricted/manageState.ts
@@ -6,7 +6,7 @@ import type {
 import { PermissionType, SubjectType } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
 import type { EnumToUnion } from '@metamask/snaps-utils';
-import { STATE_ENCRYPTION_MAGIC_VALUE } from '@metamask/snaps-utils';
+import { STATE_ENCRYPTION_MAGIC_VALUE, parseJson } from '@metamask/snaps-utils';
 import type { Json, NonEmptyArray, Hex } from '@metamask/utils';
 import { isObject, getJsonSize, assert, isValidJson } from '@metamask/utils';
 
@@ -34,21 +34,25 @@ export type ManageStateMethodHooks = {
   /**
    * A function that clears the state of the requesting Snap.
    */
-  clearSnapState: (snapId: string) => Promise<void>;
+  clearSnapState: (snapId: string, encrypted: boolean) => void;
 
   /**
    * A function that gets the encrypted state of the requesting Snap.
    *
    * @returns The current state of the Snap.
    */
-  getSnapState: (snapId: string) => Promise<string>;
+  getSnapState: (snapId: string, encrypted: boolean) => string;
 
   /**
    * A function that updates the state of the requesting Snap.
    *
    * @param newState - The new state of the Snap.
    */
-  updateSnapState: (snapId: string, newState: string) => Promise<void>;
+  updateSnapState: (
+    snapId: string,
+    newState: string,
+    encrypted: boolean,
+  ) => void;
 
   /**
    * Encrypts data with a key. This is assumed to perform symmetric encryption.
@@ -135,6 +139,7 @@ export enum ManageStateOperation {
 export type ManageStateArgs = {
   operation: EnumToUnion<ManageStateOperation>;
   newState?: Record<string, Json>;
+  encrypted?: boolean;
 };
 
 export const STORAGE_SIZE_LIMIT = 104857600; // In bytes (100MB)
@@ -269,40 +274,53 @@ export function getManageStateImplementation({
       method,
       context: { origin },
     } = options;
-    const { operation, newState } = getValidatedParams(params, method);
+    const { operation, newState, encrypted } = getValidatedParams(
+      params,
+      method,
+    );
 
-    await getUnlockPromise(true);
-    const mnemonicPhrase = await getMnemonic();
+    // If the encrypted param is undefined or null we default to true.
+    const shouldEncrypt = encrypted ?? true;
+
+    // We only need to prompt the user when the mnemonic is needed
+    // which it isnt for the clear operation or unencrypted storage.
+    if (shouldEncrypt && operation !== ManageStateOperation.ClearState) {
+      await getUnlockPromise(true);
+    }
 
     switch (operation) {
       case ManageStateOperation.ClearState:
-        await clearSnapState(origin);
+        clearSnapState(origin, shouldEncrypt);
         return null;
 
       case ManageStateOperation.GetState: {
-        const state = await getSnapState(origin);
+        const state = getSnapState(origin, shouldEncrypt);
         if (state === null) {
           return state;
         }
-        return await decryptState({
-          state,
-          decryptFunction: decrypt,
-          mnemonicPhrase,
-          snapId: origin,
-        });
+        return shouldEncrypt
+          ? await decryptState({
+              state,
+              decryptFunction: decrypt,
+              mnemonicPhrase: await getMnemonic(),
+              snapId: origin,
+            })
+          : parseJson<Record<string, Json>>(state);
       }
 
       case ManageStateOperation.UpdateState: {
         assert(newState);
 
-        const encryptedState = await encryptState({
-          state: newState,
-          encryptFunction: encrypt,
-          mnemonicPhrase,
-          snapId: origin,
-        });
+        const finalizedState = shouldEncrypt
+          ? await encryptState({
+              state: newState,
+              encryptFunction: encrypt,
+              mnemonicPhrase: await getMnemonic(),
+              snapId: origin,
+            })
+          : JSON.stringify(newState);
 
-        await updateSnapState(origin, encryptedState);
+        updateSnapState(origin, finalizedState, shouldEncrypt);
         return null;
       }
 
@@ -334,7 +352,7 @@ export function getValidatedParams(
     });
   }
 
-  const { operation, newState } = params;
+  const { operation, newState, encrypted } = params;
 
   if (
     !operation ||
@@ -343,6 +361,12 @@ export function getValidatedParams(
   ) {
     throw rpcErrors.invalidParams({
       message: 'Must specify a valid manage state "operation".',
+    });
+  }
+
+  if (encrypted !== undefined && typeof encrypted !== 'boolean') {
+    throw rpcErrors.invalidParams({
+      message: '"encrypted" parameter must be a boolean if specified.',
     });
   }
 

--- a/packages/snaps-simulator/jest.config.js
+++ b/packages/snaps-simulator/jest.config.js
@@ -5,8 +5,8 @@ const baseConfig = require('../../jest.config.base');
 module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
-      branches: 74.24,
-      functions: 79.73,
+      branches: 75.71,
+      functions: 80.76,
       lines: 90.05,
       statements: 89.93,
     },

--- a/packages/snaps-simulator/src/features/simulation/hooks.test.ts
+++ b/packages/snaps-simulator/src/features/simulation/hooks.test.ts
@@ -22,8 +22,10 @@ import {
   getAuxiliaryFiles,
   getSnapName,
   getSnapStateSelector,
+  getUnencryptedSnapStateSelector,
   resolveUserInterface,
   setSnapState,
+  setUnencryptedSnapState,
   showUserInterface,
 } from './slice';
 import { MOCK_MANIFEST_FILE } from './test/mockManifest';
@@ -132,7 +134,7 @@ describe('showInAppNotification', () => {
 
 describe('updateSnapState', () => {
   it('puts the new snap state', async () => {
-    await expectSaga(updateSnapState, snapId, 'foo')
+    await expectSaga(updateSnapState, snapId, 'foo', true)
       .withState({
         simulation: {
           snapState: null,
@@ -141,11 +143,22 @@ describe('updateSnapState', () => {
       .put(setSnapState('foo'))
       .silentRun();
   });
+
+  it('puts the new unencrypted snap state', async () => {
+    await expectSaga(updateSnapState, snapId, 'bar', false)
+      .withState({
+        simulation: {
+          unencryptedSnapState: null,
+        },
+      })
+      .put(setUnencryptedSnapState('bar'))
+      .silentRun();
+  });
 });
 
 describe('getSnapState', () => {
   it('returns the selected snap state', async () => {
-    await expectSaga(getSnapState, snapId)
+    await expectSaga(getSnapState, snapId, true)
       .withState({
         simulation: {
           snapState: 'foo',
@@ -153,6 +166,18 @@ describe('getSnapState', () => {
       })
       .select(getSnapStateSelector)
       .returns('foo')
+      .silentRun();
+  });
+
+  it('returns the selected unencrypted snap state', async () => {
+    await expectSaga(getSnapState, snapId, false)
+      .withState({
+        simulation: {
+          unencryptedSnapState: 'bar',
+        },
+      })
+      .select(getUnencryptedSnapStateSelector)
+      .returns('bar')
       .silentRun();
   });
 });

--- a/packages/snaps-simulator/src/features/simulation/hooks.ts
+++ b/packages/snaps-simulator/src/features/simulation/hooks.ts
@@ -17,8 +17,10 @@ import {
   getRequestId,
   getSnapName,
   getSnapStateSelector,
+  getUnencryptedSnapStateSelector,
   resolveUserInterface,
   setSnapState,
+  setUnencryptedSnapState,
   showUserInterface,
 } from './slice';
 
@@ -141,24 +143,36 @@ export function* showInAppNotification(
  *
  * @param _snapId - The snap id, unused for now.
  * @param newSnapState - The new state.
+ * @param encrypted - A flag to signal whether to use the encrypted storage or not.
  * @yields Puts the newSnapState
  */
 export function* updateSnapState(
   _snapId: string,
   newSnapState: string | null,
+  encrypted: boolean,
 ): SagaIterator {
-  yield put(setSnapState(newSnapState));
+  yield put(
+    encrypted
+      ? setSnapState(newSnapState)
+      : setUnencryptedSnapState(newSnapState),
+  );
 }
 
 /**
  * Gets the snap state from the simulation slice.
  *
  * @param _snapId - The snap id, unused for now.
+ * @param encrypted - A flag to signal whether to use the encrypted storage or not.
  * @returns The snap state.
  * @yields Selects the snap state from the simulation slice.
  */
-export function* getSnapState(_snapId: string): SagaIterator {
-  const state: string = yield select(getSnapStateSelector);
+export function* getSnapState(
+  _snapId: string,
+  encrypted: boolean,
+): SagaIterator {
+  const state: string = yield select(
+    encrypted ? getSnapStateSelector : getUnencryptedSnapStateSelector,
+  );
   return state;
 }
 

--- a/packages/snaps-simulator/src/features/simulation/sagas.ts
+++ b/packages/snaps-simulator/src/features/simulation/sagas.ts
@@ -105,12 +105,12 @@ export function* initSaga({ payload }: PayloadAction<string>) {
       showInAppNotification: async (
         ...args: Parameters<typeof showInAppNotification>
       ) => await runSaga(showInAppNotification, ...args).toPromise(),
-      getSnapState: async (...args: Parameters<typeof getSnapState>) =>
-        await runSaga(getSnapState, ...args).toPromise(),
+      getSnapState: (...args: Parameters<typeof getSnapState>) =>
+        runSaga(getSnapState, ...args).result(),
       updateSnapState: async (...args: Parameters<typeof updateSnapState>) =>
-        await runSaga(updateSnapState, ...args).toPromise(),
-      clearSnapState: async (...args: Parameters<typeof updateSnapState>) =>
-        await runSaga(updateSnapState, args[0], null).toPromise(),
+        runSaga(updateSnapState, ...args).result(),
+      clearSnapState: (...args: [_snapId: string, encrypted: boolean]) =>
+        runSaga(updateSnapState, args[0], null, args[1]).result(),
       maybeUpdatePhishingList: async () => Promise.resolve(),
       // TODO: Allow changing this ?
       isOnPhishingList: () => false,

--- a/packages/snaps-simulator/src/features/simulation/slice.test.ts
+++ b/packages/snaps-simulator/src/features/simulation/slice.test.ts
@@ -10,6 +10,8 @@ import {
   setStatus,
   INITIAL_STATE,
   setAuxiliaryFiles,
+  setSnapState,
+  setUnencryptedSnapState,
 } from './slice';
 import { MockExecutionService } from './test/mockExecutionService';
 import { MOCK_MANIFEST, MOCK_MANIFEST_FILE } from './test/mockManifest';
@@ -44,6 +46,24 @@ describe('simulation slice', () => {
       );
 
       expect(result.sourceCode?.value).toBe('foo');
+    });
+  });
+
+  describe('setSnapState', () => {
+    it('sets snap state', () => {
+      const json = JSON.stringify({ foo: 'bar' });
+      const result = reducer(INITIAL_STATE, setSnapState(json));
+
+      expect(result.snapState).toBe(json);
+    });
+  });
+
+  describe('setUnencryptedSnapState', () => {
+    it('sets snap state', () => {
+      const json = JSON.stringify({ foo: 'bar' });
+      const result = reducer(INITIAL_STATE, setUnencryptedSnapState(json));
+
+      expect(result.unencryptedSnapState).toBe(json);
     });
   });
 

--- a/packages/snaps-simulator/src/features/simulation/slice.ts
+++ b/packages/snaps-simulator/src/features/simulation/slice.ts
@@ -42,6 +42,7 @@ type SimulationState = {
   icon?: VirtualFile<string>;
   ui?: HandlerUserInterface | null;
   snapState: string | null;
+  unencryptedSnapState: string | null;
   requestId?: string;
 };
 
@@ -54,6 +55,7 @@ export const INITIAL_STATE: SimulationState = {
   sourceCode: null,
   auxiliaryFiles: null,
   snapState: null,
+  unencryptedSnapState: null,
 };
 
 const slice = createSlice({
@@ -100,6 +102,9 @@ const slice = createSlice({
     setSnapState: (state, action: PayloadAction<string | null>) => {
       state.snapState = action.payload;
     },
+    setUnencryptedSnapState: (state, action: PayloadAction<string | null>) => {
+      state.unencryptedSnapState = action.payload;
+    },
     sendRequest: (state, _: PayloadAction<SnapRpcHookArgs>) => {
       state.requestId = nanoid();
     },
@@ -122,6 +127,7 @@ export const {
   showUserInterface,
   closeUserInterface,
   setSnapState,
+  setUnencryptedSnapState,
   sendRequest,
 } = slice.actions;
 
@@ -165,6 +171,11 @@ export const getUserInterface = createSelector(
 export const getSnapStateSelector = createSelector(
   (state: { simulation: typeof INITIAL_STATE }) => state.simulation,
   (state) => state.snapState,
+);
+
+export const getUnencryptedSnapStateSelector = createSelector(
+  (state: { simulation: typeof INITIAL_STATE }) => state.simulation,
+  (state) => state.unencryptedSnapState,
 );
 
 export const getSnapManifest = createSelector(


### PR DESCRIPTION
Adds support for unencrypted storage. This feature can be used by passing `{ encrypted: false }` as part of the manageState parameters. This will store and read from a new state bucket that is unencrypted, this also means it can be accessed while MetaMask is locked.

Fixes https://github.com/MetaMask/snaps/issues/1813