### PR TITLE
Handle spawnSync errors in create-snap

### DIFF
--- a/packages/create-snap/src/cmds/init/initUtils.test.ts
+++ b/packages/create-snap/src/cmds/init/initUtils.test.ts
@@ -1,3 +1,4 @@
+import type { SpawnSyncReturns } from 'child_process';
 import childProcess from 'child_process';
 import { promises as fs } from 'fs';
 import pathUtils from 'path';
@@ -24,6 +25,15 @@ jest.mock('process', () => ({
 jest.mock('child_process', () => ({
   spawnSync: jest.fn(),
 }));
+
+const spawnReturnWithStatus = (status: number): SpawnSyncReturns<Buffer> => ({
+  status,
+  signal: null,
+  pid: 1000,
+  output: [],
+  stdout: Buffer.from(''),
+  stderr: Buffer.from(''),
+});
 
 describe('initUtils', () => {
   beforeEach(async () => {
@@ -69,7 +79,7 @@ describe('initUtils', () => {
     it('calls spawnSync', () => {
       const spawnSyncMock = jest
         .spyOn(childProcess, 'spawnSync')
-        .mockImplementation();
+        .mockImplementation(() => spawnReturnWithStatus(0));
 
       buildSnap('foo');
 
@@ -81,9 +91,9 @@ describe('initUtils', () => {
     });
 
     it('throws an error when execution fails', () => {
-      jest.spyOn(childProcess, 'spawnSync').mockImplementation(() => {
-        throw new Error('failed');
-      });
+      jest
+        .spyOn(childProcess, 'spawnSync')
+        .mockImplementation(() => spawnReturnWithStatus(1));
 
       expect(() => buildSnap('foo')).toThrow(
         'Init Error: Failed to build snap.',
@@ -95,14 +105,7 @@ describe('initUtils', () => {
     it('passes if the command is ran successfully', () => {
       const spawnSyncMock = jest
         .spyOn(childProcess, 'spawnSync')
-        .mockImplementation(() => ({
-          pid: 1,
-          output: [],
-          stdout: '',
-          stderr: '',
-          status: null,
-          signal: null,
-        }));
+        .mockImplementation(() => spawnReturnWithStatus(0));
 
       cloneTemplate('foo');
 
@@ -119,9 +122,7 @@ describe('initUtils', () => {
     it('throws if the command fails', () => {
       const spawnSyncMock = jest
         .spyOn(childProcess, 'spawnSync')
-        .mockImplementation(() => {
-          throw new Error('error message');
-        });
+        .mockImplementation(() => spawnReturnWithStatus(1));
 
       expect(() => cloneTemplate('foo')).toThrow(
         'Init Error: Failed to clone the template.',
@@ -134,14 +135,7 @@ describe('initUtils', () => {
     it('returns true if git is installed', () => {
       const spawnSyncMock = jest
         .spyOn(childProcess, 'spawnSync')
-        .mockImplementation(() => ({
-          pid: 1,
-          output: [],
-          stdout: '',
-          stderr: '',
-          status: null,
-          signal: null,
-        }));
+        .mockImplementation(() => spawnReturnWithStatus(0));
 
       const result = isGitInstalled();
 
@@ -155,9 +149,7 @@ describe('initUtils', () => {
     it('returns false if git is not installed', () => {
       const spawnSyncMock = jest
         .spyOn(childProcess, 'spawnSync')
-        .mockImplementation(() => {
-          throw new Error('error message');
-        });
+        .mockImplementation(() => spawnReturnWithStatus(1));
 
       const result = isGitInstalled();
 
@@ -170,14 +162,7 @@ describe('initUtils', () => {
     it('returns true if the directory is a git repository', () => {
       const spawnSyncMock = jest
         .spyOn(childProcess, 'spawnSync')
-        .mockImplementation(() => ({
-          pid: 1,
-          output: [],
-          stdout: '',
-          stderr: '',
-          status: null,
-          signal: null,
-        }));
+        .mockImplementation(() => spawnReturnWithStatus(0));
 
       const result = isInGitRepository('foo');
 
@@ -196,9 +181,7 @@ describe('initUtils', () => {
     it('returns false if the directory is not a git repository', () => {
       const spawnSyncMock = jest
         .spyOn(childProcess, 'spawnSync')
-        .mockImplementation(() => {
-          throw new Error('error message');
-        });
+        .mockImplementation(() => spawnReturnWithStatus(128));
 
       const result = isInGitRepository('foo');
 
@@ -211,14 +194,7 @@ describe('initUtils', () => {
     it('init a new repository', () => {
       const spawnSyncMock = jest
         .spyOn(childProcess, 'spawnSync')
-        .mockImplementation(() => ({
-          pid: 1,
-          output: [],
-          stdout: '',
-          stderr: '',
-          status: null,
-          signal: null,
-        }));
+        .mockImplementation(() => spawnReturnWithStatus(0));
 
       gitInit('foo');
 
@@ -232,9 +208,7 @@ describe('initUtils', () => {
     it('throws an error if it fails to init a new repository', () => {
       const spawnSyncMock = jest
         .spyOn(childProcess, 'spawnSync')
-        .mockImplementation(() => {
-          throw new Error('error message');
-        });
+        .mockImplementation(() => spawnReturnWithStatus(1));
 
       expect(() => gitInit('foo')).toThrow(
         'Init Error: Failed to init a new git repository.',
@@ -247,14 +221,7 @@ describe('initUtils', () => {
     it('run yarn and yarn install commands', () => {
       const spawnSyncMock = jest
         .spyOn(childProcess, 'spawnSync')
-        .mockImplementation(() => ({
-          pid: 1,
-          output: [],
-          stdout: '',
-          stderr: '',
-          status: null,
-          signal: null,
-        }));
+        .mockImplementation(() => spawnReturnWithStatus(0));
 
       yarnInstall('foo');
 
@@ -268,9 +235,7 @@ describe('initUtils', () => {
     it('throws an error if it fails to run a command', () => {
       const spawnSyncMock = jest
         .spyOn(childProcess, 'spawnSync')
-        .mockImplementation(() => {
-          throw new Error('error message');
-        });
+        .mockImplementation(() => spawnReturnWithStatus(1));
 
       expect(() => yarnInstall('foo')).toThrow(
         'Init Error: Failed to install dependencies.',

--- a/packages/create-snap/src/cmds/init/initUtils.ts
+++ b/packages/create-snap/src/cmds/init/initUtils.ts
@@ -44,11 +44,15 @@ export async function prepareWorkingDirectory(
  * @param directory - The directory to clone the template in.
  */
 export function cloneTemplate(directory: string) {
-  try {
-    spawnSync('git', ['clone', '--depth=1', TEMPLATE_GIT_URL, directory], {
+  const result = spawnSync(
+    'git',
+    ['clone', '--depth=1', TEMPLATE_GIT_URL, directory],
+    {
       stdio: [2],
-    });
-  } catch (error) {
+    },
+  );
+
+  if (result.error || result.status !== 0) {
     throw new Error('Init Error: Failed to clone the template.');
   }
 }
@@ -59,12 +63,8 @@ export function cloneTemplate(directory: string) {
  * @returns True if git is installed, or false otherwise.
  */
 export function isGitInstalled() {
-  try {
-    spawnSync('git', ['--version'], { stdio: 'ignore' });
-    return true;
-  } catch (error) {
-    return false;
-  }
+  const result = spawnSync('git', ['--version'], { stdio: 'ignore' });
+  return result.status === 0;
 }
 
 /**
@@ -74,15 +74,12 @@ export function isGitInstalled() {
  * @returns True if it's a git repository otherwise false.
  */
 export function isInGitRepository(directory: string) {
-  try {
-    spawnSync('git', ['rev-parse', '--is-inside-work-tree'], {
-      stdio: 'ignore',
-      cwd: pathUtils.resolve(__dirname, directory),
-    });
-    return true;
-  } catch (error) {
-    return false;
-  }
+  const result = spawnSync('git', ['rev-parse', '--is-inside-work-tree'], {
+    stdio: 'ignore',
+    cwd: pathUtils.resolve(__dirname, directory),
+  });
+
+  return result.status === 0;
 }
 
 /**
@@ -91,12 +88,12 @@ export function isInGitRepository(directory: string) {
  * @param directory - The directory to init.
  */
 export function gitInit(directory: string) {
-  try {
-    spawnSync('git', ['init'], {
-      stdio: 'ignore',
-      cwd: pathUtils.resolve(__dirname, directory),
-    });
-  } catch (error) {
+  const result = spawnSync('git', ['init'], {
+    stdio: 'ignore',
+    cwd: pathUtils.resolve(__dirname, directory),
+  });
+
+  if (result.error || result.status !== 0) {
     throw new Error('Init Error: Failed to init a new git repository.');
   }
 }
@@ -107,12 +104,12 @@ export function gitInit(directory: string) {
  * @param directory - The directory containing the project.
  */
 export function yarnInstall(directory: string) {
-  try {
-    spawnSync('yarn', ['install'], {
-      stdio: [0, 1, 2],
-      cwd: directory,
-    });
-  } catch (error) {
+  const result = spawnSync('yarn', ['install'], {
+    stdio: [0, 1, 2],
+    cwd: directory,
+  });
+
+  if (result.error || result.status !== 0) {
     throw new Error('Init Error: Failed to install dependencies.');
   }
 }
@@ -123,12 +120,12 @@ export function yarnInstall(directory: string) {
  * @param snapDirectory - The directory containing the snap.
  */
 export function buildSnap(snapDirectory: string) {
-  try {
-    spawnSync('yarn', ['build'], {
-      stdio: [0, 1, 2],
-      cwd: pathUtils.resolve(__dirname, snapDirectory),
-    });
-  } catch (error) {
+  const result = spawnSync('yarn', ['build'], {
+    stdio: [0, 1, 2],
+    cwd: pathUtils.resolve(__dirname, snapDirectory),
+  });
+
+  if (result.error || result.status !== 0) {
     throw new Error('Init Error: Failed to build snap.');
   }
 }


### PR DESCRIPTION
A recent change from execSync to spawnSync didn't mock the new call properly, resulting in falsely passing tests. spawnSync doesn't throw when there's an error, it just returns an object all the time. This commit fixes the tests and the implementation to account for this difference.