### PR TITLE
Block `wallet_revokePermissions`

### DIFF
--- a/packages/snaps-execution-environments/src/common/utils.ts
+++ b/packages/snaps-execution-environments/src/common/utils.ts
@@ -84,6 +84,7 @@ export function proxyStreamProvider(
 export const BLOCKED_RPC_METHODS = Object.freeze([
   'wallet_requestSnaps',
   'wallet_requestPermissions',
+  'wallet_revokePermissions',
   // We disallow all of these confirmations for now, since the screens are not ready for Snaps.
   'eth_sendRawTransaction',
   'eth_sendTransaction',


### PR DESCRIPTION
The dapp API is soon gonna support `wallet_revokePermissions`, we cannot allow snaps to use this until we ship special functionality that prevents snaps from revoking `initialPermissions`.