### PR TITLE
Fix issues generating checksum with binary auxiliary files

### DIFF
--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 95.98,
+  "branches": 96,
   "functions": 99,
   "lines": 98.68,
   "statements": 95.58

--- a/packages/snaps-utils/src/manifest/manifest.test.ts
+++ b/packages/snaps-utils/src/manifest/manifest.test.ts
@@ -437,6 +437,12 @@ describe('getSnapFiles', () => {
     expect(files?.[0]?.value).toBe(MOCK_AUXILIARY_FILE);
   });
 
+  it('returns the file in the specified encoding', async () => {
+    const files = await getSnapFiles(BASE_PATH, ['./src/foo.json'], null);
+    expect(files?.[0]?.value).toBeInstanceOf(Uint8Array);
+    expect(files?.[0]?.value.toString()).toBe(MOCK_AUXILIARY_FILE);
+  });
+
   it('throws an error if the file cannot be read', async () => {
     jest.spyOn(fs, 'readFile').mockImplementation(() => {
       throw new Error('foo');

--- a/packages/snaps-utils/src/manifest/manifest.ts
+++ b/packages/snaps-utils/src/manifest/manifest.ts
@@ -102,7 +102,9 @@ export async function checkManifest(
       sourceCode,
     ),
     svgIcon: await getSnapIcon(basePath, unvalidatedManifest),
-    auxiliaryFiles: (await getSnapFiles(basePath, auxiliaryFilePaths)) ?? [],
+    // Intentionally pass null as the encoding here since the files may be binary
+    auxiliaryFiles:
+      (await getSnapFiles(basePath, auxiliaryFilePaths, null)) ?? [],
     localizationFiles:
       (await getSnapFiles(basePath, localizationFilePaths)) ?? [],
   };
@@ -368,11 +370,13 @@ export function getSnapFilePaths(
  *
  * @param basePath - The path to the folder with the manifest files.
  * @param paths - The paths to the files.
+ * @param encoding - An optional encoding to pass down to readVirtualFile.
  * @returns A list of auxiliary files and their contents, if any.
  */
 export async function getSnapFiles(
   basePath: string,
   paths: string[] | undefined,
+  encoding: BufferEncoding | null = 'utf8',
 ): Promise<VirtualFile[] | undefined> {
   if (!paths) {
     return undefined;
@@ -381,7 +385,7 @@ export async function getSnapFiles(
   try {
     return await Promise.all(
       paths.map(async (filePath) =>
-        readVirtualFile(pathUtils.join(basePath, filePath), 'utf8'),
+        readVirtualFile(pathUtils.join(basePath, filePath), encoding),
       ),
     );
   } catch (error) {


### PR DESCRIPTION
Fixes an issue with the CLI generating a checksum for binary auxiliary files. Since the encoding of the files was set to `utf8` but the files were binary when fetched in the SnapController this would cause a difference in the checksum.