### PR TITLE
BREAKING: Remove `:snapAdded` event

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -543,26 +543,16 @@ describe('SnapController', () => {
 
     jest.spyOn(messenger, 'publish');
 
-    const eventSubscriptionPromise = Promise.all([
-      new Promise<void>((resolve) => {
-        messenger.subscribe('SnapController:snapAdded', (snap) => {
-          expect(snap).toStrictEqual(
-            getSnapObject({ status: SnapStatus.Installing }),
-          );
+    const eventSubscriptionPromise = new Promise<void>((resolve) => {
+      messenger.subscribe(
+        'SnapController:snapInstalled',
+        (truncatedSnap, origin) => {
+          expect(truncatedSnap).toStrictEqual(getTruncatedSnap());
+          expect(origin).toStrictEqual(MOCK_ORIGIN);
           resolve();
-        });
-      }),
-      new Promise<void>((resolve) => {
-        messenger.subscribe(
-          'SnapController:snapInstalled',
-          (truncatedSnap, origin) => {
-            expect(truncatedSnap).toStrictEqual(getTruncatedSnap());
-            expect(origin).toStrictEqual(MOCK_ORIGIN);
-            resolve();
-          },
-        );
-      }),
-    ]);
+        },
+      );
+    });
 
     const expectedSnapObject = getTruncatedSnap();
     const permissions = {
@@ -973,22 +963,12 @@ describe('SnapController', () => {
         throw new Error('foo');
       });
 
-    const eventSubscriptionPromise = Promise.all([
-      new Promise<void>((resolve) => {
-        messenger.subscribe('SnapController:snapAdded', (snap) => {
-          expect(snap).toStrictEqual(
-            getSnapObject({ status: SnapStatus.Installing }),
-          );
-          resolve();
-        });
-      }),
-      new Promise<void>((resolve) => {
-        messenger.subscribe('SnapController:snapRemoved', (truncatedSnap) => {
-          expect(truncatedSnap).toStrictEqual(getTruncatedSnap());
-          resolve();
-        });
-      }),
-    ]);
+    const eventSubscriptionPromise = new Promise<void>((resolve) => {
+      messenger.subscribe('SnapController:snapRemoved', (truncatedSnap) => {
+        expect(truncatedSnap).toStrictEqual(getTruncatedSnap());
+        resolve();
+      });
+    });
 
     await expect(
       snapController.installSnaps(MOCK_ORIGIN, {
@@ -4407,12 +4387,10 @@ describe('SnapController', () => {
         }),
       );
       const onSnapUpdated = jest.fn();
-      const onSnapAdded = jest.fn();
 
       const snap = controller.getExpect(MOCK_SNAP_ID);
 
       messenger.subscribe('SnapController:snapUpdated', onSnapUpdated);
-      messenger.subscribe('SnapController:snapAdded', onSnapAdded);
 
       const newSnap = controller.get(MOCK_SNAP_ID);
 
@@ -4429,7 +4407,6 @@ describe('SnapController', () => {
       );
       expect(newSnap?.version).toStrictEqual(snap.version);
       expect(onSnapUpdated).not.toHaveBeenCalled();
-      expect(onSnapAdded).not.toHaveBeenCalled();
 
       controller.destroy();
     });
@@ -4487,12 +4464,10 @@ describe('SnapController', () => {
         }),
       );
       const onSnapUpdated = jest.fn();
-      const onSnapAdded = jest.fn();
 
       const snap = controller.getExpect(MOCK_SNAP_ID);
 
       messenger.subscribe('SnapController:snapUpdated', onSnapUpdated);
-      messenger.subscribe('SnapController:snapAdded', onSnapAdded);
 
       const newSnap = controller.get(MOCK_SNAP_ID);
 
@@ -4510,7 +4485,6 @@ describe('SnapController', () => {
       );
       expect(newSnap?.version).toStrictEqual(snap.version);
       expect(onSnapUpdated).not.toHaveBeenCalled();
-      expect(onSnapAdded).not.toHaveBeenCalled();
 
       controller.destroy();
     });
@@ -4539,13 +4513,11 @@ describe('SnapController', () => {
       );
       const callActionSpy = jest.spyOn(messenger, 'call');
       const onSnapUpdated = jest.fn();
-      const onSnapAdded = jest.fn();
 
       await controller.installSnaps(MOCK_ORIGIN, { [MOCK_SNAP_ID]: {} });
       await controller.stopSnap(MOCK_SNAP_ID);
 
       messenger.subscribe('SnapController:snapUpdated', onSnapUpdated);
-      messenger.subscribe('SnapController:snapAdded', onSnapAdded);
 
       const result = await controller.updateSnap(
         MOCK_ORIGIN,
@@ -4659,7 +4631,6 @@ describe('SnapController', () => {
         '1.0.0',
         MOCK_ORIGIN,
       );
-      expect(onSnapAdded).toHaveBeenCalledTimes(1);
 
       controller.destroy();
     });

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -388,14 +388,6 @@ export type SnapStateChange = {
 };
 
 /**
- * Emitted when a Snap has been added to state during installation.
- */
-export type SnapAdded = {
-  type: `${typeof controllerName}:snapAdded`;
-  payload: [snap: Snap, svgIcon: string | undefined];
-};
-
-/**
  * Emitted when an installed snap has been blocked.
  */
 export type SnapBlocked = {
@@ -480,7 +472,6 @@ export type SnapDisabled = {
 };
 
 export type SnapControllerEvents =
-  | SnapAdded
   | SnapBlocked
   | SnapInstalled
   | SnapUninstalled
@@ -2347,21 +2338,12 @@ export class SnapController extends BaseController<
       }
     }
 
-    const stringifiedIcon = svgIcon?.toString();
-
-    // TODO: Consider removing this as it is unused now
-    this.messagingSystem.publish(
-      `SnapController:snapAdded`,
-      snap,
-      stringifiedIcon,
-    );
-
     this.messagingSystem.call('SubjectMetadataController:addSubjectMetadata', {
       subjectType: SubjectType.Snap,
       name: proposedName,
       origin: snap.id,
       version,
-      svgIcon: stringifiedIcon ?? null,
+      svgIcon: svgIcon?.toString() ?? null,
     });
 
     return { ...snap, sourceCode };


### PR DESCRIPTION
Following #2069 we can now remove the `snapAdded` event as it doesn't have a use-case anymore.