### PR TITLE
Add Snap error wrappers of JSON-RPC errors

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3PiDzz7GdMsESG/6ZAJqFjn2Li8oaCvw2i3k+IFooXs=",
+    "shasum": "WhJFBstL9IJJd0Ux7btR1Z8r0XWbj5YishuvEvFMOGg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "/o2NevZCcocYbJaDzVkOJFDCozfyUDVYhv+EUJoJBGY=",
+    "shasum": "C29vT/9mP49PTrRtusdJw5smO0ecTzfqLqSp6H8BFss=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5QcNsKW2OCV+Oi5jv0adqdorGJlrRXk6b2N8ggNKfJg=",
+    "shasum": "0ohHC8w3k2q7o2dTOS400GWDJ4wTGzMwxy9Mv+aJWBA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "gBlp/vQeFAxBYBB+ZtKp544lvphaUGnPdlZT3TcRYtM=",
+    "shasum": "jBfn7CLEYqgwEpovyhSbbKpqZn4Aset/OH5B8H/xh4c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "mwQVVwVq4B6u9x7VMmCQ2w2bREK0sWHcK+siAjs7e+c=",
+    "shasum": "uYIzvvgiBof8L55BT8SxeNvyTxaQTddpSCBdGsnhX9o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "adrLao09LcOWwhlW+YfcJOdGyHgb4ap2JwhKCl+HWkM=",
+    "shasum": "yjwzM13BqYnrORG5fMAwPqKg0AkqOw1ORzMW11rQUow=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "EhHC32ZDU+SWvnUAcm2ibsZdqfwlr4h+mAvmCqyPPK0=",
+    "shasum": "f/FPnBBrf7xtfCZ6gmGIld+adQWw9HgdyBxBuyExZEU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "T1KWaOynwxjLUrArL2JV/bLUqbkdVVq0gDFXekbfISA=",
+    "shasum": "MlJXaPgiKAf0xp2gTT9QcvmnpTsJaWe/iKxDkxHKzco=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "UiUa8rv9kqEP4DEs59e7ctxlOmv0fc39HXxU96FAozc=",
+    "shasum": "We6P7J0mnspgTg2sfUd/waz+7a/H7D8CTVMv/bJHWp8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7BU7O6zjdNfdXzdxaMrMWkBasBATeJdW2gvzaOKn4ik=",
+    "shasum": "/DLQuCstxX0u9plxLCfLh8zie27BDYPpLmmQPcmeLyE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7B1tbfkFvZZrfCQ6BOE13svMJpUnCAz01rm8ey5N37Y=",
+    "shasum": "dpTZVsprFi9syfWE77+nZYLY0+VYG4xrD05jBK9o/Mg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Kfj87CBq4qcjYQywETQ4ORayuEjZO+QeQWJ3aQnZgUA=",
+    "shasum": "agDxMEIAYv6V9aPUqPXk68YwcLRexyb69I1lbaY4HHs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-execution-environments/lavamoat/browserify/iframe/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/iframe/policy.json
@@ -321,6 +321,11 @@
         "external:../snaps-sdk/src/ui/index.ts": true
       }
     },
+    "external:../snaps-sdk/src/internals/error-wrappers.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/errors.ts": true
+      }
+    },
     "external:../snaps-sdk/src/internals/errors.ts": {
       "packages": {
         "@metamask/utils": true
@@ -328,6 +333,7 @@
     },
     "external:../snaps-sdk/src/internals/index.ts": {
       "packages": {
+        "external:../snaps-sdk/src/internals/error-wrappers.ts": true,
         "external:../snaps-sdk/src/internals/errors.ts": true,
         "external:../snaps-sdk/src/internals/helpers.ts": true
       }

--- a/packages/snaps-execution-environments/lavamoat/browserify/node-process/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/node-process/policy.json
@@ -385,6 +385,11 @@
         "external:../snaps-sdk/src/ui/index.ts": true
       }
     },
+    "external:../snaps-sdk/src/internals/error-wrappers.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/errors.ts": true
+      }
+    },
     "external:../snaps-sdk/src/internals/errors.ts": {
       "packages": {
         "@metamask/utils": true
@@ -392,6 +397,7 @@
     },
     "external:../snaps-sdk/src/internals/index.ts": {
       "packages": {
+        "external:../snaps-sdk/src/internals/error-wrappers.ts": true,
         "external:../snaps-sdk/src/internals/errors.ts": true,
         "external:../snaps-sdk/src/internals/helpers.ts": true
       }

--- a/packages/snaps-execution-environments/lavamoat/browserify/node-thread/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/node-thread/policy.json
@@ -385,6 +385,11 @@
         "external:../snaps-sdk/src/ui/index.ts": true
       }
     },
