### PR TITLE
Make an initial commit when creating a Snap from template

### DIFF
--- a/packages/create-snap/src/cmds/init/initHandler.test.ts
+++ b/packages/create-snap/src/cmds/init/initHandler.test.ts
@@ -56,7 +56,7 @@ describe('initialize', () => {
       jest
         .spyOn(initUtils, 'isInGitRepository')
         .mockImplementation(() => false);
-      jest.spyOn(initUtils, 'gitInit').mockImplementation();
+      jest.spyOn(initUtils, 'gitInitWithCommit').mockImplementation();
 
       const { manifest, packageJson } = getMockSnapFiles();
 
@@ -93,7 +93,7 @@ describe('initialize', () => {
         .spyOn(initUtils, 'isInGitRepository')
         .mockImplementation(() => false);
 
-      jest.spyOn(initUtils, 'gitInit').mockImplementation();
+      jest.spyOn(initUtils, 'gitInitWithCommit').mockImplementation();
 
       const { manifest, packageJson } = getMockSnapFiles();
 
@@ -130,7 +130,7 @@ describe('initialize', () => {
       jest
         .spyOn(initUtils, 'isInGitRepository')
         .mockImplementation(() => false);
-      jest.spyOn(initUtils, 'gitInit').mockImplementation();
+      jest.spyOn(initUtils, 'gitInitWithCommit').mockImplementation();
 
       const { manifest, packageJson } = getMockSnapFiles({
         packageJson: { ...getPackageJson(), main: undefined },
@@ -182,7 +182,7 @@ describe('initialize', () => {
         .spyOn(initUtils, 'isInGitRepository')
         .mockImplementation(() => true);
 
-      const gitInitMock = jest.spyOn(initUtils, 'gitInit');
+      const gitInitMock = jest.spyOn(initUtils, 'gitInitWithCommit');
 
       const expected = {
         ...getMockArgv(),

--- a/packages/create-snap/src/cmds/init/initHandler.ts
+++ b/packages/create-snap/src/cmds/init/initHandler.ts
@@ -14,7 +14,7 @@ import type { YargsArgs } from '../../types/yargs';
 import {
   buildSnap,
   cloneTemplate,
-  gitInit,
+  gitInitWithCommit,
   isGitInstalled,
   isInGitRepository,
   prepareWorkingDirectory,
@@ -80,7 +80,7 @@ export async function initHandler(argv: YargsArgs) {
 
   if (!isInGitRepository(directoryToUse)) {
     logInfo('Initializing git repository...');
-    gitInit(directoryToUse);
+    gitInitWithCommit(directoryToUse);
   }
 
   const snapLocation = pathUtils.join(directoryToUse, SNAP_LOCATION);

--- a/packages/create-snap/src/cmds/init/initUtils.test.ts
+++ b/packages/create-snap/src/cmds/init/initUtils.test.ts
@@ -7,7 +7,7 @@ import { resetFileSystem } from '../../test-utils';
 import {
   buildSnap,
   cloneTemplate,
-  gitInit,
+  gitInitWithCommit,
   isGitInstalled,
   isInGitRepository,
   prepareWorkingDirectory,
@@ -190,19 +190,32 @@ describe('initUtils', () => {
     });
   });
 
-  describe('gitInit', () => {
+  describe('gitInitWithCommit', () => {
     it('init a new repository', () => {
       const spawnSyncMock = jest
         .spyOn(childProcess, 'spawnSync')
         .mockImplementation(() => spawnReturnWithStatus(0));
 
-      gitInit('foo');
+      gitInitWithCommit('foo');
 
-      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
-      expect(spawnSyncMock).toHaveBeenCalledWith('git', ['init'], {
+      expect(spawnSyncMock).toHaveBeenCalledTimes(3);
+      expect(spawnSyncMock).toHaveBeenNthCalledWith(1, 'git', ['init'], {
         stdio: 'ignore',
         cwd: pathUtils.resolve(__dirname, 'foo'),
       });
+      expect(spawnSyncMock).toHaveBeenNthCalledWith(2, 'git', ['add', '.'], {
+        stdio: 'ignore',
+        cwd: pathUtils.resolve(__dirname, 'foo'),
+      });
+      expect(spawnSyncMock).toHaveBeenNthCalledWith(
+        3,
+        'git',
+        ['commit', '-m', 'Initial commit from @metamask/create-snap'],
+        {
+          stdio: 'ignore',
+          cwd: pathUtils.resolve(__dirname, 'foo'),
+        },
+      );
     });
 
     it('throws an error if it fails to init a new repository', () => {
@@ -210,7 +223,7 @@ describe('initUtils', () => {
         .spyOn(childProcess, 'spawnSync')
         .mockImplementation(() => spawnReturnWithStatus(1));
 
-      expect(() => gitInit('foo')).toThrow(
+      expect(() => gitInitWithCommit('foo')).toThrow(
         'Init Error: Failed to init a new git repository.',
       );
       expect(spawnSyncMock).toHaveBeenCalledTimes(1);

--- a/packages/create-snap/src/cmds/init/initUtils.ts
+++ b/packages/create-snap/src/cmds/init/initUtils.ts
@@ -83,18 +83,35 @@ export function isInGitRepository(directory: string) {
 }
 
 /**
- * Init a git repository.
+ * Init a git repository and make the first commit.
  *
  * @param directory - The directory to init.
  */
-export function gitInit(directory: string) {
-  const result = spawnSync('git', ['init'], {
-    stdio: 'ignore',
-    cwd: pathUtils.resolve(__dirname, directory),
-  });
+export function gitInitWithCommit(directory: string) {
+  const commands = [
+    {
+      cmd: 'git',
+      params: ['init'],
+    },
+    {
+      cmd: 'git',
+      params: ['add', '.'],
+    },
+    {
+      cmd: 'git',
+      params: ['commit', '-m', 'Initial commit from @metamask/create-snap'],
+    },
+  ];
 
-  if (result.error || result.status !== 0) {
-    throw new Error('Init Error: Failed to init a new git repository.');
+  for (const command of commands) {
+    const result = spawnSync(command.cmd, command.params, {
+      stdio: 'ignore',
+      cwd: pathUtils.resolve(__dirname, directory),
+    });
+
+    if (result.error || result.status !== 0) {
+      throw new Error('Init Error: Failed to init a new git repository.');
+    }
   }
 }
 


### PR DESCRIPTION
Note: merge this after #1916 

When creating a new Snap using the create-snap CLI, we make an initial commit with the code of the template. This makes it easier for devs to see the changes they make as they start hacking on the template, without having to remember to make an initial commit manually.

This is similar to what's done by other "create" projects such as CRA.

Tested:

<img width="590" alt="image" src="https://github.com/MetaMask/snaps/assets/3943143/fba9d2bd-8179-4bae-92ed-d30d0a7e937a">
