### PR TITLE
Upstream derivation path logic from the extension client

### DIFF
--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 96.01,
-  "functions": 98.53,
-  "lines": 98.6,
-  "statements": 95.55
+  "branches": 96.17,
+  "functions": 98.55,
+  "lines": 98.62,
+  "statements": 95.53
 }

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -71,6 +71,7 @@
     "@metamask/key-tree": "^9.0.0",
     "@metamask/permission-controller": "^6.0.0",
     "@metamask/rpc-errors": "^6.1.0",
+    "@metamask/slip44": "^3.1.0",
     "@metamask/snaps-registry": "^3.0.0",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.2.1",

--- a/packages/snaps-utils/src/derivation-path.test.ts
+++ b/packages/snaps-utils/src/derivation-path.test.ts
@@ -1,0 +1,34 @@
+import {
+  getSlip44ProtocolName,
+  getSnapDerivationPathName,
+} from './derivation-paths';
+
+describe('getSnapDerivationPathName', () => {
+  it('returns a name from the hardcoded list', () => {
+    expect(getSnapDerivationPathName(['m', `44'`, `784'`], 'ed25519')).toBe(
+      'Sui',
+    );
+  });
+
+  it('returns a name from the SLIP44 list where applicable', () => {
+    expect(
+      getSnapDerivationPathName(['m', `44'`, `60'`, `0'`], 'secp256k1'),
+    ).toBe('Ethereum');
+  });
+
+  it('returns null if no name found', () => {
+    expect(
+      getSnapDerivationPathName(['m', `44'`, `60'`, `0'`], 'ed25519'),
+    ).toBeNull();
+  });
+});
+
+describe('getSlip44ProtocolName', () => {
+  it('returns "Test Networks" for coinType 1', () => {
+    expect(getSlip44ProtocolName(1)).toBe('Test Networks');
+  });
+
+  it('returns a value from the SLIP44 list', () => {
+    expect(getSlip44ProtocolName(60)).toBe('Ethereum');
+  });
+});

--- a/packages/snaps-utils/src/derivation-path.test.ts
+++ b/packages/snaps-utils/src/derivation-path.test.ts
@@ -16,6 +16,12 @@ describe('getSnapDerivationPathName', () => {
     ).toBe('Ethereum');
   });
 
