### PR TITLE
Fix missing `global` in eval-worker

### DIFF
--- a/packages/snaps-utils/src/eval-worker.ts
+++ b/packages/snaps-utils/src/eval-worker.ts
@@ -22,31 +22,22 @@ lockdown({
   domainTaming: 'unsafe',
 });
 
-/**
- * Get mock endowments that don't do anything. This is useful for running the
- * eval, for snaps that try to communicate with the extension on initialisation,
- * for example.
- *
- * @returns The mock endowments.
- */
-function getMockEndowments() {
-  const endowments = generateMockEndowments();
-  return {
-    ...endowments,
-    window: endowments,
-    self: endowments,
-  };
-}
-
 const snapFilePath = process.argv[2];
 
 const snapModule: { exports?: any } = { exports: {} };
 
-new Compartment({
-  ...getMockEndowments(),
+const compartment = new Compartment({
+  ...generateMockEndowments(),
   module: snapModule,
   exports: snapModule.exports,
-}).evaluate(readFileSync(snapFilePath, 'utf8'));
+});
+
+// Mirror BaseSnapExecutor
+compartment.globalThis.self = compartment.globalThis;
+compartment.globalThis.global = compartment.globalThis;
+compartment.globalThis.window = compartment.globalThis;
+
+compartment.evaluate(readFileSync(snapFilePath, 'utf8'));
 
 const invalidExports = Object.keys(snapModule.exports).filter(
   (snapExport) => !SNAP_EXPORT_NAMES.includes(snapExport as HandlerType),


### PR DESCRIPTION
The `global` global was missing in the eval-worker, causing eval to fail when a snap tried to access `global`.

This PR changes the eval-worker to mirror the `BaseSnapExecutor`, setting up the endowments as globals in an identical way: https://github.com/MetaMask/snaps/blob/main/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts#L404-L417