### PR TITLE
Add `snap_getClientStatus`

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Js7Ka0oIkod5UQQZnjlWRm+m0xXUcZXweV/EfNNoK/s=",
+    "shasum": "eGdozFdCubvO+UCvVHVqapVI8JFeep7vZauxeX7omEE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "kXygWd9vy1CVp8gnXfF3FaVHuEIPUzm2FHQjXdMrgvs=",
+    "shasum": "6zMAUjoYwAqxUs4/Z2rxpw8G1oXtGGoOejw3f8C/0w0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "uZONVAGwoDYf4DMEyANYhVf/cUkoFg5A5B4yfuivJxs=",
+    "shasum": "+tS6cY5IRUJQZNwtoMcouAlOD1+h+yEornJm4QAHdO8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "zznfrTkjoscycX44iwaV9gF7kgGcyS+AG3sbRSHzPQI=",
+    "shasum": "apB4Sic4cCoJPo4uzvm2hxDRHe6cqr/9tIFmAG948Wg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "sDPI9A58gXZfuG2RNZz/6P7angGGxRUwAFDK+Sj8klw=",
+    "shasum": "BshN7fTI4gTDAEAoaV/+qKOEwv1n+Qb/Tvc/L1vizwk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "mzJ4yH0hpKGXtwFdYZA871cWaULqt9VJI/2vGkC2eiw=",
+    "shasum": "jNHOg6TjngJyWCkLWuhoVdIFVhDtHJ89lPDvJF0tsW0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8EZwAXVegn9lcsQ4od1BXimlcNg3bEsBzsU3DGg18SQ=",
+    "shasum": "WDT9YTZ/bnSzXFJ54S0yA0EaStvbLGsEwOVGNEw33pM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "BNJgYitooJ8YI49Q1pJR/jBE9sSiefT8WGIW4BPr9Dc=",
+    "shasum": "k23YAM/rdpxr9NWmckQ5/kCfcxyoHKJ4fL0qVj9taec=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "SIFalAk02WxDSOldnFCkcEWGxxkbd1+ef4KnDj5ejXY=",
+    "shasum": "+teIoNvXHU85OGQU8wLiGvsVOkzXlKm4F5/sz2TclAI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VDEPLP0cehLd1hUvq6dPkaIHt4Dk5qDBSwdTprvs9to=",
+    "shasum": "6eK55Mrtb87jK27VvoHl7lo2X8mtvLJtcLyRNJ0LwOY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "yRC5v7m8bcBviarsrVmA9DVH2YRPZAsNRTG4I5s4JUw=",
+    "shasum": "Xcuru23qMSNGiKSVnrYrLRiybblv4qNx+xXILnK9dcs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FGOEdBo8k4g8AgTrEvg7pxeDrzz8cuRSvoeaiZP7za8=",
+    "shasum": "u0iufVvG5pFCGVMcAK2nR53GRJLL6kRtivThQ/0seQg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "H98+H48+NdjCK5OcE9eFqMqE02OPt47sDmL+iLi0eGk=",
+    "shasum": "t9N77v/AKNen20CXk1jjfnnMnPLRt/MaPNy4vC1I3b8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "JmbP20fdj5LEZKB0L26C6w8jZmnwITHJXwTYrx7MQRY=",
+    "shasum": "UlOP2U4pzPPiLF7QATIY7DP/nJJzf4syo1exacgx+4k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-execution-environments/lavamoat/browserify/iframe/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/iframe/policy.json
@@ -314,6 +314,7 @@
         "external:../snaps-sdk/src/types/methods/get-bip32-entropy.ts": true,
         "external:../snaps-sdk/src/types/methods/get-bip32-public-key.ts": true,
         "external:../snaps-sdk/src/types/methods/get-bip44-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-client-status.ts": true,
         "external:../snaps-sdk/src/types/methods/get-entropy.ts": true,
         "external:../snaps-sdk/src/types/methods/get-file.ts": true,
         "external:../snaps-sdk/src/types/methods/get-locale.ts": true,

--- a/packages/snaps-execution-environments/lavamoat/browserify/node-process/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/node-process/policy.json
@@ -371,6 +371,7 @@
         "external:../snaps-sdk/src/types/methods/get-bip32-entropy.ts": true,
         "external:../snaps-sdk/src/types/methods/get-bip32-public-key.ts": true,
         "external:../snaps-sdk/src/types/methods/get-bip44-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-client-status.ts": true,
         "external:../snaps-sdk/src/types/methods/get-entropy.ts": true,
         "external:../snaps-sdk/src/types/methods/get-file.ts": true,
         "external:../snaps-sdk/src/types/methods/get-locale.ts": true,

--- a/packages/snaps-execution-environments/lavamoat/browserify/node-thread/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/node-thread/policy.json
@@ -371,6 +371,7 @@
         "external:../snaps-sdk/src/types/methods/get-bip32-entropy.ts": true,
         "external:../snaps-sdk/src/types/methods/get-bip32-public-key.ts": true,
         "external:../snaps-sdk/src/types/methods/get-bip44-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-client-status.ts": true,
         "external:../snaps-sdk/src/types/methods/get-entropy.ts": true,
         "external:../snaps-sdk/src/types/methods/get-file.ts": true,
         "external:../snaps-sdk/src/types/methods/get-locale.ts": true,

