### PR TITLE
Refactor `getNodeStream`

### DIFF
--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -63,7 +63,6 @@
     "json-rpc-middleware-stream": "^5.0.0",
     "nanoid": "^3.1.31",
     "readable-stream": "^3.6.2",
-    "readable-web-to-node-stream": "^3.0.2",
     "tar-stream": "^3.1.6"
   },
   "devDependencies": {

--- a/packages/snaps-controllers/src/types/vendor/readable-stream.d.ts
+++ b/packages/snaps-controllers/src/types/vendor/readable-stream.d.ts
@@ -2,10 +2,9 @@
 declare module 'readable-stream' {
   export type {
     DuplexOptions,
-    Readable,
     Writable,
     TransformCallback,
     Transform,
   } from 'stream';
-  export { Duplex, pipeline } from 'stream';
+  export { Duplex, pipeline, Readable } from 'stream';
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5266,7 +5266,6 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     readable-stream: ^3.6.2
-    readable-web-to-node-stream: ^3.0.2
     rimraf: ^4.1.2
     tar-stream: ^3.1.6
     ts-node: ^10.9.1


### PR DESCRIPTION
Refactor `getNodeStream` to stop using `readable-web-to-node-stream` which may be causing issues during NPM download. TBD