### PR TITLE
Publish locales folder in localization snap

### DIFF
--- a/packages/examples/packages/localization/package.json
+++ b/packages/examples/packages/localization/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist/",
     "snap.manifest.json",
-    "images/icon.svg"
+    "images/icon.svg",
+    "locales/"
   ],
   "scripts": {
     "build": "mm-snap build",


### PR DESCRIPTION
The localization snap was missing package.json configuration to correctly publish the locales folder which is needed for install.