### PR TITLE
Set `snaps-sdk` version to `0.0.0`

### DIFF
--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-sdk",
-  "version": "3.1.0",
+  "version": "0.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"


### PR DESCRIPTION
The package isn't published yet, so the version should be `0.0.0`.