### PR TITLE
Populate subject metadata

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 91.21,
+  "branches": 91.01,
   "functions": 96.35,
   "lines": 97.68,
   "statements": 97.36

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -46,7 +46,7 @@
     "@metamask/base-controller": "^4.0.0",
     "@metamask/json-rpc-engine": "^7.3.1",
     "@metamask/object-multiplex": "^2.0.0",
-    "@metamask/permission-controller": "^7.0.0",
+    "@metamask/permission-controller": "^7.1.0",
     "@metamask/phishing-controller": "^8.0.1",
     "@metamask/post-message-stream": "^7.0.0",
     "@metamask/rpc-errors": "^6.1.0",

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -3921,6 +3921,18 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
+        18,
+        'SubjectMetadataController:addSubjectMetadata',
+        {
+          subjectType: SubjectType.Snap,
+          name: MOCK_SNAP_NAME,
+          origin: MOCK_SNAP_ID,
+          version: '1.0.2',
+          svgIcon: DEFAULT_SNAP_ICON,
+        },
+      );
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
         19,
         'ExecutionService:executeSnap',
         expect.objectContaining({}),

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -3,10 +3,11 @@ import {
   createAsyncMiddleware,
   JsonRpcEngine,
 } from '@metamask/json-rpc-engine';
-import type {
-  Caveat,
-  SubjectPermissions,
-  ValidPermission,
+import {
+  SubjectType,
+  type Caveat,
+  type SubjectPermissions,
+  type ValidPermission,
 } from '@metamask/permission-controller';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import { WALLET_SNAP_PERMISSION_KEY } from '@metamask/snaps-rpc-methods';
@@ -39,6 +40,7 @@ import {
   MOCK_SNAP_ID,
   getMockLocalizationFile,
   getMockSnapFilesWithUpdatedChecksum,
+  MOCK_SNAP_NAME,
 } from '@metamask/snaps-utils/test-utils';
 import type { SemVerRange, SemVerVersion } from '@metamask/utils';
 import {
@@ -578,7 +580,7 @@ describe('SnapController', () => {
       [MOCK_SNAP_ID]: expectedSnapObject,
     });
 
-    expect(messenger.call).toHaveBeenCalledTimes(10);
+    expect(messenger.call).toHaveBeenCalledTimes(11);
 
     expect(messenger.call).toHaveBeenNthCalledWith(
       1,
@@ -605,6 +607,18 @@ describe('SnapController', () => {
 
     expect(messenger.call).toHaveBeenNthCalledWith(
       3,
+      'SubjectMetadataController:addSubjectMetadata',
+      {
+        subjectType: SubjectType.Snap,
+        name: MOCK_SNAP_NAME,
+        origin: MOCK_SNAP_ID,
+        version: '1.0.0',
+        svgIcon: DEFAULT_SNAP_ICON,
+      },
+    );
+
+    expect(messenger.call).toHaveBeenNthCalledWith(
+      4,
       'ApprovalController:updateRequestState',
       {
         id: expect.any(String),
@@ -616,13 +630,13 @@ describe('SnapController', () => {
     );
 
     expect(messenger.call).toHaveBeenNthCalledWith(
-      4,
+      5,
       'PermissionController:grantPermissions',
       expect.any(Object),
     );
 
     expect(messenger.call).toHaveBeenNthCalledWith(
-      5,
+      6,
       'ApprovalController:addRequest',
       expect.objectContaining({
         requestData: {
@@ -641,13 +655,13 @@ describe('SnapController', () => {
     );
 
     expect(messenger.call).toHaveBeenNthCalledWith(
-      6,
+      7,
       'ExecutionService:executeSnap',
       expect.any(Object),
     );
 
     expect(messenger.call).toHaveBeenNthCalledWith(
-      7,
+      8,
       'ApprovalController:updateRequestState',
       {
         id: expect.any(String),
@@ -916,7 +930,7 @@ describe('SnapController', () => {
     );
 
     expect(messenger.call).toHaveBeenNthCalledWith(
-      4,
+      5,
       'ApprovalController:updateRequestState',
       expect.objectContaining({
         id: expect.any(String),
@@ -982,10 +996,10 @@ describe('SnapController', () => {
       }),
     ).rejects.toThrow('foo');
 
-    expect(messengerCallMock).toHaveBeenCalledTimes(8);
+    expect(messengerCallMock).toHaveBeenCalledTimes(9);
 
     expect(messengerCallMock).toHaveBeenNthCalledWith(
-      3,
+      4,
       'ApprovalController:updateRequestState',
       expect.objectContaining({
         id: expect.any(String),
@@ -2828,7 +2842,7 @@ describe('SnapController', () => {
 
       expect(result).toStrictEqual({ [MOCK_LOCAL_SNAP_ID]: truncatedSnap });
 
-      expect(messenger.call).toHaveBeenCalledTimes(12);
+      expect(messenger.call).toHaveBeenCalledTimes(13);
 
       expect(messenger.call).toHaveBeenNthCalledWith(
         1,
@@ -2851,7 +2865,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        5,
+        6,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -2863,7 +2877,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        6,
+        7,
         'PermissionController:grantPermissions',
         {
           approvedPermissions: permissions,
@@ -2880,7 +2894,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        7,
+        8,
         'ApprovalController:addRequest',
         expect.objectContaining({
           type: SNAP_APPROVAL_RESULT,
@@ -2900,13 +2914,13 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        8,
+        9,
         'ExecutionService:executeSnap',
         expect.objectContaining({}),
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        9,
+        10,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -2977,7 +2991,7 @@ describe('SnapController', () => {
         [MOCK_LOCAL_SNAP_ID]: truncatedSnap,
       });
 
-      expect(messenger.call).toHaveBeenCalledTimes(23);
+      expect(messenger.call).toHaveBeenCalledTimes(25);
 
       expect(messenger.call).toHaveBeenNthCalledWith(
         1,
@@ -3000,7 +3014,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        3,
+        4,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -3012,7 +3026,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        4,
+        5,
         'PermissionController:grantPermissions',
         {
           approvedPermissions: permissions,
@@ -3029,7 +3043,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        5,
+        6,
         'ApprovalController:addRequest',
         expect.objectContaining({
           id: expect.any(String),
@@ -3050,13 +3064,13 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        6,
+        7,
         'ExecutionService:executeSnap',
         expect.anything(),
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        7,
+        8,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -3068,7 +3082,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        11,
+        12,
         'ApprovalController:addRequest',
         expect.objectContaining({
           type: SNAP_APPROVAL_INSTALL,
@@ -3088,13 +3102,13 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        12,
+        13,
         'ExecutionService:terminateSnap',
         MOCK_LOCAL_SNAP_ID,
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        16,
+        18,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -3106,7 +3120,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        17,
+        19,
         'PermissionController:grantPermissions',
         {
           approvedPermissions: permissions,
@@ -3123,7 +3137,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        18,
+        20,
         'ApprovalController:addRequest',
         expect.objectContaining({
           id: expect.any(String),
@@ -3144,13 +3158,13 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        19,
+        21,
         'ExecutionService:executeSnap',
         expect.objectContaining({ snapId: MOCK_LOCAL_SNAP_ID }),
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        20,
+        22,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -3225,7 +3239,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        6,
+        7,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -3310,7 +3324,7 @@ describe('SnapController', () => {
       expect(result).toStrictEqual({
         [MOCK_SNAP_ID]: truncatedSnap,
       });
-      expect(messenger.call).toHaveBeenCalledTimes(10);
+      expect(messenger.call).toHaveBeenCalledTimes(11);
 
       expect(messenger.call).toHaveBeenNthCalledWith(
         1,
@@ -3330,7 +3344,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        3,
+        4,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -3342,7 +3356,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        4,
+        5,
         'PermissionController:grantPermissions',
         {
           approvedPermissions: permissions,
@@ -3359,7 +3373,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        5,
+        6,
         'ApprovalController:addRequest',
         expect.objectContaining({
           id: expect.any(String),
@@ -3380,13 +3394,13 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        6,
+        7,
         'ExecutionService:executeSnap',
         expect.objectContaining({}),
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        7,
+        8,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -3515,7 +3529,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        3,
+        4,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -3548,7 +3562,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        4,
+        5,
         'PermissionController:grantPermissions',
         {
           approvedPermissions: {
@@ -3641,7 +3655,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        3,
+        4,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -3657,7 +3671,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        4,
+        5,
         'PermissionController:grantPermissions',
         {
           approvedPermissions: {
@@ -3723,7 +3737,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        6,
+        7,
         'PermissionController:grantPermissions',
         {
           approvedPermissions: {
@@ -3827,10 +3841,22 @@ describe('SnapController', () => {
         [MOCK_SNAP_ID]: { version: newVersionRange },
       });
 
-      expect(messenger.call).toHaveBeenCalledTimes(21);
+      expect(messenger.call).toHaveBeenCalledTimes(23);
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        12,
+        3,
+        'SubjectMetadataController:addSubjectMetadata',
+        {
+          subjectType: SubjectType.Snap,
+          name: MOCK_SNAP_NAME,
+          origin: MOCK_SNAP_ID,
+          version: '1.0.0',
+          svgIcon: DEFAULT_SNAP_ICON,
+        },
+      );
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        13,
         'ApprovalController:addRequest',
         {
           origin: MOCK_ORIGIN,
@@ -3852,13 +3878,13 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        14,
+        15,
         'PermissionController:getPermissions',
         MOCK_SNAP_ID,
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        15,
+        16,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -3874,7 +3900,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        16,
+        17,
         'ApprovalController:addRequest',
         expect.objectContaining({
           id: expect.any(String),
@@ -3895,13 +3921,13 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        17,
+        19,
         'ExecutionService:executeSnap',
         expect.objectContaining({}),
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        18,
+        20,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -4533,10 +4559,10 @@ describe('SnapController', () => {
           date: expect.any(Number),
         },
       ]);
-      expect(callActionSpy).toHaveBeenCalledTimes(21);
+      expect(callActionSpy).toHaveBeenCalledTimes(23);
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        12,
+        13,
         'ApprovalController:addRequest',
         {
           origin: MOCK_ORIGIN,
@@ -4558,13 +4584,13 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        14,
+        15,
         'PermissionController:getPermissions',
         MOCK_SNAP_ID,
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        15,
+        16,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -4580,7 +4606,7 @@ describe('SnapController', () => {
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        16,
+        17,
         'ApprovalController:addRequest',
         expect.objectContaining({
           id: expect.any(String),
@@ -4601,13 +4627,13 @@ describe('SnapController', () => {
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        17,
+        19,
         'ExecutionService:executeSnap',
         expect.objectContaining({}),
       );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        20,
+        22,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -4713,7 +4739,7 @@ describe('SnapController', () => {
 
       const isRunning = controller.isRunning(MOCK_SNAP_ID);
 
-      expect(callActionSpy).toHaveBeenCalledTimes(12);
+      expect(callActionSpy).toHaveBeenCalledTimes(13);
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
         1,
@@ -4793,7 +4819,7 @@ describe('SnapController', () => {
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        11,
+        12,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -5052,10 +5078,10 @@ describe('SnapController', () => {
 
       await controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID, detect());
 
-      expect(callActionSpy).toHaveBeenCalledTimes(23);
+      expect(callActionSpy).toHaveBeenCalledTimes(25);
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        12,
+        13,
         'ApprovalController:addRequest',
         {
           origin: MOCK_ORIGIN,
@@ -5077,7 +5103,7 @@ describe('SnapController', () => {
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        15,
+        16,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),
@@ -5099,7 +5125,7 @@ describe('SnapController', () => {
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        16,
+        17,
         'ApprovalController:addRequest',
         {
           origin: MOCK_ORIGIN,
@@ -5121,13 +5147,13 @@ describe('SnapController', () => {
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        17,
+        19,
         'PermissionController:revokePermissions',
         { [MOCK_SNAP_ID]: ['snap_manageState'] },
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        18,
+        20,
         'PermissionController:grantPermissions',
         {
           approvedPermissions: { 'endowment:network-access': {} },
@@ -5144,13 +5170,13 @@ describe('SnapController', () => {
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        19,
+        21,
         'ExecutionService:executeSnap',
         expect.anything(),
       );
 
       expect(callActionSpy).toHaveBeenNthCalledWith(
-        22,
+        24,
         'ApprovalController:updateRequestState',
         expect.objectContaining({
           id: expect.any(String),

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2361,7 +2361,7 @@ export class SnapController extends BaseController<
       name: proposedName,
       origin: snap.id,
       version,
-      svgIcon: stringifiedIcon,
+      svgIcon: stringifiedIcon ?? null,
     });
 
     return { ...snap, sourceCode };

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2277,7 +2277,7 @@ export class SnapController extends BaseController<
     } = files;
 
     assertIsSnapManifest(manifest.result);
-    const { version } = manifest.result;
+    const { version, proposedName } = manifest.result;
 
     const sourceCode = sourceCodeFile.toString();
 
@@ -2345,11 +2345,21 @@ export class SnapController extends BaseController<
       }
     }
 
+    const stringifiedIcon = svgIcon?.toString();
+
     this.messagingSystem.publish(
       `SnapController:snapAdded`,
       snap,
-      svgIcon?.toString(),
+      stringifiedIcon,
     );
+
+    this.messagingSystem.call('SubjectMetadataController:addSubjectMetadata', {
+      subjectType: SubjectType.Snap,
+      name: proposedName,
+      origin: snap.id,
+      version,
+      svgIcon: stringifiedIcon,
+    });
 
     return { ...snap, sourceCode };
   }

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -9,6 +9,7 @@ import type {
   GetEndowments,
   GetPermissions,
   GetSubjectMetadata,
+  AddSubjectMetadata,
   GetSubjects,
   GrantPermissions,
   HasPermission,
@@ -497,6 +498,7 @@ export type AllowedActions =
   | GetPermissions
   | GetSubjects
   | GetSubjectMetadata
+  | AddSubjectMetadata
   | HasPermission
   | HasPermissions
   | RevokePermissions
@@ -2347,6 +2349,7 @@ export class SnapController extends BaseController<
 
     const stringifiedIcon = svgIcon?.toString();
 
+    // TODO: Consider removing this as it is unused now
     this.messagingSystem.publish(
       `SnapController:snapAdded`,
       snap,

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -263,6 +263,11 @@ export const getControllerMessenger = (registry = new MockSnapsRegistry()) => {
     () => MOCK_SNAP_SUBJECT_METADATA,
   );
 
+  messenger.registerActionHandler(
+    'SubjectMetadataController:addSubjectMetadata',
+    () => undefined,
+  );
+
   messenger.registerActionHandler('ExecutionService:executeSnap', asyncNoOp);
   messenger.registerActionHandler(
     'ExecutionService:handleRpcRequest',
@@ -368,6 +373,7 @@ export const getSnapControllerMessenger = (
       'SnapController:decrementActiveReferences',
       'SnapController:getRegistryMetadata',
       'SubjectMetadataController:getSubjectMetadata',
+      'SubjectMetadataController:addSubjectMetadata',
       'SnapsRegistry:get',
       'SnapsRegistry:getMetadata',
       'SnapsRegistry:update',

--- a/packages/snaps-rpc-methods/package.json
+++ b/packages/snaps-rpc-methods/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@metamask/key-tree": "^9.0.0",
-    "@metamask/permission-controller": "^7.0.0",
+    "@metamask/permission-controller": "^7.1.0",
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -56,7 +56,7 @@
     "@metamask/eth-json-rpc-middleware": "^12.0.1",
     "@metamask/json-rpc-engine": "^7.3.1",
     "@metamask/key-tree": "^9.0.0",
-    "@metamask/permission-controller": "^7.0.0",
+    "@metamask/permission-controller": "^7.1.0",
     "@metamask/snaps-controllers": "workspace:^",
     "@metamask/snaps-execution-environments": "workspace:^",
     "@metamask/snaps-rpc-methods": "workspace:^",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -69,7 +69,7 @@
     "@babel/types": "^7.23.0",
     "@metamask/base-controller": "^4.0.0",
     "@metamask/key-tree": "^9.0.0",
-    "@metamask/permission-controller": "^7.0.0",
+    "@metamask/permission-controller": "^7.1.0",
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/slip44": "^3.1.0",
     "@metamask/snaps-registry": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4913,9 +4913,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/permission-controller@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "@metamask/permission-controller@npm:7.0.0"
+"@metamask/permission-controller@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "@metamask/permission-controller@npm:7.1.0"
   dependencies:
     "@metamask/base-controller": ^4.0.1
     "@metamask/controller-utils": ^8.0.1
@@ -4928,7 +4928,7 @@ __metadata:
     nanoid: ^3.1.31
   peerDependencies:
     "@metamask/approval-controller": ^5.1.1
-  checksum: d4724ba9c3a4bebb2e128ee25f7609895f1e6dc61303ca15ebe219f24a754130ab28894b9fcb426228226becb9c1951579f81f39e8581fba58b3f5531d63b792
+  checksum: 889213cca32cbf5b32b7e71c70ded0aeea32eae169ec67fb0d0bc8dcaa183b222f9d5417f657e331d7fb21ecb71f250cf1c932110d4b1e2167972b30bd012098
   languageName: node
   linkType: hard
 
@@ -5208,7 +5208,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/json-rpc-engine": ^7.3.1
     "@metamask/object-multiplex": ^2.0.0
-    "@metamask/permission-controller": ^7.0.0
+    "@metamask/permission-controller": ^7.1.0
     "@metamask/phishing-controller": ^8.0.1
     "@metamask/post-message-stream": ^7.0.0
     "@metamask/rpc-errors": ^6.1.0
@@ -5480,7 +5480,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/json-rpc-engine": ^7.3.1
     "@metamask/key-tree": ^9.0.0
-    "@metamask/permission-controller": ^7.0.0
+    "@metamask/permission-controller": ^7.1.0
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-sdk": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
@@ -5575,7 +5575,7 @@ __metadata:
     "@metamask/eth-json-rpc-middleware": ^12.0.1
     "@metamask/json-rpc-engine": ^7.3.1
     "@metamask/key-tree": ^9.0.0
-    "@metamask/permission-controller": ^7.0.0
+    "@metamask/permission-controller": ^7.1.0
     "@metamask/snaps-controllers": "workspace:^"
     "@metamask/snaps-execution-environments": "workspace:^"
     "@metamask/snaps-rpc-methods": "workspace:^"
@@ -5675,7 +5675,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/key-tree": ^9.0.0
-    "@metamask/permission-controller": ^7.0.0
+    "@metamask/permission-controller": ^7.1.0
     "@metamask/post-message-stream": ^7.0.0
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/slip44": ^3.1.0


### PR DESCRIPTION
Populate subject metadata in the SnapController, allowing us to reduce code duplication in clients of the following snippet: https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/metamask-controller.js#L2367-L2373

This change is also required for preinstalled snaps to work.