### PR TITLE
BREAKING: Use origin bound hooks for `invokeKeyring`

### DIFF
--- a/packages/snaps-rpc-methods/src/permitted/invokeKeyring.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/invokeKeyring.test.ts
@@ -79,7 +79,6 @@ describe('wallet_invokeKeyring', () => {
       expect(response.result).toBe('bar');
       expect(hooks.handleSnapRpcRequest).toHaveBeenCalledWith({
         handler: HandlerType.OnKeyringRequest,
-        origin: 'metamask.io',
         request: { method: 'foo' },
         snapId: MOCK_SNAP_ID,
       });


### PR DESCRIPTION
For _permitted RPC methods_ we are able to bind the hooks to the origin, we prefer this over passing the origin where available.