### PR TITLE
Bump Chromedriver to `^119.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@types/node": "18.14.2",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
-    "chromedriver": "^118.0.1",
+    "chromedriver": "^119.0.0",
     "depcheck": "^1.4.7",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",

--- a/scripts/install-chrome.sh
+++ b/scripts/install-chrome.sh
@@ -5,12 +5,12 @@ set -u
 set -o pipefail
 
 # To get the latest version, see <https://www.ubuntuupdates.org/ppa/google_chrome?dist=stable>
-CHROME_VERSION='118.0.5993.88-1'
+CHROME_VERSION='119.0.6045.105-1'
 CHROME_BINARY="google-chrome-stable_${CHROME_VERSION}_amd64.deb"
 CHROME_BINARY_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/${CHROME_BINARY}"
 
 # To retrieve this checksum, run the `wget` and `shasum` commands below
-CHROME_BINARY_SHA512SUM='cae6a5cd8632ad350b41f4dfaf80449e6cf19d0b02816b9a1600f54b15df2adf5c4ded3792bfbe3855fa11a79ea256622f50180aa3c6779cedd75a55e7a6da9d'
+CHROME_BINARY_SHA512SUM='57526e6e5b9d5936e22555b879d066347da011a8b5f3f207bb5a353e1668accd87d7e789eab48250397c7bfec1682413a699ee4b33604493ef001a895558e7b2'
 
 wget -O "${CHROME_BINARY}" -t 5 "${CHROME_BINARY_URL}"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10012,9 +10012,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromedriver@npm:^118.0.1":
-  version: 118.0.1
-  resolution: "chromedriver@npm:118.0.1"
+"chromedriver@npm:^119.0.0":
+  version: 119.0.0
+  resolution: "chromedriver@npm:119.0.0"
   dependencies:
     "@testim/chrome-version": ^1.1.3
     axios: ^1.4.0
@@ -10025,7 +10025,7 @@ __metadata:
     tcp-port-used: ^1.0.1
   bin:
     chromedriver: bin/chromedriver
-  checksum: a9dc76ee3d411ae7db51ea709ab22823178e460d52763a8353ac64cad9760a47ebb1f86475390e66280d004cc79a9775d99b9cdb62b11a04cc6deff22ea8ef82
+  checksum: a54790c55f7c07606ee378eeb144e289660f859ae1d625a89297de9b376e6cf4e86776bfb09708d7220264052b5f9a0755d760a1c1c80f1a9053718d4c5132a8
   languageName: node
   linkType: hard
 
@@ -20137,7 +20137,7 @@ __metadata:
     "@types/node": 18.14.2
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
-    chromedriver: ^118.0.1
+    chromedriver: ^119.0.0
     depcheck: ^1.4.7
     eslint: ^8.27.0
     eslint-config-prettier: ^8.5.0


### PR DESCRIPTION
This bumps `chromedriver` to `^119.0.0` to match the latest stable Google Chrome version.