### PR TITLE
Bump `base-controller` and `permission-controller`

### DIFF
--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@metamask/approval-controller": "^5.0.0",
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/base-controller": "^4.0.0",
     "@metamask/json-rpc-engine": "^7.3.0",
     "@metamask/object-multiplex": "^2.0.0",
     "@metamask/permission-controller": "^5.0.1",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -46,7 +46,7 @@
     "@metamask/base-controller": "^4.0.0",
     "@metamask/json-rpc-engine": "^7.3.0",
     "@metamask/object-multiplex": "^2.0.0",
-    "@metamask/permission-controller": "^5.0.1",
+    "@metamask/permission-controller": "^6.0.0",
     "@metamask/phishing-controller": "^8.0.0",
     "@metamask/post-message-stream": "^7.0.0",
     "@metamask/rpc-errors": "^6.1.0",

--- a/packages/snaps-controllers/src/cronjob/CronjobController.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.ts
@@ -1,5 +1,5 @@
 import type { RestrictedControllerMessenger } from '@metamask/base-controller';
-import { BaseControllerV2 as BaseController } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import type { GetPermissions } from '@metamask/permission-controller';
 import type { SnapId } from '@metamask/snaps-sdk';
 import type {

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -3,7 +3,7 @@ import type {
   UpdateRequestState,
 } from '@metamask/approval-controller';
 import type { RestrictedControllerMessenger } from '@metamask/base-controller';
-import { BaseControllerV2 as BaseController } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import type {
   Caveat,
   GetEndowments,

--- a/packages/snaps-controllers/src/snaps/registry/json.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.ts
@@ -1,5 +1,5 @@
 import type { RestrictedControllerMessenger } from '@metamask/base-controller';
-import { BaseControllerV2 as BaseController } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import type { SnapsRegistryDatabase } from '@metamask/snaps-registry';
 import { verify } from '@metamask/snaps-registry';
 import { getTargetVersion } from '@metamask/snaps-utils';

--- a/packages/snaps-rpc-methods/package.json
+++ b/packages/snaps-rpc-methods/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@metamask/key-tree": "^9.0.0",
-    "@metamask/permission-controller": "^5.0.1",
+    "@metamask/permission-controller": "^6.0.0",
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -51,7 +51,7 @@
     "@emotion/react": "^11.10.8",
     "@emotion/styled": "^11.10.8",
     "@ethersproject/units": "^5.7.0",
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/base-controller": "^4.0.0",
     "@metamask/browser-passworder": "^4.1.0",
     "@metamask/eth-json-rpc-middleware": "^12.0.1",
     "@metamask/json-rpc-engine": "^7.3.0",

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -56,7 +56,7 @@
     "@metamask/eth-json-rpc-middleware": "^12.0.1",
     "@metamask/json-rpc-engine": "^7.3.0",
     "@metamask/key-tree": "^9.0.0",
-    "@metamask/permission-controller": "^5.0.1",
+    "@metamask/permission-controller": "^6.0.0",
     "@metamask/snaps-controllers": "workspace:^",
     "@metamask/snaps-execution-environments": "workspace:^",
     "@metamask/snaps-rpc-methods": "workspace:^",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@babel/core": "^7.23.2",
     "@babel/types": "^7.23.0",
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/base-controller": "^4.0.0",
     "@metamask/key-tree": "^9.0.0",
     "@metamask/permission-controller": "^5.0.1",
     "@metamask/rpc-errors": "^6.1.0",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -69,7 +69,7 @@
     "@babel/types": "^7.23.0",
     "@metamask/base-controller": "^4.0.0",
     "@metamask/key-tree": "^9.0.0",
-    "@metamask/permission-controller": "^5.0.1",
+    "@metamask/permission-controller": "^6.0.0",
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/snaps-registry": "^2.1.1",
     "@metamask/snaps-sdk": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3682,19 +3682,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/approval-controller@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@metamask/approval-controller@npm:4.1.0"
-  dependencies:
-    "@metamask/base-controller": ^3.2.3
-    "@metamask/rpc-errors": ^6.1.0
-    "@metamask/utils": ^8.1.0
-    immer: ^9.0.6
-    nanoid: ^3.1.31
-  checksum: b75c900fc656cfc141f8954ccb48346970d561ba83852ec1d27cecddb6606033e03ea560d7253847bd09dfb8317548c9be9cb92c50d906e55134d892d3785806
-  languageName: node
-  linkType: hard
-
 "@metamask/approval-controller@npm:^5.0.0":
   version: 5.0.0
   resolution: "@metamask/approval-controller@npm:5.0.0"
@@ -3719,16 +3706,6 @@ __metadata:
   bin:
     auto-changelog: dist/cli.js
   checksum: 3405f1f85d02684a95945ab253523619014bdae5da6121fb540140f8b21ddf2dda104683d91a24176c4c67a44fb9446d2e607d94a532a2bbb4f08a08a1e5a605
-  languageName: node
-  linkType: hard
-
-"@metamask/base-controller@npm:^3.2.3":
-  version: 3.2.3
-  resolution: "@metamask/base-controller@npm:3.2.3"
-  dependencies:
-    "@metamask/utils": ^8.1.0
-    immer: ^9.0.6
-  checksum: f49fcf2bf892ec25657c2d72a50b3c4f3cad59acb1b74d9fdcdf564107b8f38f73647c696aaa9699d94828b5797d8f1479dab44a2dbcda987c268b0088bb3b76
   languageName: node
   linkType: hard
 
@@ -3947,21 +3924,6 @@ __metadata:
     typescript: ~4.8.4
   languageName: unknown
   linkType: soft
-
-"@metamask/controller-utils@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "@metamask/controller-utils@npm:5.0.2"
-  dependencies:
-    "@metamask/eth-query": ^3.0.1
-    "@metamask/utils": ^8.1.0
-    "@spruceid/siwe-parser": 1.1.3
-    eth-ens-namehash: ^2.0.8
-    ethereumjs-util: ^7.0.10
-    ethjs-unit: ^0.1.6
-    fast-deep-equal: ^3.1.3
-  checksum: 2345ab9ee0ba900fe2249d80009acfcf458bc60b30418234d00f5f04247b1182a585050572237f8ab09aa23032a24b99ad96399fc0798a0e9a114a29c3bf90d6
-  languageName: node
-  linkType: hard
 
 "@metamask/controller-utils@npm:^6.0.0":
   version: 6.0.0
@@ -4281,16 +4243,6 @@ __metadata:
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/utils": ^8.2.0
   checksum: 1c02ac329917015eab035e666677cc1acde620e94c1586af4bfa4656b4dc69569af07daae3ed31ce0e046d06c19c873559e89aebcaa7109a8d225a63b526e9a6
-  languageName: node
-  linkType: hard
-
-"@metamask/eth-query@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@metamask/eth-query@npm:3.0.1"
-  dependencies:
-    json-rpc-random-id: ^1.0.0
-    xtend: ^4.0.1
-  checksum: b9a323dff67328eace7d54fc8b0bc4dd763bf15760870656cbd5aad5380d1ee4489fb5c59506290d5f77cf55e74e530ee97b52702a329f1090ec03a6158434b7
   languageName: node
   linkType: hard
 
@@ -4894,13 +4846,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/permission-controller@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@metamask/permission-controller@npm:5.0.1"
+"@metamask/permission-controller@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@metamask/permission-controller@npm:6.0.0"
   dependencies:
-    "@metamask/approval-controller": ^4.1.0
-    "@metamask/base-controller": ^3.2.3
-    "@metamask/controller-utils": ^5.0.2
+    "@metamask/approval-controller": ^5.0.0
+    "@metamask/base-controller": ^4.0.0
+    "@metamask/controller-utils": ^6.0.0
     "@metamask/json-rpc-engine": ^7.3.0
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/utils": ^8.2.0
@@ -4909,8 +4861,8 @@ __metadata:
     immer: ^9.0.6
     nanoid: ^3.1.31
   peerDependencies:
-    "@metamask/approval-controller": ^4.1.0
-  checksum: fc61df3f5532b35b9ec26ca712848d680d616103e3d06470691412ee8b5a4b70e27d530065f601b64e0a5c2022aa129b8e6ddcc7c3e8325720aa0f639e3e10ba
+    "@metamask/approval-controller": ^5.0.0
+  checksum: 0d11a70cbb36aba5f76ee7d1ca8dea4eddcd51f81d3226907e0298797b65e0a21dc086f99284cdcd8d0382d21d0bb03f0536be2c4c508cf906be70be687163ad
   languageName: node
   linkType: hard
 
@@ -5183,7 +5135,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/json-rpc-engine": ^7.3.0
     "@metamask/object-multiplex": ^2.0.0
-    "@metamask/permission-controller": ^5.0.1
+    "@metamask/permission-controller": ^6.0.0
     "@metamask/phishing-controller": ^8.0.0
     "@metamask/post-message-stream": ^7.0.0
     "@metamask/rpc-errors": ^6.1.0
@@ -5454,7 +5406,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/json-rpc-engine": ^7.3.0
     "@metamask/key-tree": ^9.0.0
-    "@metamask/permission-controller": ^5.0.1
+    "@metamask/permission-controller": ^6.0.0
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-sdk": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
@@ -5549,7 +5501,7 @@ __metadata:
     "@metamask/eth-json-rpc-middleware": ^12.0.1
     "@metamask/json-rpc-engine": ^7.3.0
     "@metamask/key-tree": ^9.0.0
-    "@metamask/permission-controller": ^5.0.1
+    "@metamask/permission-controller": ^6.0.0
     "@metamask/snaps-controllers": "workspace:^"
     "@metamask/snaps-execution-environments": "workspace:^"
     "@metamask/snaps-rpc-methods": "workspace:^"
@@ -5649,7 +5601,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/key-tree": ^9.0.0
-    "@metamask/permission-controller": ^5.0.1
+    "@metamask/permission-controller": ^6.0.0
     "@metamask/post-message-stream": ^7.0.0
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-registry": ^2.1.1
@@ -12686,16 +12638,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethjs-unit@npm:^0.1.6":
-  version: 0.1.6
-  resolution: "ethjs-unit@npm:0.1.6"
-  dependencies:
-    bn.js: 4.11.6
-    number-to-bn: 1.7.0
-  checksum: df6b4752ff7461a59a20219f4b1684c631ea601241c39660e3f6c6bd63c950189723841c22b3c6c0ebeb3c9fc99e0e803e3c613101206132603705fcbcf4def5
-  languageName: node
-  linkType: hard
-
 "event-stream@npm:=3.3.4":
   version: 3.3.4
   resolution: "event-stream@npm:3.3.4"
@@ -16052,7 +15994,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-rpc-random-id@npm:^1.0.0, json-rpc-random-id@npm:^1.0.1":
+"json-rpc-random-id@npm:^1.0.1":
   version: 1.0.1
   resolution: "json-rpc-random-id@npm:1.0.1"
   checksum: fcd2e884193a129ace4002bd65a86e9cdb206733b4693baea77bd8b372cf8de3043fbea27716a2c9a716581a908ca8d978d9dfec4847eb2cf77edb4cf4b2252c

--- a/yarn.lock
+++ b/yarn.lock
@@ -3926,16 +3926,17 @@ __metadata:
   linkType: soft
 
 "@metamask/controller-utils@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@metamask/controller-utils@npm:6.0.0"
+  version: 6.1.0
+  resolution: "@metamask/controller-utils@npm:6.1.0"
   dependencies:
+    "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-unit": ^0.2.1
     "@metamask/utils": ^8.2.0
     "@spruceid/siwe-parser": 1.1.3
     eth-ens-namehash: ^2.0.8
     ethereumjs-util: ^7.0.10
     fast-deep-equal: ^3.1.3
-  checksum: 84da6625adcdab27b246bfcc58a2840e86fbfc70ef134d98d94f6c3bcc46a8bf7352dbdb83dd064b204a75dd371056ba533e5ff6ee4a09bf7397e8af75963207
+  checksum: 0f0f9a5bc199f9a6c75926f12fa52bd486634091dfbb2db2b98f49b6a09407da9edc0b4a14613ea5c65d8b6cd1f4817acb0e5cffc9b0586f90084e440bf81322
   languageName: node
   linkType: hard
 
@@ -4243,6 +4244,16 @@ __metadata:
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/utils": ^8.2.0
   checksum: 1c02ac329917015eab035e666677cc1acde620e94c1586af4bfa4656b4dc69569af07daae3ed31ce0e046d06c19c873559e89aebcaa7109a8d225a63b526e9a6
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-query@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@metamask/eth-query@npm:4.0.0"
+  dependencies:
+    json-rpc-random-id: ^1.0.0
+    xtend: ^4.0.1
+  checksum: f2e529cf2aa362c20b81433f69840c2830444b3e060a3d9cc778235b8f595f4e1e3a6505b7f14930c4e1566efc9de0ee879e4566f3a6ab184521bdf40f5895d4
   languageName: node
   linkType: hard
 
@@ -15994,7 +16005,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-rpc-random-id@npm:^1.0.1":
+"json-rpc-random-id@npm:^1.0.0, json-rpc-random-id@npm:^1.0.1":
   version: 1.0.1
   resolution: "json-rpc-random-id@npm:1.0.1"
   checksum: fcd2e884193a129ace4002bd65a86e9cdb206733b4693baea77bd8b372cf8de3043fbea27716a2c9a716581a908ca8d978d9dfec4847eb2cf77edb4cf4b2252c

--- a/yarn.lock
+++ b/yarn.lock
@@ -3722,7 +3722,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^3.2.0, @metamask/base-controller@npm:^3.2.3":
+"@metamask/base-controller@npm:^3.2.3":
   version: 3.2.3
   resolution: "@metamask/base-controller@npm:3.2.3"
   dependencies:
@@ -5176,7 +5176,7 @@ __metadata:
     "@lavamoat/allow-scripts": ^2.5.1
     "@metamask/approval-controller": ^5.0.0
     "@metamask/auto-changelog": ^3.4.3
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^4.0.0
     "@metamask/eslint-config": ^12.1.0
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
@@ -5539,7 +5539,7 @@ __metadata:
     "@emotion/styled": ^11.10.8
     "@ethersproject/units": ^5.7.0
     "@metamask/auto-changelog": ^3.4.3
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^4.0.0
     "@metamask/browser-passworder": ^4.1.0
     "@metamask/eslint-config": ^12.1.0
     "@metamask/eslint-config-browser": ^11.1.0
@@ -5643,7 +5643,7 @@ __metadata:
     "@esbuild-plugins/node-modules-polyfill": ^0.2.2
     "@lavamoat/allow-scripts": ^2.5.1
     "@metamask/auto-changelog": ^3.4.3
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^4.0.0
     "@metamask/eslint-config": ^12.1.0
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0


### PR DESCRIPTION
This PR bumps `base-controller` and `permission-controller` to the latest version. It also handles some breaking changes in the latest version of `base-controller`.

Replaces #1988 
Replaces #1986