--- a/packages/snaps-execution-environments/lavamoat/browserify/offscreen/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/offscreen/policy.json
@@ -215,6 +215,7 @@
         "external:../snaps-sdk/src/types/methods/get-bip32-entropy.ts": true,
         "external:../snaps-sdk/src/types/methods/get-bip32-public-key.ts": true,
         "external:../snaps-sdk/src/types/methods/get-bip44-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-client-status.ts": true,
         "external:../snaps-sdk/src/types/methods/get-entropy.ts": true,
         "external:../snaps-sdk/src/types/methods/get-file.ts": true,
         "external:../snaps-sdk/src/types/methods/get-locale.ts": true,

--- a/packages/snaps-execution-environments/lavamoat/browserify/worker-executor/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/worker-executor/policy.json
@@ -314,6 +314,7 @@
         "external:../snaps-sdk/src/types/methods/get-bip32-entropy.ts": true,
         "external:../snaps-sdk/src/types/methods/get-bip32-public-key.ts": true,
         "external:../snaps-sdk/src/types/methods/get-bip44-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-client-status.ts": true,
         "external:../snaps-sdk/src/types/methods/get-entropy.ts": true,
         "external:../snaps-sdk/src/types/methods/get-file.ts": true,
         "external:../snaps-sdk/src/types/methods/get-locale.ts": true,

--- a/packages/snaps-execution-environments/lavamoat/browserify/worker-pool/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/worker-pool/policy.json
@@ -215,6 +215,7 @@
         "external:../snaps-sdk/src/types/methods/get-bip32-entropy.ts": true,
         "external:../snaps-sdk/src/types/methods/get-bip32-public-key.ts": true,
         "external:../snaps-sdk/src/types/methods/get-bip44-entropy.ts": true,
+        "external:../snaps-sdk/src/types/methods/get-client-status.ts": true,
         "external:../snaps-sdk/src/types/methods/get-entropy.ts": true,
         "external:../snaps-sdk/src/types/methods/get-file.ts": true,
         "external:../snaps-sdk/src/types/methods/get-locale.ts": true,

--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -12,8 +12,8 @@ module.exports = deepmerge(baseConfig, {
     global: {
       branches: 92.91,
       functions: 100,
-      lines: 99.19,
-      statements: 97.5,
+      lines: 99.2,
+      statements: 97.52,
     },
   },
 });

