### PR TITLE
Refactor `NpmLocation` class

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 90.09,
   "functions": 96.36,
-  "lines": 97.12,
-  "statements": 96.81
+  "lines": 97.18,
+  "statements": 96.87
 }

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 90.8,
+  "branches": 91.03,
   "functions": 96.36,
-  "lines": 97.63,
-  "statements": 97.3
+  "lines": 97.69,
+  "statements": 97.37
 }

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -2,5 +2,5 @@
   "branches": 90.8,
   "functions": 96.36,
   "lines": 97.63,
-  "statements": 97.37
+  "statements": 97.3
 }

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 90.09,
+  "branches": 90.8,
   "functions": 96.36,
-  "lines": 97.18,
-  "statements": 96.87
+  "lines": 97.63,
+  "statements": 97.37
 }

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 90.09,
-  "functions": 96.35,
-  "lines": 97.31,
-  "statements": 96.99
+  "functions": 96.36,
+  "lines": 97.12,
+  "statements": 96.81
 }

--- a/packages/snaps-controllers/src/snaps/location/npm.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.ts
@@ -206,7 +206,7 @@ export abstract class BaseNpmLocation implements SnapLocation {
 }
 
 // Safety limit for tarballs, 250 MB in bytes
-const TARBALL_SIZE_SAFETY_LIMIT = 262144000;
+export const TARBALL_SIZE_SAFETY_LIMIT = 262144000;
 
 // Main NPM implementation, contains a browser tarball fetching implementation.
 export class NpmLocation extends BaseNpmLocation {
@@ -235,7 +235,6 @@ export class NpmLocation extends BaseNpmLocation {
       tarballSize <= TARBALL_SIZE_SAFETY_LIMIT,
       'Snap tarball exceeds size limit',
     );
-    const tarballResponseBody = tarballResponse.body;
     return new Promise((resolve, reject) => {
       const files = new Map();
 
@@ -252,7 +251,8 @@ export class NpmLocation extends BaseNpmLocation {
       if ('DecompressionStream' in globalThis) {
         const decompressionStream = new DecompressionStream('gzip');
         const decompressedStream =
-          tarballResponseBody.pipeThrough(decompressionStream);
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          tarballResponse.body!.pipeThrough(decompressionStream);
 
         pipeline(
           getNodeStream(decompressedStream),
@@ -265,7 +265,8 @@ export class NpmLocation extends BaseNpmLocation {
       }
 
       pipeline(
-        getNodeStream(tarballResponseBody),
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        getNodeStream(tarballResponse.body!),
         createGunzip(),
         tarballStream,
         (error: unknown) => {

--- a/packages/snaps-controllers/src/snaps/location/npm.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.ts
@@ -340,7 +340,6 @@ export function getNpmCanonicalBasePath(registryUrl: URL, packageName: string) {
     }
     canonicalBase += '@';
   }
-  canonicalBase += registryUrl.host;
   return `${canonicalBase}${registryUrl.host}/${packageName}/`;
 }
 

--- a/packages/snaps-controllers/src/snaps/location/npm.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.ts
@@ -227,6 +227,7 @@ export class NpmLocation extends BaseNpmLocation {
         `Failed to fetch tarball for package "${this.meta.packageName}".`,
       );
     }
+
     // We assume that NPM is a good actor and provides us with a valid `content-length` header.
     const tarballSizeString = tarballResponse.headers.get('content-length');
     assert(tarballSizeString, 'Snap tarball has invalid content-length');


### PR DESCRIPTION
Refactor `NpmLocation` to move most logic to a `BaseNpmLocation` class that can be extended in the mobile client. A class extending the base class only need to implement `fetchNpmTarball` reducing code duplication. As part of this refactor I've also simplified the implementation in multiple places and improved the coverage.

Fixes https://github.com/MetaMask/snaps/issues/2040