+    "external:../snaps-sdk/src/internals/error-wrappers.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/errors.ts": true
+      }
+    },
     "external:../snaps-sdk/src/internals/errors.ts": {
       "packages": {
         "@metamask/utils": true
@@ -392,6 +397,7 @@
     },
     "external:../snaps-sdk/src/internals/index.ts": {
       "packages": {
+        "external:../snaps-sdk/src/internals/error-wrappers.ts": true,
         "external:../snaps-sdk/src/internals/errors.ts": true,
         "external:../snaps-sdk/src/internals/helpers.ts": true
       }

--- a/packages/snaps-execution-environments/lavamoat/browserify/offscreen/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/offscreen/policy.json
@@ -155,6 +155,11 @@
         "external:../snaps-sdk/src/ui/index.ts": true
       }
     },
+    "external:../snaps-sdk/src/internals/error-wrappers.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/errors.ts": true
+      }
+    },
     "external:../snaps-sdk/src/internals/errors.ts": {
       "packages": {
         "@metamask/utils": true
@@ -162,6 +167,7 @@
     },
     "external:../snaps-sdk/src/internals/index.ts": {
       "packages": {
+        "external:../snaps-sdk/src/internals/error-wrappers.ts": true,
         "external:../snaps-sdk/src/internals/errors.ts": true,
         "external:../snaps-sdk/src/internals/helpers.ts": true
       }

--- a/packages/snaps-execution-environments/lavamoat/browserify/worker-executor/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/worker-executor/policy.json
@@ -321,6 +321,11 @@
         "external:../snaps-sdk/src/ui/index.ts": true
       }
     },
+    "external:../snaps-sdk/src/internals/error-wrappers.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/errors.ts": true
+      }
+    },
     "external:../snaps-sdk/src/internals/errors.ts": {
       "packages": {
         "@metamask/utils": true
@@ -328,6 +333,7 @@
     },
     "external:../snaps-sdk/src/internals/index.ts": {
       "packages": {
+        "external:../snaps-sdk/src/internals/error-wrappers.ts": true,
         "external:../snaps-sdk/src/internals/errors.ts": true,
         "external:../snaps-sdk/src/internals/helpers.ts": true
       }

--- a/packages/snaps-execution-environments/lavamoat/browserify/worker-pool/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/worker-pool/policy.json
@@ -155,6 +155,11 @@
         "external:../snaps-sdk/src/ui/index.ts": true
       }
     },