+  it('returns null if we fail to use SLIP44', () => {
+    expect(
+      getSnapDerivationPathName(['m', `44'`, `999999999'`, `0'`], 'secp256k1'),
+    ).toBeNull();
+  });
+
   it('returns null if no name found', () => {
     expect(
       getSnapDerivationPathName(['m', `44'`, `60'`, `0'`], 'ed25519'),
@@ -30,5 +36,9 @@ describe('getSlip44ProtocolName', () => {
 
   it('returns a value from the SLIP44 list', () => {
     expect(getSlip44ProtocolName(60)).toBe('Ethereum');
+  });
+
+  it('returns null for values not in the list', () => {
+    expect(getSlip44ProtocolName(999999999)).toBeNull();
   });
 });

--- a/packages/snaps-utils/src/derivation-paths.ts
+++ b/packages/snaps-utils/src/derivation-paths.ts
@@ -1,0 +1,198 @@
+import type { SupportedCurve } from '@metamask/key-tree';
+import slip44 from '@metamask/slip44';
+
+import { isEqual } from './array';
+
+export type SnapsDerivationPath = {
+  path: ['m', ...string[]];
+  curve: SupportedCurve;
+  name: string;
+};
+
+export const SNAPS_DERIVATION_PATHS: SnapsDerivationPath[] = [
+  {
+    path: ['m', `44'`, `0'`],
+    curve: 'ed25519',
+    name: 'Test BIP-32 Path (ed25519)',
+  },
+  {
+    path: ['m', `44'`, `1'`],
+    curve: 'secp256k1',
+    name: 'Testnet',
+  },
+  {
+    path: ['m', `44'`, `0'`],
+    curve: 'secp256k1',
+    name: 'Bitcoin Legacy',
+  },
+  {
+    path: ['m', `49'`, `0'`],
+    curve: 'secp256k1',
+    name: 'Bitcoin Nested SegWit',
+  },
+  {
+    path: ['m', `49'`, `1'`],
+    curve: 'secp256k1',
+    name: 'Bitcoin Testnet Nested SegWit',
+  },
+  {
+    path: ['m', `84'`, `0'`],
+    curve: 'secp256k1',
+    name: 'Bitcoin Native SegWit',
+  },
+  {
+    path: ['m', `84'`, `1'`],
+    curve: 'secp256k1',
+    name: 'Bitcoin Testnet Native SegWit',
+  },
+  {
+    path: ['m', `44'`, `501'`],
+    curve: 'ed25519',
+    name: 'Solana',
+  },
+  {
+    path: ['m', `44'`, `501'`, "0'", "0'"],
+    curve: 'ed25519',
+    name: 'Solana',
+  },
+  {
+    path: ['m', `44'`, `2'`],
+    curve: 'secp256k1',
+    name: 'Litecoin',
+  },
+  {
+    path: ['m', `44'`, `3'`],
+    curve: 'secp256k1',
+    name: 'Dogecoin',
+  },
+  {
+    path: ['m', `44'`, `60'`],
+    curve: 'secp256k1',
+    name: 'Ethereum',
+  },
+  {
+    path: ['m', `44'`, `118'`],
+    curve: 'secp256k1',
+    name: 'Atom',
+  },
+  {
+    path: ['m', `44'`, `145'`],
+    curve: 'secp256k1',
+    name: 'Bitcoin Cash',
+  },
+  {
+    path: ['m', `44'`, `637'`],
+    curve: 'ed25519',
+    name: 'Aptos',
+  },
+  {
+    path: ['m', `44'`, `714'`],
+    curve: 'secp256k1',
+    name: 'Binance (BNB)',
+  },
+  {
+    path: ['m', `44'`, `784'`],
+    curve: 'ed25519',
+    name: 'Sui',
+  },
+  {
+    path: ['m', `44'`, `931'`],
+    curve: 'secp256k1',
+    name: 'THORChain (RUNE)',
+  },
+  {
+    path: ['m', `44'`, `330'`],
+    curve: 'secp256k1',
+    name: 'Terra (LUNA)',
+  },
+  {
+    path: ['m', `44'`, `459'`],
+    curve: 'secp256k1',
+    name: 'Kava',
+  },
+  {
+    path: ['m', `44'`, `529'`],
+    curve: 'secp256k1',
+    name: 'Secret Network',
+  },
+  {
+    path: ['m', `44'`, `397'`, `0'`],
+    curve: 'ed25519',
+    name: 'NEAR Protocol',
+  },
+  {
+    path: ['m', `44'`, `1'`, `0'`],
+    curve: 'ed25519',
+    name: 'Testnet',
+  },
+  {
+    path: ['m', `44'`, `472'`],
+    curve: 'ed25519',
+    name: 'Arweave',
+  },
+  {
+    path: ['m', `44'`, `12586'`],
+    curve: 'secp256k1',
+    name: 'Mina',
+  },
+  {
+    path: ['m', `44'`, `1729'`, `0'`, `0'`],
+    curve: 'ed25519',
+    name: 'Tezos',
+  },
+  {
+    path: ['m', `1789'`, `0'`],
+    curve: 'ed25519',
+    name: 'Vega',
+  },
+];
+
+/**
+ * Gets the name of a derivation path supported by snaps.
+ *
+ * @param path - The derivation path.
+ * @param curve - The curve used to derive the keys.
+ * @returns The name of the derivation path, otherwise null.
+ */
+export function getSnapDerivationPathName(
+  path: SnapsDerivationPath['path'],
+  curve: SupportedCurve,
+): string | null {
+  const pathMetadata = SNAPS_DERIVATION_PATHS.find(
+    (derivationPath) =>
+      derivationPath.curve === curve && isEqual(derivationPath.path, path),
+  );
+
+  if (pathMetadata) {
+    return pathMetadata.name;
+  }
+
+  // If the curve is secp256k1 and the path is a valid BIP44 path
+  // we try looking for the network/protocol name in SLIP44
+  if (
+    curve === 'secp256k1' &&
+    path[0] === 'm' &&
+    path[1] === `44'` &&
+    path[2].endsWith(`'`)
+  ) {
+    const coinType = path[2].slice(0, -1);
+    return getSlip44ProtocolName(coinType) ?? null;
+  }
+
+  return null;
+}
+
+/**
+ * Gets the name of the SLIP-44 protocol corresponding to the specified
+ * `coin_type`.
+ *
+ * @param coinType - The SLIP-44 `coin_type` value whose name
+ * to retrieve.
+ * @returns The name of the protocol, otherwise null.
+ */
+export function getSlip44ProtocolName(coinType: number | string) {
+  if (String(coinType) === '1') {
+    return 'Test Networks';
+  }
+  return slip44[coinType as keyof typeof slip44]?.name ?? null;
+}

--- a/packages/snaps-utils/src/derivation-paths.ts
+++ b/packages/snaps-utils/src/derivation-paths.ts
@@ -194,5 +194,6 @@ export function getSlip44ProtocolName(coinType: number | string) {
   if (String(coinType) === '1') {
     return 'Test Networks';
   }
+
   return slip44[coinType as keyof typeof slip44]?.name ?? null;
 }

--- a/packages/snaps-utils/src/index.browser.ts
+++ b/packages/snaps-utils/src/index.browser.ts
@@ -7,6 +7,7 @@ export * from './checksum';
 export * from './cronjob';
 export * from './deep-clone';
 export * from './default-endowments';
+export * from './derivation-paths';
 export * from './entropy';
 export * from './errors';
 export * from './handlers';

--- a/packages/snaps-utils/src/index.ts
+++ b/packages/snaps-utils/src/index.ts
@@ -7,6 +7,7 @@ export * from './cronjob';
 export * from './checksum';
 export * from './deep-clone';
 export * from './default-endowments';
+export * from './derivation-paths';
 export * from './entropy';
 export * from './eval';
 export * from './errors';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5048,6 +5048,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/slip44@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@metamask/slip44@npm:3.1.0"
+  checksum: 63de4b85448990bde7760704d2f646ff33b34b22799b570c0bb1f7f08b1ebea9784495759611979ca4a5872094b093b63c28c6f6d94aa614cbd692576fcb134f
+  languageName: node
+  linkType: hard
+
 "@metamask/snaps-browserify-plugin@workspace:^, @metamask/snaps-browserify-plugin@workspace:packages/snaps-browserify-plugin":
   version: 0.0.0-use.local
   resolution: "@metamask/snaps-browserify-plugin@workspace:packages/snaps-browserify-plugin"
@@ -5672,6 +5679,7 @@ __metadata:
     "@metamask/permission-controller": ^6.0.0
     "@metamask/post-message-stream": ^7.0.0
     "@metamask/rpc-errors": ^6.1.0
+    "@metamask/slip44": ^3.1.0
     "@metamask/snaps-registry": ^3.0.0
     "@metamask/snaps-sdk": "workspace:^"
     "@metamask/utils": ^8.2.1


### PR DESCRIPTION
Upstreams derivation path logic from the extension client to be used across all clients.

Fixes https://github.com/MetaMask/snaps/issues/1467