### PR TITLE
Add support for initial connections

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 90.96,
-  "functions": 96.51,
-  "lines": 97.78,
-  "statements": 97.46
+  "branches": 90.88,
+  "functions": 96.52,
+  "lines": 97.81,
+  "statements": 97.5
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -3479,6 +3479,113 @@ describe('SnapController', () => {
       snapController.destroy();
     });
 
+    it('grants connection permission to initialConnections', async () => {
+      const rootMessenger = getControllerMessenger();
+      const messenger = getSnapControllerMessenger(rootMessenger);
+
+      rootMessenger.registerActionHandler(
+        'PermissionController:getPermissions',
+        () => ({}),
+      );
+
+      const initialConnections = {
+        'npm:filsnap': {},
+        'https://snaps.metamask.io': {},
+      };
+
+      const { manifest } = await getMockSnapFilesWithUpdatedChecksum({
+        manifest: getSnapManifest({
+          initialConnections,
+        }),
+      });
+
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          detectSnapLocation: loopbackDetect({ manifest }),
+        }),
+      );
+
+      await snapController.installSnaps(MOCK_ORIGIN, {
+        [MOCK_SNAP_ID]: {},
+      });
+
+      const approvedPermissions = {
+        [WALLET_SNAP_PERMISSION_KEY]: {
+          caveats: [
+            {
+              type: SnapCaveatType.SnapIds,
+              value: {
+                [MOCK_SNAP_ID]: {},
+              },
+            },
+          ],
+        },
+      };
+
+      expect(messenger.call).toHaveBeenCalledWith(
+        'PermissionController:grantPermissions',
+        { approvedPermissions, subject: { origin: 'npm:filsnap' } },
+      );
+
+      expect(messenger.call).toHaveBeenCalledWith(
+        'PermissionController:grantPermissions',
+        {
+          approvedPermissions,
+          subject: { origin: 'https://snaps.metamask.io' },
+        },
+      );
+
+      snapController.destroy();
+    });
+
+    it('updates existing caveats to satisfy initialConnections', async () => {
+      const rootMessenger = getControllerMessenger();
+      const messenger = getSnapControllerMessenger(rootMessenger);
+
+      const initialConnections = {
+        'npm:filsnap': {},
+        'https://snaps.metamask.io': {},
+      };
+
+      const { manifest } = await getMockSnapFilesWithUpdatedChecksum({
+        manifest: getSnapManifest({
+          initialConnections,
+        }),
+      });
+
+      const snapId = `${MOCK_SNAP_ID}_foo`;
+
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          detectSnapLocation: loopbackDetect({ manifest }),
+        }),
+      );
+
+      await snapController.installSnaps(MOCK_ORIGIN, {
+        [snapId]: {},
+      });
+
+      expect(messenger.call).toHaveBeenCalledWith(
+        'PermissionController:updateCaveat',
+        'npm:filsnap',
+        WALLET_SNAP_PERMISSION_KEY,
+        SnapCaveatType.SnapIds,
+        expect.objectContaining({ [snapId]: {} }),
+      );
+
+      expect(messenger.call).toHaveBeenCalledWith(
+        'PermissionController:updateCaveat',
+        'https://snaps.metamask.io',
+        WALLET_SNAP_PERMISSION_KEY,
+        SnapCaveatType.SnapIds,
+        expect.objectContaining({ [snapId]: {} }),
+      );
+
+      snapController.destroy();
+    });
+
     it('supports preinstalled snaps', async () => {
       const rootMessenger = getControllerMessenger();
       jest.spyOn(rootMessenger, 'call');

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -5786,7 +5786,7 @@ describe('SnapController', () => {
 
       const initialConnections = {
         [MOCK_ORIGIN]: {},
-        'snaps.metamask.io': {},
+        'https://snaps.metamask.io': {},
         'npm:filsnap': {},
       };
 
@@ -5829,7 +5829,10 @@ describe('SnapController', () => {
 
       expect(messenger.call).toHaveBeenCalledWith(
         'PermissionController:grantPermissions',
-        { approvedPermissions, subject: { origin: 'snaps.metamask.io' } },
+        {
+          approvedPermissions,
+          subject: { origin: 'https://snaps.metamask.io' },
+        },
       );
 
       expect(messenger.call).not.toHaveBeenCalledWith(

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1637,9 +1637,7 @@ export class SnapController extends BaseController<
 
     const existingCaveat = subjectPermissions?.[
       WALLET_SNAP_PERMISSION_KEY
-    ]?.caveats?.find((caveat) => caveat.type === SnapCaveatType.SnapIds) as
-      | Caveat<string, Json>
-      | undefined;
+    ]?.caveats?.find((caveat) => caveat.type === SnapCaveatType.SnapIds);
 
     const subjectHasSnap = Boolean(
       (existingCaveat?.value as Record<string, Json>)?.[snapId],
@@ -1673,7 +1671,7 @@ export class SnapController extends BaseController<
           },
         ],
       },
-    };
+    } as RequestedPermissions;
 
     this.messagingSystem.call('PermissionController:grantPermissions', {
       approvedPermissions,

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -2,5 +2,5 @@
   "branches": 96.05,
   "functions": 98.55,
   "lines": 98.62,
-  "statements": 95.45
+  "statements": 95.36
 }

--- a/packages/snaps-utils/src/manifest/manifest.ts
+++ b/packages/snaps-utils/src/manifest/manifest.ts
@@ -25,8 +25,9 @@ const MANIFEST_SORT_ORDER: Record<keyof SnapManifest, number> = {
   proposedName: 4,
   repository: 5,
   source: 6,
-  initialPermissions: 7,
-  manifestVersion: 8,
+  initialConnections: 7,
+  initialPermissions: 8,
+  manifestVersion: 9,
 };
 
 /**

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -189,6 +189,11 @@ export type SnapPermissions = InferMatching<
 
 export const SnapAuxilaryFilesStruct = array(string());
 
+// TODO: Consider typing this stricter?
+export const InitialConnectionsStruct = record(string(), object());
+
+export type InitialConnections = Infer<typeof InitialConnectionsStruct>;
+
 export const SnapManifestStruct = object({
   version: VersionStruct,
   description: size(string(), 1, 280),
@@ -215,6 +220,7 @@ export const SnapManifestStruct = object({
     files: optional(SnapAuxilaryFilesStruct),
     locales: optional(SnapAuxilaryFilesStruct),
   }),
+  initialConnections: optional(InitialConnectionsStruct),
   initialPermissions: PermissionsStruct,
   manifestVersion: literal('0.1'),
   $schema: optional(string()), // enables JSON-Schema linting in VSC and other IDEs

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -23,6 +23,7 @@ import {
   string,
   type,
   union,
+  intersection,
 } from 'superstruct';
 
 import { isEqual } from '../array';
@@ -32,7 +33,7 @@ import { KeyringOriginsStruct, RpcOriginsStruct } from '../json-rpc';
 import { ChainIdStruct } from '../namespace';
 import { SnapIdStruct } from '../snaps';
 import type { InferMatching } from '../structs';
-import { NameStruct, NpmSnapFileNames } from '../types';
+import { NameStruct, NpmSnapFileNames, uri } from '../types';
 
 // BIP-43 purposes that cannot be used for entropy derivation. These are in the
 // string form, ending with `'`.
@@ -189,8 +190,10 @@ export type SnapPermissions = InferMatching<
 
 export const SnapAuxilaryFilesStruct = array(string());
 
-// TODO: Consider typing this stricter?
-export const InitialConnectionsStruct = record(string(), object({}));
+export const InitialConnectionsStruct = record(
+  intersection([string(), uri()]),
+  object({}),
+);
 
 export type InitialConnections = Infer<typeof InitialConnectionsStruct>;
 

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -190,7 +190,7 @@ export type SnapPermissions = InferMatching<
 export const SnapAuxilaryFilesStruct = array(string());
 
 // TODO: Consider typing this stricter?
-export const InitialConnectionsStruct = record(string(), object());
+export const InitialConnectionsStruct = record(string(), object({}));
 
 export type InitialConnections = Infer<typeof InitialConnectionsStruct>;
 

--- a/packages/snaps-utils/src/test-utils/manifest.ts
+++ b/packages/snaps-utils/src/test-utils/manifest.ts
@@ -88,6 +88,7 @@ export const DEFAULT_SNAP_SHASUM =
  * @param manifest.iconPath - The path to the icon of the snap.
  * @param manifest.files - Auxiliary files loaded at runtime by the snap.
  * @param manifest.locales - Localization files of the snap.
+ * @param manifest.initialConnections - Initial connections for the snap.
  * @returns The snap manifest.
  */
 export const getSnapManifest = ({
@@ -102,6 +103,7 @@ export const getSnapManifest = ({
   iconPath = DEFAULT_ICON_PATH,
   files = undefined,
   locales = undefined,
+  initialConnections = undefined,
 }: GetSnapManifestOptions = {}): SnapManifest => {
   return {
     version: version as SemVerVersion,
@@ -121,6 +123,7 @@ export const getSnapManifest = ({
       ...(files ? { files } : {}),
       ...(locales ? { locales } : {}),
     },
+    ...(initialConnections ? { initialConnections } : {}),
     initialPermissions,
     manifestVersion: '0.1' as const,
   };

--- a/packages/snaps-utils/src/test-utils/snap.ts
+++ b/packages/snaps-utils/src/test-utils/snap.ts
@@ -12,7 +12,7 @@ import {
 
 export const MOCK_SNAP_ID = 'npm:@metamask/example-snap' as SnapId;
 export const MOCK_LOCAL_SNAP_ID = 'local:http://localhost:8080' as SnapId;
-export const MOCK_ORIGIN = 'example.com';
+export const MOCK_ORIGIN = 'https://example.com';
 
 type GetPersistedSnapObjectOptions = Partial<MakeSemVer<PersistedSnap>>;
 type GetSnapObjectOptions = Partial<MakeSemVer<Snap>>;


### PR DESCRIPTION
Adds `initialConnections`, a new field for the manifest that can be used to pre-approve certain origins for communication with your snap, as such:
```
  "initialConnections": {
    "https://snaps.metamask.io": {},
    "npm:filsnap": {}
  },
  "initialPermissions": {
    "endowment:rpc": {
      "dapps": true,
      "snaps": true
    }
  },
```

This will automatically grant the subjects the required permissions to invoke the snap after an installation or update has completed. The user can still revoke these permissions in the UI anytime in the future.

Closes https://github.com/MetaMask/snaps/issues/2037