+    "external:../snaps-sdk/src/internals/error-wrappers.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/errors.ts": true
+      }
+    },
     "external:../snaps-sdk/src/internals/errors.ts": {
       "packages": {
         "@metamask/utils": true
@@ -162,6 +167,7 @@
     },
     "external:../snaps-sdk/src/internals/index.ts": {
       "packages": {
+        "external:../snaps-sdk/src/internals/error-wrappers.ts": true,
         "external:../snaps-sdk/src/internals/errors.ts": true,
         "external:../snaps-sdk/src/internals/helpers.ts": true
       }

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@metamask/key-tree": "^9.0.0",
     "@metamask/providers": "^13.0.0",
+    "@metamask/rpc-errors": "^6.1.0",
     "@metamask/utils": "^8.1.0",
     "is-svg": "^4.4.0",
     "superstruct": "^1.0.3"
@@ -48,7 +49,6 @@
     "@metamask/eslint-config-jest": "^12.1.0",
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
-    "@metamask/rpc-errors": "^6.1.0",
     "@swc/cli": "^0.1.62",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",

--- a/packages/snaps-sdk/src/error-wrappers.test.ts
+++ b/packages/snaps-sdk/src/error-wrappers.test.ts
@@ -1,0 +1,723 @@
+import {
+  ChainDisconnectedError,
+  DisconnectedError,
+  InternalError,
+  InvalidInputError,
+  InvalidParamsError,
+  InvalidRequestError,
+  LimitExceededError,
+  MethodNotFoundError,
+  MethodNotSupportedError,
+  ParseError,
+  ResourceNotFoundError,
+  ResourceUnavailableError,
+  TransactionRejected,
+  UnauthorizedError,
+  UnsupportedMethodError,
+  UserRejectedRequestError,
+} from './error-wrappers';
+import { SnapError } from './errors';
+
+describe('Snap errors', () => {
+  describe('InternalError', () => {
+    it('creates a SnapError', () => {
+      const wrapped = new InternalError('foo');
+
+      expect(wrapped).toBeInstanceOf(Error);
+      expect(wrapped).toBeInstanceOf(SnapError);
+      expect(wrapped).toBeInstanceOf(InternalError);
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.code).toBe(-32603);
+      expect(wrapped.data).toStrictEqual({});
+      expect(wrapped.stack).toBeDefined();
+      expect(wrapped.toJSON()).toStrictEqual({
+        code: -31002,
+        message: 'Snap Error',
+        data: {
+          cause: {
+            code: -32603,
+            message: 'foo',
+            stack: wrapped.stack,
+            data: {},
+          },
+        },
+      });
+    });
+
+    it('creates a SnapError with data', () => {
+      const wrapped = new InternalError('foo', {
+        foo: 'bar',
+      });
+
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.data).toStrictEqual({
+        foo: 'bar',
+      });
+    });
+
+    it('creates a SnapError without a message', () => {
+      const wrapped = new InternalError();
+
+      expect(wrapped.message).toBe('Internal JSON-RPC error.');
+    });
+  });
+
+  describe('InvalidInputError', () => {
+    it('creates a SnapError', () => {
+      const wrapped = new InvalidInputError('foo');
+
+      expect(wrapped).toBeInstanceOf(Error);
+      expect(wrapped).toBeInstanceOf(SnapError);
+      expect(wrapped).toBeInstanceOf(InvalidInputError);
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.code).toBe(-32000);
+      expect(wrapped.data).toStrictEqual({});
+      expect(wrapped.stack).toBeDefined();
+      expect(wrapped.toJSON()).toStrictEqual({
+        code: -31002,
+        message: 'Snap Error',
+        data: {
+          cause: {
+            code: -32000,
+            message: 'foo',
+            stack: wrapped.stack,
+            data: {},
+          },
+        },
+      });
+    });
+
+    it('creates a SnapError with data', () => {
+      const wrapped = new InvalidInputError('foo', {
+        foo: 'bar',
+      });
+
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.data).toStrictEqual({
+        foo: 'bar',
+      });
+    });
+
+    it('creates a SnapError without a message', () => {
+      const wrapped = new InvalidInputError();
+
+      expect(wrapped.message).toBe('Invalid input.');
+    });
+  });
+
+  describe('InvalidParamsError', () => {
+    it('creates a SnapError', () => {
+      const wrapped = new InvalidParamsError('foo');
+
+      expect(wrapped).toBeInstanceOf(Error);
+      expect(wrapped).toBeInstanceOf(SnapError);
+      expect(wrapped).toBeInstanceOf(InvalidParamsError);
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.code).toBe(-32602);
+      expect(wrapped.data).toStrictEqual({});
+      expect(wrapped.stack).toBeDefined();
+      expect(wrapped.toJSON()).toStrictEqual({
+        code: -31002,
+        message: 'Snap Error',
+        data: {
+          cause: {
+            code: -32602,
+            message: 'foo',
+            stack: wrapped.stack,
+            data: {},
+          },
+        },
+      });
+    });
+
+    it('creates a SnapError with data', () => {
+      const wrapped = new InvalidParamsError('foo', {
+        foo: 'bar',
+      });
+
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.data).toStrictEqual({
+        foo: 'bar',
+      });
+    });
+
+    it('creates a SnapError without a message', () => {
+      const wrapped = new InvalidParamsError();
+
+      expect(wrapped.message).toBe('Invalid method parameter(s).');
+    });
+  });
+
+  describe('InvalidRequestError', () => {
+    it('creates a SnapError', () => {
+      const wrapped = new InvalidRequestError('foo');
+
+      expect(wrapped).toBeInstanceOf(Error);
+      expect(wrapped).toBeInstanceOf(SnapError);
+      expect(wrapped).toBeInstanceOf(InvalidRequestError);
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.code).toBe(-32600);
+      expect(wrapped.data).toStrictEqual({});
+      expect(wrapped.stack).toBeDefined();
+      expect(wrapped.toJSON()).toStrictEqual({
+        code: -31002,
+        message: 'Snap Error',
+        data: {
+          cause: {
+            code: -32600,
+            message: 'foo',
+            stack: wrapped.stack,
+            data: {},
+          },
+        },
+      });
+    });
+
+    it('creates a SnapError with data', () => {
+      const wrapped = new InvalidRequestError('foo', {
+        foo: 'bar',
+      });
+
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.data).toStrictEqual({
+        foo: 'bar',
+      });
+    });
+
+    it('creates a SnapError without a message', () => {
+      const wrapped = new InvalidRequestError();
+
+      expect(wrapped.message).toBe(
+        'The JSON sent is not a valid Request object.',
+      );
+    });
+  });
+
+  describe('LimitExceededError', () => {
+    it('creates a SnapError', () => {
+      const wrapped = new LimitExceededError('foo');
+
+      expect(wrapped).toBeInstanceOf(Error);
+      expect(wrapped).toBeInstanceOf(SnapError);
+      expect(wrapped).toBeInstanceOf(LimitExceededError);
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.code).toBe(-32005);
+      expect(wrapped.data).toStrictEqual({});
+      expect(wrapped.stack).toBeDefined();
+      expect(wrapped.toJSON()).toStrictEqual({
+        code: -31002,
+        message: 'Snap Error',
+        data: {
+          cause: {
+            code: -32005,
+            message: 'foo',
+            stack: wrapped.stack,
+            data: {},
+          },
+        },
+      });
+    });
+
+    it('creates a SnapError with data', () => {
+      const wrapped = new LimitExceededError('foo', {
+        foo: 'bar',
+      });
+
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.data).toStrictEqual({
+        foo: 'bar',
+      });
+    });
+
+    it('creates a SnapError without a message', () => {
+      const wrapped = new LimitExceededError();
+
+      expect(wrapped.message).toBe('Request limit exceeded.');
+    });
+  });
+
+  describe('MethodNotFoundError', () => {
+    it('creates a SnapError', () => {
+      const wrapped = new MethodNotFoundError('foo');
+
+      expect(wrapped).toBeInstanceOf(Error);
+      expect(wrapped).toBeInstanceOf(SnapError);
+      expect(wrapped).toBeInstanceOf(MethodNotFoundError);
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.code).toBe(-32601);
+      expect(wrapped.data).toStrictEqual({});
+      expect(wrapped.stack).toBeDefined();
+      expect(wrapped.toJSON()).toStrictEqual({
+        code: -31002,
+        message: 'Snap Error',
+        data: {
+          cause: {
+            code: -32601,
+            message: 'foo',
+            stack: wrapped.stack,
+            data: {},
+          },
+        },
+      });
+    });
+
+    it('creates a SnapError with data', () => {
+      const wrapped = new MethodNotFoundError('foo', {
+        foo: 'bar',
+      });
+
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.data).toStrictEqual({
+        foo: 'bar',
+      });
+    });
+
+    it('creates a SnapError without a message', () => {
+      const wrapped = new MethodNotFoundError();
+
+      expect(wrapped.message).toBe(
+        'The method does not exist / is not available.',
+      );
+    });
+  });
+
+  describe('MethodNotSupportedError', () => {
+    it('creates a SnapError', () => {
+      const wrapped = new MethodNotSupportedError('foo');
+
+      expect(wrapped).toBeInstanceOf(Error);
+      expect(wrapped).toBeInstanceOf(SnapError);
+      expect(wrapped).toBeInstanceOf(MethodNotSupportedError);
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.code).toBe(-32004);
+      expect(wrapped.data).toStrictEqual({});
+      expect(wrapped.stack).toBeDefined();
+      expect(wrapped.toJSON()).toStrictEqual({
+        code: -31002,
+        message: 'Snap Error',
+        data: {
+          cause: {
+            code: -32004,
+            message: 'foo',
+            stack: wrapped.stack,
+            data: {},
+          },
+        },
+      });
+    });
+
+    it('creates a SnapError with data', () => {
+      const wrapped = new MethodNotSupportedError('foo', {
+        foo: 'bar',
+      });
+
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.data).toStrictEqual({
+        foo: 'bar',
+      });
+    });
+
+    it('creates a SnapError without a message', () => {
+      const wrapped = new MethodNotSupportedError();
+
+      expect(wrapped.message).toBe('Method not supported.');
+    });
+  });
+
+  describe('ParseError', () => {
+    it('creates a SnapError', () => {
+      const wrapped = new ParseError('foo');
+
+      expect(wrapped).toBeInstanceOf(Error);
+      expect(wrapped).toBeInstanceOf(SnapError);
+      expect(wrapped).toBeInstanceOf(ParseError);
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.code).toBe(-32700);
+      expect(wrapped.data).toStrictEqual({});
+      expect(wrapped.stack).toBeDefined();
+      expect(wrapped.toJSON()).toStrictEqual({
+        code: -31002,
+        message: 'Snap Error',
+        data: {
+          cause: {
+            code: -32700,
+            message: 'foo',
+            stack: wrapped.stack,
+            data: {},
+          },
+        },
+      });
+    });
+
+    it('creates a SnapError with data', () => {
+      const wrapped = new ParseError('foo', {
+        foo: 'bar',
+      });
+
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.data).toStrictEqual({
+        foo: 'bar',
+      });
+    });
+
+    it('creates a SnapError without a message', () => {
+      const wrapped = new ParseError();
+
+      expect(wrapped.message).toBe(
+        'Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text.',
+      );
+    });
+  });
+
+  describe('ResourceNotFoundError', () => {
+    it('creates a SnapError', () => {
+      const wrapped = new ResourceNotFoundError('foo');
+
+      expect(wrapped).toBeInstanceOf(Error);
+      expect(wrapped).toBeInstanceOf(SnapError);
+      expect(wrapped).toBeInstanceOf(ResourceNotFoundError);
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.code).toBe(-32001);
+      expect(wrapped.data).toStrictEqual({});
+      expect(wrapped.stack).toBeDefined();
+      expect(wrapped.toJSON()).toStrictEqual({
+        code: -31002,
+        message: 'Snap Error',
+        data: {
+          cause: {
+            code: -32001,
+            message: 'foo',
+            stack: wrapped.stack,
+            data: {},
+          },
+        },
+      });
+    });
+
+    it('creates a SnapError with data', () => {
+      const wrapped = new ResourceNotFoundError('foo', {
+        foo: 'bar',
+      });
+
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.data).toStrictEqual({
+        foo: 'bar',
+      });
+    });
+
+    it('creates a SnapError without a message', () => {
+      const wrapped = new ResourceNotFoundError();
+
+      expect(wrapped.message).toBe('Resource not found.');
+    });
+  });
+
+  describe('ResourceUnavailableError', () => {
+    it('creates a SnapError', () => {
+      const wrapped = new ResourceUnavailableError('foo');
+
+      expect(wrapped).toBeInstanceOf(Error);
+      expect(wrapped).toBeInstanceOf(SnapError);
+      expect(wrapped).toBeInstanceOf(ResourceUnavailableError);
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.code).toBe(-32002);
+      expect(wrapped.data).toStrictEqual({});
+      expect(wrapped.stack).toBeDefined();
+      expect(wrapped.toJSON()).toStrictEqual({
+        code: -31002,
+        message: 'Snap Error',
+        data: {
+          cause: {
+            code: -32002,
+            message: 'foo',
+            stack: wrapped.stack,
+            data: {},
+          },
+        },
+      });
+    });
+
+    it('creates a SnapError with data', () => {
+      const wrapped = new ResourceUnavailableError('foo', {
+        foo: 'bar',
+      });
+
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.data).toStrictEqual({
+        foo: 'bar',
+      });
+    });
+
+    it('creates a SnapError without a message', () => {
+      const wrapped = new ResourceUnavailableError();
+
+      expect(wrapped.message).toBe('Resource unavailable.');
+    });
+  });
+
+  describe('TransactionRejected', () => {
+    it('creates a SnapError', () => {
+      const wrapped = new TransactionRejected('foo');
+
+      expect(wrapped).toBeInstanceOf(Error);
+      expect(wrapped).toBeInstanceOf(SnapError);
+      expect(wrapped).toBeInstanceOf(TransactionRejected);
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.code).toBe(-32003);
+      expect(wrapped.data).toStrictEqual({});
+      expect(wrapped.stack).toBeDefined();
+      expect(wrapped.toJSON()).toStrictEqual({
+        code: -31002,
+        message: 'Snap Error',
+        data: {
+          cause: {
+            code: -32003,
+            message: 'foo',
+            stack: wrapped.stack,
+            data: {},
+          },
+        },
+      });
+    });
+
+    it('creates a SnapError with data', () => {
+      const wrapped = new TransactionRejected('foo', {
+        foo: 'bar',
+      });
+
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.data).toStrictEqual({
+        foo: 'bar',
+      });
+    });
+
+    it('creates a SnapError without a message', () => {
+      const wrapped = new TransactionRejected();
+
+      expect(wrapped.message).toBe('Transaction rejected.');
+    });
+  });
+
+  describe('ChainDisconnectedError', () => {
+    it('creates a SnapError', () => {
+      const wrapped = new ChainDisconnectedError('foo');
+
+      expect(wrapped).toBeInstanceOf(Error);
+      expect(wrapped).toBeInstanceOf(SnapError);
+      expect(wrapped).toBeInstanceOf(ChainDisconnectedError);
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.code).toBe(4901);
+      expect(wrapped.data).toStrictEqual({});
+      expect(wrapped.stack).toBeDefined();
+      expect(wrapped.toJSON()).toStrictEqual({
+        code: -31002,
+        message: 'Snap Error',
+        data: {
+          cause: {
+            code: 4901,
+            message: 'foo',
+            stack: wrapped.stack,
+            data: {},
+          },
+        },
+      });
+    });
+
+    it('creates a SnapError with data', () => {
+      const wrapped = new ChainDisconnectedError('foo', {
+        foo: 'bar',
+      });
+
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.data).toStrictEqual({
+        foo: 'bar',
+      });
+    });
+
+    it('creates a SnapError without a message', () => {
+      const wrapped = new ChainDisconnectedError();
+
+      expect(wrapped.message).toBe(
+        'The provider is disconnected from the specified chain.',
+      );
+    });
+  });
+
+  describe('DisconnectedError', () => {
+    it('creates a SnapError', () => {
+      const wrapped = new DisconnectedError('foo');
+
+      expect(wrapped).toBeInstanceOf(Error);
+      expect(wrapped).toBeInstanceOf(SnapError);
+      expect(wrapped).toBeInstanceOf(DisconnectedError);
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.code).toBe(4900);
+      expect(wrapped.data).toStrictEqual({});
+      expect(wrapped.stack).toBeDefined();
+      expect(wrapped.toJSON()).toStrictEqual({
+        code: -31002,
+        message: 'Snap Error',
+        data: {
+          cause: {
+            code: 4900,
+            message: 'foo',
+            stack: wrapped.stack,
+            data: {},
+          },
+        },
+      });
+    });
+
+    it('creates a SnapError with data', () => {
+      const wrapped = new DisconnectedError('foo', {
+        foo: 'bar',
+      });
+
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.data).toStrictEqual({
+        foo: 'bar',
+      });
+    });
+
+    it('creates a SnapError without a message', () => {
+      const wrapped = new DisconnectedError();
+
+      expect(wrapped.message).toBe(
+        'The provider is disconnected from all chains.',
+      );
+    });
+  });
+
+  describe('UnauthorizedError', () => {
+    it('creates a SnapError', () => {
+      const wrapped = new UnauthorizedError('foo');
+
+      expect(wrapped).toBeInstanceOf(Error);
+      expect(wrapped).toBeInstanceOf(SnapError);
+      expect(wrapped).toBeInstanceOf(UnauthorizedError);
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.code).toBe(4100);
+      expect(wrapped.data).toStrictEqual({});
+      expect(wrapped.stack).toBeDefined();
+      expect(wrapped.toJSON()).toStrictEqual({
+        code: -31002,
+        message: 'Snap Error',
+        data: {
+          cause: {
+            code: 4100,
+            message: 'foo',
+            stack: wrapped.stack,
+            data: {},
+          },
+        },
+      });
+    });
+
+    it('creates a SnapError with data', () => {
+      const wrapped = new UnauthorizedError('foo', {
+        foo: 'bar',
+      });
+
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.data).toStrictEqual({
+        foo: 'bar',
+      });
+    });
+
+    it('creates a SnapError without a message', () => {
+      const wrapped = new UnauthorizedError();
+
+      expect(wrapped.message).toBe(
+        'The requested account and/or method has not been authorized by the user.',
+      );
+    });
+  });
+
+  describe('UnsupportedMethodError', () => {
+    it('creates a SnapError', () => {
+      const wrapped = new UnsupportedMethodError('foo');
+
+      expect(wrapped).toBeInstanceOf(Error);
+      expect(wrapped).toBeInstanceOf(SnapError);
+      expect(wrapped).toBeInstanceOf(UnsupportedMethodError);
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.code).toBe(4200);
+      expect(wrapped.data).toStrictEqual({});
+      expect(wrapped.stack).toBeDefined();
+      expect(wrapped.toJSON()).toStrictEqual({
+        code: -31002,
+        message: 'Snap Error',
+        data: {
+          cause: {
+            code: 4200,
+            message: 'foo',
+            stack: wrapped.stack,
+            data: {},
+          },
+        },
+      });
+    });
+
+    it('creates a SnapError with data', () => {
+      const wrapped = new UnsupportedMethodError('foo', {
+        foo: 'bar',
+      });
+
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.data).toStrictEqual({
+        foo: 'bar',
+      });
+    });
+
+    it('creates a SnapError without a message', () => {
+      const wrapped = new UnsupportedMethodError();
+
+      expect(wrapped.message).toBe(
+        'The requested method is not supported by this Ethereum provider.',
+      );
+    });
+  });
+
+  describe('UserRejectedRequestError', () => {
+    it('creates a SnapError', () => {
+      const wrapped = new UserRejectedRequestError('foo');
+
+      expect(wrapped).toBeInstanceOf(Error);
+      expect(wrapped).toBeInstanceOf(SnapError);
+      expect(wrapped).toBeInstanceOf(UserRejectedRequestError);
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.code).toBe(4001);
+      expect(wrapped.data).toStrictEqual({});
+      expect(wrapped.stack).toBeDefined();
+      expect(wrapped.toJSON()).toStrictEqual({
+        code: -31002,
+        message: 'Snap Error',
+        data: {
+          cause: {
+            code: 4001,
+            message: 'foo',
+            stack: wrapped.stack,
+            data: {},
+          },
+        },
+      });
+    });
+
+    it('creates a SnapError with data', () => {
+      const wrapped = new UserRejectedRequestError('foo', {
+        foo: 'bar',
+      });
+
+      expect(wrapped.message).toBe('foo');
+      expect(wrapped.data).toStrictEqual({
+        foo: 'bar',
+      });
+    });
+
+    it('creates a SnapError without a message', () => {
+      const wrapped = new UserRejectedRequestError();
+
+      expect(wrapped.message).toBe('User rejected the request.');
+    });
+  });
+});

