### PR TITLE
Use prototype `startsWith` for middleware

### DIFF
--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -10,7 +10,7 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 88.37,
+      branches: 89.92,
       functions: 100,
       lines: 98.19,
       statements: 96.53,

--- a/packages/snaps-rpc-methods/src/permitted/middleware.ts
+++ b/packages/snaps-rpc-methods/src/permitted/middleware.ts
@@ -23,7 +23,10 @@ export function createSnapsMethodMiddleware(
     const handler =
       methodHandlers[request.method as keyof typeof methodHandlers];
     if (handler) {
-      if (request.method.startsWith('snap_') && !isSnap) {
+      if (
+        String.prototype.startsWith.call(request.method, 'snap_') &&
+        !isSnap
+      ) {
         return end(rpcErrors.methodNotFound());
       }
 


### PR DESCRIPTION
To be on the safe side we should use the prototype `startsWith` for snaps method middleware.