### PR TITLE
Await stream communication

### DIFF
--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 81.29,
-  "functions": 92.59,
-  "lines": 92.03,
-  "statements": 91.71
+  "branches": 80.71,
+  "functions": 92.02,
+  "lines": 91.66,
+  "statements": 91.36
 }

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1607,6 +1607,11 @@ describe('BaseSnapExecutor', () => {
     });
 
     expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      method: 'OutboundResponse',
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
       id: 3,
       jsonrpc: '2.0',
       result: 'Timeout resolved for second call.',
@@ -1709,6 +1714,11 @@ describe('BaseSnapExecutor', () => {
           code: -1000,
         },
       },
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      method: 'OutboundResponse',
     });
 
     expect(await executor.readCommand()).toStrictEqual({

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -450,12 +450,17 @@ export class BaseSnapExecutor {
     const request = async (args: RequestArguments) => {
       const sanitizedArgs = sanitizeRequestArguments(args);
       assertSnapOutboundRequest(sanitizedArgs);
-      await this.#notify({ method: 'OutboundRequest' });
-      try {
-        return await withTeardown(originalRequest(sanitizedArgs), this as any);
-      } finally {
-        await this.#notify({ method: 'OutboundResponse' });
-      }
+      return await withTeardown(
+        (async () => {
+          await this.#notify({ method: 'OutboundRequest' });
+          try {
+            return await originalRequest(sanitizedArgs);
+          } finally {
+            await this.#notify({ method: 'OutboundResponse' });
+          }
+        })(),
+        this as any,
+      );
     };
 
     // Proxy target is intentionally set to be an empty object, to ensure
@@ -491,12 +496,17 @@ export class BaseSnapExecutor {
     const request = async (args: RequestArguments) => {
       const sanitizedArgs = sanitizeRequestArguments(args);
       assertEthereumOutboundRequest(sanitizedArgs);
-      await this.#notify({ method: 'OutboundRequest' });
-      try {
-        return await withTeardown(originalRequest(sanitizedArgs), this as any);
-      } finally {
-        await this.#notify({ method: 'OutboundResponse' });
-      }
+      return await withTeardown(
+        (async () => {
+          await this.#notify({ method: 'OutboundRequest' });
+          try {
+            return await originalRequest(sanitizedArgs);
+          } finally {
+            await this.#notify({ method: 'OutboundResponse' });
+          }
+        })(),
+        this as any,
+      );
     };
 
     const streamProviderProxy = proxyStreamProvider(provider, request);

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -264,6 +264,8 @@ export class BaseSnapExecutor {
   }
 
   // Awaitable function that writes back to the command stream
+  // To prevent snap execution from blocking writing we wrap in a promise
+  // and await it before continuing execution
   async #write(chunk: Json) {
     return new Promise<void>((resolve, reject) => {
       this.commandStream.write(chunk, (error) => {


### PR DESCRIPTION
Await stream communication calls to ensure message delivery. This prevents issues where a snap could grab execution and prevent stream messages from being reliably delivered.