### PR TITLE
Remove separate internals export from SDK

### DIFF
--- a/packages/snaps-jest/src/internals/types.ts
+++ b/packages/snaps-jest/src/internals/types.ts
@@ -1,5 +1,4 @@
-import type { NotificationType } from '@metamask/snaps-sdk';
-import type { EnumToUnion } from '@metamask/snaps-sdk/internals';
+import type { NotificationType, EnumToUnion } from '@metamask/snaps-sdk';
 import type { ApplicationState, Dispatch } from '@metamask/snaps-simulator';
 
 declare global {

--- a/packages/snaps-jest/src/matchers.ts
+++ b/packages/snaps-jest/src/matchers.ts
@@ -5,8 +5,7 @@
 
 import type { MatcherFunction } from '@jest/expect';
 import { expect } from '@jest/globals';
-import type { NotificationType } from '@metamask/snaps-sdk';
-import type { EnumToUnion } from '@metamask/snaps-sdk/internals';
+import type { NotificationType, EnumToUnion } from '@metamask/snaps-sdk';
 import type { Component } from '@metamask/snaps-ui';
 import type { Json } from '@metamask/utils';
 import { hasProperty } from '@metamask/utils';

--- a/packages/snaps-jest/src/types.ts
+++ b/packages/snaps-jest/src/types.ts
@@ -1,5 +1,4 @@
-import type { NotificationType } from '@metamask/snaps-sdk';
-import type { EnumToUnion } from '@metamask/snaps-sdk/internals';
+import type { NotificationType, EnumToUnion } from '@metamask/snaps-sdk';
 import type { Component } from '@metamask/snaps-ui';
 import type { JsonRpcId, JsonRpcParams } from '@metamask/utils';
 import type { Infer } from 'superstruct';

--- a/packages/snaps-rpc-methods/src/restricted/dialog.ts
+++ b/packages/snaps-rpc-methods/src/restricted/dialog.ts
@@ -5,9 +5,8 @@ import type {
 } from '@metamask/permission-controller';
 import { PermissionType, SubjectType } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { DialogParams } from '@metamask/snaps-sdk';
 import { DialogType } from '@metamask/snaps-sdk';
-import type { EnumToUnion } from '@metamask/snaps-sdk/internals';
+import type { DialogParams, EnumToUnion } from '@metamask/snaps-sdk';
 import type { Component } from '@metamask/snaps-ui';
 import { ComponentStruct, assertUILinksAreSafe } from '@metamask/snaps-ui';
 import type { InferMatching } from '@metamask/snaps-utils';

--- a/packages/snaps-rpc-methods/src/restricted/notify.ts
+++ b/packages/snaps-rpc-methods/src/restricted/notify.ts
@@ -5,9 +5,12 @@ import type {
 } from '@metamask/permission-controller';
 import { PermissionType, SubjectType } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { NotifyParams, NotifyResult } from '@metamask/snaps-sdk';
 import { NotificationType } from '@metamask/snaps-sdk';
-import type { EnumToUnion } from '@metamask/snaps-sdk/internals';
+import type {
+  NotifyParams,
+  NotifyResult,
+  EnumToUnion,
+} from '@metamask/snaps-sdk';
 import { assertLinksAreSafe } from '@metamask/snaps-ui';
 import type { NonEmptyArray } from '@metamask/utils';
 import { isObject } from '@metamask/utils';

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -6,19 +6,6 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "sideEffects": false,
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
-    },
-    "./internals": {
-      "import": "./dist/esm/internals/index.js",
-      "require": "./dist/cjs/internals/index.js",
-      "types": "./dist/types/internals/index.d.ts"
-    },
-    "./package.json": "./package.json"
-  },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/snaps-sdk/src/index.ts
+++ b/packages/snaps-sdk/src/index.ts
@@ -1,1 +1,2 @@
+export * from './internals';
 export * from './types';

--- a/packages/snaps-sdk/src/internals/helpers.ts
+++ b/packages/snaps-sdk/src/internals/helpers.ts
@@ -17,6 +17,7 @@ import type { JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
  *
  * const foo: FooValue = Foo.Bar; // Works
  * const foo: FooValue = 'bar'; // Also works
+ * @internal
  */
 export type EnumToUnion<Type extends string> = `${Type}`;
 
@@ -27,6 +28,7 @@ export type EnumToUnion<Type extends string> = `${Type}`;
  * @example
  * // MyMethod is { method: 'my_method', params: { foo: string } }
  * type MyMethod = Method<'my_method', { foo: string }>;
+ * @internal
  */
 export type Method<
   MethodName extends string,

--- a/packages/snaps-sdk/src/internals/index.ts
+++ b/packages/snaps-sdk/src/internals/index.ts
@@ -1,4 +1,1 @@
-// Internals that are used by the SDK but not exposed to the user. These can be
-// imported from other packages using `@metamask/snaps-sdk/internals`.
-
 export * from './helpers';

--- a/packages/snaps-utils/src/enum.ts
+++ b/packages/snaps-utils/src/enum.ts
@@ -1,4 +1,4 @@
-import type { EnumToUnion } from '@metamask/snaps-sdk/internals';
+import type { EnumToUnion } from '@metamask/snaps-sdk';
 import type { Struct } from 'superstruct';
 
 import { literal } from './structs';

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -7,7 +7,6 @@
     "module": "CommonJS",
     "moduleResolution": "node",
     "paths": {
-      "@metamask/*/internals": ["../*/src/internals"],
       "@metamask/*/test-utils": ["../*/src/test-utils"],
       "@metamask/*": ["../*/src"]
     },


### PR DESCRIPTION
The `/internals` export is causing issues with Browserify. The easiest solution for now is to remove it, until we switch to the Webpack LavaMoat bundler.