### PR TITLE
Improve `SnapController` constructor typing

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 90.07,
+  "branches": 90.09,
   "functions": 96.35,
-  "lines": 97.3,
+  "lines": 97.31,
   "statements": 96.99
 }


### PR DESCRIPTION
Improve SnapController constructor typing to improve compatibility with mobile. Most of the constructor arguments have sane defaults provided by the SnapController itself and are therefore allowed to be undefined. The feature flags are also allowed to be true, false and undefined.

These issues weren't caught until now because the extension integration is not typed.