### PR TITLE
Update manage state example

### DIFF
--- a/packages/examples/packages/manage-state/README.md
+++ b/packages/examples/packages/manage-state/README.md
@@ -44,5 +44,9 @@ JSON-RPC methods:
   if one is set, or a default state otherwise.
 - `clearState` - Reset the state to the default state.
 
+Each of the methods also takes an `encrypted` parameter.
+This parameter can be used to choose between using encrypted or unencrypted storage.
+Encrypted storage requires MetaMask to be unlocked, unencrypted storage does not.
+
 For more information, you can refer to
 [the end-to-end tests](./src/index.test.ts).

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cbGV5hLqH9XM36yTNtuIT3p/vmcETr7S7Tf8K5Eou9k=",
+    "shasum": "efSYhLYSllngrQTU4u5zE9fiWb/m/gdzl5wkhACjTjw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/src/index.test.ts
+++ b/packages/examples/packages/manage-state/src/index.test.ts
@@ -45,6 +45,41 @@ describe('onRpcRequest', () => {
 
       await close();
     });
+
+    it('sets the unencrypted state to the params', async () => {
+      const { request, close } = await installSnap();
+
+      expect(
+        await request({
+          method: 'setState',
+          params: {
+            items: ['foo'],
+            encrypted: false,
+          },
+        }),
+      ).toRespondWith(true);
+
+      expect(
+        await request({
+          method: 'getState',
+        }),
+      ).toRespondWith({
+        items: [],
+      });
+
+      expect(
+        await request({
+          method: 'getState',
+          params: {
+            encrypted: false,
+          },
+        }),
+      ).toRespondWith({
+        items: ['foo'],
+      });
+
+      await close();
+    });
   });
 
   describe('getState', () => {
@@ -82,6 +117,31 @@ describe('onRpcRequest', () => {
 
       await close();
     });
+
+    it('returns the unencrypted state', async () => {
+      const { request, close } = await installSnap();
+
+      await request({
+        method: 'setState',
+        params: {
+          items: ['foo'],
+          encrypted: false,
+        },
+      });
+
+      const response = await request({
+        method: 'getState',
+        params: {
+          encrypted: false,
+        },
+      });
+
+      expect(response).toRespondWith({
+        items: ['foo'],
+      });
+
+      await close();
+    });
   });
 
   describe('clearState', () => {
@@ -104,6 +164,40 @@ describe('onRpcRequest', () => {
       expect(
         await request({
           method: 'getState',
+        }),
+      ).toRespondWith({
+        items: [],
+      });
+
+      await close();
+    });
+
+    it('clears the unencrypted state', async () => {
+      const { request, close } = await installSnap();
+
+      await request({
+        method: 'setState',
+        params: {
+          items: ['foo'],
+          encrypted: false,
+        },
+      });
+
+      expect(
+        await request({
+          method: 'clearState',
+          params: {
+            encrypted: false,
+          },
+        }),
+      ).toRespondWith(true);
+
+      expect(
+        await request({
+          method: 'getState',
+          params: {
+            encrypted: false,
+          },
         }),
       ).toRespondWith({
         items: [],

--- a/packages/examples/packages/manage-state/src/types.ts
+++ b/packages/examples/packages/manage-state/src/types.ts
@@ -1,8 +1,10 @@
 import type { State } from './utils';
 
+export type BaseParams = { encrypted?: boolean };
+
 /**
  * The parameters for the `setState` JSON-RPC method.
  *
  * The current state will be merged with the new state.
  */
-export type SetStateParams = Partial<State>;
+export type SetStateParams = BaseParams & Partial<State>;

--- a/packages/examples/packages/manage-state/src/utils.ts
+++ b/packages/examples/packages/manage-state/src/utils.ts
@@ -30,9 +30,10 @@ export async function getState(encrypted?: boolean): Promise<State> {
       // For this particular example, we use the `ManageStateOperation.GetState`
       // enum value, but you can also use the string value `'get'` instead.
       operation: ManageStateOperation.GetState,
-      // By default all state is encrypted, but you can choose to not encrypt it
-      // To do this you may set this flag to false
-      // This will use a separate unencrypted storage from the encrypted state
+
+      // By default all state is encrypted, but you can choose to not encrypt it.
+      // To do this you may set this flag to false.
+      // This will use a separate unencrypted storage from the encrypted state.
       encrypted,
     },
   });
@@ -50,7 +51,10 @@ export async function getState(encrypted?: boolean): Promise<State> {
  * browser.
  *
  * @param newState - The new state of the snap.
- * @param encrypted - An optional flag to indicate whether to use encrypted storage or not.
+ * @param encrypted - An optional flag to indicate whether to use encrypted
+ * storage or not. Unencrypted storage does not require the user to unlock
+ * MetaMask in order to access it, but it should not be used for sensitive data.
+ * Defaults to true.
  * @see https://docs.metamask.io/snaps/reference/rpc-api/#snap_managestate
  */
 export async function setState(newState: State, encrypted?: boolean) {
@@ -62,9 +66,10 @@ export async function setState(newState: State, encrypted?: boolean) {
       // enum value, but you can also use the string value `'update'` instead.
       operation: ManageStateOperation.UpdateState,
       newState,
-      // By default all state is encrypted, but you can choose to not encrypt it
-      // To do this you may set this flag to false
-      // This will use a separate unencrypted storage from the encrypted state
+
+      // By default all state is encrypted, but you can choose to not encrypt it.
+      // To do this you may set this flag to false.
+      // This will use a separate unencrypted storage from the encrypted state.
       encrypted,
     },
   });
@@ -87,9 +92,10 @@ export async function clearState(encrypted?: boolean) {
     // enum value, but you can also use the string value `'clear'` instead.
     params: {
       operation: ManageStateOperation.ClearState,
-      // By default all state is encrypted, but you can choose to not encrypt it
-      // To do this you may set this flag to false
-      // This will use a separate unencrypted storage from the encrypted state
+
+      // By default all state is encrypted, but you can choose to not encrypt it.
+      // To do this you may set this flag to false.
+      // This will use a separate unencrypted storage from the encrypted state.
       encrypted,
     },
   });

--- a/packages/examples/packages/manage-state/src/utils.ts
+++ b/packages/examples/packages/manage-state/src/utils.ts
@@ -18,16 +18,23 @@ const DEFAULT_STATE = {
  *
  * This uses the `snap_manageState` JSON-RPC method to get the state.
  *
+ * @param encrypted - An optional flag to indicate whether to use encrypted storage or not.
  * @returns The current state of the snap.
  * @see https://docs.metamask.io/snaps/reference/rpc-api/#snap_managestate
  */
-export async function getState(): Promise<State> {
+export async function getState(encrypted?: boolean): Promise<State> {
   const state = await snap.request({
     method: 'snap_manageState',
 
-    // For this particular example, we use the `ManageStateOperation.GetState`
-    // enum value, but you can also use the string value `'get'` instead.
-    params: { operation: ManageStateOperation.GetState },
+    params: {
+      // For this particular example, we use the `ManageStateOperation.GetState`
+      // enum value, but you can also use the string value `'get'` instead.
+      operation: ManageStateOperation.GetState,
+      // By default all state is encrypted, but you can choose to not encrypt it
+      // To do this you may set this flag to false
+      // This will use a separate unencrypted storage from the encrypted state
+      encrypted,
+    },
   });
 
   // If the snap does not have state, `state` will be `null`. Instead, we return
@@ -43,15 +50,23 @@ export async function getState(): Promise<State> {
  * browser.
  *
  * @param newState - The new state of the snap.
+ * @param encrypted - An optional flag to indicate whether to use encrypted storage or not.
  * @see https://docs.metamask.io/snaps/reference/rpc-api/#snap_managestate
  */
-export async function setState(newState: State) {
+export async function setState(newState: State, encrypted?: boolean) {
   await snap.request({
     method: 'snap_manageState',
 
-    // For this particular example, we use the `ManageStateOperation.UpdateState`
-    // enum value, but you can also use the string value `'update'` instead.
-    params: { operation: ManageStateOperation.UpdateState, newState },
+    params: {
+      // For this particular example, we use the `ManageStateOperation.UpdateState`
+      // enum value, but you can also use the string value `'update'` instead.
+      operation: ManageStateOperation.UpdateState,
+      newState,
+      // By default all state is encrypted, but you can choose to not encrypt it
+      // To do this you may set this flag to false
+      // This will use a separate unencrypted storage from the encrypted state
+      encrypted,
+    },
   });
 }
 
@@ -61,14 +76,21 @@ export async function setState(newState: State) {
  *
  * This uses the `snap_manageState` JSON-RPC method to clear the state.
  *
+ * @param encrypted - An optional flag to indicate whether to use encrypted storage or not.
  * @see https://docs.metamask.io/snaps/reference/rpc-api/#snap_managestate
  */
-export async function clearState() {
+export async function clearState(encrypted?: boolean) {
   await snap.request({
     method: 'snap_manageState',
 
     // For this particular example, we use the `ManageStateOperation.ClearState`
     // enum value, but you can also use the string value `'clear'` instead.
-    params: { operation: ManageStateOperation.ClearState },
+    params: {
+      operation: ManageStateOperation.ClearState,
+      // By default all state is encrypted, but you can choose to not encrypt it
+      // To do this you may set this flag to false
+      // This will use a separate unencrypted storage from the encrypted state
+      encrypted,
+    },
   });
 }

--- a/packages/test-snaps/src/api.ts
+++ b/packages/test-snaps/src/api.ts
@@ -16,6 +16,7 @@ export enum Tag {
   Accounts = 'Accounts',
   InstalledSnaps = 'Installed Snaps',
   TestState = 'Test State',
+  UnencryptedTestState = 'Unencrypted Test State',
 }
 
 /**

--- a/packages/test-snaps/src/features/snaps/manage-state/ManageState.tsx
+++ b/packages/test-snaps/src/features/snaps/manage-state/ManageState.tsx
@@ -10,7 +10,8 @@ import {
 import { useSnapState } from './hooks';
 
 export const ManageState: FunctionComponent = () => {
-  const state = useSnapState();
+  const encryptedState = useSnapState(true);
+  const unencryptedState = useSnapState(false);
 
   return (
     <Snap
@@ -22,12 +23,21 @@ export const ManageState: FunctionComponent = () => {
     >
       <Result className="mb-3">
         <span id="retrieveManageStateResult">
-          {JSON.stringify(state, null, 2)}
+          {JSON.stringify(encryptedState, null, 2)}
         </span>
       </Result>
 
-      <SendData />
-      <ClearData />
+      <SendData encrypted={true} />
+      <ClearData encrypted={true} />
+
+      <Result className="mb-3">
+        <span id="retrieveManageStateUnencryptedResult">
+          {JSON.stringify(unencryptedState, null, 2)}
+        </span>
+      </Result>
+
+      <SendData encrypted={false} />
+      <ClearData encrypted={false} />
     </Snap>
   );
 };

--- a/packages/test-snaps/src/features/snaps/manage-state/components/ClearData.tsx
+++ b/packages/test-snaps/src/features/snaps/manage-state/components/ClearData.tsx
@@ -7,29 +7,38 @@ import { Result } from '../../../../components';
 import { getSnapId } from '../../../../utils';
 import { MANAGE_STATE_PORT, MANAGE_STATE_SNAP_ID } from '../constants';
 
-export const ClearData: FunctionComponent = () => {
+export const ClearData: FunctionComponent<{ encrypted: boolean }> = ({
+  encrypted,
+}) => {
   const [invokeSnap, { isLoading, data, error }] = useInvokeMutation();
 
   const handleClick = () => {
     invokeSnap({
       snapId: getSnapId(MANAGE_STATE_SNAP_ID, MANAGE_STATE_PORT),
       method: 'clearState',
-      tags: [Tag.TestState],
+      params: { encrypted },
+      tags: [encrypted ? Tag.TestState : Tag.UnencryptedTestState],
     }).catch(logError);
   };
 
   return (
     <>
       <Button
-        id="clearManageState"
+        id={encrypted ? 'clearManageState' : 'clearUnencryptedManageState'}
         onClick={handleClick}
         disabled={isLoading}
         className="mb-3"
       >
         Clear Data
       </Button>
-      <Result>
-        <span id="clearManageStateResult">
+      <Result className="mb-3">
+        <span
+          id={
+            encrypted
+              ? 'clearManageStateResult'
+              : 'clearUnencryptedManageStateResult'
+          }
+        >
           {JSON.stringify(data, null, 2)}
           {JSON.stringify(error, null, 2)}
         </span>

--- a/packages/test-snaps/src/features/snaps/manage-state/components/SendData.tsx
+++ b/packages/test-snaps/src/features/snaps/manage-state/components/SendData.tsx
@@ -9,10 +9,12 @@ import { getSnapId } from '../../../../utils';
 import { MANAGE_STATE_PORT, MANAGE_STATE_SNAP_ID } from '../constants';
 import { useSnapState } from '../hooks';
 
-export const SendData: FunctionComponent = () => {
+export const SendData: FunctionComponent<{ encrypted: boolean }> = ({
+  encrypted,
+}) => {
   const [value, setValue] = useState('');
   const [invokeSnap, { isLoading, data, error }] = useInvokeMutation();
-  const snapState = useSnapState();
+  const snapState = useSnapState(encrypted);
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);
@@ -25,8 +27,9 @@ export const SendData: FunctionComponent = () => {
       method: 'setState',
       params: {
         items: [...snapState.items, value],
+        encrypted,
       },
-      tags: [Tag.TestState],
+      tags: [encrypted ? Tag.TestState : Tag.UnencryptedTestState],
     }).catch(logError);
   };
 
@@ -40,18 +43,28 @@ export const SendData: FunctionComponent = () => {
             placeholder="Value"
             value={value}
             onChange={handleChange}
-            id="dataManageState"
+            id={encrypted ? 'dataManageState' : 'dataUnencryptedManageState'}
             className="mb-3"
           />
         </Form.Group>
 
-        <Button type="submit" id="sendManageState" disabled={isLoading}>
+        <Button
+          type="submit"
+          id={encrypted ? 'sendManageState' : 'sendUnencryptedManageState'}
+          disabled={isLoading}
+        >
           Send Data
         </Button>
       </Form>
 
       <Result className="mb-3">
-        <span id="sendManageStateResult">
+        <span
+          id={
+            encrypted
+              ? 'sendManageStateResult'
+              : 'sendUnencryptedManageStateResult'
+          }
+        >
           {JSON.stringify(data, null, 2)}
           {JSON.stringify(error, null, 2)}
         </span>

--- a/packages/test-snaps/src/features/snaps/manage-state/hooks/useSnapState.ts
+++ b/packages/test-snaps/src/features/snaps/manage-state/hooks/useSnapState.ts
@@ -9,9 +9,10 @@ export type State = {
 /**
  * Hook to retrieve the state of the snap.
  *
+ * @param encrypted - A flag to indicate whether to use encrypted storage or not.
  * @returns The state of the snap.
  */
-export function useSnapState() {
+export function useSnapState(encrypted: boolean) {
   const snapId = getSnapId(MANAGE_STATE_SNAP_ID, MANAGE_STATE_PORT);
   const isInstalled = useInstalled(snapId);
 
@@ -19,7 +20,8 @@ export function useSnapState() {
     {
       snapId,
       method: 'getState',
-      tags: [Tag.TestState],
+      params: { encrypted },
+      tags: [encrypted ? Tag.TestState : Tag.UnencryptedTestState],
     },
     {
       skip: !isInstalled,


### PR DESCRIPTION
Updates manage state example to support both encrypted and unencrypted state.

Also adds support for the new unencrypted mode to `test-snaps`.