### PR TITLE
Revert "Release 17.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "17.0.0",
+  "version": "16.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/create-snap/CHANGELOG.md
+++ b/packages/create-snap/CHANGELOG.md
@@ -6,13 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.1.0]
-### Added
-- Create an initial commit when creating a Snap from the template ([#1917](https://github.com/MetaMask/snaps/pull/1917))
-
-### Fixed
-- Handle unhandled errors ([#1916](https://github.com/MetaMask/snaps/pull/1916))
-
 ## [3.0.1]
 ### Changed
 - Update multiple MetaMask dependencies ([#1841](https://github.com/MetaMask/snaps/pull/1841))
@@ -47,8 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@3.1.0...HEAD
-[3.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@3.0.1...@metamask/create-snap@3.1.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@3.0.1...HEAD
 [3.0.1]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@3.0.0...@metamask/create-snap@3.0.1
 [3.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@2.0.0...@metamask/create-snap@3.0.0
 [2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@1.0.1...@metamask/create-snap@2.0.0

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/create-snap",
-  "version": "3.1.0",
+  "version": "3.0.1",
   "description": "A CLI for creating MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/example-snaps",
-  "version": "2.1.0",
+  "version": "2.0.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/examples/packages/home-page/CHANGELOG.md
+++ b/packages/examples/packages/home-page/CHANGELOG.md
@@ -6,9 +6,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Added
-- Initial release ([#1918](https://github.com/MetaMask/snaps/pull/1918))
-
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/home-page-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/releases/tag/@metamask/home-page-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/

--- a/packages/examples/packages/home-page/package.json
+++ b/packages/examples/packages/home-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/home-page-example-snap",
-  "version": "1.0.0",
+  "version": "2.0.1",
   "description": "MetaMask example snap demonstrating the use of home pages.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "2.0.1",
   "description": "MetaMask example snap demonstrating the use of home pages.",
   "proposedName": "Home Page Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "h4lZbWhqk2nDiYbAKV4Rtxuk7COhpHQ3Cs4dpcyOZA8=",
+    "shasum": "z1oaU6dzx96vdZaigaRbphPUNuqfDEMmY/eFmJfB36Q=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/CHANGELOG.md
+++ b/packages/examples/packages/localization/CHANGELOG.md
@@ -6,9 +6,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-### Added
-- Initial release ([#1889](https://github.com/MetaMask/snaps/pull/1889))
-
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/localization-example-snap@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/snaps/releases/tag/@metamask/localization-example-snap@1.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/

--- a/packages/examples/packages/localization/package.json
+++ b/packages/examples/packages/localization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/localization-example-snap",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "MetaMask example snap demonstrating how to localize a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "{{ description }}",
   "proposedName": "{{ name }}",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "RJaMLctawZfKf8pgIVsEMs0mL+uFSN/z9EiaCcHs7rM=",
+    "shasum": "oTKaUSb5S2GF/j+yCW1it4KIOrk3Mr0lXMUKM1CK7fA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/CHANGELOG.md
+++ b/packages/examples/packages/manage-state/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0]
-### Changed
-- Add support for unencrypted storage ([#1915](https://github.com/MetaMask/snaps/pull/1915))
-
 ## [2.0.1]
 ### Changed
 - Update multiple MetaMask dependencies ([#1841](https://github.com/MetaMask/snaps/pull/1841))
@@ -40,8 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@2.1.0...HEAD
-[2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@2.0.1...@metamask/manage-state-example-snap@2.1.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@2.0.1...HEAD
 [2.0.1]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@2.0.0...@metamask/manage-state-example-snap@2.0.1
 [2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@1.0.0...@metamask/manage-state-example-snap@2.0.0
 [1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@0.38.1-flask.1...@metamask/manage-state-example-snap@1.0.0

--- a/packages/examples/packages/manage-state/package.json
+++ b/packages/examples/packages/manage-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/manage-state-example-snap",
-  "version": "2.1.0",
+  "version": "2.0.1",
   "description": "MetaMask example snap demonstrating the use of `snap_manageState`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.0",
+  "version": "2.0.1",
   "description": "MetaMask example snap demonstrating the use of `snap_manageState`.",
   "proposedName": "Manage State Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ACW7x+/92AYr+m6wrXmAR5A6TSPlDRh1oeISc6V0zNI=",
+    "shasum": "A0VD6n5CcgM3RexT3/lfupBZExAcutrhbdJKh+Qcsog=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/CHANGELOG.md
+++ b/packages/examples/packages/transaction-insights/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.2]
-### Changed
-- Update example insight snap to support transaction insights v2 ([#1911](https://github.com/MetaMask/snaps/pull/1911))
-
 ## [2.0.1]
 ### Changed
 - Update multiple MetaMask dependencies ([#1841](https://github.com/MetaMask/snaps/pull/1841))
@@ -40,8 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@2.0.2...HEAD
-[2.0.2]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@2.0.1...@metamask/insights-example-snap@2.0.2
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@2.0.1...HEAD
 [2.0.1]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@2.0.0...@metamask/insights-example-snap@2.0.1
 [2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@1.0.0...@metamask/insights-example-snap@2.0.0
 [1.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@0.38.1-flask.1...@metamask/insights-example-snap@1.0.0

--- a/packages/examples/packages/transaction-insights/package.json
+++ b/packages/examples/packages/transaction-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/insights-example-snap",
-  "version": "2.0.2",
+  "version": "2.0.1",
   "description": "MetaMask example snap demonstrating the use of the Transaction Insights API.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2",
+  "version": "2.0.1",
   "description": "MetaMask example snap demonstrating the use of the Transaction Insights API.",
   "proposedName": "Insights Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "zLSzD33NlFTiWARmNKmmWZNv8dXmDkszSLApTnGDyRk=",
+    "shasum": "aP4ofH4R8Mf1YOYueZaK+b+oMDGmWu7tebNhHmRPbQc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-controllers/CHANGELOG.md
+++ b/packages/snaps-controllers/CHANGELOG.md
@@ -6,12 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.3.0]
-### Added
-- Add manifest localization functionality ([#1889](https://github.com/MetaMask/snaps/pull/1889))
-- Add support for unencrypted storage using `snap_manageState` ([#1902](https://github.com/MetaMask/snaps/pull/1902))
-- Add `OnHomePage` export ([#1896](https://github.com/MetaMask/snaps/pull/1896))
-
 ## [3.2.0]
 ### Added
 - Add support for links in custom UI and notifications ([#1814](https://github.com/MetaMask/snaps/pull/1814))
@@ -107,8 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@3.3.0...HEAD
-[3.3.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@3.2.0...@metamask/snaps-controllers@3.3.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@3.2.0...HEAD
 [3.2.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@3.1.1...@metamask/snaps-controllers@3.2.0
 [3.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@3.1.0...@metamask/snaps-controllers@3.1.1
 [3.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@3.0.0...@metamask/snaps-controllers@3.1.0

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-controllers",
-  "version": "3.3.0",
+  "version": "3.2.0",
   "description": "Controllers for MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-execution-environments/CHANGELOG.md
+++ b/packages/snaps-execution-environments/CHANGELOG.md
@@ -6,13 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.2.0]
-### Added
-- Add `OnHomePage` export ([#1896](https://github.com/MetaMask/snaps/pull/1896))
-
-### Fixed
-- Await stream message delivery ([#1928](https://github.com/MetaMask/snaps/pull/1928))
-
 ## [3.1.0]
 ### Changed
 - Improve error handling ([#1841](https://github.com/MetaMask/snaps/pull/1841))
@@ -91,8 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@3.2.0...HEAD
-[3.2.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@3.1.0...@metamask/snaps-execution-environments@3.2.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@3.1.0...HEAD
 [3.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@3.0.0...@metamask/snaps-execution-environments@3.1.0
 [3.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@2.0.1...@metamask/snaps-execution-environments@3.0.0
 [2.0.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@2.0.0...@metamask/snaps-execution-environments@2.0.1

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-execution-environments",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "description": "Snap sandbox environments for executing SES javascript",
   "repository": {
     "type": "git",

--- a/packages/snaps-rpc-methods/CHANGELOG.md
+++ b/packages/snaps-rpc-methods/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.3.0]
-### Added
-- Add support for unencrypted storage using `snap_manageState` ([#1902](https://github.com/MetaMask/snaps/pull/1902))
-
 ## [3.2.1]
 ### Fixed
 - Fix `assertLinksAreSafe` import ([#1908](https://github.com/MetaMask/snaps/pull/1908))
@@ -61,8 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rpc-methods@3.3.0...HEAD
-[3.3.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rpc-methods@3.2.1...@metamask/snaps-rpc-methods@3.3.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rpc-methods@3.2.1...HEAD
 [3.2.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rpc-methods@3.2.0...@metamask/snaps-rpc-methods@3.2.1
 [3.2.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rpc-methods@3.1.0...@metamask/snaps-rpc-methods@3.2.0
 [3.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rpc-methods@3.0.0...@metamask/snaps-rpc-methods@3.1.0

--- a/packages/snaps-rpc-methods/package.json
+++ b/packages/snaps-rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-rpc-methods",
-  "version": "3.3.0",
+  "version": "3.2.1",
   "description": "MetaMask Snaps JSON-RPC method implementations.",
   "repository": {
     "type": "git",

--- a/packages/snaps-simulator/CHANGELOG.md
+++ b/packages/snaps-simulator/CHANGELOG.md
@@ -6,11 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.3.0]
-### Added
-- Add manifest localization functionality ([#1889](https://github.com/MetaMask/snaps/pull/1889))
-- Add support for unencrypted storage using `snap_manageState` ([#1902](https://github.com/MetaMask/snaps/pull/1902))
-
 ## [2.2.0]
 ### Added
 - Add support for links in custom UI ([#1814](https://github.com/MetaMask/snaps/pull/1814))
@@ -61,8 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@2.3.0...HEAD
-[2.3.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@2.2.0...@metamask/snaps-simulator@2.3.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@2.2.0...HEAD
 [2.2.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@2.1.0...@metamask/snaps-simulator@2.2.0
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@2.0.0...@metamask/snaps-simulator@2.1.0
 [2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-simulator@1.0.0...@metamask/snaps-simulator@2.0.0

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-simulator",
-  "version": "2.3.0",
+  "version": "2.2.0",
   "description": "A simulator for MetaMask Snaps, to be used for testing and development",
   "homepage": "https://github.com/MetaMask/snaps#readme",
   "bugs": {

--- a/packages/snaps-types/CHANGELOG.md
+++ b/packages/snaps-types/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.1.0]
-### Added
-- Add types for `OnHomePage` export ([#1918](https://github.com/MetaMask/snaps/pull/1918))
-
 ## [3.0.1]
 ### Changed
 - Update multiple MetaMask dependencies ([#1841](https://github.com/MetaMask/snaps/pull/1841))
@@ -53,8 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@3.1.0...HEAD
-[3.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@3.0.1...@metamask/snaps-types@3.1.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@3.0.1...HEAD
 [3.0.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@3.0.0...@metamask/snaps-types@3.0.1
 [3.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@2.0.0...@metamask/snaps-types@3.0.0
 [2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-types@0.38.3-flask.1...@metamask/snaps-types@2.0.0

--- a/packages/snaps-types/package.json
+++ b/packages/snaps-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-types",
-  "version": "3.1.0",
+  "version": "3.0.1",
   "description": "TypeScript types for developing MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-utils/CHANGELOG.md
+++ b/packages/snaps-utils/CHANGELOG.md
@@ -6,11 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.3.0]
-### Added
-- Add manifest localization functionality ([#1889](https://github.com/MetaMask/snaps/pull/1889))
-- Add `OnHomePage` export ([#1896](https://github.com/MetaMask/snaps/pull/1896))
-
 ## [3.2.0]
 ### Added
 - Add support for links in custom UI and notifications ([#1814](https://github.com/MetaMask/snaps/pull/1814))
@@ -76,8 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@3.3.0...HEAD
-[3.3.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@3.2.0...@metamask/snaps-utils@3.3.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@3.2.0...HEAD
 [3.2.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@3.1.0...@metamask/snaps-utils@3.2.0
 [3.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@3.0.0...@metamask/snaps-utils@3.1.0
 [3.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@2.0.1...@metamask/snaps-utils@3.0.0

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-utils",
-  "version": "3.3.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/test-snaps/CHANGELOG.md
+++ b/packages/test-snaps/CHANGELOG.md
@@ -6,14 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.2.0]
-### Added
-- Add home page example ([#1918](https://github.com/MetaMask/snaps/pull/1918))
-
-### Changed
-- Replace `getLocale` example with localization example ([#1889](https://github.com/MetaMask/snaps/pull/1889))
-- Update manage state example ([#1915](https://github.com/MetaMask/snaps/pull/1915))
-
 ## [2.1.0]
 ### Added
 - Add `snap_getFile` example snap ([#1893](https://github.com/MetaMask/snaps/pull/1893))
@@ -63,8 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix NPM package name of the network access snap ([#1621](https://github.com/MetaMask/snaps/pull/1621))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@2.2.0...HEAD
-[2.2.0]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@2.1.0...@metamask/test-snaps@2.2.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@2.1.0...HEAD
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@2.0.1...@metamask/test-snaps@2.1.0
 [2.0.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@2.0.0...@metamask/test-snaps@2.0.1
 [2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@1.1.0...@metamask/test-snaps@2.0.0

--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-snaps",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "private": true,
   "description": "The test snaps website for MetaMask Snaps, used for end-to-end testing.",
   "repository": {


### PR DESCRIPTION
Reverts MetaMask/snaps#1939

There was a problem with the release due to an incorrectly set version of an unreleased package.