### PR TITLE
Fix a few issues with passing non-serializable JSON

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 90.26,
+  "branches": 90.47,
   "functions": 96.32,
-  "lines": 97.22,
-  "statements": 96.9
+  "lines": 97.28,
+  "statements": 96.96
 }

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.test.ts
@@ -1,4 +1,5 @@
 import { HandlerType } from '@metamask/snaps-utils';
+import { MOCK_SNAP_ID } from '@metamask/snaps-utils/test-utils';
 
 import { createService } from '../test-utils';
 import type { ExecutionServiceArgs } from './AbstractExecutionService';
@@ -99,6 +100,31 @@ describe('AbstractExecutionService', () => {
       }),
     ).rejects.toThrow(
       `Snap execution service returned no RPC handler for running snap "${snapId}".`,
+    );
+  });
+
+  it('throws an error if RPC request is non JSON serializable', async () => {
+    const { service } = createService(MockExecutionService);
+    await service.executeSnap({
+      snapId: MOCK_SNAP_ID,
+      sourceCode: `
+        console.log('foo');
+      `,
+      endowments: ['console'],
+    });
+
+    await expect(
+      service.handleRpcRequest(MOCK_SNAP_ID, {
+        origin: 'foo.com',
+        handler: HandlerType.OnRpcRequest,
+        request: {
+          id: 6,
+          method: 'bar',
+          params: undefined,
+        },
+      }),
+    ).rejects.toThrow(
+      'Invalid JSON-RPC request: At path: params -- Expected the value to satisfy a union of `record | array`, but received: [object Object].',
     );
   });
 });

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.ts
@@ -10,7 +10,12 @@ import type {
   JsonRpcRequest,
   PendingJsonRpcResponse,
 } from '@metamask/utils';
-import { Duration, isJsonRpcNotification, isObject } from '@metamask/utils';
+import {
+  Duration,
+  assertIsJsonRpcRequest,
+  isJsonRpcNotification,
+  isObject,
+} from '@metamask/utils';
 import { createStreamMiddleware } from 'json-rpc-middleware-stream';
 import { nanoid } from 'nanoid';
 import { pipeline } from 'readable-stream';
@@ -362,9 +367,7 @@ export abstract class AbstractExecutionService<WorkerType>
     jobId: string,
     message: JsonRpcRequest,
   ): Promise<Json | undefined> {
-    if (typeof message !== 'object') {
-      throw new Error('Must send object.');
-    }
+    assertIsJsonRpcRequest(message);
 
     const job = this.jobs.get(jobId);
     if (!job) {

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 79.57,
+  "branches": 80.68,
   "functions": 89.72,
-  "lines": 90.6,
-  "statements": 90.2
+  "lines": 90.78,
+  "statements": 90.38
 }

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 80.68,
+  "branches": 80.82,
   "functions": 89.72,
-  "lines": 90.78,
-  "statements": 90.38
+  "lines": 90.79,
+  "statements": 90.39
 }

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1932,6 +1932,7 @@ describe('BaseSnapExecutor', () => {
         MOCK_SNAP_ID,
         HandlerType.OnRpcRequest,
         MOCK_ORIGIN,
+        // @ts-expect-error Invalid JSON
         { jsonrpc: '2.0', method: 'foo', params: undefined },
       ],
     });
@@ -1945,6 +1946,24 @@ describe('BaseSnapExecutor', () => {
         stack: expect.any(String),
       },
     });
+  });
+
+  it('logs when receiving an invalid RPC request that cannot be responded to', async () => {
+    const executor = new TestSnapExecutor();
+
+    const consoleSpy = spy(console, 'log');
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      // @ts-expect-error Invalid JSON
+      id: undefined,
+      method: 'snapRpc',
+      params: [MOCK_SNAP_ID, HandlerType.OnRpcRequest, MOCK_ORIGIN, {}],
+    });
+
+    expect(consoleSpy.calls[0]?.args[0]).toStrictEqual(
+      'Command stream received a non-JSON-RPC request, and was unable to respond.',
+    );
   });
 
   it('contains the self-referential global scopes', async () => {

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1921,6 +1921,32 @@ describe('BaseSnapExecutor', () => {
     });
   });
 
+  it('throws when receiving an invalid RPC request', async () => {
+    const executor = new TestSnapExecutor();
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'snapRpc',
+      params: [
+        MOCK_SNAP_ID,
+        HandlerType.OnRpcRequest,
+        MOCK_ORIGIN,
+        { jsonrpc: '2.0', method: 'foo', params: undefined },
+      ],
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 2,
+      error: {
+        code: -32603,
+        message: 'JSON-RPC requests must be JSON serializable objects.',
+        stack: expect.any(String),
+      },
+    });
+  });
+
   it('contains the self-referential global scopes', async () => {
     const CODE = `
       module.exports.onRpcRequest = () => globalThis !== undefined &&

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -17,6 +17,7 @@ import {
   SNAP_EXPORTS,
   WrappedSnapError,
   unwrapError,
+  logInfo,
 } from '@metamask/snaps-utils';
 import type {
   JsonRpcNotification,
@@ -229,6 +230,10 @@ export class BaseSnapExecutor {
           id: (message as Pick<JsonRpcRequest, 'id'>).id,
           jsonrpc: '2.0',
         });
+      } else {
+        logInfo(
+          'Command stream received a non-JSON-RPC request, and was unable to respond.',
+        );
       }
       return;
     }


### PR DESCRIPTION
`AbstractExecutionService` will now properly guard against passing invalid JSON-RPC requests and `BaseSnapExecutor` will try to respond with an error if it receives an invalid JSON-RPC request that is deemed valid enough to respond.