### PR TITLE
Add support for preinstalled snaps

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 91.09,
-  "functions": 96.49,
-  "lines": 97.77,
+  "branches": 90.96,
+  "functions": 96.51,
+  "lines": 97.78,
   "statements": 97.46
 }

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 91.19,
-  "functions": 96.44,
-  "lines": 97.73,
-  "statements": 97.42
+  "branches": 91.09,
+  "functions": 96.49,
+  "lines": 97.77,
+  "statements": 97.46
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -3568,7 +3568,9 @@ describe('SnapController', () => {
         preinstalledSnaps,
         rootMessenger,
         state: {
-          snaps: getPersistedSnapsState(),
+          snaps: getPersistedSnapsState(
+            getPersistedSnapObject({ preinstalled: true }),
+          ),
         },
       });
       const [snapController] = getSnapControllerWithEES(snapControllerOptions);

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -3500,6 +3500,7 @@ describe('SnapController', () => {
           ],
         },
       ];
+
       const snapControllerOptions = getSnapControllerWithEESOptions({
         preinstalledSnaps,
         rootMessenger,
@@ -3621,7 +3622,7 @@ describe('SnapController', () => {
       snapController.destroy();
     });
 
-    it('skips snaps that would be a downgrade', async () => {
+    it('skips preinstalling a Snap if a newer version is already installed', async () => {
       const rootMessenger = getControllerMessenger();
       jest.spyOn(rootMessenger, 'call');
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1029,13 +1029,27 @@ export class SnapController extends BaseController<
       assert(sourceCode, 'Source code not provided for preinstalled snap.');
 
       assert(
+        !iconPath || (iconPath && svgIcon),
+        'Icon not provided for preinstalled snap.',
+      );
+
+      assert(
         manifest.source.files === undefined,
         'Auxiliary files are not currently supported for preinstalled snaps.',
       );
 
+      const localizationFiles =
+        manifest.source.locales?.map((path) =>
+          virtualFiles.find((file) => file.path === path),
+        ) ?? [];
+
+      const validatedLocalizationFiles = getValidatedLocalizationFiles(
+        localizationFiles.filter(Boolean) as VirtualFile<unknown>[],
+      );
+
       assert(
-        manifest.source.locales === undefined,
-        'Localization files are not currently supported for preinstalled snaps.',
+        localizationFiles.length === validatedLocalizationFiles.length,
+        'Missing localization files for preinstalled snap.',
       );
 
       const filesObject: FetchedSnapFiles = {
@@ -1043,7 +1057,7 @@ export class SnapController extends BaseController<
         sourceCode,
         svgIcon,
         auxiliaryFiles: [],
-        localizationFiles: [],
+        localizationFiles: validatedLocalizationFiles,
       };
 
       // Add snap to the SnapController state

--- a/packages/snaps-utils/src/snaps.ts
+++ b/packages/snaps-utils/src/snaps.ts
@@ -126,6 +126,20 @@ export type Snap = TruncatedSnap & {
    * Localization files which are used to translate the manifest.
    */
   localizationFiles?: LocalizationFile[];
+
+  /**
+   * Flag to signal whether this snap was preinstalled or not.
+   *
+   * A lack of specifying this option will be deemed as not preinstalled.
+   */
+  preinstalled?: boolean;
+
+  /**
+   * Flag to signal whether this snap is removable or not.
+   *
+   * A lack of specifying this option will be deemed as removable.
+   */
+  removable?: boolean;
 };
 
 export type TruncatedSnapFields =

--- a/packages/snaps-utils/src/test-utils/snap.ts
+++ b/packages/snaps-utils/src/test-utils/snap.ts
@@ -32,6 +32,8 @@ export const getPersistedSnapObject = ({
   ],
   auxiliaryFiles = [],
   localizationFiles = [],
+  removable = undefined,
+  preinstalled = undefined,
 }: GetPersistedSnapObjectOptions = {}): PersistedSnap => {
   return {
     blocked,
@@ -45,6 +47,8 @@ export const getPersistedSnapObject = ({
     versionHistory,
     auxiliaryFiles,
     localizationFiles,
+    removable,
+    preinstalled,
   } as const;
 };
 
@@ -62,6 +66,8 @@ export const getSnapObject = ({
   ],
   auxiliaryFiles = [],
   localizationFiles = [],
+  removable = undefined,
+  preinstalled = undefined,
 }: GetSnapObjectOptions = {}): Snap => {
   return {
     blocked,
@@ -75,6 +81,8 @@ export const getSnapObject = ({
     versionHistory,
     auxiliaryFiles,
     localizationFiles,
+    removable,
+    preinstalled,
   } as const;
 };
 


### PR DESCRIPTION
Adds the notion of preinstalled snaps, these are snaps that will be automatically inserted into the SnapController state on boot and made available for execution. This proves useful for platforms where installing arbitrary snaps is not supported or for shipping MetaMask-built functionality as snaps.

Closes https://github.com/MetaMask/MetaMask-planning/issues/1742