--- a/packages/snaps-sdk/src/error-wrappers.ts
+++ b/packages/snaps-sdk/src/error-wrappers.ts
@@ -1,0 +1,173 @@
+import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
+
+import { createSnapError } from './internals';
+
+/**
+ * A JSON-RPC 2.0 Internal (-32603) error.
+ *
+ * This can be thrown by a Snap to indicate that an internal error occurred,
+ * without crashing the Snap.
+ *
+ * @see https://www.jsonrpc.org/specification#error_object
+ */
+export const InternalError = createSnapError(rpcErrors.internal);
+
+/**
+ * An Ethereum JSON-RPC Invalid Input (-32000) error.
+ *
+ * This can be thrown by a Snap to indicate that the input to a method is
+ * invalid, without crashing the Snap.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-1474#error-codes
+ */
+export const InvalidInputError = createSnapError(rpcErrors.invalidInput);
+
+/**
+ * A JSON-RPC 2.0 Invalid Params (-32602) error.
+ *
+ * This can be thrown by a Snap to indicate that the parameters to a method are
+ * invalid, without crashing the Snap.
+ *
+ * @see https://www.jsonrpc.org/specification#error_object
+ */
+export const InvalidParamsError = createSnapError(rpcErrors.invalidParams);
+
+/**
+ * A JSON-RPC 2.0 Invalid Request (-32600) error.
+ *
+ * This can be thrown by a Snap to indicate that the request is invalid, without
+ * crashing the Snap.
+ *
+ * @see https://www.jsonrpc.org/specification#error_object
+ */
+export const InvalidRequestError = createSnapError(rpcErrors.invalidRequest);
+
+/**
+ * An Ethereum JSON-RPC Limit Exceeded (-32005) error.
+ *
+ * This can be thrown by a Snap to indicate that a limit has been exceeded,
+ * without crashing the Snap.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-1474#error-codes
+ */
+export const LimitExceededError = createSnapError(rpcErrors.limitExceeded);
+
+/**
+ * An Ethereum JSON-RPC Method Not Found (-32601) error.
+ *
+ * This can be thrown by a Snap to indicate that a method does not exist,
+ * without crashing the Snap.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-1474#error-codes
+ */
+export const MethodNotFoundError = createSnapError(rpcErrors.methodNotFound);
+
+/**
+ * An Ethereum JSON-RPC Method Not Supported (-32004) error.
+ *
+ * This can be thrown by a Snap to indicate that a method is not supported,
+ * without crashing the Snap.
+ */
+export const MethodNotSupportedError = createSnapError(
+  rpcErrors.methodNotSupported,
+);
+
+/**
+ * A JSON-RPC 2.0 Parse (-32700) error.
+ *
+ * This can be thrown by a Snap to indicate that a request is not valid JSON,
+ * without crashing the Snap.
+ *
+ * @see https://www.jsonrpc.org/specification#error_object
+ */
+export const ParseError = createSnapError(rpcErrors.parse);
+
+/**
+ * An Ethereum JSON-RPC Resource Not Found (-32001) error.
+ *
+ * This can be thrown by a Snap to indicate that a resource does not exist,
+ * without crashing the Snap.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-1474#error-codes
+ */
+export const ResourceNotFoundError = createSnapError(
+  rpcErrors.resourceNotFound,
+);
+
+/**
+ * An Ethereum JSON-RPC Resource Unavailable (-32002) error.
+ *
+ * This can be thrown by a Snap to indicate that a resource is unavailable,
+ * without crashing the Snap.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-1474#error-codes
+ */
+export const ResourceUnavailableError = createSnapError(
+  rpcErrors.resourceUnavailable,
+);
+
+/**
+ * An Ethereum JSON-RPC Transaction Rejected (-32003) error.
+ *
+ * This can be thrown by a Snap to indicate that a transaction was rejected,
+ * without crashing the Snap.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-1474#error-codes
+ */
+export const TransactionRejected = createSnapError(
+  rpcErrors.transactionRejected,
+);
+
+/**
+ * An Ethereum Provider Chain Disconnected (4901) error.
+ *
+ * This can be thrown by a Snap to indicate that the provider is disconnected
+ * from the requested chain, without crashing the Snap.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-1193#provider-errors
+ */
+export const ChainDisconnectedError = createSnapError(
+  providerErrors.chainDisconnected,
+);
+
+/**
+ * An Ethereum Provider Disconnected (4900) error.
+ *
+ * This can be thrown by a Snap to indicate that the provider is disconnected,
+ * without crashing the Snap.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-1193#provider-errors
+ */
+export const DisconnectedError = createSnapError(providerErrors.disconnected);
+
+/**
+ * An Ethereum Provider Unauthorized (4100) error.
+ *
+ * This can be thrown by a Snap to indicate that the requested method / account
+ * is not authorized by the user, without crashing the Snap.
+ */
+export const UnauthorizedError = createSnapError(providerErrors.unauthorized);
+
+/**
+ * An Ethereum Provider Unsupported Method (4200) error.
+ *
+ * This can be thrown by a Snap to indicate that the requested method is not
+ * supported by the provider, without crashing the Snap.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-1193#provider-errors
+ */
+export const UnsupportedMethodError = createSnapError(
+  providerErrors.unsupportedMethod,
+);
+
+/**
+ * An Ethereum Provider User Rejected Request (4001) error.
+ *
+ * This can be thrown by a Snap to indicate that the user rejected the request,
+ * without crashing the Snap.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-1193#provider-errors
+ */
+export const UserRejectedRequestError = createSnapError(
+  providerErrors.userRejectedRequest,
+);

