### PR TITLE
Include Snap icon in allowed paths in CLI server

### DIFF
--- a/packages/snaps-cli/src/webpack/server.test.ts
+++ b/packages/snaps-cli/src/webpack/server.test.ts
@@ -30,7 +30,11 @@ describe('getAllowedPaths', () => {
     const manifest = getSnapManifest();
 
     const allowedPaths = getAllowedPaths(config, manifest);
-    expect(allowedPaths).toStrictEqual(['dist/index.js', 'snap.manifest.json']);
+    expect(allowedPaths).toStrictEqual([
+      'dist/index.js',
+      'snap.manifest.json',
+      'images/icon.svg',
+    ]);
   });
 
   it('returns the allowed paths for a given config with auxiliary files', () => {
@@ -55,6 +59,7 @@ describe('getAllowedPaths', () => {
       'snap.manifest.json',
       'src/foo.js',
       'src/bar.js',
+      'images/icon.svg',
     ]);
   });
 
@@ -80,6 +85,7 @@ describe('getAllowedPaths', () => {
       'snap.manifest.json',
       'src/en.json',
       'src/de.json',
+      'images/icon.svg',
     ]);
   });
 
@@ -108,6 +114,7 @@ describe('getAllowedPaths', () => {
       'src/bar.js',
       'src/en.json',
       'src/de.json',
+      'images/icon.svg',
     ]);
   });
 });

--- a/packages/snaps-cli/src/webpack/server.test.ts
+++ b/packages/snaps-cli/src/webpack/server.test.ts
@@ -117,6 +117,25 @@ describe('getAllowedPaths', () => {
       'images/icon.svg',
     ]);
   });
+
+  it('returns the allowed paths for a given config without an icon', () => {
+    const config = getMockConfig('webpack', {
+      input: 'src/index.js',
+      output: {
+        path: '/foo/dist',
+        filename: 'index.js',
+      },
+      server: {
+        root: '/foo',
+      },
+    });
+
+    const manifest = getSnapManifest();
+    delete manifest.source.location.npm.iconPath;
+
+    const allowedPaths = getAllowedPaths(config, manifest);
+    expect(allowedPaths).toStrictEqual(['dist/index.js', 'snap.manifest.json']);
+  });
 });
 
 describe('getServer', () => {

--- a/packages/snaps-cli/src/webpack/server.ts
+++ b/packages/snaps-cli/src/webpack/server.ts
@@ -54,6 +54,18 @@ export function getAllowedPaths(
       ),
     ) ?? [];
 
+  const otherFiles = manifest.source.location.npm.iconPath
+    ? [
+        getRelativePath(
+          config.server.root,
+          resolvePath(
+            config.server.root,
+            manifest.source.location.npm.iconPath,
+          ),
+        ),
+      ]
+    : [];
+
   return [
     getRelativePath(
       config.server.root,
@@ -69,6 +81,7 @@ export function getAllowedPaths(
     ),
     ...auxiliaryFiles,
     ...localizationFiles,
+    ...otherFiles,
   ];
 }
 


### PR DESCRIPTION
The Snap icon path was not included in the allowed files to be served from the CLI server after #1979. This fixes that.