### PR TITLE
Include localization files in checksum calculations

### DIFF
--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "RJaMLctawZfKf8pgIVsEMs0mL+uFSN/z9EiaCcHs7rM=",
+    "shasum": "kxtjQB6U/ihrvbwlfJqzGYt+6NJWCgpO0LHh6ESqyBA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-utils/src/manifest/manifest.test.ts
+++ b/packages/snaps-utils/src/manifest/manifest.test.ts
@@ -177,7 +177,12 @@ describe('checkManifest', () => {
   });
 
   it('throws an error if the localization files are invalid', async () => {
-    const localizationFile = getMockLocalizationFile({ locale: 'en' });
+    const localizationFile = getMockLocalizationFile({
+      locale: 'en',
+      // @ts-expect-error - Invalid type.
+      messages: 'foo',
+    });
+
     const { manifest } = getMockSnapFiles({
       manifest: getSnapManifest({
         locales: ['locales/en.json'],
@@ -189,11 +194,11 @@ describe('checkManifest', () => {
     await fs.mkdir(join(BASE_PATH, 'locales'));
     await fs.writeFile(
       join(BASE_PATH, 'locales/en.json'),
-      JSON.stringify('[]'),
+      JSON.stringify(localizationFile),
     );
 
     await expect(checkManifest(BASE_PATH)).rejects.toThrow(
-      'Failed to validate localization file "/snap/locales/en.json": Expected an object, but received: "[]".',
+      'Failed to validate localization file "/snap/locales/en.json": At path: messages -- Expected an object, but received: "foo".',
     );
   });
 

--- a/packages/snaps-utils/src/snaps.ts
+++ b/packages/snaps-utils/src/snaps.ts
@@ -173,13 +173,17 @@ function getChecksummableManifest(
  * @returns The Base64-encoded SHA-256 digest of the source code.
  */
 export function getSnapChecksum(files: FetchedSnapFiles): string {
-  const { manifest, sourceCode, svgIcon, auxiliaryFiles } = files;
+  const { manifest, sourceCode, svgIcon, auxiliaryFiles, localizationFiles } =
+    files;
+
   const all = [
     getChecksummableManifest(manifest),
     sourceCode,
     svgIcon,
     ...auxiliaryFiles,
+    ...localizationFiles,
   ].filter((file) => file !== undefined);
+
   return base64.encode(checksumFiles(all as VirtualFile[]));
 }
 


### PR DESCRIPTION
Localization files were previously not included in the checksum calculations, meaning you could change those files without the checksum changing.