### PR TITLE
Fix coercing of address values in sendTransaction

### DIFF
--- a/packages/snaps-jest/src/internals/structs.ts
+++ b/packages/snaps-jest/src/internals/structs.ts
@@ -49,7 +49,7 @@ export const TransactionOptionsStruct = object({
   // TODO: Move this coercer to `@metamask/utils`.
   from: coerce(StrictHexStruct, optional(BytesLikeStruct), (value) => {
     if (value) {
-      return valueToBytes(value);
+      return bytesToHex(valueToBytes(value));
     }
 
     return bytesToHex(randomBytes(20));
@@ -62,7 +62,7 @@ export const TransactionOptionsStruct = object({
   // TODO: Move this coercer to `@metamask/utils`.
   to: coerce(StrictHexStruct, optional(BytesLikeStruct), (value) => {
     if (value) {
-      return valueToBytes(value);
+      return bytesToHex(valueToBytes(value));
     }
 
     return bytesToHex(randomBytes(20));


### PR DESCRIPTION
When using the `snaps-jest` `sendTransaction` function with address values the coercing would fail and throw because the coerced value doesn't match the expected output (in this case hexadecimal). This PR fixes this oversight by converting the coerced value to hex.