### PR TITLE
BREAKING: Move handler types to SDK

### DIFF
--- a/packages/examples/packages/bip32/package.json
+++ b/packages/examples/packages/bip32/package.json
@@ -34,7 +34,6 @@
     "@metamask/key-tree": "^9.0.0",
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/snaps-sdk": "workspace:^",
-    "@metamask/snaps-types": "workspace:^",
     "@metamask/snaps-ui": "workspace:^",
     "@metamask/utils": "^8.1.0",
     "@noble/ed25519": "^1.6.0",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+Ne2em9ImF5lpf2/yUgaoxuH3/e/aor0o2dn99DsFWg=",
+    "shasum": "vFlTu8q42PboHqLABN36nBmcx+DnUwDRRCxFwlJ16Ck=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/src/index.ts
+++ b/packages/examples/packages/bip32/src/index.ts
@@ -1,6 +1,6 @@
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import { DialogType } from '@metamask/snaps-sdk';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
 import { panel, text, heading, copyable } from '@metamask/snaps-ui';
 import {
   add0x,

--- a/packages/examples/packages/bip32/tsconfig.json
+++ b/packages/examples/packages/bip32/tsconfig.json
@@ -9,9 +9,6 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
-    },
-    {
       "path": "../../../snaps-sdk"
     },
     {

--- a/packages/examples/packages/bip44/package.json
+++ b/packages/examples/packages/bip44/package.json
@@ -34,7 +34,6 @@
     "@metamask/key-tree": "^9.0.0",
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/snaps-sdk": "workspace:^",
-    "@metamask/snaps-types": "workspace:^",
     "@metamask/snaps-ui": "workspace:^",
     "@metamask/utils": "^8.1.0",
     "@noble/bls12-381": "^1.2.0"

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hS4THTUa84JrJR5Ar+K3MwTHzE9qidaCqiDtG15EIfQ=",
+    "shasum": "Oiv12trzteVv2P04KfUkW3moGNz6nx8PrPK0oENq0bc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/src/index.ts
+++ b/packages/examples/packages/bip44/src/index.ts
@@ -1,6 +1,6 @@
 import { rpcErrors, providerErrors } from '@metamask/rpc-errors';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import { DialogType } from '@metamask/snaps-sdk';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
 import { panel, text, heading, copyable } from '@metamask/snaps-ui';
 import { bytesToHex, stringToBytes } from '@metamask/utils';
 import { getPublicKey, sign } from '@noble/bls12-381';

--- a/packages/examples/packages/bip44/tsconfig.json
+++ b/packages/examples/packages/bip44/tsconfig.json
@@ -9,9 +9,6 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
-    },
-    {
       "path": "../../../snaps-sdk"
     },
     {

--- a/packages/examples/packages/browserify-plugin/package.json
+++ b/packages/examples/packages/browserify-plugin/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/examples/packages/browserify-plugin/src/index.ts
+++ b/packages/examples/packages/browserify-plugin/src/index.ts
@@ -1,5 +1,5 @@
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the

--- a/packages/examples/packages/browserify-plugin/tsconfig.json
+++ b/packages/examples/packages/browserify-plugin/tsconfig.json
@@ -10,7 +10,7 @@
   "include": ["src", "scripts", "babel.config.json"],
   "references": [
     {
-      "path": "../../../snaps-types"
+      "path": "../../../snaps-sdk"
     },
     {
       "path": "../../../snaps-browserify-plugin"

--- a/packages/examples/packages/browserify/package.json
+++ b/packages/examples/packages/browserify/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/examples/packages/browserify/src/index.ts
+++ b/packages/examples/packages/browserify/src/index.ts
@@ -1,5 +1,5 @@
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the

--- a/packages/examples/packages/browserify/tsconfig.json
+++ b/packages/examples/packages/browserify/tsconfig.json
@@ -10,7 +10,7 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
+      "path": "../../../snaps-sdk"
     },
     {
       "path": "../../../snaps-jest"

--- a/packages/examples/packages/cronjobs/package.json
+++ b/packages/examples/packages/cronjobs/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-types": "workspace:^",
+    "@metamask/snaps-sdk": "workspace:^",
     "@metamask/snaps-ui": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/cronjobs/src/index.ts
+++ b/packages/examples/packages/cronjobs/src/index.ts
@@ -1,5 +1,5 @@
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnCronjobHandler } from '@metamask/snaps-types';
+import type { OnCronjobHandler } from '@metamask/snaps-sdk';
 import { panel, text, heading } from '@metamask/snaps-ui';
 
 /**

--- a/packages/examples/packages/cronjobs/tsconfig.json
+++ b/packages/examples/packages/cronjobs/tsconfig.json
@@ -9,7 +9,7 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
+      "path": "../../../snaps-sdk"
     },
     {
       "path": "../../../snaps-ui"

--- a/packages/examples/packages/dialogs/package.json
+++ b/packages/examples/packages/dialogs/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/snaps-sdk": "workspace:^",
-    "@metamask/snaps-types": "workspace:^",
     "@metamask/snaps-ui": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "10rZzfHm+UXnimMUxslMk7CE4dRBNGrBbOBgqpbrTtA=",
+    "shasum": "hS/TvMPnSKpfGoXEkPPtM+zMptv2gRX7lTlsSDOZb8c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/src/index.ts
+++ b/packages/examples/packages/dialogs/src/index.ts
@@ -1,6 +1,6 @@
 import { rpcErrors } from '@metamask/rpc-errors';
 import { DialogType } from '@metamask/snaps-sdk';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import { panel, text, heading } from '@metamask/snaps-ui';
 
 /**

--- a/packages/examples/packages/dialogs/tsconfig.json
+++ b/packages/examples/packages/dialogs/tsconfig.json
@@ -9,9 +9,6 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
-    },
-    {
       "path": "../../../snaps-sdk"
     },
     {

--- a/packages/examples/packages/errors/package.json
+++ b/packages/examples/packages/errors/package.json
@@ -31,7 +31,7 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/examples/packages/errors/src/index.ts
+++ b/packages/examples/packages/errors/src/index.ts
@@ -1,4 +1,4 @@
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 export const onRpcRequest: OnRpcRequestHandler = async () => {
   // eslint-disable-next-line no-new, @typescript-eslint/no-floating-promises

--- a/packages/examples/packages/errors/tsconfig.json
+++ b/packages/examples/packages/errors/tsconfig.json
@@ -9,10 +9,7 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
-    },
-    {
-      "path": "../../../snaps-ui"
+      "path": "../../../snaps-sdk"
     },
     {
       "path": "../../../snaps-jest"

--- a/packages/examples/packages/ethereum-provider/package.json
+++ b/packages/examples/packages/ethereum-provider/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-types": "workspace:^",
+    "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.1.0"
   },
   "devDependencies": {

--- a/packages/examples/packages/ethereum-provider/src/index.ts
+++ b/packages/examples/packages/ethereum-provider/src/index.ts
@@ -1,5 +1,5 @@
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import type { Hex } from '@metamask/utils';
 import { assert, stringToBytes, bytesToHex } from '@metamask/utils';
 

--- a/packages/examples/packages/ethereum-provider/tsconfig.json
+++ b/packages/examples/packages/ethereum-provider/tsconfig.json
@@ -9,10 +9,7 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
-    },
-    {
-      "path": "../../../snaps-ui"
+      "path": "../../../snaps-sdk"
     },
     {
       "path": "../../../snaps-jest"

--- a/packages/examples/packages/ethers-js/package.json
+++ b/packages/examples/packages/ethers-js/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-types": "workspace:^",
+    "@metamask/snaps-sdk": "workspace:^",
     "@metamask/snaps-ui": "workspace:^",
     "ethers": "^6.3.0"
   },

--- a/packages/examples/packages/ethers-js/src/index.ts
+++ b/packages/examples/packages/ethers-js/src/index.ts
@@ -1,5 +1,5 @@
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import { panel, heading, copyable, text } from '@metamask/snaps-ui';
 import { Wallet } from 'ethers';
 

--- a/packages/examples/packages/ethers-js/tsconfig.json
+++ b/packages/examples/packages/ethers-js/tsconfig.json
@@ -9,7 +9,7 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
+      "path": "../../../snaps-sdk"
     },
     {
       "path": "../../../snaps-ui"

--- a/packages/examples/packages/get-entropy/package.json
+++ b/packages/examples/packages/get-entropy/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/snaps-sdk": "workspace:^",
-    "@metamask/snaps-types": "workspace:^",
     "@metamask/snaps-ui": "workspace:^",
     "@metamask/utils": "^8.1.0",
     "@noble/bls12-381": "^1.2.0"

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9AoC4hU3sGsq2HWitriuICPnU1lbLHC3rq+SkozCUwE=",
+    "shasum": "quVJens+ULBSoasW4pUoM4YP5N8p+SpyDffOMc6Q11Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/src/index.ts
+++ b/packages/examples/packages/get-entropy/src/index.ts
@@ -1,6 +1,6 @@
 import { rpcErrors, providerErrors } from '@metamask/rpc-errors';
 import { DialogType } from '@metamask/snaps-sdk';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import { panel, text, heading, copyable } from '@metamask/snaps-ui';
 import { bytesToHex, stringToBytes } from '@metamask/utils';
 import { sign } from '@noble/bls12-381';

--- a/packages/examples/packages/get-entropy/tsconfig.json
+++ b/packages/examples/packages/get-entropy/tsconfig.json
@@ -9,9 +9,6 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
-    },
-    {
       "path": "../../../snaps-sdk"
     },
     {

--- a/packages/examples/packages/get-file/package.json
+++ b/packages/examples/packages/get-file/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/examples/packages/get-file/src/index.ts
+++ b/packages/examples/packages/get-file/src/index.ts
@@ -1,5 +1,5 @@
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the

--- a/packages/examples/packages/get-file/tsconfig.json
+++ b/packages/examples/packages/get-file/tsconfig.json
@@ -9,10 +9,7 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
-    },
-    {
-      "path": "../../../snaps-ui"
+      "path": "../../../snaps-sdk"
     },
     {
       "path": "../../../snaps-jest"

--- a/packages/examples/packages/home-page/package.json
+++ b/packages/examples/packages/home-page/package.json
@@ -31,7 +31,7 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/snaps-types": "workspace:^",
+    "@metamask/snaps-sdk": "workspace:^",
     "@metamask/snaps-ui": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/home-page/src/index.ts
+++ b/packages/examples/packages/home-page/src/index.ts
@@ -1,4 +1,4 @@
-import type { OnHomePageHandler } from '@metamask/snaps-types';
+import type { OnHomePageHandler } from '@metamask/snaps-sdk';
 import { panel, text, heading } from '@metamask/snaps-ui';
 
 /**

--- a/packages/examples/packages/home-page/tsconfig.json
+++ b/packages/examples/packages/home-page/tsconfig.json
@@ -9,7 +9,7 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
+      "path": "../../../snaps-sdk"
     },
     {
       "path": "../../../snaps-ui"

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@metamask/key-tree": "^9.0.0",
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-types": "workspace:^",
+    "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.1.0",
     "@noble/hashes": "^1.3.1"
   },

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/src/index.ts
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/src/index.ts
@@ -1,5 +1,5 @@
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import { assert, stringToBytes } from '@metamask/utils';
 import { keccak_256 as keccak256 } from '@noble/hashes/sha3';
 

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/tsconfig.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/tsconfig.json
@@ -9,7 +9,7 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../../../snaps-types"
+      "path": "../../../../../snaps-sdk"
     },
     {
       "path": "../../../../../snaps-jest"

--- a/packages/examples/packages/invoke-snap/packages/core-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/package.json
@@ -34,7 +34,6 @@
     "@metamask/key-tree": "^9.0.0",
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/snaps-sdk": "workspace:^",
-    "@metamask/snaps-types": "workspace:^",
     "@metamask/snaps-ui": "workspace:^",
     "@metamask/utils": "^8.1.0",
     "@noble/curves": "^1.1.0",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cVOCxq/RX989RcDV3FcWNWAOdR4VWufYC/0hgeKWpDM=",
+    "shasum": "pHFf1bazmVzdooZXDfXOhpWCos54j6T+TdXoDlm1V7o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/src/index.ts
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/src/index.ts
@@ -1,6 +1,6 @@
 import { rpcErrors, providerErrors } from '@metamask/rpc-errors';
 import { DialogType } from '@metamask/snaps-sdk';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import { panel, text, heading, copyable } from '@metamask/snaps-ui';
 import { add0x, assert, hexToBytes } from '@metamask/utils';
 import { secp256k1 } from '@noble/curves/secp256k1';

--- a/packages/examples/packages/invoke-snap/packages/core-signer/tsconfig.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/tsconfig.json
@@ -9,9 +9,6 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../../../snaps-types"
-    },
-    {
       "path": "../../../../../snaps-sdk"
     },
     {

--- a/packages/examples/packages/json-rpc/package.json
+++ b/packages/examples/packages/json-rpc/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/examples/packages/json-rpc/src/index.ts
+++ b/packages/examples/packages/json-rpc/src/index.ts
@@ -1,5 +1,5 @@
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the

--- a/packages/examples/packages/json-rpc/tsconfig.json
+++ b/packages/examples/packages/json-rpc/tsconfig.json
@@ -9,7 +9,7 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
+      "path": "../../../snaps-sdk"
     },
     {
       "path": "../../../snaps-jest"

--- a/packages/examples/packages/lifecycle-hooks/package.json
+++ b/packages/examples/packages/lifecycle-hooks/package.json
@@ -31,7 +31,7 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/snaps-types": "workspace:^",
+    "@metamask/snaps-sdk": "workspace:^",
     "@metamask/snaps-ui": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/lifecycle-hooks/src/index.ts
+++ b/packages/examples/packages/lifecycle-hooks/src/index.ts
@@ -1,4 +1,4 @@
-import type { OnInstallHandler, OnUpdateHandler } from '@metamask/snaps-types';
+import type { OnInstallHandler, OnUpdateHandler } from '@metamask/snaps-sdk';
 import { heading, panel, text } from '@metamask/snaps-ui';
 
 /**

--- a/packages/examples/packages/lifecycle-hooks/tsconfig.json
+++ b/packages/examples/packages/lifecycle-hooks/tsconfig.json
@@ -9,7 +9,10 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
+      "path": "../../../snaps-sdk"
+    },
+    {
+      "path": "../../../snaps-ui"
     },
     {
       "path": "../../../snaps-jest"

--- a/packages/examples/packages/localization/package.json
+++ b/packages/examples/packages/localization/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/examples/packages/localization/src/index.ts
+++ b/packages/examples/packages/localization/src/index.ts
@@ -1,5 +1,5 @@
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 import { getMessage } from './locales';
 

--- a/packages/examples/packages/localization/tsconfig.json
+++ b/packages/examples/packages/localization/tsconfig.json
@@ -9,10 +9,7 @@
   "include": ["src", "locales/*.json", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
-    },
-    {
-      "path": "../../../snaps-ui"
+      "path": "../../../snaps-sdk"
     },
     {
       "path": "../../../snaps-jest"

--- a/packages/examples/packages/manage-state/package.json
+++ b/packages/examples/packages/manage-state/package.json
@@ -32,8 +32,7 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-sdk": "workspace:^",
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "w52rs9nA/168Vwgk2Xux70nlznBCuqgFKv5ozP9Sijs=",
+    "shasum": "QABCZPnE2qG6CVjidksOyFwbKB9u+SwQ9n3e6OzFE9c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/src/index.ts
+++ b/packages/examples/packages/manage-state/src/index.ts
@@ -1,5 +1,5 @@
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 import type { BaseParams, SetStateParams } from './types';
 import { clearState, getState, setState } from './utils';

--- a/packages/examples/packages/manage-state/tsconfig.json
+++ b/packages/examples/packages/manage-state/tsconfig.json
@@ -9,9 +9,6 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
-    },
-    {
       "path": "../../../snaps-sdk"
     },
     {

--- a/packages/examples/packages/name-lookup/package.json
+++ b/packages/examples/packages/name-lookup/package.json
@@ -31,7 +31,7 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/examples/packages/name-lookup/src/index.test.ts
+++ b/packages/examples/packages/name-lookup/src/index.test.ts
@@ -1,11 +1,11 @@
 import { describe, it } from '@jest/globals';
-import type { OnNameLookupArgs } from '@metamask/snaps-types';
+import type { ChainId } from '@metamask/snaps-sdk';
 
 import { onNameLookup } from '.';
 
 const DOMAIN_MOCK = 'test.domain';
 const ADDRESS_MOCK = '0xc0ffee254729296a45a3885639AC7E10F9d54979';
-const CHAIN_ID_MOCK = 'eip155:1';
+const CHAIN_ID_MOCK = 'eip155:1' as ChainId;
 
 describe('onNameLookup', () => {
   it('returns resolved address if domain', async () => {
@@ -45,8 +45,9 @@ describe('onNameLookup', () => {
   it('returns null if no domain or address', async () => {
     const request = {
       chainId: CHAIN_ID_MOCK,
-    } as OnNameLookupArgs;
+    };
 
+    // @ts-expect-error - Testing invalid request.
     expect(await onNameLookup(request)).toBeNull();
   });
 });

--- a/packages/examples/packages/name-lookup/src/index.ts
+++ b/packages/examples/packages/name-lookup/src/index.ts
@@ -1,4 +1,4 @@
-import type { OnNameLookupHandler } from '@metamask/snaps-types';
+import type { OnNameLookupHandler } from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming name lookup requests from the MetaMask clients.

--- a/packages/examples/packages/name-lookup/tsconfig.json
+++ b/packages/examples/packages/name-lookup/tsconfig.json
@@ -9,7 +9,7 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
+      "path": "../../../snaps-sdk"
     },
     {
       "path": "../../../snaps-jest"

--- a/packages/examples/packages/network-access/package.json
+++ b/packages/examples/packages/network-access/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-types": "workspace:^",
+    "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.1.0"
   },
   "devDependencies": {

--- a/packages/examples/packages/network-access/src/index.ts
+++ b/packages/examples/packages/network-access/src/index.ts
@@ -1,5 +1,5 @@
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import { assert } from '@metamask/utils';
 
 import type { FetchParams } from './types';

--- a/packages/examples/packages/network-access/tsconfig.json
+++ b/packages/examples/packages/network-access/tsconfig.json
@@ -9,7 +9,7 @@
   "include": ["src", "package.json", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
+      "path": "../../../snaps-sdk"
     },
     {
       "path": "../../../snaps-jest"

--- a/packages/examples/packages/notifications/package.json
+++ b/packages/examples/packages/notifications/package.json
@@ -32,8 +32,7 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-sdk": "workspace:^",
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "d9R8nMT6nRpxmvVxHMFq5d1n8NRWTGCrW47KmAvsAPo=",
+    "shasum": "3tURebEzqLrC80sRrUy/sXLBumaWAI6qJHxrk71VX2c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/src/index.ts
+++ b/packages/examples/packages/notifications/src/index.ts
@@ -1,6 +1,6 @@
 import { rpcErrors } from '@metamask/rpc-errors';
 import { NotificationType } from '@metamask/snaps-sdk';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the

--- a/packages/examples/packages/notifications/tsconfig.json
+++ b/packages/examples/packages/notifications/tsconfig.json
@@ -9,13 +9,7 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
-    },
-    {
       "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-ui"
     },
     {
       "path": "../../../snaps-jest"

--- a/packages/examples/packages/rollup-plugin/package.json
+++ b/packages/examples/packages/rollup-plugin/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",

--- a/packages/examples/packages/rollup-plugin/src/index.ts
+++ b/packages/examples/packages/rollup-plugin/src/index.ts
@@ -1,5 +1,5 @@
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the

--- a/packages/examples/packages/rollup-plugin/tsconfig.json
+++ b/packages/examples/packages/rollup-plugin/tsconfig.json
@@ -9,7 +9,7 @@
   "include": ["src", "rollup.config.js"],
   "references": [
     {
-      "path": "../../../snaps-types"
+      "path": "../../../snaps-sdk"
     },
     {
       "path": "../../../snaps-rollup-plugin"

--- a/packages/examples/packages/transaction-insights/package.json
+++ b/packages/examples/packages/transaction-insights/package.json
@@ -31,7 +31,7 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/snaps-types": "workspace:^",
+    "@metamask/snaps-sdk": "workspace:^",
     "@metamask/snaps-ui": "workspace:^",
     "@metamask/utils": "^8.1.0"
   },

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+O5MYM16m/hOmfKxnMuErrvdBBWQK98JeT2v/ytW03c=",
+    "shasum": "8EUnyGuJxtysKLHL5AohBTxI73cqlGep66dEkPL3Q7Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/src/index.ts
+++ b/packages/examples/packages/transaction-insights/src/index.ts
@@ -1,5 +1,5 @@
-import type { OnTransactionHandler } from '@metamask/snaps-types';
-import { SeverityLevel } from '@metamask/snaps-types';
+import type { OnTransactionHandler } from '@metamask/snaps-sdk';
+import { SeverityLevel } from '@metamask/snaps-sdk';
 import { panel, text } from '@metamask/snaps-ui';
 import { hasProperty } from '@metamask/utils';
 

--- a/packages/examples/packages/transaction-insights/tsconfig.json
+++ b/packages/examples/packages/transaction-insights/tsconfig.json
@@ -9,7 +9,7 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
+      "path": "../../../snaps-sdk"
     },
     {
       "path": "../../../snaps-ui"

--- a/packages/examples/packages/wasm/package.json
+++ b/packages/examples/packages/wasm/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/examples/packages/wasm/src/index.ts
+++ b/packages/examples/packages/wasm/src/index.ts
@@ -1,5 +1,5 @@
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 // eslint-disable-next-line import/order
 import { instantiate } from '../build/program';

--- a/packages/examples/packages/wasm/tsconfig.json
+++ b/packages/examples/packages/wasm/tsconfig.json
@@ -9,13 +9,10 @@
   "include": ["src", "snap.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
+      "path": "../../../snaps-sdk"
     },
     {
       "path": "../../../snaps-ui"
-    },
-    {
-      "path": "../../../snaps-webpack-plugin"
     },
     {
       "path": "../../../snaps-jest"

--- a/packages/examples/packages/webpack-plugin/package.json
+++ b/packages/examples/packages/webpack-plugin/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/examples/packages/webpack-plugin/src/index.ts
+++ b/packages/examples/packages/webpack-plugin/src/index.ts
@@ -1,5 +1,5 @@
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-types';
+import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the

--- a/packages/examples/packages/webpack-plugin/tsconfig.json
+++ b/packages/examples/packages/webpack-plugin/tsconfig.json
@@ -9,7 +9,7 @@
   "include": ["src", "webpack.config.ts"],
   "references": [
     {
-      "path": "../../../snaps-types"
+      "path": "../../../snaps-sdk"
     },
     {
       "path": "../../../snaps-webpack-plugin"

--- a/packages/snaps-execution-environments/lavamoat/browserify/iframe/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/iframe/policy.json
@@ -308,6 +308,52 @@
         "eslint>debug>ms": true
       }
     },
+    "external:../snaps-sdk/src/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/index.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/handlers/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/handlers/cronjob.ts": true,
+        "external:../snaps-sdk/src/types/handlers/home-page.ts": true,
+        "external:../snaps-sdk/src/types/handlers/keyring.ts": true,
+        "external:../snaps-sdk/src/types/handlers/lifecycle.ts": true,
+        "external:../snaps-sdk/src/types/handlers/name-lookup.ts": true,
+        "external:../snaps-sdk/src/types/handlers/rpc-request.ts": true,
+        "external:../snaps-sdk/src/types/handlers/transaction.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/caip.ts": true,
+        "external:../snaps-sdk/src/types/global.ts": true,
+        "external:../snaps-sdk/src/types/handlers/index.ts": true,
+        "external:../snaps-sdk/src/types/methods/index.ts": true,
+        "external:../snaps-sdk/src/types/permissions.ts": true,
+        "external:../snaps-sdk/src/types/provider.ts": true,
+        "external:../snaps-sdk/src/types/snap.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/methods/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/methods/dialog.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip32-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip32-public-key.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip44-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-file.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-locale.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-snaps.ts": true,
+        "external:../snaps-sdk/src/types/methods/invoke-keyring.ts": true,
+        "external:../snaps-sdk/src/types/methods/invoke-snap.ts": true,
+        "external:../snaps-sdk/src/types/methods/manage-accounts.ts": true,
+        "external:../snaps-sdk/src/types/methods/manage-state.ts": true,
+        "external:../snaps-sdk/src/types/methods/methods.ts": true,
+        "external:../snaps-sdk/src/types/methods/notify.ts": true,
+        "external:../snaps-sdk/src/types/methods/request-snaps.ts": true
+      }
+    },
     "external:../snaps-ui/src/builder.ts": {
       "packages": {
         "@metamask/utils": true,
@@ -345,6 +391,7 @@
     },
     "external:../snaps-utils/src/handlers.ts": {
       "packages": {
+        "external:../snaps-sdk/src/index.ts": true,
         "external:../snaps-ui/src/index.ts": true,
         "external:../snaps-utils/src/handler-types.ts": true,
         "superstruct": true

--- a/packages/snaps-execution-environments/lavamoat/browserify/node-process/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/node-process/policy.json
@@ -372,6 +372,52 @@
         "util": true
       }
     },
+    "external:../snaps-sdk/src/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/index.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/handlers/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/handlers/cronjob.ts": true,
+        "external:../snaps-sdk/src/types/handlers/home-page.ts": true,
+        "external:../snaps-sdk/src/types/handlers/keyring.ts": true,
+        "external:../snaps-sdk/src/types/handlers/lifecycle.ts": true,
+        "external:../snaps-sdk/src/types/handlers/name-lookup.ts": true,
+        "external:../snaps-sdk/src/types/handlers/rpc-request.ts": true,
+        "external:../snaps-sdk/src/types/handlers/transaction.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/caip.ts": true,
+        "external:../snaps-sdk/src/types/global.ts": true,
+        "external:../snaps-sdk/src/types/handlers/index.ts": true,
+        "external:../snaps-sdk/src/types/methods/index.ts": true,
+        "external:../snaps-sdk/src/types/permissions.ts": true,
+        "external:../snaps-sdk/src/types/provider.ts": true,
+        "external:../snaps-sdk/src/types/snap.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/methods/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/methods/dialog.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip32-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip32-public-key.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip44-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-file.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-locale.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-snaps.ts": true,
+        "external:../snaps-sdk/src/types/methods/invoke-keyring.ts": true,
+        "external:../snaps-sdk/src/types/methods/invoke-snap.ts": true,
+        "external:../snaps-sdk/src/types/methods/manage-accounts.ts": true,
+        "external:../snaps-sdk/src/types/methods/manage-state.ts": true,
+        "external:../snaps-sdk/src/types/methods/methods.ts": true,
+        "external:../snaps-sdk/src/types/methods/notify.ts": true,
+        "external:../snaps-sdk/src/types/methods/request-snaps.ts": true
+      }
+    },
     "external:../snaps-ui/src/builder.ts": {
       "packages": {
         "@metamask/utils": true,
@@ -409,6 +455,7 @@
     },
     "external:../snaps-utils/src/handlers.ts": {
       "packages": {
+        "external:../snaps-sdk/src/index.ts": true,
         "external:../snaps-ui/src/index.ts": true,
         "external:../snaps-utils/src/handler-types.ts": true,
         "superstruct": true

--- a/packages/snaps-execution-environments/lavamoat/browserify/node-thread/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/node-thread/policy.json
@@ -372,6 +372,52 @@
         "util": true
       }
     },
+    "external:../snaps-sdk/src/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/index.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/handlers/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/handlers/cronjob.ts": true,
+        "external:../snaps-sdk/src/types/handlers/home-page.ts": true,
+        "external:../snaps-sdk/src/types/handlers/keyring.ts": true,
+        "external:../snaps-sdk/src/types/handlers/lifecycle.ts": true,
+        "external:../snaps-sdk/src/types/handlers/name-lookup.ts": true,
+        "external:../snaps-sdk/src/types/handlers/rpc-request.ts": true,
+        "external:../snaps-sdk/src/types/handlers/transaction.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/caip.ts": true,
+        "external:../snaps-sdk/src/types/global.ts": true,
+        "external:../snaps-sdk/src/types/handlers/index.ts": true,
+        "external:../snaps-sdk/src/types/methods/index.ts": true,
+        "external:../snaps-sdk/src/types/permissions.ts": true,
+        "external:../snaps-sdk/src/types/provider.ts": true,
+        "external:../snaps-sdk/src/types/snap.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/methods/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/methods/dialog.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip32-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip32-public-key.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip44-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-file.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-locale.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-snaps.ts": true,
+        "external:../snaps-sdk/src/types/methods/invoke-keyring.ts": true,
+        "external:../snaps-sdk/src/types/methods/invoke-snap.ts": true,
+        "external:../snaps-sdk/src/types/methods/manage-accounts.ts": true,
+        "external:../snaps-sdk/src/types/methods/manage-state.ts": true,
+        "external:../snaps-sdk/src/types/methods/methods.ts": true,
+        "external:../snaps-sdk/src/types/methods/notify.ts": true,
+        "external:../snaps-sdk/src/types/methods/request-snaps.ts": true
+      }
+    },
     "external:../snaps-ui/src/builder.ts": {
       "packages": {
         "@metamask/utils": true,
@@ -409,6 +455,7 @@
     },
     "external:../snaps-utils/src/handlers.ts": {
       "packages": {
+        "external:../snaps-sdk/src/index.ts": true,
         "external:../snaps-ui/src/index.ts": true,
         "external:../snaps-utils/src/handler-types.ts": true,
         "superstruct": true

--- a/packages/snaps-execution-environments/lavamoat/browserify/offscreen/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/offscreen/policy.json
@@ -142,6 +142,52 @@
         "eslint>debug>ms": true
       }
     },
+    "external:../snaps-sdk/src/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/index.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/handlers/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/handlers/cronjob.ts": true,
+        "external:../snaps-sdk/src/types/handlers/home-page.ts": true,
+        "external:../snaps-sdk/src/types/handlers/keyring.ts": true,
+        "external:../snaps-sdk/src/types/handlers/lifecycle.ts": true,
+        "external:../snaps-sdk/src/types/handlers/name-lookup.ts": true,
+        "external:../snaps-sdk/src/types/handlers/rpc-request.ts": true,
+        "external:../snaps-sdk/src/types/handlers/transaction.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/caip.ts": true,
+        "external:../snaps-sdk/src/types/global.ts": true,
+        "external:../snaps-sdk/src/types/handlers/index.ts": true,
+        "external:../snaps-sdk/src/types/methods/index.ts": true,
+        "external:../snaps-sdk/src/types/permissions.ts": true,
+        "external:../snaps-sdk/src/types/provider.ts": true,
+        "external:../snaps-sdk/src/types/snap.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/methods/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/methods/dialog.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip32-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip32-public-key.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip44-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-file.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-locale.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-snaps.ts": true,
+        "external:../snaps-sdk/src/types/methods/invoke-keyring.ts": true,
+        "external:../snaps-sdk/src/types/methods/invoke-snap.ts": true,
+        "external:../snaps-sdk/src/types/methods/manage-accounts.ts": true,
+        "external:../snaps-sdk/src/types/methods/manage-state.ts": true,
+        "external:../snaps-sdk/src/types/methods/methods.ts": true,
+        "external:../snaps-sdk/src/types/methods/notify.ts": true,
+        "external:../snaps-sdk/src/types/methods/request-snaps.ts": true
+      }
+    },
     "external:../snaps-ui/src/builder.ts": {
       "packages": {
         "@metamask/utils": true,
@@ -179,6 +225,7 @@
     },
     "external:../snaps-utils/src/handlers.ts": {
       "packages": {
+        "external:../snaps-sdk/src/index.ts": true,
         "external:../snaps-ui/src/index.ts": true,
         "external:../snaps-utils/src/handler-types.ts": true,
         "superstruct": true

--- a/packages/snaps-execution-environments/lavamoat/browserify/worker-executor/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/worker-executor/policy.json
@@ -308,6 +308,52 @@
         "eslint>debug>ms": true
       }
     },
+    "external:../snaps-sdk/src/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/index.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/handlers/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/handlers/cronjob.ts": true,
+        "external:../snaps-sdk/src/types/handlers/home-page.ts": true,
+        "external:../snaps-sdk/src/types/handlers/keyring.ts": true,
+        "external:../snaps-sdk/src/types/handlers/lifecycle.ts": true,
+        "external:../snaps-sdk/src/types/handlers/name-lookup.ts": true,
+        "external:../snaps-sdk/src/types/handlers/rpc-request.ts": true,
+        "external:../snaps-sdk/src/types/handlers/transaction.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/caip.ts": true,
+        "external:../snaps-sdk/src/types/global.ts": true,
+        "external:../snaps-sdk/src/types/handlers/index.ts": true,
+        "external:../snaps-sdk/src/types/methods/index.ts": true,
+        "external:../snaps-sdk/src/types/permissions.ts": true,
+        "external:../snaps-sdk/src/types/provider.ts": true,
+        "external:../snaps-sdk/src/types/snap.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/methods/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/methods/dialog.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip32-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip32-public-key.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip44-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-file.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-locale.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-snaps.ts": true,
+        "external:../snaps-sdk/src/types/methods/invoke-keyring.ts": true,
+        "external:../snaps-sdk/src/types/methods/invoke-snap.ts": true,
+        "external:../snaps-sdk/src/types/methods/manage-accounts.ts": true,
+        "external:../snaps-sdk/src/types/methods/manage-state.ts": true,
+        "external:../snaps-sdk/src/types/methods/methods.ts": true,
+        "external:../snaps-sdk/src/types/methods/notify.ts": true,
+        "external:../snaps-sdk/src/types/methods/request-snaps.ts": true
+      }
+    },
     "external:../snaps-ui/src/builder.ts": {
       "packages": {
         "@metamask/utils": true,
@@ -345,6 +391,7 @@
     },
     "external:../snaps-utils/src/handlers.ts": {
       "packages": {
+        "external:../snaps-sdk/src/index.ts": true,
         "external:../snaps-ui/src/index.ts": true,
         "external:../snaps-utils/src/handler-types.ts": true,
         "superstruct": true

--- a/packages/snaps-execution-environments/lavamoat/browserify/worker-pool/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/worker-pool/policy.json
@@ -142,6 +142,52 @@
         "eslint>debug>ms": true
       }
     },
+    "external:../snaps-sdk/src/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/index.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/handlers/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/handlers/cronjob.ts": true,
+        "external:../snaps-sdk/src/types/handlers/home-page.ts": true,
+        "external:../snaps-sdk/src/types/handlers/keyring.ts": true,
+        "external:../snaps-sdk/src/types/handlers/lifecycle.ts": true,
+        "external:../snaps-sdk/src/types/handlers/name-lookup.ts": true,
+        "external:../snaps-sdk/src/types/handlers/rpc-request.ts": true,
+        "external:../snaps-sdk/src/types/handlers/transaction.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/caip.ts": true,
+        "external:../snaps-sdk/src/types/global.ts": true,
+        "external:../snaps-sdk/src/types/handlers/index.ts": true,
+        "external:../snaps-sdk/src/types/methods/index.ts": true,
+        "external:../snaps-sdk/src/types/permissions.ts": true,
+        "external:../snaps-sdk/src/types/provider.ts": true,
+        "external:../snaps-sdk/src/types/snap.ts": true
+      }
+    },
+    "external:../snaps-sdk/src/types/methods/index.ts": {
+      "packages": {
+        "external:../snaps-sdk/src/types/methods/dialog.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip32-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip32-public-key.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-bip44-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-file.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-locale.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-snaps.ts": true,
+        "external:../snaps-sdk/src/types/methods/invoke-keyring.ts": true,
+        "external:../snaps-sdk/src/types/methods/invoke-snap.ts": true,
+        "external:../snaps-sdk/src/types/methods/manage-accounts.ts": true,
+        "external:../snaps-sdk/src/types/methods/manage-state.ts": true,
+        "external:../snaps-sdk/src/types/methods/methods.ts": true,
+        "external:../snaps-sdk/src/types/methods/notify.ts": true,
+        "external:../snaps-sdk/src/types/methods/request-snaps.ts": true
+      }
+    },
     "external:../snaps-ui/src/builder.ts": {
       "packages": {
         "@metamask/utils": true,
@@ -179,6 +225,7 @@
     },
     "external:../snaps-utils/src/handlers.ts": {
       "packages": {
+        "external:../snaps-sdk/src/index.ts": true,
         "external:../snaps-ui/src/index.ts": true,
         "external:../snaps-utils/src/handler-types.ts": true,
         "superstruct": true

--- a/packages/snaps-sdk/src/types/caip.ts
+++ b/packages/snaps-sdk/src/types/caip.ts
@@ -4,3 +4,10 @@
  * @see https://chainagnostic.org/CAIPs/caip-2
  */
 export type ChainId = `${string}:${string}`;
+
+/**
+ * A CAIP-10 account ID, i.e., a chain ID and an account address.
+ *
+ * @see https://chainagnostic.org/CAIPs/caip-10
+ */
+export type AccountId = `${ChainId}:${string}`;

--- a/packages/snaps-sdk/src/types/handlers/cronjob.ts
+++ b/packages/snaps-sdk/src/types/handlers/cronjob.ts
@@ -1,0 +1,14 @@
+import type { JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
+
+/**
+ * The `onCronjob` handler. This is called on a regular interval, as defined by
+ * the Snap's manifest.
+ *
+ * Note that using this handler requires the `endowment:cronjob` permission.
+ *
+ * @param args - The request arguments.
+ * @param args.request - The JSON-RPC request sent to the snap. The parameters
+ * are defined by the Snap's manifest.
+ */
+export type OnCronjobHandler<Params extends JsonRpcParams = JsonRpcParams> =
+  (args: { request: JsonRpcRequest<Params> }) => Promise<unknown>;

--- a/packages/snaps-sdk/src/types/handlers/home-page.ts
+++ b/packages/snaps-sdk/src/types/handlers/home-page.ts
@@ -1,0 +1,21 @@
+import type { Component } from '@metamask/snaps-ui';
+
+/**
+ * The `onHomePage` handler. This is called when the user navigates to the
+ * Snap's home page in the MetaMask UI.
+ *
+ * This function does not receive any arguments.
+ *
+ * @returns The content to display on the home page. See
+ * {@link OnHomePageResponse}.
+ */
+export type OnHomePageHandler = () => Promise<OnHomePageResponse>;
+
+/**
+ * The content to display on the home page.
+ *
+ * @property content - A custom UI component, that will be shown in MetaMask.
+ */
+export type OnHomePageResponse = {
+  content: Component;
+};

--- a/packages/snaps-sdk/src/types/handlers/index.ts
+++ b/packages/snaps-sdk/src/types/handlers/index.ts
@@ -1,0 +1,7 @@
+export * from './cronjob';
+export * from './home-page';
+export * from './keyring';
+export * from './lifecycle';
+export * from './name-lookup';
+export * from './rpc-request';
+export * from './transaction';

--- a/packages/snaps-sdk/src/types/handlers/keyring.ts
+++ b/packages/snaps-sdk/src/types/handlers/keyring.ts
@@ -1,0 +1,23 @@
+import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
+
+/**
+ * The `onKeyringRequest` handler, which is called when a Snap receives a
+ * keyring request.
+ *
+ * Note that using this handler requires the `endowment:keyring` permission.
+ *
+ * @param args - The request arguments.
+ * @param args.origin - The origin of the request. This can be the ID of another
+ * Snap, or the URL of a website.
+ * @param args.request - The keyring request sent to the Snap. This includes
+ * the method name and parameters.
+ * @returns The response to the keyring request. This must be a
+ * JSON-serializable value. In order to return an error, throw a `SnapError`
+ * instead.
+ */
+export type OnKeyringRequestHandler<
+  Params extends JsonRpcParams = JsonRpcParams,
+> = (args: {
+  origin: string;
+  request: JsonRpcRequest<Params>;
+}) => Promise<Json>;

--- a/packages/snaps-sdk/src/types/handlers/lifecycle.ts
+++ b/packages/snaps-sdk/src/types/handlers/lifecycle.ts
@@ -1,0 +1,44 @@
+import type { JsonRpcRequest } from '@metamask/utils';
+
+/**
+ * A lifecycle event handler. This is called whenever a lifecycle event occurs,
+ * such as the Snap being installed or updated.
+ *
+ * Note that using this handler requires the `endowment:lifecycle-hooks`
+ * permission.
+ *
+ * @param args - The request arguments.
+ * @param args.request - The JSON-RPC request sent to the Snap. This does not
+ * contain any parameters.
+ */
+export type LifecycleEventHandler = (args: {
+  request: JsonRpcRequest;
+}) => Promise<unknown>;
+
+/**
+ * The `onInstall` handler. This is called after the Snap is installed.
+ *
+ * Note that using this handler requires the `endowment:lifecycle-hooks`
+ * permission.
+ *
+ * This type is an alias for {@link LifecycleEventHandler}.
+ *
+ * @param args - The request arguments.
+ * @param args.request - The JSON-RPC request sent to the Snap. This does not
+ * contain any parameters.
+ */
+export type OnInstallHandler = LifecycleEventHandler;
+
+/**
+ * The `onUpdate` handler. This is called after the Snap is updated.
+ *
+ * Note that using this handler requires the `endowment:lifecycle-hooks`
+ * permission.
+ *
+ * This type is an alias for {@link LifecycleEventHandler}.
+ *
+ * @param args - The request arguments.
+ * @param args.request - The JSON-RPC request sent to the Snap. This does not
+ * contain any parameters.
+ */
+export type OnUpdateHandler = LifecycleEventHandler;

--- a/packages/snaps-sdk/src/types/handlers/name-lookup.ts
+++ b/packages/snaps-sdk/src/types/handlers/name-lookup.ts
@@ -1,0 +1,67 @@
+import type { ChainId } from '@metamask/snaps-sdk';
+
+type BaseOnNameLookupArgs = {
+  chainId: ChainId;
+};
+
+/**
+ * The arguments for a domain lookup.
+ *
+ * @property domain - The human-readable domain name that is to be resolved.
+ */
+export type DomainLookupArgs = BaseOnNameLookupArgs & {
+  domain: string;
+  address?: never;
+};
+
+/**
+ * The result of a domain lookup.
+ *
+ * @property resolvedAddress - The resolved address.
+ */
+export type DomainLookupResult = {
+  resolvedAddress: string;
+  resolvedDomain?: never;
+};
+
+/**
+ * The arguments for an address lookup.
+ *
+ * @property address - The address that is to be resolved.
+ */
+export type AddressLookupArgs = BaseOnNameLookupArgs & {
+  address: string;
+  domain?: never;
+};
+
+/**
+ * The result of an address lookup.
+ *
+ * @property resolvedDomain - The resolved domain name.
+ */
+export type AddressLookupResult = {
+  resolvedDomain: string;
+  resolvedAddress?: never;
+};
+
+/**
+ * The `onNameLookup` handler, which is called when MetaMask needs to resolve an
+ * address or domain.
+ *
+ * Note that using this handler requires the `endowment:name-lookup` permission.
+ *
+ * @param args - The request arguments.
+ * @param args.chainId - The CAIP-2 {@link ChainId} of the network the
+ * transaction is being submitted to.
+ * @param args.domain - The human-readable address that is to be resolved. This
+ * is mutually exclusive with `args.address`.
+ * @param args.address - The address that is to be resolved. This is mutually
+ * exclusive with `args.domain`.
+ * @returns The resolved domain or address from the lookup. Must be either
+ * {@link AddressLookupResult}, {@link DomainLookupResult}, or `null` if the
+ * address or domain could not be resolved.
+ */
+export type OnNameLookupHandler = {
+  (args: AddressLookupArgs): Promise<AddressLookupResult | null>;
+  (args: DomainLookupArgs): Promise<DomainLookupResult | null>;
+};

--- a/packages/snaps-sdk/src/types/handlers/name-lookup.ts
+++ b/packages/snaps-sdk/src/types/handlers/name-lookup.ts
@@ -1,4 +1,4 @@
-import type { ChainId } from '@metamask/snaps-sdk';
+import type { ChainId } from '../caip';
 
 type BaseOnNameLookupArgs = {
   chainId: ChainId;

--- a/packages/snaps-sdk/src/types/handlers/name-lookup.ts
+++ b/packages/snaps-sdk/src/types/handlers/name-lookup.ts
@@ -61,7 +61,6 @@ export type AddressLookupResult = {
  * {@link AddressLookupResult}, {@link DomainLookupResult}, or `null` if the
  * address or domain could not be resolved.
  */
-export type OnNameLookupHandler = {
-  (args: AddressLookupArgs): Promise<AddressLookupResult | null>;
-  (args: DomainLookupArgs): Promise<DomainLookupResult | null>;
-};
+export type OnNameLookupHandler = (
+  args: AddressLookupArgs | DomainLookupArgs,
+) => Promise<AddressLookupResult | DomainLookupResult | null>;

--- a/packages/snaps-sdk/src/types/handlers/rpc-request.ts
+++ b/packages/snaps-sdk/src/types/handlers/rpc-request.ts
@@ -1,0 +1,20 @@
+import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
+
+/**
+ * The `onRpcRequest` handler, which is called when a Snap receives a JSON-RPC
+ * request. This can be called from another Snap, or from a website, depending
+ * on the Snap's `endowment:rpc` permission.
+ *
+ * Note that using this handler requires the `endowment:rpc` permission.
+ *
+ * @param args - The request arguments.
+ * @param args.origin - The origin of the request. This can be the ID of another
+ * Snap, or the URL of a website.
+ * @param args.request - The JSON-RPC request sent to the snap. This includes
+ * the method name and parameters.
+ * @returns The response to the JSON-RPC request. This must be a
+ * JSON-serializable value. In order to return an error, throw a `SnapError`
+ * instead.
+ */
+export type OnRpcRequestHandler<Params extends JsonRpcParams = JsonRpcParams> =
+  (args: { origin: string; request: JsonRpcRequest<Params> }) => Promise<Json>;

--- a/packages/snaps-sdk/src/types/handlers/transaction.test.ts
+++ b/packages/snaps-sdk/src/types/handlers/transaction.test.ts
@@ -1,0 +1,8 @@
+import { SeverityLevel } from './transaction';
+
+describe('SeverityLevel', () => {
+  it('has the correct values', () => {
+    expect(Object.values(SeverityLevel)).toHaveLength(1);
+    expect(SeverityLevel.Critical).toBe('critical');
+  });
+});

--- a/packages/snaps-sdk/src/types/handlers/transaction.ts
+++ b/packages/snaps-sdk/src/types/handlers/transaction.ts
@@ -111,6 +111,6 @@ export type OnTransactionHandler = (args: {
  * level is supported: `critical`.
  */
 export type OnTransactionResponse = {
-  component: Component;
+  content: Component;
   severity?: EnumToUnion<SeverityLevel>;
 };

--- a/packages/snaps-sdk/src/types/handlers/transaction.ts
+++ b/packages/snaps-sdk/src/types/handlers/transaction.ts
@@ -1,0 +1,116 @@
+import type { ChainId } from '@metamask/snaps-sdk';
+import type { EnumToUnion } from '@metamask/snaps-sdk/internals';
+import type { Component } from '@metamask/snaps-ui';
+
+/**
+ * The severity level of content being returned from a transaction insight.
+ * Currently only one level is supported:
+ *
+ * - `critical` - The transaction is critical and should not be submitted by the
+ * user.
+ */
+export enum SeverityLevel {
+  Critical = 'critical',
+}
+
+/**
+ * An EIP-1559 (type 2) transaction object.
+ *
+ * @property from - The address the transaction is being sent from.
+ * @property to - The address the transaction is being sent to.
+ * @property nonce - The nonce of the transaction.
+ * @property value - The value of the transaction.
+ * @property data - The data of the transaction.
+ * @property gas - The gas limit of the transaction.
+ * @property maxFeePerGas - The maximum fee per gas of the transaction.
+ * @property maxPriorityFeePerGas - The maximum priority fee per gas of the
+ * transaction.
+ * @property estimateSuggested - The suggested gas price for the transaction.
+ * @property estimateUsed - The gas price used for the transaction.
+ * @see https://eips.ethereum.org/EIPS/eip-1559
+ */
+export type EIP1559Transaction = {
+  from: string;
+  to: string;
+  nonce: string;
+  value: string;
+  data: string;
+  gas: string;
+  maxFeePerGas: string;
+  maxPriorityFeePerGas: string;
+  estimateSuggested: string;
+  estimateUsed: string;
+};
+
+/**
+ * A legacy (type "0") transaction object.
+ *
+ * @property from - The address the transaction is being sent from.
+ * @property to - The address the transaction is being sent to.
+ * @property nonce - The nonce of the transaction.
+ * @property value - The value of the transaction.
+ * @property data - The data of the transaction.
+ * @property gas - The gas limit of the transaction.
+ * @property gasPrice - The gas price of the transaction.
+ * @property estimateSuggested - The suggested gas price for the transaction.
+ * @property estimateUsed - The gas price used for the transaction.
+ */
+export type LegacyTransaction = {
+  from: string;
+  to: string;
+  nonce: string;
+  value: string;
+  data: string;
+  gas: string;
+  gasPrice: string;
+  estimateSuggested: string;
+  estimateUsed: string;
+};
+
+/**
+ * A transaction object. This can be either an EIP-1559 transaction or a legacy
+ * transaction.
+ *
+ * @see EIP1559Transaction
+ * @see LegacyTransaction
+ */
+export type Transaction = EIP1559Transaction | LegacyTransaction;
+
+/**
+ * The `onTransaction` handler. This is called whenever a transaction is
+ * submitted to the snap. It can return insights about the transaction, which
+ * will be displayed to the user.
+ *
+ * Note that using this handler requires the `endowment:transaction-insights`
+ * permission.
+ *
+ * @param args - The request arguments.
+ * @param args.transaction - The transaction object, containing the address,
+ * value, data, and other properties of the transaction.
+ * @param args.chainId - The CAIP-2 {@link ChainId} of the network the
+ * transaction is being submitted to.
+ * @param args.transactionOrigin - The origin of the transaction. This is the
+ * URL of the website that submitted the transaction. This is only available if
+ * the Snap has enabled the `allowTransactionOrigin` option in the
+ * `endowment:transaction-insight` permission.
+ * @returns An object containing insights about the transaction. See
+ * {@link OnTransactionResponse}. Can also return `null` if no insights are
+ * available.
+ */
+export type OnTransactionHandler = (args: {
+  transaction: Transaction;
+  chainId: ChainId;
+  transactionOrigin?: string;
+}) => Promise<OnTransactionResponse | null>;
+
+/**
+ * The response from a Snap's `onTransaction` handler.
+ *
+ * @property component - A custom UI component, that will be shown in MetaMask.
+ * @property severity - The severity level of the content. Currently only one
+ * level is supported: `critical`.
+ */
+export type OnTransactionResponse = {
+  component: Component;
+  severity?: EnumToUnion<SeverityLevel>;
+};

--- a/packages/snaps-sdk/src/types/handlers/transaction.ts
+++ b/packages/snaps-sdk/src/types/handlers/transaction.ts
@@ -1,6 +1,7 @@
-import type { ChainId } from '@metamask/snaps-sdk';
-import type { EnumToUnion } from '@metamask/snaps-sdk/internals';
 import type { Component } from '@metamask/snaps-ui';
+
+import type { EnumToUnion } from '../../internals';
+import type { ChainId } from '../caip';
 
 /**
  * The severity level of content being returned from a transaction insight.

--- a/packages/snaps-sdk/src/types/index.ts
+++ b/packages/snaps-sdk/src/types/index.ts
@@ -3,6 +3,7 @@
 import './global';
 
 export * from './caip';
+export * from './handlers';
 export * from './methods';
 export * from './permissions';
 export * from './provider';

--- a/packages/snaps-sdk/src/types/methods/get-bip44-entropy.ts
+++ b/packages/snaps-sdk/src/types/methods/get-bip44-entropy.ts
@@ -1,4 +1,4 @@
-import type { JsonBIP44Node } from '@metamask/key-tree';
+import type { JsonBIP44CoinTypeNode } from '@metamask/key-tree';
 
 import type { Bip44Entropy } from '../permissions';
 
@@ -14,4 +14,4 @@ export type GetBip44EntropyParams = Bip44Entropy;
  *
  * @see https://github.com/MetaMask/key-tree#usage
  */
-export type GetBip44EntropyResult = JsonBIP44Node;
+export type GetBip44EntropyResult = JsonBIP44CoinTypeNode;

--- a/packages/snaps-types/src/types.ts
+++ b/packages/snaps-types/src/types.ts
@@ -1,19 +1,3 @@
 // Exported again for convenience.
 export type { Json, JsonRpcRequest } from '@metamask/utils';
-export type {
-  AccountId,
-  ChainId,
-  OnCronjobHandler,
-  OnNameLookupHandler,
-  OnRpcRequestHandler,
-  OnTransactionHandler,
-  OnTransactionResponse,
-  OnNameLookupArgs,
-  OnNameLookupResponse,
-  OnInstallHandler,
-  OnUpdateHandler,
-  OnKeyringRequestHandler,
-  OnHomePageHandler,
-  OnHomePageResponse,
-} from '@metamask/snaps-utils';
-export { SeverityLevel, SnapError } from '@metamask/snaps-utils';
+export { SnapError } from '@metamask/snaps-utils';

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 96.14,
-  "functions": 98.11,
+  "branches": 96.11,
+  "functions": 98.1,
   "lines": 98.48,
-  "statements": 95.45
+  "statements": 95.44
 }

--- a/packages/snaps-utils/src/namespace.ts
+++ b/packages/snaps-utils/src/namespace.ts
@@ -1,3 +1,4 @@
+import type { AccountId, ChainId } from '@metamask/snaps-sdk';
 import type { Infer } from 'superstruct';
 import {
   array,
@@ -9,6 +10,8 @@ import {
   size,
   string,
 } from 'superstruct';
+
+import type { InferMatching } from './structs';
 
 export const CHAIN_ID_REGEX =
   /^(?<namespace>[-a-z0-9]{3,8}):(?<reference>[-a-zA-Z0-9]{1,32})$/u;
@@ -85,11 +88,10 @@ export const ChainIdStruct = pattern<ChainId, null>(
   ChainIdStringStruct,
   CHAIN_ID_REGEX,
 );
-export type ChainId = `${string}:${string}`;
-export type Caip2ChainId = Infer<typeof ChainIdStruct>;
+
+export type Caip2ChainId = InferMatching<typeof ChainIdStruct, ChainId>;
 
 export const AccountIdStruct = pattern(string(), ACCOUNT_ID_REGEX);
-export type AccountId = `${ChainId}:${string}`;
 
 export const AccountIdArrayStruct = array(AccountIdStruct);
 export const AccountAddressStruct = pattern(string(), ACCOUNT_ADDRESS_REGEX);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3736,7 +3736,6 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/utils": ^8.1.0
     "@noble/ed25519": ^1.6.0
@@ -3779,7 +3778,6 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/utils": ^8.1.0
     "@noble/bls12-381": ^1.2.0
@@ -3827,7 +3825,7 @@ __metadata:
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -3865,7 +3863,7 @@ __metadata:
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-browserify-plugin": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -3905,7 +3903,7 @@ __metadata:
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@metamask/utils": ^8.1.0
     "@noble/hashes": ^1.3.1
     "@swc/core": 1.3.78
@@ -3961,7 +3959,6 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/utils": ^8.1.0
     "@noble/curves": ^1.1.0
@@ -4068,7 +4065,7 @@ __metadata:
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
@@ -4108,7 +4105,6 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/utils": ^8.1.0
     "@swc/core": 1.3.78
@@ -4146,7 +4142,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -4296,7 +4292,7 @@ __metadata:
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@metamask/utils": ^8.1.0
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
@@ -4334,7 +4330,7 @@ __metadata:
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/utils": ^8.1.0
     "@swc/core": 1.3.78
@@ -4404,7 +4400,6 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/utils": ^8.1.0
     "@noble/bls12-381": ^1.2.0
@@ -4444,7 +4439,7 @@ __metadata:
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -4480,7 +4475,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
@@ -4517,7 +4512,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@metamask/utils": ^8.1.0
     "@swc/core": 1.3.78
@@ -4595,7 +4590,7 @@ __metadata:
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -4645,7 +4640,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@metamask/snaps-ui": "workspace:^"
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
@@ -4683,7 +4678,7 @@ __metadata:
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -4721,7 +4716,6 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -4757,7 +4751,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -4794,7 +4788,7 @@ __metadata:
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@metamask/utils": ^8.1.0
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
@@ -4833,7 +4827,6 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -4946,7 +4939,7 @@ __metadata:
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-rollup-plugin": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@rollup/plugin-babel": ^6.0.3
     "@rollup/plugin-commonjs": ^25.0.1
     "@rollup/plugin-node-resolve": ^15.1.0
@@ -5601,7 +5594,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/snaps-types@workspace:^, @metamask/snaps-types@workspace:packages/snaps-types":
+"@metamask/snaps-types@workspace:packages/snaps-types":
   version: 0.0.0-use.local
   resolution: "@metamask/snaps-types@workspace:packages/snaps-types"
   dependencies:
@@ -5937,7 +5930,7 @@ __metadata:
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -5974,7 +5967,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-jest": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
     "@metamask/snaps-webpack-plugin": "workspace:^"
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26


### PR DESCRIPTION
This moves all handler types (`OnRpcRequestHandler`, `OnTransactionHandler`, and so on) to `snaps-sdk`.

## Breaking changes

- All handler types were moved from `snaps-utils` to `snaps-sdk`.