### PR TITLE
Add missing reference to `snaps-execution-environments` in `snaps-simulator`

### DIFF
--- a/packages/snaps-simulator/tsconfig.build.json
+++ b/packages/snaps-simulator/tsconfig.build.json
@@ -17,6 +17,7 @@
     "./src/**/__snapshots__"
   ],
   "references": [
+    { "path": "../snaps-execution-environments/tsconfig.build.json" },
     { "path": "../snaps-rpc-methods/tsconfig.build.json" },
     { "path": "../snaps-controllers/tsconfig.build.json" },
     { "path": "../snaps-utils/tsconfig.build.json" },

--- a/packages/snaps-simulator/tsconfig.json
+++ b/packages/snaps-simulator/tsconfig.json
@@ -7,6 +7,7 @@
   },
   "include": ["./src", "webpack.config.ts", "package.json"],
   "references": [
+    { "path": "../snaps-execution-environments" },
     { "path": "../snaps-rpc-methods" },
     { "path": "../snaps-controllers" },
     { "path": "../snaps-utils" },


### PR DESCRIPTION
This adds the missing reference to `snaps-execution-environments` in `snaps-simulator`.