### PR TITLE
Add missing `assertLinksAreSafe` browser export in `snaps-utils`

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "adQhG5j7eRG+JT1HGGcBIRJtuLFlrrTjYb5TSThBV5I=",
+    "shasum": "JrnDsJMfsEZxgw95O3kphaNSPa3AqXwM43eUyEt+cc8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+a6gylQ+IkgelhRXu+eKQyHluJN9iUDSgssKq+QC64E=",
+    "shasum": "HBo1Gel+d8SXoKh/wxAGXVJpX30Lk5oVYVhlxs7Cn9g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Akbb6U8wRJmIBYq4Y+TUY6pyD0fDEOwUP2vPQOv2xqw=",
+    "shasum": "zoKAVd+LXM/AtJm0MnqJIxS/06JRYDEpuaepS6DtO6M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wV+/W+jXzTyS/cdp6LF/e09iV0MxnMd/NuLyIRd9QLY=",
+    "shasum": "4Jpgl058I8MFOIGj5YKdP1Wnyf5pOgl2CANR8A8OtYE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "YCnE4aXzO8bX7SBqjNHQz10BM4yPPYgk4txVNfbzvyE=",
+    "shasum": "1/Fe0uZqRYsQEf2xiwRSdDNOEtkdf4qcGTcouE2if98=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wciVZZ0uG0JhpLYoiEt66AHyhY51QGYIXRhGlEGPgV4=",
+    "shasum": "KOd0xd2XiY/EV73gIdj2liYj0AjooRuI6NAqOGbohaQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "pEMDnR5bXAjrx7O1Q4jSyAN4IcJ86QB43WrVZa4FyYI=",
+    "shasum": "7rpcxDzmCPOP+9+V6iaz//dn2UIvpWz3L6nusNZ97d4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "/qpsF/YJsZAQa0E8/YnzCY3q5SjFSTgYb64j7+rgczs=",
+    "shasum": "YPdQh7VNO5Cy+7QPy8+UdfCP5Ik9dgrbOHDVmVB72Js=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-utils/src/index.browser.ts
+++ b/packages/snaps-utils/src/index.browser.ts
@@ -24,3 +24,4 @@ export * from './types';
 export * from './validation';
 export * from './versions';
 export * from './virtual-file/index.browser';
+export { assertLinksAreSafe } from '@metamask/snaps-ui';


### PR DESCRIPTION
this adds the missing `assertLinksAreSafe` browser export in `snaps-utils`