### PR TITLE
Fix `assertLinksAreSafe` import

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "adQhG5j7eRG+JT1HGGcBIRJtuLFlrrTjYb5TSThBV5I=",
+    "shasum": "IRszUKE17jyrodnG0pmG8LrHASWVWB0V2iecYJ6GLes=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+a6gylQ+IkgelhRXu+eKQyHluJN9iUDSgssKq+QC64E=",
+    "shasum": "iBUiclCnj3KNLRmIMLOcQURQOqAVMPxv6A+opW8jX+w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Akbb6U8wRJmIBYq4Y+TUY6pyD0fDEOwUP2vPQOv2xqw=",
+    "shasum": "iG9h3+e6fMyIIran1dm8ljFln/nwM/I3bKNeh8Nx6Qc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wV+/W+jXzTyS/cdp6LF/e09iV0MxnMd/NuLyIRd9QLY=",
+    "shasum": "crsrlV73iUKsTK0h2cHiYKJLSpdF8cU5isJnITEmFjQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-locale/snap.manifest.json
+++ b/packages/examples/packages/get-locale/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "YCnE4aXzO8bX7SBqjNHQz10BM4yPPYgk4txVNfbzvyE=",
+    "shasum": "C5l1eAO0LBeIGCrM4K58eG4tkDdJevIuhUB5oaIpXho=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wciVZZ0uG0JhpLYoiEt66AHyhY51QGYIXRhGlEGPgV4=",
+    "shasum": "XZZmkJJ+/xk9o3o18+bcEOg+YfBoJtSZLIQcSHkbK/w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "pEMDnR5bXAjrx7O1Q4jSyAN4IcJ86QB43WrVZa4FyYI=",
+    "shasum": "Yq4dOhW5EH3Imyz9aoICJ79C2dvGRWtul0M2fbAofRg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "/qpsF/YJsZAQa0E8/YnzCY3q5SjFSTgYb64j7+rgczs=",
+    "shasum": "deg0KqSp+LaqIwRteAl4IWW6i5y9OO6XF/RNismrhj4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-rpc-methods/src/restricted/notify.ts
+++ b/packages/snaps-rpc-methods/src/restricted/notify.ts
@@ -5,8 +5,8 @@ import type {
 } from '@metamask/permission-controller';
 import { PermissionType, SubjectType } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
+import { assertLinksAreSafe } from '@metamask/snaps-ui';
 import type { EnumToUnion } from '@metamask/snaps-utils';
-import { assertLinksAreSafe } from '@metamask/snaps-utils';
 import type { NonEmptyArray } from '@metamask/utils';
 import { isObject } from '@metamask/utils';
 

--- a/packages/snaps-utils/src/index.ts
+++ b/packages/snaps-utils/src/index.ts
@@ -29,4 +29,3 @@ export * from './types';
 export * from './validation';
 export * from './versions';
 export * from './virtual-file';
-export { assertLinksAreSafe } from '@metamask/snaps-ui';


### PR DESCRIPTION
Fixes the import for the link validation code in the `snap_notify` RPC method. This also removes the `assertLinksAreSafe` export from `snaps-utils` as it was flawed (broken in the browser) and unnecessary.