### PR TITLE
Bump `snaps-registry`

### DIFF
--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "BM0j/V7cf9ii7afLVn7u8GMjIthkwyJohQ6Uiu8YjKw=",
+    "shasum": "ukr1CZCWazIUxgL2A5tuJ+6oXQHVjH0TrO8iPYd++QE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -50,7 +50,7 @@
     "@metamask/phishing-controller": "^8.0.0",
     "@metamask/post-message-stream": "^7.0.0",
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-registry": "^2.1.1",
+    "@metamask/snaps-registry": "^3.0.0",
     "@metamask/snaps-rpc-methods": "workspace:^",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",

--- a/packages/snaps-controllers/src/snaps/registry/json.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.ts
@@ -207,7 +207,7 @@ export class JsonSnapsRegistry extends BaseController<
 
       if (this.#publicKey) {
         const signature = await this.#safeFetch(this.#url.signature);
-        await this.#verifySignature(database, signature);
+        this.#verifySignature(database, signature);
       }
 
       this.update((state) => {
@@ -346,10 +346,10 @@ export class JsonSnapsRegistry extends BaseController<
    * @throws If the signature is invalid.
    * @private
    */
-  async #verifySignature(database: string, signature: string) {
+  #verifySignature(database: string, signature: string) {
     assert(this.#publicKey, 'No public key provided.');
 
-    const valid = await verify({
+    const valid = verify({
       registry: database,
       signature: JSON.parse(signature),
       publicKey: this.#publicKey,

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -71,7 +71,7 @@
     "@metamask/key-tree": "^9.0.0",
     "@metamask/permission-controller": "^6.0.0",
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/snaps-registry": "^2.1.1",
+    "@metamask/snaps-registry": "^3.0.0",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.2.1",
     "@noble/hashes": "^1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5190,7 +5190,7 @@ __metadata:
     "@metamask/phishing-controller": ^8.0.0
     "@metamask/post-message-stream": ^7.0.0
     "@metamask/rpc-errors": ^6.1.0
-    "@metamask/snaps-registry": ^2.1.1
+    "@metamask/snaps-registry": ^3.0.0
     "@metamask/snaps-rpc-methods": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
@@ -5394,14 +5394,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/snaps-registry@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "@metamask/snaps-registry@npm:2.1.1"
+"@metamask/snaps-registry@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@metamask/snaps-registry@npm:3.0.0"
   dependencies:
     "@metamask/utils": ^8.1.0
-    "@noble/secp256k1": ^1.7.1
+    "@noble/curves": ^1.2.0
+    "@noble/hashes": ^1.3.2
     superstruct: ^1.0.3
-  checksum: 274002c44f0fe028740c19d1014f844aa4b534862abc530f872baaad8b7b3b2445ffaefbd0a5a957b5102a5b04fe51e6f03a03b1236c8818abc4c748076d6475
+  checksum: d816190ee4f345f04b1dcdbbee48fc7153c12192e2deca16f7947c9f3ee437dddc286fd66c21cdf02d18798c4df799bbc377bc839c11a419226aa00b95b645b0
   languageName: node
   linkType: hard
 
@@ -5655,7 +5656,7 @@ __metadata:
     "@metamask/permission-controller": ^6.0.0
     "@metamask/post-message-stream": ^7.0.0
     "@metamask/rpc-errors": ^6.1.0
-    "@metamask/snaps-registry": ^2.1.1
+    "@metamask/snaps-registry": ^3.0.0
     "@metamask/snaps-sdk": "workspace:^"
     "@metamask/utils": ^8.2.1
     "@noble/hashes": ^1.3.1
@@ -6075,12 +6076,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:1.1.0, @noble/curves@npm:^1.1.0, @noble/curves@npm:~1.1.0":
+"@noble/curves@npm:1.1.0, @noble/curves@npm:~1.1.0":
   version: 1.1.0
   resolution: "@noble/curves@npm:1.1.0"
   dependencies:
     "@noble/hashes": 1.3.1
   checksum: 2658cdd3f84f71079b4e3516c47559d22cf4b55c23ac8ee9d2b1f8e5b72916d9689e59820e0f9d9cb4a46a8423af5b56dc6bb7782405c88be06a015180508db5
+  languageName: node
+  linkType: hard
+
+"@noble/curves@npm:^1.1.0, @noble/curves@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@noble/curves@npm:1.2.0"
+  dependencies:
+    "@noble/hashes": 1.3.2
+  checksum: bb798d7a66d8e43789e93bc3c2ddff91a1e19fdb79a99b86cd98f1e5eff0ee2024a2672902c2576ef3577b6f282f3b5c778bebd55761ddbb30e36bf275e83dd0
   languageName: node
   linkType: hard
 
@@ -6105,7 +6115,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:^1.0.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:~1.3.0, @noble/hashes@npm:~1.3.1, @noble/hashes@npm:~1.3.2":
+"@noble/hashes@npm:1.3.2, @noble/hashes@npm:^1.0.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2, @noble/hashes@npm:~1.3.0, @noble/hashes@npm:~1.3.1, @noble/hashes@npm:~1.3.2":
   version: 1.3.2
   resolution: "@noble/hashes@npm:1.3.2"
   checksum: fe23536b436539d13f90e4b9be843cc63b1b17666a07634a2b1259dded6f490be3d050249e6af98076ea8f2ea0d56f578773c2197f2aa0eeaa5fba5bc18ba474


### PR DESCRIPTION
Bumps `snaps-registry` to the latest version to fix some incompatibilities with React Native.