### PR TITLE
Improve base64 encoding/decoding speeds

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 90.11,
-  "functions": 96.34,
-  "lines": 97.29,
+  "functions": 96.35,
+  "lines": 97.3,
   "statements": 96.98
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -47,6 +47,7 @@ import {
   base64ToBytes,
   stringToBytes,
 } from '@metamask/utils';
+import { File } from 'buffer';
 import fetchMock from 'jest-fetch-mock';
 import { createEngineStream } from 'json-rpc-middleware-stream';
 import { pipeline } from 'readable-stream';
@@ -6583,6 +6584,11 @@ describe('SnapController', () => {
 
     it('supports hex encoding', async () => {
       fetchMock.disableMocks();
+
+      // We can remove this once we drop Node 18
+      Object.defineProperty(globalThis, 'File', {
+        value: File,
+      });
 
       // Because jest-fetch-mock replaces native fetch, we mock it here
       Object.defineProperty(globalThis, 'fetch', {

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -69,7 +69,7 @@ import {
   unwrapError,
   OnHomePageResponseStruct,
   getValidatedLocalizationFiles,
-  asyncEncode,
+  encodeBase64,
 } from '@metamask/snaps-utils';
 import type { Json, NonEmptyArray, SemVerRange } from '@metamask/utils';
 import {
@@ -2381,7 +2381,7 @@ export class SnapController extends BaseController<
         auxiliaryFiles.map(async (file) => {
           // This should still be safe
           // eslint-disable-next-line require-atomic-updates
-          file.data.base64 = await asyncEncode(file);
+          file.data.base64 = await encodeBase64(file);
         }),
       );
 

--- a/packages/snaps-simulator/src/features/simulation/hooks.test.ts
+++ b/packages/snaps-simulator/src/features/simulation/hooks.test.ts
@@ -1,6 +1,7 @@
 import { AuxiliaryFileEncoding, DialogType, text } from '@metamask/snaps-sdk';
 import { VirtualFile, normalizeRelative } from '@metamask/snaps-utils';
-import { stringToBytes } from '@metamask/utils';
+import { base64ToBytes, stringToBytes } from '@metamask/utils';
+import { File } from 'buffer';
 import { expectSaga } from 'redux-saga-test-plan';
 
 import { addNotification } from '../notifications';
@@ -37,6 +38,15 @@ jest.mock('@reduxjs/toolkit', () => ({
   ...jest.requireActual('@reduxjs/toolkit'),
   nanoid: () => 'foo',
 }));
+
+// Because jest-fetch-mock replaces native fetch, we mock it here
+Object.defineProperty(globalThis, 'fetch', {
+  value: async (dataUrl: string) => {
+    const base64 = dataUrl.replace('data:application/octet-stream;base64,', '');
+    const u8 = base64ToBytes(base64);
+    return new File([u8], '');
+  },
+});
 
 const snapId = 'local:http://localhost:8080';
 

--- a/packages/snaps-simulator/src/features/simulation/hooks.ts
+++ b/packages/snaps-simulator/src/features/simulation/hooks.ts
@@ -196,5 +196,5 @@ export function* getSnapFile(
     return null;
   }
 
-  return encodeAuxiliaryFile(base64, encoding);
+  return yield call(encodeAuxiliaryFile, base64, encoding);
 }

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 96,
-  "functions": 99,
-  "lines": 98.68,
-  "statements": 95.58
+  "branches": 96.01,
+  "functions": 98.53,
+  "lines": 98.6,
+  "statements": 95.55
 }

--- a/packages/snaps-utils/src/auxiliary-files.test.ts
+++ b/packages/snaps-utils/src/auxiliary-files.test.ts
@@ -5,24 +5,26 @@ import { base64 } from '@scure/base';
 import { encodeAuxiliaryFile } from './auxiliary-files';
 
 describe('encodeAuxiliaryFile', () => {
-  it('returns value without modifying it for base64', () => {
+  it('returns value without modifying it for base64', async () => {
     const value = base64.encode(stringToBytes('foo'));
     expect(
-      encodeAuxiliaryFile(value, AuxiliaryFileEncoding.Base64),
+      await encodeAuxiliaryFile(value, AuxiliaryFileEncoding.Base64),
     ).toStrictEqual(value);
   });
 
-  it('re-encodes to hex when requested', () => {
+  it('re-encodes to hex when requested', async () => {
     const bytes = stringToBytes('foo');
     const value = base64.encode(bytes);
-    expect(encodeAuxiliaryFile(value, AuxiliaryFileEncoding.Hex)).toStrictEqual(
-      bytesToHex(bytes),
-    );
+    expect(
+      await encodeAuxiliaryFile(value, AuxiliaryFileEncoding.Hex),
+    ).toStrictEqual(bytesToHex(bytes));
   });
 
-  it('returns plaintext when requested', () => {
+  it('returns plaintext when requested', async () => {
     const bytes = stringToBytes('foo');
     const value = base64.encode(bytes);
-    expect(encodeAuxiliaryFile(value, AuxiliaryFileEncoding.Utf8)).toBe('foo');
+    expect(await encodeAuxiliaryFile(value, AuxiliaryFileEncoding.Utf8)).toBe(
+      'foo',
+    );
   });
 });

--- a/packages/snaps-utils/src/auxiliary-files.ts
+++ b/packages/snaps-utils/src/auxiliary-files.ts
@@ -1,6 +1,7 @@
 import { AuxiliaryFileEncoding } from '@metamask/snaps-sdk';
 import { bytesToHex, bytesToString } from '@metamask/utils';
-import { base64 } from '@scure/base';
+
+import { asyncDecode } from './base64';
 
 /**
  * Re-encodes an auxiliary file if needed depending on the requested file encoding.
@@ -9,7 +10,7 @@ import { base64 } from '@scure/base';
  * @param encoding - The chosen encoding.
  * @returns The file encoded in the requested encoding.
  */
-export function encodeAuxiliaryFile(
+export async function encodeAuxiliaryFile(
   value: string,
   encoding: AuxiliaryFileEncoding,
 ) {
@@ -19,7 +20,7 @@ export function encodeAuxiliaryFile(
   }
 
   // TODO: Use @metamask/utils for this
-  const decoded = base64.decode(value);
+  const decoded = await asyncDecode(value);
   if (encoding === AuxiliaryFileEncoding.Utf8) {
     return bytesToString(decoded);
   }

--- a/packages/snaps-utils/src/auxiliary-files.ts
+++ b/packages/snaps-utils/src/auxiliary-files.ts
@@ -1,7 +1,7 @@
 import { AuxiliaryFileEncoding } from '@metamask/snaps-sdk';
 import { bytesToHex, bytesToString } from '@metamask/utils';
 
-import { asyncDecode } from './base64';
+import { decodeBase64 } from './base64';
 
 /**
  * Re-encodes an auxiliary file if needed depending on the requested file encoding.
@@ -20,7 +20,7 @@ export async function encodeAuxiliaryFile(
   }
 
   // TODO: Use @metamask/utils for this
-  const decoded = await asyncDecode(value);
+  const decoded = await decodeBase64(value);
   if (encoding === AuxiliaryFileEncoding.Utf8) {
     return bytesToString(decoded);
   }

--- a/packages/snaps-utils/src/base64.test.ts
+++ b/packages/snaps-utils/src/base64.test.ts
@@ -1,10 +1,50 @@
-import { stringToBytes } from '@metamask/utils';
+import { bytesToBase64, stringToBytes } from '@metamask/utils';
 
 import { asyncDecode, asyncEncode } from './base64';
 import { VirtualFile } from './virtual-file';
 
+// Very basic mock that mimics the base64 encoding logic of the browser
+class MockFileReader {
+  onload?: () => any;
+
+  onerror?: () => any;
+
+  result?: any;
+
+  error?: any;
+
+  readAsDataURL(file: File) {
+    file
+      .arrayBuffer()
+      .then((buffer) => {
+        const u8 = new Uint8Array(buffer);
+
+        this.result = `data:application/octet-stream;base64,${bytesToBase64(
+          u8,
+        )}`;
+
+        this.onload?.();
+      })
+      .catch((error) => {
+        this.error = error;
+        this.onerror?.();
+      });
+  }
+}
+
 describe('asyncEncode', () => {
   it('encodes vfile to base64', async () => {
+    const vfile = new VirtualFile(
+      stringToBytes(JSON.stringify({ foo: 'bar' })),
+    );
+    expect(await asyncEncode(vfile)).toBe('eyJmb28iOiJiYXIifQ==');
+  });
+
+  it('uses FileReader API when available', async () => {
+    Object.defineProperty(globalThis, 'FileReader', {
+      value: MockFileReader,
+    });
+
     const vfile = new VirtualFile(
       stringToBytes(JSON.stringify({ foo: 'bar' })),
     );

--- a/packages/snaps-utils/src/base64.test.ts
+++ b/packages/snaps-utils/src/base64.test.ts
@@ -1,0 +1,21 @@
+import { stringToBytes } from '@metamask/utils';
+
+import { asyncDecode, asyncEncode } from './base64';
+import { VirtualFile } from './virtual-file';
+
+describe('asyncEncode', () => {
+  it('encodes vfile to base64', async () => {
+    const vfile = new VirtualFile(
+      stringToBytes(JSON.stringify({ foo: 'bar' })),
+    );
+    expect(await asyncEncode(vfile)).toBe('eyJmb28iOiJiYXIifQ==');
+  });
+});
+
+describe('asyncDecode', () => {
+  it('decodes base64 string to bytes', async () => {
+    expect(await asyncDecode('eyJmb28iOiJiYXIifQ==')).toStrictEqual(
+      stringToBytes(JSON.stringify({ foo: 'bar' })),
+    );
+  });
+});

--- a/packages/snaps-utils/src/base64.test.ts
+++ b/packages/snaps-utils/src/base64.test.ts
@@ -1,4 +1,5 @@
 import { bytesToBase64, stringToBytes } from '@metamask/utils';
+import { File } from 'buffer';
 
 import { asyncDecode, asyncEncode } from './base64';
 import { VirtualFile } from './virtual-file';
@@ -33,6 +34,11 @@ class MockFileReader {
 }
 
 describe('asyncEncode', () => {
+  // We can remove this once we drop Node 18
+  Object.defineProperty(globalThis, 'File', {
+    value: File,
+  });
+
   it('encodes vfile to base64', async () => {
     const vfile = new VirtualFile(
       stringToBytes(JSON.stringify({ foo: 'bar' })),

--- a/packages/snaps-utils/src/base64.test.ts
+++ b/packages/snaps-utils/src/base64.test.ts
@@ -1,7 +1,7 @@
 import { bytesToBase64, stringToBytes } from '@metamask/utils';
 import { File } from 'buffer';
 
-import { asyncDecode, asyncEncode } from './base64';
+import { decodeBase64, encodeBase64 } from './base64';
 import { VirtualFile } from './virtual-file';
 
 // Very basic mock that mimics the base64 encoding logic of the browser
@@ -33,7 +33,7 @@ class MockFileReader {
   }
 }
 
-describe('asyncEncode', () => {
+describe('encodeBase64', () => {
   // We can remove this once we drop Node 18
   Object.defineProperty(globalThis, 'File', {
     value: File,
@@ -43,7 +43,7 @@ describe('asyncEncode', () => {
     const vfile = new VirtualFile(
       stringToBytes(JSON.stringify({ foo: 'bar' })),
     );
-    expect(await asyncEncode(vfile)).toBe('eyJmb28iOiJiYXIifQ==');
+    expect(await encodeBase64(vfile)).toBe('eyJmb28iOiJiYXIifQ==');
   });
 
   it('uses FileReader API when available', async () => {
@@ -54,13 +54,13 @@ describe('asyncEncode', () => {
     const vfile = new VirtualFile(
       stringToBytes(JSON.stringify({ foo: 'bar' })),
     );
-    expect(await asyncEncode(vfile)).toBe('eyJmb28iOiJiYXIifQ==');
+    expect(await encodeBase64(vfile)).toBe('eyJmb28iOiJiYXIifQ==');
   });
 });
 
-describe('asyncDecode', () => {
+describe('decodeBase64', () => {
   it('decodes base64 string to bytes', async () => {
-    expect(await asyncDecode('eyJmb28iOiJiYXIifQ==')).toStrictEqual(
+    expect(await decodeBase64('eyJmb28iOiJiYXIifQ==')).toStrictEqual(
       stringToBytes(JSON.stringify({ foo: 'bar' })),
     );
   });

--- a/packages/snaps-utils/src/base64.ts
+++ b/packages/snaps-utils/src/base64.ts
@@ -1,0 +1,44 @@
+import { bytesToBase64 } from '@metamask/utils';
+
+import { getChecksumBytes } from './checksum';
+import type { VirtualFile } from './virtual-file';
+
+/**
+ * Provides fast, asynchronous base64 encoding.
+ *
+ * @param input - The input value, assumed to be coercable to bytes.
+ * @returns A base64 string.
+ */
+export async function asyncEncode(input: Uint8Array | VirtualFile | string) {
+  const bytes = getChecksumBytes(input);
+  // In the browser, FileReader is much faster than bytesToBase64.
+  if ('FileReader' in globalThis) {
+    return await new Promise((resolve, reject) => {
+      const reader = Object.assign(new FileReader(), {
+        onload: () =>
+          resolve(
+            (reader.result as string).replace(
+              'data:application/octet-stream;base64,',
+              '',
+            ),
+          ),
+        onerror: () => reject(reader.error),
+      });
+      reader.readAsDataURL(
+        new File([bytes], '', { type: 'application/octet-stream' }),
+      );
+    });
+  }
+  return bytesToBase64(bytes);
+}
+
+/**
+ * Provides fast, asynchronous base64 decoding.
+ *
+ * @param base64 - A base64 string.
+ * @returns A Uint8Array of bytes.
+ */
+export async function asyncDecode(base64: string) {
+  const res = await fetch(`data:application/octet-stream;base64,${base64}`);
+  return new Uint8Array(await res.arrayBuffer());
+}

--- a/packages/snaps-utils/src/base64.ts
+++ b/packages/snaps-utils/src/base64.ts
@@ -1,6 +1,6 @@
 import { bytesToBase64 } from '@metamask/utils';
 
-import { getChecksumBytes } from './checksum';
+import { getBytes } from './bytes';
 import type { VirtualFile } from './virtual-file';
 
 /**
@@ -10,7 +10,7 @@ import type { VirtualFile } from './virtual-file';
  * @returns A base64 string.
  */
 export async function asyncEncode(input: Uint8Array | VirtualFile | string) {
-  const bytes = getChecksumBytes(input);
+  const bytes = getBytes(input);
   // In the browser, FileReader is much faster than bytesToBase64.
   if ('FileReader' in globalThis) {
     return await new Promise((resolve, reject) => {

--- a/packages/snaps-utils/src/base64.ts
+++ b/packages/snaps-utils/src/base64.ts
@@ -9,7 +9,7 @@ import type { VirtualFile } from './virtual-file';
  * @param input - The input value, assumed to be coercable to bytes.
  * @returns A base64 string.
  */
-export async function asyncEncode(input: Uint8Array | VirtualFile | string) {
+export async function encodeBase64(input: Uint8Array | VirtualFile | string) {
   const bytes = getBytes(input);
   // In the browser, FileReader is much faster than bytesToBase64.
   if ('FileReader' in globalThis) {
@@ -38,7 +38,9 @@ export async function asyncEncode(input: Uint8Array | VirtualFile | string) {
  * @param base64 - A base64 string.
  * @returns A Uint8Array of bytes.
  */
-export async function asyncDecode(base64: string) {
-  const res = await fetch(`data:application/octet-stream;base64,${base64}`);
-  return new Uint8Array(await res.arrayBuffer());
+export async function decodeBase64(base64: string) {
+  const response = await fetch(
+    `data:application/octet-stream;base64,${base64}`,
+  );
+  return new Uint8Array(await response.arrayBuffer());
 }

--- a/packages/snaps-utils/src/bytes.test.ts
+++ b/packages/snaps-utils/src/bytes.test.ts
@@ -1,0 +1,24 @@
+import { getBytes } from './bytes';
+import { VirtualFile } from './virtual-file';
+
+describe('getBytes', () => {
+  const FOO_BAR_STR = 'foo bar';
+  const FOO_BAR_UINT8 = new Uint8Array([
+    0x66, 0x6f, 0x6f, 0x20, 0x62, 0x61, 0x72,
+  ]);
+
+  it('handles Uint8Array', () => {
+    expect(getBytes(FOO_BAR_UINT8)).toStrictEqual(FOO_BAR_UINT8);
+  });
+
+  it('handles strings', () => {
+    expect(getBytes(FOO_BAR_STR)).toStrictEqual(FOO_BAR_UINT8);
+  });
+
+  it('handles virtual files', () => {
+    expect(getBytes(new VirtualFile(FOO_BAR_UINT8))).toStrictEqual(
+      FOO_BAR_UINT8,
+    );
+    expect(getBytes(new VirtualFile(FOO_BAR_STR))).toStrictEqual(FOO_BAR_UINT8);
+  });
+});

--- a/packages/snaps-utils/src/bytes.ts
+++ b/packages/snaps-utils/src/bytes.ts
@@ -1,0 +1,21 @@
+import { stringToBytes } from '@metamask/utils';
+
+import { VirtualFile } from './virtual-file';
+
+/**
+ * Convert a bytes-like input value to a Uint8Array.
+ *
+ * @param bytes - A bytes-like value.
+ * @returns The input value converted to a Uint8Array if necessary.
+ */
+export function getBytes(bytes: VirtualFile | Uint8Array | string): Uint8Array {
+  // Unwrap VirtualFiles to extract the content
+  // The content is then either a string or Uint8Array
+  const unwrapped = bytes instanceof VirtualFile ? bytes.value : bytes;
+
+  if (typeof unwrapped === 'string') {
+    return stringToBytes(unwrapped);
+  }
+
+  return unwrapped;
+}

--- a/packages/snaps-utils/src/checksum.test.ts
+++ b/packages/snaps-utils/src/checksum.test.ts
@@ -2,7 +2,7 @@ import * as nobleHashes from '@noble/hashes/sha256';
 import { base64 } from '@scure/base';
 import { webcrypto } from 'crypto';
 
-import { checksum, checksumFiles, getChecksumBytes } from './checksum';
+import { checksum, checksumFiles } from './checksum';
 import { VirtualFile } from './index.browser';
 
 const EMPTY_SHA256 = '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';
@@ -137,24 +137,5 @@ describe('checkumFiles', () => {
     const hash2 = base64.encode(await checksumFiles(files2));
 
     expect(hash1).toBe(hash2);
-  });
-});
-
-describe('getChecksumBytes', () => {
-  it('handles Uint8Array', () => {
-    expect(getChecksumBytes(FOO_BAR_UINT8)).toStrictEqual(FOO_BAR_UINT8);
-  });
-
-  it('handles strings', () => {
-    expect(getChecksumBytes(FOO_BAR_STR)).toStrictEqual(FOO_BAR_UINT8);
-  });
-
-  it('handles virtual files', () => {
-    expect(getChecksumBytes(new VirtualFile(FOO_BAR_UINT8))).toStrictEqual(
-      FOO_BAR_UINT8,
-    );
-    expect(getChecksumBytes(new VirtualFile(FOO_BAR_STR))).toStrictEqual(
-      FOO_BAR_UINT8,
-    );
   });
 });

--- a/packages/snaps-utils/src/checksum.ts
+++ b/packages/snaps-utils/src/checksum.ts
@@ -1,27 +1,8 @@
-import { assert, concatBytes, stringToBytes } from '@metamask/utils';
+import { assert, concatBytes } from '@metamask/utils';
 import { sha256 } from '@noble/hashes/sha256';
 
-import { VirtualFile } from './virtual-file/VirtualFile';
-
-/**
- * Convert an input value to a Uint8Array for use in a checksum.
- *
- * @param bytes - A value to use for a checksum calculation.
- * @returns The input value converted to a Uint8Array if necessary.
- */
-export function getChecksumBytes(
-  bytes: VirtualFile | Uint8Array | string,
-): Uint8Array {
-  // Unwrap VirtualFiles to extract the content
-  // The content is then either a string or Uint8Array
-  const unwrapped = bytes instanceof VirtualFile ? bytes.value : bytes;
-
-  if (typeof unwrapped === 'string') {
-    return stringToBytes(unwrapped);
-  }
-
-  return unwrapped;
-}
+import { getBytes } from './bytes';
+import type { VirtualFile } from './virtual-file/VirtualFile';
 
 /**
  * Calculates checksum for a single byte array.
@@ -32,7 +13,7 @@ export function getChecksumBytes(
 export async function checksum(
   bytes: VirtualFile | Uint8Array | string,
 ): Promise<Uint8Array> {
-  const value = getChecksumBytes(bytes);
+  const value = getBytes(bytes);
   // Use crypto.subtle.digest whenever possible as it is faster.
   if (
     'crypto' in globalThis &&

--- a/packages/snaps-utils/src/index.browser.ts
+++ b/packages/snaps-utils/src/index.browser.ts
@@ -1,5 +1,6 @@
 export * from './array';
 export * from './auxiliary-files';
+export * from './base64';
 export * from './caveats';
 export * from './checksum';
 export * from './cronjob';

--- a/packages/snaps-utils/src/index.browser.ts
+++ b/packages/snaps-utils/src/index.browser.ts
@@ -1,6 +1,7 @@
 export * from './array';
 export * from './auxiliary-files';
 export * from './base64';
+export * from './bytes';
 export * from './caveats';
 export * from './checksum';
 export * from './cronjob';

--- a/packages/snaps-utils/src/index.ts
+++ b/packages/snaps-utils/src/index.ts
@@ -1,5 +1,6 @@
 export * from './array';
 export * from './auxiliary-files';
+export * from './base64';
 export * from './caveats';
 export * from './cronjob';
 export * from './checksum';

--- a/packages/snaps-utils/src/index.ts
+++ b/packages/snaps-utils/src/index.ts
@@ -1,6 +1,7 @@
 export * from './array';
 export * from './auxiliary-files';
 export * from './base64';
+export * from './bytes';
 export * from './caveats';
 export * from './cronjob';
 export * from './checksum';

--- a/packages/snaps-utils/src/virtual-file/VirtualFile.ts
+++ b/packages/snaps-utils/src/virtual-file/VirtualFile.ts
@@ -79,6 +79,7 @@ export class VirtualFile<Result = unknown> {
     } else if (this.value instanceof Uint8Array && encoding === 'hex') {
       return bytesToHex(this.value);
     } else if (this.value instanceof Uint8Array && encoding === 'base64') {
+      // For large files, this is quite slow, instead use `asyncEncode()`
       // TODO: Use @metamask/utils for this
       return base64.encode(this.value);
     }

--- a/packages/snaps-utils/src/virtual-file/VirtualFile.ts
+++ b/packages/snaps-utils/src/virtual-file/VirtualFile.ts
@@ -79,7 +79,7 @@ export class VirtualFile<Result = unknown> {
     } else if (this.value instanceof Uint8Array && encoding === 'hex') {
       return bytesToHex(this.value);
     } else if (this.value instanceof Uint8Array && encoding === 'base64') {
-      // For large files, this is quite slow, instead use `asyncEncode()`
+      // For large files, this is quite slow, instead use `encodeBase64()`
       // TODO: Use @metamask/utils for this
       return base64.encode(this.value);
     }


### PR DESCRIPTION
Adds new base64 encoding and decoding utilities that have faster performance characteristics than the current implementation. This also fixes an issue where the client would sometimes get unresponsive while encoding large files.

Fixes #1984 

```
async base64 encoding of 98095974 bytes took 596 ms
sync base64 encoding of 98095974 bytes took 86004 ms
async base64 decoding of 98095974 bytes took 5525 ms
sync base64 decoding of 98095974 bytes took 73044 ms
```