### PR TITLE
Fix duplicate `SnapController:snapInstalled` event & erroneous snap removal

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 90.07,
   "functions": 96.35,
-  "lines": 97.3,
+  "lines": 97.31,
   "statements": 96.99
 }


### PR DESCRIPTION
A duplicate `SnapController:snapInstalled` event is fired even when an origin attempts to install a snap that is already installed in the extension (by another origin). The culprit was the `pendingInstalls` array in the `installSnaps` function in the `SnapController` which was the list used to fire the `SnapController:snapInstalled` event. The implementation is changed to make `pendingInstalls` a set that has a member removed if the snap is already installed. With the previous logic, in the case of an installation failure, we were still removing a snap even if it had been installed by another origin previously.