### PR TITLE
Add type tests to SDK

### DIFF
--- a/packages/snaps-sdk/.eslintrc.js
+++ b/packages/snaps-sdk/.eslintrc.js
@@ -4,4 +4,18 @@ module.exports = {
   parserOptions: {
     tsconfigRootDir: __dirname,
   },
+
+  overrides: [
+    {
+      files: ['*.test.ts'],
+      rules: {
+        'jest/expect-expect': [
+          'error',
+          {
+            assertFunctionNames: ['expect', 'expectTypeOf'],
+          },
+        ],
+      },
+    },
+  ],
 };

--- a/packages/snaps-sdk/jest.config.js
+++ b/packages/snaps-sdk/jest.config.js
@@ -13,4 +13,8 @@ module.exports = deepmerge(baseConfig, {
       statements: 100,
     },
   },
+
+  transform: {
+    '^.+\\.(t|j)sx?$': 'ts-jest',
+  },
 });

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -65,11 +65,13 @@
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
+    "expect-type": "^0.17.3",
     "jest": "^29.0.2",
     "jest-it-up": "^2.0.0",
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^4.1.2",
+    "ts-jest": "^29.1.1",
     "typescript": "~4.8.4"
   },
   "engines": {

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -51,7 +51,6 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/cli": "^0.1.62",
     "@swc/core": "1.3.78",
-    "@swc/jest": "^0.2.26",
     "@types/jest": "^27.5.1",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",

--- a/packages/snaps-sdk/src/internals/helpers.test.ts
+++ b/packages/snaps-sdk/src/internals/helpers.test.ts
@@ -1,0 +1,44 @@
+import { expectTypeOf } from 'expect-type';
+
+import type { EnumToUnion, Method } from './helpers';
+
+describe('EnumToUnion', () => {
+  it('creates a union type from an enum', () => {
+    enum Foo {
+      Bar = 'bar',
+      Baz = 'baz',
+    }
+
+    expectTypeOf<EnumToUnion<Foo>>().toEqualTypeOf<'bar' | 'baz'>();
+  });
+
+  it('creates a union type from a single enum value', () => {
+    enum Foo {
+      Bar = 'bar',
+      Baz = 'baz',
+    }
+
+    expectTypeOf<EnumToUnion<Foo.Bar>>().toEqualTypeOf<'bar'>();
+    expectTypeOf<EnumToUnion<Foo.Bar>>().toEqualTypeOf<'bar'>();
+  });
+});
+
+describe('Method', () => {
+  it('creates a JSON-RPC method with the given name and params', () => {
+    expectTypeOf<Method<'foo', { foo: string }>>().toEqualTypeOf<{
+      method: 'foo';
+      params: { foo: string };
+    }>();
+
+    expectTypeOf<Method<'foo', [string]>>().toEqualTypeOf<{
+      method: 'foo';
+      params: [string];
+    }>();
+  });
+
+  it('creates a JSON-RPC method with the given name and no params', () => {
+    expectTypeOf<Method<'bar', never>>().toEqualTypeOf<{
+      method: 'bar';
+    }>();
+  });
+});

--- a/packages/snaps-sdk/src/types/caip.test.ts
+++ b/packages/snaps-sdk/src/types/caip.test.ts
@@ -1,0 +1,15 @@
+import { expectTypeOf } from 'expect-type';
+
+import type { AccountId, ChainId } from './caip';
+
+describe('ChainId', () => {
+  it('has a colon-separated namespace and reference', () => {
+    expectTypeOf<'foo:bar'>().toMatchTypeOf<ChainId>();
+  });
+});
+
+describe('AccountId', () => {
+  it('has a colon-separated chain ID and account address', () => {
+    expectTypeOf<'foo:bar:baz'>().toMatchTypeOf<AccountId>();
+  });
+});

--- a/packages/snaps-sdk/src/types/methods/dialog.test.ts
+++ b/packages/snaps-sdk/src/types/methods/dialog.test.ts
@@ -1,3 +1,12 @@
+import { expectTypeOf } from 'expect-type';
+
+import type { text } from '../../ui';
+import type {
+  ConfirmationDialog,
+  PromptDialog,
+  AlertDialog,
+  DialogParams,
+} from './dialog';
 import { DialogType } from './dialog';
 
 describe('DialogType', () => {
@@ -6,5 +15,125 @@ describe('DialogType', () => {
     expect(DialogType.Alert).toBe('alert');
     expect(DialogType.Confirmation).toBe('confirmation');
     expect(DialogType.Prompt).toBe('prompt');
+  });
+});
+
+describe('AlertDialog', () => {
+  it('accepts the type as enum', () => {
+    expectTypeOf<{
+      type: DialogType.Alert;
+      content: ReturnType<typeof text>;
+    }>().toMatchTypeOf<AlertDialog>();
+  });
+
+  it('accepts the type as string', () => {
+    expectTypeOf<{
+      type: 'alert';
+      content: ReturnType<typeof text>;
+    }>().toMatchTypeOf<AlertDialog>();
+  });
+
+  it('does not accept other types', () => {
+    expectTypeOf<{
+      type: DialogType.Confirmation;
+      content: ReturnType<typeof text>;
+    }>().not.toMatchTypeOf<AlertDialog>();
+
+    expectTypeOf<{
+      type: 'confirmation';
+      content: ReturnType<typeof text>;
+    }>().not.toMatchTypeOf<AlertDialog>();
+  });
+});
+
+describe('ConfirmationDialog', () => {
+  it('accepts the type as enum', () => {
+    expectTypeOf<{
+      type: DialogType.Confirmation;
+      content: ReturnType<typeof text>;
+    }>().toMatchTypeOf<ConfirmationDialog>();
+  });
+
+  it('accepts the type as string', () => {
+    expectTypeOf<{
+      type: 'confirmation';
+      content: ReturnType<typeof text>;
+    }>().toMatchTypeOf<ConfirmationDialog>();
+  });
+
+  it('does not accept other types', () => {
+    expectTypeOf<{
+      type: DialogType.Alert;
+      content: ReturnType<typeof text>;
+    }>().not.toMatchTypeOf<ConfirmationDialog>();
+
+    expectTypeOf<{
+      type: 'alert';
+      content: ReturnType<typeof text>;
+    }>().not.toMatchTypeOf<ConfirmationDialog>();
+  });
+});
+
+describe('PromptDialog', () => {
+  it('accepts the type as enum', () => {
+    expectTypeOf<{
+      type: DialogType.Prompt;
+      content: ReturnType<typeof text>;
+    }>().toMatchTypeOf<PromptDialog>();
+  });
+
+  it('accepts the type as string', () => {
+    expectTypeOf<{
+      type: 'prompt';
+      content: ReturnType<typeof text>;
+    }>().toMatchTypeOf<PromptDialog>();
+  });
+
+  it('does not accept other types', () => {
+    expectTypeOf<{
+      type: DialogType.Alert;
+      content: ReturnType<typeof text>;
+    }>().not.toMatchTypeOf<PromptDialog>();
+
+    expectTypeOf<{
+      type: 'alert';
+      content: ReturnType<typeof text>;
+    }>().not.toMatchTypeOf<PromptDialog>();
+  });
+});
+
+describe('DialogParams', () => {
+  it('accepts the type as enum', () => {
+    expectTypeOf<{
+      type: DialogType.Alert;
+      content: ReturnType<typeof text>;
+    }>().toMatchTypeOf<DialogParams>();
+
+    expectTypeOf<{
+      type: DialogType.Confirmation;
+      content: ReturnType<typeof text>;
+    }>().toMatchTypeOf<DialogParams>();
+
+    expectTypeOf<{
+      type: DialogType.Prompt;
+      content: ReturnType<typeof text>;
+    }>().toMatchTypeOf<DialogParams>();
+  });
+
+  it('accepts the type as string', () => {
+    expectTypeOf<{
+      type: 'alert';
+      content: ReturnType<typeof text>;
+    }>().toMatchTypeOf<DialogParams>();
+
+    expectTypeOf<{
+      type: 'confirmation';
+      content: ReturnType<typeof text>;
+    }>().toMatchTypeOf<DialogParams>();
+
+    expectTypeOf<{
+      type: 'prompt';
+      content: ReturnType<typeof text>;
+    }>().toMatchTypeOf<DialogParams>();
   });
 });

--- a/packages/snaps-sdk/src/types/methods/get-file.test.ts
+++ b/packages/snaps-sdk/src/types/methods/get-file.test.ts
@@ -1,3 +1,6 @@
+import { expectTypeOf } from 'expect-type';
+
+import type { GetFileParams } from './get-file';
 import { AuxiliaryFileEncoding } from './get-file';
 
 describe('AuxiliaryFileEncoding', () => {
@@ -6,5 +9,21 @@ describe('AuxiliaryFileEncoding', () => {
     expect(AuxiliaryFileEncoding.Base64).toBe('base64');
     expect(AuxiliaryFileEncoding.Hex).toBe('hex');
     expect(AuxiliaryFileEncoding.Utf8).toBe('utf8');
+  });
+});
+
+describe('GetFileParams', () => {
+  it('accepts the type as enum', () => {
+    expectTypeOf<{
+      path: string;
+      encoding: AuxiliaryFileEncoding.Hex;
+    }>().toMatchTypeOf<GetFileParams>();
+  });
+
+  it('accepts the type as string', () => {
+    expectTypeOf<{
+      path: string;
+      encoding: 'hex';
+    }>().toMatchTypeOf<GetFileParams>();
   });
 });

--- a/packages/snaps-sdk/src/types/methods/manage-state.test.ts
+++ b/packages/snaps-sdk/src/types/methods/manage-state.test.ts
@@ -1,3 +1,12 @@
+import type { Json } from '@metamask/utils';
+import { expectTypeOf } from 'expect-type';
+
+import type {
+  ClearStateOperation,
+  GetStateOperation,
+  ManageStateParams,
+  UpdateStateOperation,
+} from './manage-state';
 import { ManageStateOperation } from './manage-state';
 
 describe('ManageStateOperation', () => {
@@ -6,5 +15,95 @@ describe('ManageStateOperation', () => {
     expect(ManageStateOperation.ClearState).toBe('clear');
     expect(ManageStateOperation.GetState).toBe('get');
     expect(ManageStateOperation.UpdateState).toBe('update');
+  });
+});
+
+describe('ClearStateOperation', () => {
+  it('accepts the type as enum', () => {
+    expectTypeOf<{
+      operation: ManageStateOperation.ClearState;
+    }>().toMatchTypeOf<ClearStateOperation>();
+  });
+
+  it('accepts the type as string', () => {
+    expectTypeOf<{
+      operation: 'clear';
+    }>().toMatchTypeOf<ClearStateOperation>();
+  });
+
+  it('does not accept other types', () => {
+    expectTypeOf<{
+      operation: ManageStateOperation.GetState;
+    }>().not.toMatchTypeOf<ClearStateOperation>();
+
+    expectTypeOf<{
+      operation: 'get';
+    }>().not.toMatchTypeOf<ClearStateOperation>();
+  });
+});
+
+describe('GetStateOperation', () => {
+  it('accepts the type as enum', () => {
+    expectTypeOf<{
+      operation: ManageStateOperation.GetState;
+    }>().toMatchTypeOf<GetStateOperation>();
+  });
+
+  it('accepts the type as string', () => {
+    expectTypeOf<{
+      operation: 'get';
+    }>().toMatchTypeOf<GetStateOperation>();
+  });
+
+  it('does not accept other types', () => {
+    expectTypeOf<{
+      operation: ManageStateOperation.ClearState;
+    }>().not.toMatchTypeOf<GetStateOperation>();
+
+    expectTypeOf<{
+      operation: 'clear';
+    }>().not.toMatchTypeOf<GetStateOperation>();
+  });
+});
+
+describe('UpdateStateOperation', () => {
+  it('accepts the type as enum', () => {
+    expectTypeOf<{
+      operation: ManageStateOperation.UpdateState;
+      newState: Record<string, Json>;
+    }>().toMatchTypeOf<UpdateStateOperation>();
+  });
+
+  it('accepts the type as string', () => {
+    expectTypeOf<{
+      operation: 'update';
+      newState: Record<string, Json>;
+    }>().toMatchTypeOf<UpdateStateOperation>();
+  });
+
+  it('does not accept other types', () => {
+    expectTypeOf<{
+      operation: ManageStateOperation.ClearState;
+      newState: Record<string, Json>;
+    }>().not.toMatchTypeOf<UpdateStateOperation>();
+
+    expectTypeOf<{
+      operation: 'clear';
+      newState: Record<string, Json>;
+    }>().not.toMatchTypeOf<UpdateStateOperation>();
+  });
+});
+
+describe('ManageStateParams', () => {
+  it('accepts the type as enum', () => {
+    expectTypeOf<{
+      operation: ManageStateOperation.ClearState;
+    }>().toMatchTypeOf<ManageStateParams>();
+  });
+
+  it('accepts the type as string', () => {
+    expectTypeOf<{
+      operation: 'clear';
+    }>().toMatchTypeOf<ManageStateParams>();
   });
 });

--- a/packages/snaps-sdk/src/types/methods/notify.test.ts
+++ b/packages/snaps-sdk/src/types/methods/notify.test.ts
@@ -1,3 +1,6 @@
+import { expectTypeOf } from 'expect-type';
+
+import type { NotifyParams } from './notify';
 import { NotificationType } from './notify';
 
 describe('NotificationType', () => {
@@ -5,5 +8,21 @@ describe('NotificationType', () => {
     expect(Object.values(NotificationType)).toHaveLength(2);
     expect(NotificationType.InApp).toBe('inApp');
     expect(NotificationType.Native).toBe('native');
+  });
+});
+
+describe('NotifyParams', () => {
+  it('accepts the type as enum', () => {
+    expectTypeOf<{
+      type: NotificationType.InApp;
+      message: string;
+    }>().toMatchTypeOf<NotifyParams>();
+  });
+
+  it('accepts the type as string', () => {
+    expectTypeOf<{
+      type: 'inApp';
+      message: string;
+    }>().toMatchTypeOf<NotifyParams>();
   });
 });

--- a/packages/snaps-sdk/src/types/permissions.test.ts
+++ b/packages/snaps-sdk/src/types/permissions.test.ts
@@ -1,0 +1,83 @@
+import { expectTypeOf } from 'expect-type';
+
+import type {
+  Bip32Entropy,
+  Bip44Entropy,
+  Cronjob,
+  InitialPermissions,
+  RequestedSnap,
+} from './permissions';
+
+describe('Cronjob', () => {
+  it('has an expression and JSON-RPC request', () => {
+    const cronjob = {
+      expression: '* * * * *',
+      request: {
+        method: 'bar',
+        params: {
+          foo: 'bar',
+        },
+      },
+    };
+
+    expectTypeOf(cronjob).toMatchTypeOf<Cronjob>();
+  });
+});
+
+describe('Bip32Entropy', () => {
+  it('supports secp256k1', () => {
+    const entropy = {
+      curve: 'secp256k1' as const,
+      path: ['m', "44'"],
+    };
+
+    expectTypeOf(entropy).toMatchTypeOf<Bip32Entropy>();
+  });
+
+  it('supports ed25519', () => {
+    const entropy = {
+      curve: 'ed25519' as const,
+      path: ['m', "44'"],
+    };
+
+    expectTypeOf(entropy).toMatchTypeOf<Bip32Entropy>();
+  });
+});
+
+describe('Bip44Entropy', () => {
+  it('has a coin type', () => {
+    const entropy = {
+      coinType: 60,
+    };
+
+    expectTypeOf(entropy).toMatchTypeOf<Bip44Entropy>();
+  });
+});
+
+describe('RequestedSnap', () => {
+  it('has an optional version', () => {
+    const snap = {
+      version: '1.0.0',
+    };
+
+    expectTypeOf(snap).toMatchTypeOf<RequestedSnap>();
+  });
+
+  it('works without version', () => {
+    const snap = {};
+
+    expectTypeOf(snap).toMatchTypeOf<RequestedSnap>();
+  });
+});
+
+describe('InitialPermissions', () => {
+  it('does not accept anything for certain permissions', () => {
+    const permissions = {
+      'endowment:network-access': {
+        foo: 'bar',
+      },
+    };
+
+    expectTypeOf(permissions).not.toMatchTypeOf<InitialPermissions>();
+  });
+});

--- a/packages/snaps-sdk/src/types/provider.test.ts
+++ b/packages/snaps-sdk/src/types/provider.test.ts
@@ -1,0 +1,18 @@
+import { expectTypeOf } from 'expect-type';
+
+import type { SnapsEthereumProvider, SnapsProvider } from './provider';
+
+describe('SnapsEthereumProvider', () => {
+  it('only has the expected methods', () => {
+    expectTypeOf<SnapsEthereumProvider>().toHaveProperty('request');
+    expectTypeOf<SnapsEthereumProvider>().toHaveProperty('on');
+    expectTypeOf<SnapsEthereumProvider>().toHaveProperty('removeListener');
+    expectTypeOf<SnapsEthereumProvider>().not.toHaveProperty('isConnected');
+  });
+});
+
+describe('SnapsProvider', () => {
+  it('has a request method', () => {
+    expectTypeOf<SnapsProvider>().toHaveProperty('request');
+  });
+});

--- a/packages/snaps-sdk/src/types/snap.test.ts
+++ b/packages/snaps-sdk/src/types/snap.test.ts
@@ -1,0 +1,13 @@
+import { expectTypeOf } from 'expect-type';
+
+import type { SnapId } from './snap';
+
+describe('SnapId', () => {
+  it('is a string', () => {
+    expectTypeOf<SnapId>().toMatchTypeOf<string>();
+  });
+
+  it('does not allow other strings', () => {
+    expectTypeOf<SnapId>().not.toEqualTypeOf<string>();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5456,7 +5456,6 @@ __metadata:
     "@metamask/utils": ^8.2.1
     "@swc/cli": ^0.1.62
     "@swc/core": 1.3.78
-    "@swc/jest": ^0.2.26
     "@types/jest": ^27.5.1
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -5470,6 +5470,7 @@ __metadata:
     eslint-plugin-n: ^15.7.0
     eslint-plugin-prettier: ^4.2.1
     eslint-plugin-promise: ^6.1.1
+    expect-type: ^0.17.3
     is-svg: ^4.4.0
     jest: ^29.0.2
     jest-it-up: ^2.0.0
@@ -5477,6 +5478,7 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^4.1.2
     superstruct: ^1.0.3
+    ts-jest: ^29.1.1
     typescript: ~4.8.4
   languageName: unknown
   linkType: soft
@@ -9588,6 +9590,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bs-logger@npm:0.x":
+  version: 0.2.6
+  resolution: "bs-logger@npm:0.2.6"
+  dependencies:
+    fast-json-stable-stringify: 2.x
+  checksum: d34bdaf68c64bd099ab97c3ea608c9ae7d3f5faa1178b3f3f345acd94e852e608b2d4f9103fb2e503f5e69780e98293df41691b84be909b41cf5045374d54606
+  languageName: node
+  linkType: hard
+
 "bs58@npm:^4.0.0":
   version: 4.0.1
   resolution: "bs58@npm:4.0.1"
@@ -12777,6 +12788,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expect-type@npm:^0.17.3":
+  version: 0.17.3
+  resolution: "expect-type@npm:0.17.3"
+  checksum: 6c8bc2fc6815c4a1745d3d2d9ba95a033d00eba3a1352acefe267898c60e183b86224df88a048e655da4d2d9e1790c0cb5eb8e36d4c98c077af7676ad3f99558
+  languageName: node
+  linkType: hard
+
 "expect-webdriverio@npm:^4.2.5, expect-webdriverio@npm:^4.4.1":
   version: 4.4.1
   resolution: "expect-webdriverio@npm:4.4.1"
@@ -12952,7 +12970,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
+"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
   checksum: b191531e36c607977e5b1c47811158733c34ccb3bfde92c44798929e9b4154884378536d26ad90dfecd32e1ffc09c545d23535ad91b3161a27ddbb8ebe0cbecb
@@ -15757,7 +15775,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^29.7.0":
+"jest-util@npm:^29.0.0, jest-util@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-util@npm:29.7.0"
   dependencies:
@@ -16525,6 +16543,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.memoize@npm:4.x":
+  version: 4.1.2
+  resolution: "lodash.memoize@npm:4.1.2"
+  checksum: 9ff3942feeccffa4f1fafa88d32f0d24fdc62fd15ded5a74a5f950ff5f0c6f61916157246744c620173dddf38d37095a92327d5fd3861e2063e736a5c207d089
+  languageName: node
+  linkType: hard
+
 "lodash.memoize@npm:~3.0.3":
   version: 3.0.4
   resolution: "lodash.memoize@npm:3.0.4"
@@ -16752,7 +16777,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-error@npm:^1.1.1":
+"make-error@npm:1.x, make-error@npm:^1.1.1":
   version: 1.3.6
   resolution: "make-error@npm:1.3.6"
   checksum: b86e5e0e25f7f777b77fabd8e2cbf15737972869d852a22b7e73c17623928fccb826d8e46b9951501d3f20e51ad74ba8c59ed584f610526a48f8ccf88aaec402
@@ -20341,7 +20366,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.0, semver@npm:^7.5.4":
+"semver@npm:^7.0.0, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.0, semver@npm:^7.5.3, semver@npm:^7.5.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:
@@ -21729,6 +21754,39 @@ __metadata:
   version: 1.0.5
   resolution: "trough@npm:1.0.5"
   checksum: d6c8564903ed00e5258bab92134b020724dbbe83148dc72e4bf6306c03ed8843efa1bcc773fa62410dd89161ecb067432dd5916501793508a9506cacbc408e25
+  languageName: node
+  linkType: hard
+
+"ts-jest@npm:^29.1.1":
+  version: 29.1.1
+  resolution: "ts-jest@npm:29.1.1"
+  dependencies:
+    bs-logger: 0.x
+    fast-json-stable-stringify: 2.x
+    jest-util: ^29.0.0
+    json5: ^2.2.3
+    lodash.memoize: 4.x
+    make-error: 1.x
+    semver: ^7.5.3
+    yargs-parser: ^21.0.1
+  peerDependencies:
+    "@babel/core": ">=7.0.0-beta.0 <8"
+    "@jest/types": ^29.0.0
+    babel-jest: ^29.0.0
+    jest: ^29.0.0
+    typescript: ">=4.3 <6"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@jest/types":
+      optional: true
+    babel-jest:
+      optional: true
+    esbuild:
+      optional: true
+  bin:
+    ts-jest: cli.js
+  checksum: a8c9e284ed4f819526749f6e4dc6421ec666f20ab44d31b0f02b4ed979975f7580b18aea4813172d43e39b29464a71899f8893dd29b06b4a351a3af8ba47b402
   languageName: node
   linkType: hard
 
@@ -23254,7 +23312,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^21.1.1":
+"yargs-parser@npm:^21.0.1, yargs-parser@npm:^21.1.1":
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
   checksum: ed2d96a616a9e3e1cc7d204c62ecc61f7aaab633dcbfab2c6df50f7f87b393993fe6640d017759fe112d0cb1e0119f2b4150a87305cc873fd90831c6a58ccf1c


### PR DESCRIPTION
This adds type tests to the most important parts of the SDK. This helps us to catch potential type regressions in this package.

Note that this also required using `ts-jest` for running tests, since otherwise potential type issues would not be caught.