### PR TITLE
Add `wallet_getAllSnaps` method to get all installed Snaps

### DIFF
--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -13,7 +13,7 @@ module.exports = deepmerge(baseConfig, {
       branches: 89.92,
       functions: 100,
       lines: 98.19,
-      statements: 96.53,
+      statements: 96.78,
     },
   },
 });

--- a/packages/snaps-rpc-methods/src/permitted/getAllSnaps.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getAllSnaps.test.ts
@@ -87,10 +87,8 @@ describe('wallet_getAllSnaps', () => {
         jsonrpc: '2.0',
         id: 1,
         error: expect.objectContaining({
-          code: -32600,
-          message: expect.stringContaining(
-            'The origin "https://example.com" is not allowed to invoke the method "wallet_getAllSnaps".',
-          ),
+          code: -32601,
+          message: 'The method does not exist / is not available.',
         }),
       });
     });

--- a/packages/snaps-rpc-methods/src/permitted/getAllSnaps.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getAllSnaps.test.ts
@@ -1,0 +1,98 @@
+import { JsonRpcEngine } from '@metamask/json-rpc-engine';
+import type { GetSnapsResult } from '@metamask/snaps-sdk';
+import type { PendingJsonRpcResponse } from '@metamask/utils';
+
+import { getAllSnapsHandler } from './getAllSnaps';
+
+describe('wallet_getAllSnaps', () => {
+  describe('getAllSnapsHandler', () => {
+    it('has the expected shape', () => {
+      expect(getAllSnapsHandler).toMatchObject({
+        methodNames: ['wallet_getAllSnaps'],
+        implementation: expect.any(Function),
+        hookNames: {
+          getAllSnaps: true,
+        },
+      });
+    });
+  });
+
+  describe('implementation', () => {
+    it('returns the result received from the `getAllSnaps` hook', async () => {
+      const { implementation } = getAllSnapsHandler;
+
+      const getAllSnaps = jest.fn().mockResolvedValue(['foo', 'bar']);
+      const hooks = {
+        getAllSnaps,
+      };
+
+      const engine = new JsonRpcEngine();
+      engine.push((request, response, next, end) => {
+        const result = implementation(
+          // @ts-expect-error - `origin` is not part of the type, but in practice
+          // it is added by the MetaMask middleware stack.
+          { ...request, origin: 'https://snaps.metamask.io' },
+          response as PendingJsonRpcResponse<GetSnapsResult>,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'wallet_getAllSnaps',
+      });
+
+      expect(response).toStrictEqual({
+        jsonrpc: '2.0',
+        id: 1,
+        result: ['foo', 'bar'],
+      });
+    });
+
+    it('returns an error if the origin is not allowed', async () => {
+      const { implementation } = getAllSnapsHandler;
+
+      const getAllSnaps = jest.fn().mockResolvedValue(['foo', 'bar']);
+      const hooks = {
+        getAllSnaps,
+      };
+
+      const engine = new JsonRpcEngine();
+      engine.push((request, response, next, end) => {
+        const result = implementation(
+          // @ts-expect-error - `origin` is not part of the type, but in practice
+          // it is added by the MetaMask middleware stack.
+          { ...request, origin: 'https://example.com' },
+          response as PendingJsonRpcResponse<GetSnapsResult>,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'wallet_getAllSnaps',
+      });
+
+      expect(response).toStrictEqual({
+        jsonrpc: '2.0',
+        id: 1,
+        error: expect.objectContaining({
+          code: -32600,
+          message: expect.stringContaining(
+            'The origin "https://example.com" is not allowed to invoke the method "wallet_getAllSnaps".',
+          ),
+        }),
+      });
+    });
+  });
+});

--- a/packages/snaps-rpc-methods/src/permitted/getAllSnaps.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getAllSnaps.ts
@@ -36,8 +36,8 @@ export type GetAllSnapsHooks = {
 };
 
 /**
- * The `wallet_getSnaps` method implementation.
- * Fetches available snaps for the requesting origin and adds them to the JSON-RPC response.
+ * The `wallet_getAllSnaps` method implementation.
+ * Fetches all installed snaps and adds them to the JSON-RPC response.
  *
  * @param request - The JSON-RPC request object.
  * @param response - The JSON-RPC response object.

--- a/packages/snaps-rpc-methods/src/permitted/getAllSnaps.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getAllSnaps.ts
@@ -56,14 +56,10 @@ async function getAllSnapsImplementation(
   { getAllSnaps }: GetAllSnapsHooks,
 ): Promise<void> {
   // The origin is added by the MetaMask middleware stack.
-  const { origin, method } = request as JsonRpcRequest & { origin: string };
+  const { origin } = request as JsonRpcRequest & { origin: string };
 
   if (origin !== 'https://snaps.metamask.io') {
-    return end(
-      rpcErrors.invalidRequest({
-        message: `The origin "${origin}" is not allowed to invoke the method "${method}".`,
-      }),
-    );
+    return end(rpcErrors.methodNotFound());
   }
 
   response.result = await getAllSnaps();

--- a/packages/snaps-rpc-methods/src/permitted/getAllSnaps.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getAllSnaps.ts
@@ -1,0 +1,71 @@
+import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
+import type { PermittedHandlerExport } from '@metamask/permission-controller';
+import { rpcErrors } from '@metamask/rpc-errors';
+import type { GetSnapsResult } from '@metamask/snaps-sdk';
+import type {
+  JsonRpcParams,
+  JsonRpcRequest,
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
+
+import type { MethodHooksObject } from '../utils';
+
+const hookNames: MethodHooksObject<GetAllSnapsHooks> = {
+  getAllSnaps: true,
+};
+
+/**
+ * `wallet_getAllSnaps` gets all installed Snaps. Currently, this can only be
+ * called from `https://snaps.metamask.io`.
+ */
+export const getAllSnapsHandler: PermittedHandlerExport<
+  GetAllSnapsHooks,
+  JsonRpcParams,
+  GetSnapsResult
+> = {
+  methodNames: ['wallet_getAllSnaps'],
+  implementation: getAllSnapsImplementation,
+  hookNames,
+};
+
+export type GetAllSnapsHooks = {
+  /**
+   * @returns All installed Snaps.
+   */
+  getAllSnaps: () => Promise<GetSnapsResult>;
+};
+
+/**
+ * The `wallet_getSnaps` method implementation.
+ * Fetches available snaps for the requesting origin and adds them to the JSON-RPC response.
+ *
+ * @param request - The JSON-RPC request object.
+ * @param response - The JSON-RPC response object.
+ * @param _next - The `json-rpc-engine` "next" callback. Not used by this
+ * function.
+ * @param end - The `json-rpc-engine` "end" callback.
+ * @param hooks - The RPC method hooks.
+ * @param hooks.getAllSnaps - A function that returns all installed snaps.
+ * @returns Nothing.
+ */
+async function getAllSnapsImplementation(
+  request: JsonRpcRequest,
+  response: PendingJsonRpcResponse<GetSnapsResult>,
+  _next: unknown,
+  end: JsonRpcEngineEndCallback,
+  { getAllSnaps }: GetAllSnapsHooks,
+): Promise<void> {
+  // The origin is added by the MetaMask middleware stack.
+  const { origin, method } = request as JsonRpcRequest & { origin: string };
+
+  if (origin !== 'https://snaps.metamask.io') {
+    return end(
+      rpcErrors.invalidRequest({
+        message: `The origin "${origin}" is not allowed to invoke the method "${method}".`,
+      }),
+    );
+  }
+
+  response.result = await getAllSnaps();
+  return end();
+}

--- a/packages/snaps-rpc-methods/src/permitted/handlers.ts
+++ b/packages/snaps-rpc-methods/src/permitted/handlers.ts
@@ -1,3 +1,4 @@
+import { getAllSnapsHandler } from './getAllSnaps';
 import { getFileHandler } from './getFile';
 import { getSnapsHandler } from './getSnaps';
 import { invokeKeyringHandler } from './invokeKeyring';
@@ -6,6 +7,7 @@ import { requestSnapsHandler } from './requestSnaps';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export const methodHandlers = {
+  wallet_getAllSnaps: getAllSnapsHandler,
   wallet_getSnaps: getSnapsHandler,
   wallet_requestSnaps: requestSnapsHandler,
   wallet_invokeSnap: invokeSnapSugarHandler,

--- a/packages/snaps-rpc-methods/src/permitted/index.ts
+++ b/packages/snaps-rpc-methods/src/permitted/index.ts
@@ -1,7 +1,10 @@
+import type { GetAllSnapsHooks } from './getAllSnaps';
 import type { GetSnapsHooks } from './getSnaps';
 import type { RequestSnapsHooks } from './requestSnaps';
 
-export type PermittedRpcMethodHooks = GetSnapsHooks & RequestSnapsHooks;
+export type PermittedRpcMethodHooks = GetAllSnapsHooks &
+  GetSnapsHooks &
+  RequestSnapsHooks;
 
 export * from './handlers';
 export * from './middleware';


### PR DESCRIPTION
This adds a new permitted JSON-RPC method `wallet_getAllSnaps`, returning all the installed Snaps, regardless of whether the origin has installed them. This method is permitted in the sense that it doesn't require a permission to be called, but it's only callable from the Snaps Directory (`https://snaps.metamask.io`).

This is a temporary solution until we have a proper connection flow in the Snaps Directory.