--- a/packages/snaps-rpc-methods/src/permitted/getClientStatus.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getClientStatus.test.ts
@@ -1,0 +1,55 @@
+import { JsonRpcEngine } from '@metamask/json-rpc-engine';
+import type { GetClientStatusResult } from '@metamask/snaps-sdk';
+import type { PendingJsonRpcResponse } from '@metamask/utils';
+
+import { getClientStatusHandler } from './getClientStatus';
+
+describe('snap_getClientStatus', () => {
+  describe('getClientStatusHandler', () => {
+    it('has the expected shape', () => {
+      expect(getClientStatusHandler).toMatchObject({
+        methodNames: ['snap_getClientStatus'],
+        implementation: expect.any(Function),
+        hookNames: {
+          getIsLocked: true,
+        },
+      });
+    });
+  });
+
+  describe('implementation', () => {
+    it('returns the result', async () => {
+      const { implementation } = getClientStatusHandler;
+
+      const getIsLocked = jest.fn().mockReturnValue(true);
+      const hooks = {
+        getIsLocked,
+      };
+
+      const engine = new JsonRpcEngine();
+      engine.push((request, response, next, end) => {
+        const result = implementation(
+          request,
+          response as PendingJsonRpcResponse<GetClientStatusResult>,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'snap_getClientStatus',
+      });
+
+      expect(response).toStrictEqual({
+        jsonrpc: '2.0',
+        id: 1,
+        result: { locked: true },
+      });
+    });
+  });
+});

--- a/packages/snaps-rpc-methods/src/permitted/getClientStatus.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getClientStatus.ts
@@ -1,0 +1,58 @@
+import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
+import type { PermittedHandlerExport } from '@metamask/permission-controller';
+import type { GetClientStatusResult } from '@metamask/snaps-sdk';
+import type {
+  JsonRpcParams,
+  JsonRpcRequest,
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
+
+import type { MethodHooksObject } from '../utils';
+
+const hookNames: MethodHooksObject<GetClientStatusHooks> = {
+  getIsLocked: true,
+};
+
+/**
+ * `snap_getClientStatus` returns useful information about the client running the snap.
+ */
+export const getClientStatusHandler: PermittedHandlerExport<
+  GetClientStatusHooks,
+  JsonRpcParams,
+  GetClientStatusResult
+> = {
+  methodNames: ['snap_getClientStatus'],
+  implementation: getClientStatusImplementation,
+  hookNames,
+};
+
+export type GetClientStatusHooks = {
+  /**
+   * @returns Whether the client is locked or not.
+   */
+  getIsLocked: () => boolean;
+};
+
+/**
+ * The `snap_getClientStatus` method implementation.
+ * Returns useful information about the client running the snap.
+ *
+ * @param _request - The JSON-RPC request object. Not used by this function.
+ * @param response - The JSON-RPC response object.
+ * @param _next - The `json-rpc-engine` "next" callback. Not used by this
+ * function.
+ * @param end - The `json-rpc-engine` "end" callback.
+ * @param hooks - The RPC method hooks.
+ * @param hooks.getIsLocked - A function that returns whether the client is locked or not.
+ * @returns Nothing.
+ */
+async function getClientStatusImplementation(
+  _request: JsonRpcRequest,
+  response: PendingJsonRpcResponse<GetClientStatusResult>,
+  _next: unknown,
+  end: JsonRpcEngineEndCallback,
+  { getIsLocked }: GetClientStatusHooks,
+): Promise<void> {
+  response.result = { locked: getIsLocked() };
+  return end();
+}

--- a/packages/snaps-rpc-methods/src/permitted/handlers.ts
+++ b/packages/snaps-rpc-methods/src/permitted/handlers.ts
@@ -1,4 +1,5 @@
 import { getAllSnapsHandler } from './getAllSnaps';
+import { getClientStatusHandler } from './getClientStatus';
 import { getFileHandler } from './getFile';
 import { getSnapsHandler } from './getSnaps';
 import { invokeKeyringHandler } from './invokeKeyring';
@@ -12,6 +13,7 @@ export const methodHandlers = {
   wallet_requestSnaps: requestSnapsHandler,
   wallet_invokeSnap: invokeSnapSugarHandler,
   wallet_invokeKeyring: invokeKeyringHandler,
+  snap_getClientStatus: getClientStatusHandler,
   snap_getFile: getFileHandler,
 };
 /* eslint-enable @typescript-eslint/naming-convention */

--- a/packages/snaps-rpc-methods/src/permitted/index.ts
+++ b/packages/snaps-rpc-methods/src/permitted/index.ts
@@ -1,8 +1,10 @@
 import type { GetAllSnapsHooks } from './getAllSnaps';
+import type { GetClientStatusHooks } from './getClientStatus';
 import type { GetSnapsHooks } from './getSnaps';
 import type { RequestSnapsHooks } from './requestSnaps';
 
 export type PermittedRpcMethodHooks = GetAllSnapsHooks &
+  GetClientStatusHooks &
   GetSnapsHooks &
   RequestSnapsHooks;
 

--- a/packages/snaps-sdk/src/types/methods/get-client-status.ts
+++ b/packages/snaps-sdk/src/types/methods/get-client-status.ts
@@ -1,0 +1,13 @@
+/**
+ * The request parameters for the `snap_getClientStatus` method.
+ *
+ * This method does not accept any parameters.
+ */
+export type GetClientStatusParams = never;
+
+/**
+ * The result returned by the `snap_getClientStatus` method.
+ *
+ * It returns an object containing useful information about the client.
+ */
+export type GetClientStatusResult = { locked: boolean };

--- a/packages/snaps-sdk/src/types/methods/index.ts
+++ b/packages/snaps-sdk/src/types/methods/index.ts
@@ -2,6 +2,7 @@ export * from './dialog';
 export * from './get-bip32-entropy';
 export * from './get-bip32-public-key';
 export * from './get-bip44-entropy';
+export * from './get-client-status';
 export * from './get-entropy';
 export * from './get-file';
 export * from './get-locale';

--- a/packages/snaps-sdk/src/types/methods/methods.ts
+++ b/packages/snaps-sdk/src/types/methods/methods.ts
@@ -12,6 +12,10 @@ import type {
   GetBip44EntropyParams,
   GetBip44EntropyResult,
 } from './get-bip44-entropy';
+import type {
+  GetClientStatusParams,
+  GetClientStatusResult,
+} from './get-client-status';
 import type { GetEntropyParams, GetEntropyResult } from './get-entropy';
 import type { GetFileParams, GetFileResult } from './get-file';
 import type { GetLocaleParams, GetLocaleResult } from './get-locale';
@@ -39,6 +43,7 @@ export type SnapMethods = {
   snap_getBip32Entropy: [GetBip32EntropyParams, GetBip32EntropyResult];
   snap_getBip32PublicKey: [GetBip32PublicKeyParams, GetBip32PublicKeyResult];
   snap_getBip44Entropy: [GetBip44EntropyParams, GetBip44EntropyResult];
+  snap_getClientStatus: [GetClientStatusParams, GetClientStatusResult];
   snap_getEntropy: [GetEntropyParams, GetEntropyResult];
   snap_getFile: [GetFileParams, GetFileResult];
   snap_getLocale: [GetLocaleParams, GetLocaleResult];


### PR DESCRIPTION
Add the `snap_getClientStatus` RPC method. This RPC method is meant to return useful information about the client executing the snap. Currently it returns whether the client is in a locked state or not.