--- a/packages/snaps-sdk/src/internals/error-wrappers.test.ts
+++ b/packages/snaps-sdk/src/internals/error-wrappers.test.ts
@@ -1,0 +1,30 @@
+import { rpcErrors } from '@metamask/rpc-errors';
+
+import { SnapError } from '../errors';
+import { createSnapError } from './error-wrappers';
+
+describe('createSnapError', () => {
+  it('creates a SnapError from an rpc-errors function', () => {
+    const Constructor = createSnapError(rpcErrors.invalidParams);
+    const error = new Constructor('foo');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(SnapError);
+    expect(error.message).toBe('foo');
+    expect(error.code).toBe(-32602);
+    expect(error.data).toStrictEqual({});
+    expect(error.stack).toBeDefined();
+    expect(error.toJSON()).toStrictEqual({
+      code: -31002,
+      message: 'Snap Error',
+      data: {
+        cause: {
+          code: -32602,
+          message: 'foo',
+          stack: error.stack,
+          data: {},
+        },
+      },
+    });
+  });
+});

--- a/packages/snaps-sdk/src/internals/error-wrappers.ts
+++ b/packages/snaps-sdk/src/internals/error-wrappers.ts
@@ -1,0 +1,31 @@
+import type { rpcErrors } from '@metamask/rpc-errors';
+import type { Json } from '@metamask/utils';
+
+import { SnapError } from '../errors';
+
+export type JsonRpcErrorFunction = typeof rpcErrors.parse;
+
+/**
+ * Create a `SnapError` class from an error function from
+ * `@metamask/rpc-errors`. This is useful for creating custom error classes
+ * which can be thrown by a Snap.
+ *
+ * The created class will inherit the message, code, and data properties from
+ * the error function.
+ *
+ * @param fn - The error function to create the class from.
+ * @returns The created `SnapError` class.
+ */
+export function createSnapError(fn: JsonRpcErrorFunction) {
+  return class SnapJsonRpcError extends SnapError {
+    constructor(message?: string, data?: Record<string, Json>) {
+      const error = fn(message);
+
+      super({
+        code: error.code,
+        message: error.message,
+        data,
+      });
+    }
+  };
+}

--- a/packages/snaps-sdk/src/internals/index.ts
+++ b/packages/snaps-sdk/src/internals/index.ts
@@ -1,2 +1,3 @@
+export * from './error-wrappers';
 export * from './errors';
 export * from './helpers';


### PR DESCRIPTION
This adds Snap error wrappers of `@metamask/rpc-errors`' error functions. All error functions are wrapped in a class that extends `SnapError`, meaning they can be thrown without causing the Snap to crash.

These errors should not be thrown from internal APIs.

Closes #1825.