### PR TITLE
deps(snaps-controllers): @metamask/object-multiplex@^1.2.0->^2.0.0

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -136,6 +136,8 @@ gen_enforced_dependency(WorkspaceCwd, DependencyIdent, OtherDependencyRange, Dep
   workspace_has_dependency(OtherWorkspaceCwd, DependencyIdent, OtherDependencyRange, OtherDependencyType),
   WorkspaceCwd \= OtherWorkspaceCwd,
   DependencyRange \= OtherDependencyRange,
+  % TODO: Remove below line once @metamask/object-multiplex is bumped to ^2.0.0 in snaps-execution-environments
+  DependencyIdent \= '@metamask/object-multiplex',
   npm_version_range_out_of_sync(DependencyRange, OtherDependencyRange).
 
 % If a dependency is listed under "dependencies", it should not be listed under

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -45,7 +45,7 @@
     "@metamask/approval-controller": "^4.1.0",
     "@metamask/base-controller": "^3.2.0",
     "@metamask/json-rpc-engine": "^7.1.1",
-    "@metamask/object-multiplex": "^1.2.0",
+    "@metamask/object-multiplex": "^2.0.0",
     "@metamask/permission-controller": "^5.0.0",
     "@metamask/phishing-controller": "^7.0.0",
     "@metamask/post-message-stream": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4850,6 +4850,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/object-multiplex@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/object-multiplex@npm:2.0.0"
+  dependencies:
+    once: ^1.4.0
+    readable-stream: ^3.6.2
+  checksum: 54baea752a3ac7c2742c376512e00d4902d383e9da8787574d3b21eb0081523309e24e3915a98f3ae0341d65712b6832d2eb7eeb862f4ef0da1ead52dcde5387
+  languageName: node
+  linkType: hard
+
 "@metamask/permission-controller@npm:^5.0.0":
   version: 5.0.0
   resolution: "@metamask/permission-controller@npm:5.0.0"
@@ -5135,7 +5145,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/json-rpc-engine": ^7.1.1
-    "@metamask/object-multiplex": ^1.2.0
+    "@metamask/object-multiplex": ^2.0.0
     "@metamask/permission-controller": ^5.0.0
     "@metamask/phishing-controller": ^7.0.0
     "@metamask/post-message-stream": ^7.0.0


### PR DESCRIPTION
- `@metamask/snaps-controllers`: **BREAKING**: Bump `@metamask/object-multiplex` from `^1.2.0` to `^2.0.0`
  - [CHANGELOG](https://github.com/MetaMask/object-multiplex/blob/main/CHANGELOG.md)

#### Blocking
- https://github.com/MetaMask/keyring-api/pull/183