### PR TITLE
Fix idle snap timeout for unused snap

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -2,5 +2,5 @@
   "branches": 90.07,
   "functions": 96.35,
   "lines": 97.3,
-  "statements": 96.98
+  "statements": 96.99
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -1149,6 +1149,28 @@ describe('SnapController', () => {
     snapController.destroy();
   });
 
+  it('terminates idle snap that hasnt had any requests', async () => {
+    const options = getSnapControllerOptions({
+      idleTimeCheckInterval: 10,
+      maxIdleTime: 50,
+      state: {
+        snaps: getPersistedSnapsState(),
+      },
+    });
+
+    const snapController = getSnapController(options);
+    const snap = snapController.getExpect(MOCK_SNAP_ID);
+
+    await snapController.startSnap(snap.id);
+    expect(snapController.state.snaps[snap.id].status).toBe('running');
+
+    await sleep(100);
+
+    expect(snapController.state.snaps[snap.id].status).toBe('stopped');
+
+    snapController.destroy();
+  });
+
   it('does not timeout while waiting for response from MetaMask', async () => {
     const sourceCode = `
     module.exports.onRpcRequest = () => ethereum.request({ method: 'eth_blockNumber', params: [] });


### PR DESCRIPTION
Fixes an issue where a snap that never had an incoming RPC request would never be torn down by the idle timeout.