### PR TITLE
Disable E2E testing method that uses the network

### DIFF
--- a/packages/examples/packages/images/src/index.test.ts
+++ b/packages/examples/packages/images/src/index.test.ts
@@ -52,7 +52,9 @@ describe('onRpcRequest', () => {
   });
 
   describe('getCat', () => {
-    it('shows a cat', async () => {
+    // This test is flaky so we disable it for now
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('shows a cat', async () => {
       const { request, close } = await installSnap();
 
       const response = request({


### PR DESCRIPTION
Disable E2E testing of the `getCat` method in the image example as it uses the network.