### PR TITLE
Move offscreen logic to shared proxy classes

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 90.88,
-  "functions": 96.52,
+  "functions": 96.54,
   "lines": 97.81,
   "statements": 97.5
 }

--- a/packages/snaps-controllers/src/services/ProxyPostMessageStream.test.ts
+++ b/packages/snaps-controllers/src/services/ProxyPostMessageStream.test.ts
@@ -3,7 +3,6 @@ import { MockPostMessageStream, sleep } from '@metamask/snaps-utils/test-utils';
 import { ProxyPostMessageStream } from './ProxyPostMessageStream';
 
 const MOCK_JOB_ID = 'job-id';
-const MOCK_FRAME_URL = 'frame-url';
 
 describe('ProxyPostMessageStream', () => {
   it('wraps messages with an iframe url and job id', async () => {
@@ -13,9 +12,6 @@ describe('ProxyPostMessageStream', () => {
     const stream = new ProxyPostMessageStream({
       stream: mockStream,
       jobId: MOCK_JOB_ID,
-      extra: {
-        frameUrl: MOCK_FRAME_URL,
-      },
     });
 
     const message = { foo: 'bar' };
@@ -24,9 +20,6 @@ describe('ProxyPostMessageStream', () => {
     expect(write).toHaveBeenCalledWith({
       jobId: MOCK_JOB_ID,
       data: message,
-      extra: {
-        frameUrl: MOCK_FRAME_URL,
-      },
     });
 
     mockStream.destroy();

--- a/packages/snaps-controllers/src/services/ProxyPostMessageStream.ts
+++ b/packages/snaps-controllers/src/services/ProxyPostMessageStream.ts
@@ -22,22 +22,18 @@ export class ProxyPostMessageStream extends BasePostMessageStream {
 
   readonly #jobId: string;
 
-  readonly #extra?: Record<string, unknown>;
-
   /**
    * Initializes a new `ProxyPostMessageStream` instance.
    *
    * @param args - The constructor arguments.
    * @param args.stream - The underlying stream to use for communication.
    * @param args.jobId - The ID of the job this stream is associated with.
-   * @param args.extra - Extra data to include in the post message.
    */
-  constructor({ stream, jobId, extra }: ProxyPostMessageStreamArgs) {
+  constructor({ stream, jobId }: ProxyPostMessageStreamArgs) {
     super();
 
     this.#stream = stream;
     this.#jobId = jobId;
-    this.#extra = extra;
 
     this.#stream.on('data', this.#onData.bind(this));
   }
@@ -66,7 +62,6 @@ export class ProxyPostMessageStream extends BasePostMessageStream {
     this.#stream.write({
       jobId: this.#jobId,
       data,
-      extra: this.#extra,
     });
   }
 }

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.test.ts
@@ -11,7 +11,6 @@ import { getMockedFunction } from '../../test-utils/mock';
 import { OffscreenExecutionService } from './OffscreenExecutionService';
 
 const DOCUMENT_URL = new URL('https://foo');
-const FRAME_URL = new URL('https://bar');
 
 /**
  * Create a response message for the given request. This function assumes that
@@ -109,7 +108,6 @@ describe('OffscreenExecutionService', () => {
   it('can boot', async () => {
     const { service } = createService(OffscreenExecutionService, {
       documentUrl: DOCUMENT_URL,
-      frameUrl: FRAME_URL,
     });
 
     expect(service).toBeDefined();
@@ -119,7 +117,6 @@ describe('OffscreenExecutionService', () => {
   it('creates a document if it does not exist', async () => {
     const { service } = createService(OffscreenExecutionService, {
       documentUrl: DOCUMENT_URL,
-      frameUrl: FRAME_URL,
     });
 
     const hasDocument = chrome.offscreen.hasDocument as jest.MockedFunction<
@@ -161,7 +158,6 @@ describe('OffscreenExecutionService', () => {
   it('writes a termination command to the stream', async () => {
     const { service } = createService(OffscreenExecutionService, {
       documentUrl: DOCUMENT_URL,
-      frameUrl: FRAME_URL,
     });
 
     expect(

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
@@ -1,21 +1,15 @@
 import { BrowserRuntimePostMessageStream } from '@metamask/post-message-stream';
-import { nanoid } from 'nanoid';
 
-import type { ExecutionServiceArgs, Job } from '../AbstractExecutionService';
-import { AbstractExecutionService } from '../AbstractExecutionService';
-import { ProxyPostMessageStream } from '../ProxyPostMessageStream';
+import type { ExecutionServiceArgs } from '../AbstractExecutionService';
+import { ProxyExecutionService } from '../proxy/ProxyExecutionService';
 
 type OffscreenExecutionEnvironmentServiceArgs = {
   documentUrl: URL;
   frameUrl: URL;
 } & ExecutionServiceArgs;
 
-export class OffscreenExecutionService extends AbstractExecutionService<string> {
+export class OffscreenExecutionService extends ProxyExecutionService {
   public readonly documentUrl: URL;
-
-  public readonly frameUrl: URL;
-
-  readonly #runtimeStream: BrowserRuntimePostMessageStream;
 
   /**
    * Create a new offscreen execution service.
@@ -40,32 +34,14 @@ export class OffscreenExecutionService extends AbstractExecutionService<string> 
     super({
       messenger,
       setupSnapProvider,
+      frameUrl,
+      stream: new BrowserRuntimePostMessageStream({
+        name: 'parent',
+        target: 'child',
+      }),
     });
 
     this.documentUrl = documentUrl;
-    this.frameUrl = frameUrl;
-    this.#runtimeStream = new BrowserRuntimePostMessageStream({
-      name: 'parent',
-      target: 'child',
-    });
-  }
-
-  /**
-   * Send a termination command to the offscreen document.
-   *
-   * @param job - The job to terminate.
-   */
-  protected async terminateJob(job: Job<string>) {
-    // The `AbstractExecutionService` will have already closed the job stream,
-    // so we write to the runtime stream directly.
-    this.#runtimeStream.write({
-      jobId: job.id,
-      data: {
-        jsonrpc: '2.0',
-        method: 'terminateJob',
-        id: nanoid(),
-      },
-    });
   }
 
   /**
@@ -76,20 +52,9 @@ export class OffscreenExecutionService extends AbstractExecutionService<string> 
    */
   protected async initEnvStream(jobId: string) {
     // Lazily create the offscreen document.
-    await this.createDocument();
+    await this.#createDocument();
 
-    const stream = new ProxyPostMessageStream({
-      stream: this.#runtimeStream,
-      extra: {
-        // TODO: Rather than injecting the frame URL here, we should come up
-        // with a better way to do this. The frame URL is needed to avoid hard
-        // coding it in the offscreen execution environment.
-        frameUrl: this.frameUrl.toString(),
-      },
-      jobId,
-    });
-
-    return { worker: jobId, stream };
+    return super.initEnvStream(jobId);
   }
 
   /**
@@ -97,7 +62,7 @@ export class OffscreenExecutionService extends AbstractExecutionService<string> 
    *
    * If the document already exists, this does nothing.
    */
-  private async createDocument() {
+  async #createDocument() {
     // Extensions can only have a single offscreen document.
     if (await chrome.offscreen.hasDocument()) {
       return;

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
@@ -5,7 +5,6 @@ import { ProxyExecutionService } from '../proxy/ProxyExecutionService';
 
 type OffscreenExecutionEnvironmentServiceArgs = {
   documentUrl: URL;
-  frameUrl: URL;
 } & ExecutionServiceArgs;
 
 export class OffscreenExecutionService extends ProxyExecutionService {
@@ -18,8 +17,6 @@ export class OffscreenExecutionService extends ProxyExecutionService {
    * @param args.documentUrl - The URL of the offscreen document to use as the
    * execution environment. This must be a URL relative to the location where
    * this is called. This cannot be a public (http(s)) URL.
-   * @param args.frameUrl - The URL of the iframe to load inside the offscreen
-   * document.
    * @param args.messenger - The messenger to use for communication with the
    * `SnapController`.
    * @param args.setupSnapProvider - The function to use to set up the snap
@@ -27,14 +24,12 @@ export class OffscreenExecutionService extends ProxyExecutionService {
    */
   constructor({
     documentUrl,
-    frameUrl,
     messenger,
     setupSnapProvider,
   }: OffscreenExecutionEnvironmentServiceArgs) {
     super({
       messenger,
       setupSnapProvider,
-      frameUrl,
       stream: new BrowserRuntimePostMessageStream({
         name: 'parent',
         target: 'child',

--- a/packages/snaps-controllers/src/services/proxy/ProxyExecutionService.ts
+++ b/packages/snaps-controllers/src/services/proxy/ProxyExecutionService.ts
@@ -7,20 +7,15 @@ import { ProxyPostMessageStream } from '../ProxyPostMessageStream';
 
 type ProxyExecutionEnvironmentServiceArgs = {
   stream: BasePostMessageStream;
-  frameUrl: URL;
 } & ExecutionServiceArgs;
 
 export class ProxyExecutionService extends AbstractExecutionService<string> {
-  public readonly frameUrl: URL;
-
   readonly #stream: BasePostMessageStream;
 
   /**
    * Create a new proxy execution service.
    *
    * @param args - The constructor arguments.
-   * @param args.frameUrl - The URL of the iframe to load inside the proxy
-   * executor.
    * @param args.messenger - The messenger to use for communication with the
    * `SnapController`.
    * @param args.setupSnapProvider - The function to use to set up the snap
@@ -30,7 +25,6 @@ export class ProxyExecutionService extends AbstractExecutionService<string> {
    */
   constructor({
     stream,
-    frameUrl,
     messenger,
     setupSnapProvider,
   }: ProxyExecutionEnvironmentServiceArgs) {
@@ -40,7 +34,6 @@ export class ProxyExecutionService extends AbstractExecutionService<string> {
     });
 
     this.#stream = stream;
-    this.frameUrl = frameUrl;
   }
 
   /**
@@ -70,12 +63,6 @@ export class ProxyExecutionService extends AbstractExecutionService<string> {
   protected async initEnvStream(jobId: string) {
     const stream = new ProxyPostMessageStream({
       stream: this.#stream,
-      extra: {
-        // TODO: Rather than injecting the frame URL here, we should come up
-        // with a better way to do this. The frame URL is needed to avoid hard
-        // coding it in the execution environment.
-        frameUrl: this.frameUrl.toString(),
-      },
       jobId,
     });
 

--- a/packages/snaps-controllers/src/services/proxy/ProxyExecutionService.ts
+++ b/packages/snaps-controllers/src/services/proxy/ProxyExecutionService.ts
@@ -1,0 +1,84 @@
+import type { BasePostMessageStream } from '@metamask/post-message-stream';
+import { nanoid } from 'nanoid';
+
+import type { ExecutionServiceArgs, Job } from '../AbstractExecutionService';
+import { AbstractExecutionService } from '../AbstractExecutionService';
+import { ProxyPostMessageStream } from '../ProxyPostMessageStream';
+
+type ProxyExecutionEnvironmentServiceArgs = {
+  stream: BasePostMessageStream;
+  frameUrl: URL;
+} & ExecutionServiceArgs;
+
+export class ProxyExecutionService extends AbstractExecutionService<string> {
+  public readonly frameUrl: URL;
+
+  readonly #stream: BasePostMessageStream;
+
+  /**
+   * Create a new proxy execution service.
+   *
+   * @param args - The constructor arguments.
+   * @param args.frameUrl - The URL of the iframe to load inside the proxy
+   * executor.
+   * @param args.messenger - The messenger to use for communication with the
+   * `SnapController`.
+   * @param args.setupSnapProvider - The function to use to set up the snap
+   * provider.
+   * @param args.stream - The stream to use for communicating with the proxy
+   * executor.
+   */
+  constructor({
+    stream,
+    frameUrl,
+    messenger,
+    setupSnapProvider,
+  }: ProxyExecutionEnvironmentServiceArgs) {
+    super({
+      messenger,
+      setupSnapProvider,
+    });
+
+    this.#stream = stream;
+    this.frameUrl = frameUrl;
+  }
+
+  /**
+   * Send a termination command to the proxy stream.
+   *
+   * @param job - The job to terminate.
+   */
+  protected async terminateJob(job: Job<string>) {
+    // The `AbstractExecutionService` will have already closed the job stream,
+    // so we write to the runtime stream directly.
+    this.#stream.write({
+      jobId: job.id,
+      data: {
+        jsonrpc: '2.0',
+        method: 'terminateJob',
+        id: nanoid(),
+      },
+    });
+  }
+
+  /**
+   * Create a new stream for the specified job. This wraps the root stream
+   * in a stream specific to the job.
+   *
+   * @param jobId - The job ID.
+   */
+  protected async initEnvStream(jobId: string) {
+    const stream = new ProxyPostMessageStream({
+      stream: this.#stream,
+      extra: {
+        // TODO: Rather than injecting the frame URL here, we should come up
+        // with a better way to do this. The frame URL is needed to avoid hard
+        // coding it in the execution environment.
+        frameUrl: this.frameUrl.toString(),
+      },
+      jobId,
+    });
+
+    return { worker: jobId, stream };
+  }
+}

--- a/packages/snaps-execution-environments/.depcheckrc.json
+++ b/packages/snaps-execution-environments/.depcheckrc.json
@@ -17,6 +17,7 @@
     "typescript",
     "vite",
     "wdio-*",
-    "webdriverio"
+    "webdriverio",
+    "@metamask/snaps-execution-environments"
   ]
 }

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 80.95,
+  "branches": 80.4,
   "functions": 89.79,
-  "lines": 90.88,
-  "statements": 90.35
+  "lines": 90.9,
+  "statements": 90.37
 }

--- a/packages/snaps-execution-environments/src/offscreen/index.ts
+++ b/packages/snaps-execution-environments/src/offscreen/index.ts
@@ -2,7 +2,7 @@ import { BrowserRuntimePostMessageStream } from '@metamask/post-message-stream';
 
 import { executeLockdownEvents } from '../common/lockdown/lockdown-events';
 import { executeLockdownMore } from '../common/lockdown/lockdown-more';
-import { OffscreenSnapExecutor } from './OffscreenSnapExecutor';
+import { ProxySnapExecutor } from '../proxy/ProxySnapExecutor';
 
 // Lockdown is already applied in LavaMoat
 executeLockdownMore();
@@ -14,4 +14,4 @@ const parentStream = new BrowserRuntimePostMessageStream({
   target: 'parent',
 });
 
-OffscreenSnapExecutor.initialize(parentStream);
+ProxySnapExecutor.initialize(parentStream);

--- a/packages/snaps-execution-environments/src/proxy/ProxySnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/proxy/ProxySnapExecutor.test.browser.ts
@@ -3,6 +3,7 @@ import { MockPostMessageStream } from '@metamask/snaps-utils/test-utils';
 import { ProxySnapExecutor } from './ProxySnapExecutor';
 
 const MOCK_JOB_ID = 'job-id';
+const IFRAME_URL = 'http://localhost:4568';
 
 /**
  * Write a message to the stream, wrapped with the job ID and frame URL.
@@ -56,7 +57,7 @@ describe('ProxySnapExecutor', () => {
   it('forwards messages to the iframe', async () => {
     const mockStream = new MockPostMessageStream();
 
-    ProxySnapExecutor.initialize(mockStream);
+    ProxySnapExecutor.initialize(mockStream, IFRAME_URL);
 
     writeMessage(mockStream, {
       name: 'command',
@@ -82,7 +83,7 @@ describe('ProxySnapExecutor', () => {
   it('terminates the iframe', async () => {
     const mockStream = new MockPostMessageStream();
 
-    const executor = ProxySnapExecutor.initialize(mockStream);
+    const executor = ProxySnapExecutor.initialize(mockStream, IFRAME_URL);
 
     // Send ping to ensure that the iframe is created.
     writeMessage(mockStream, {

--- a/packages/snaps-execution-environments/src/proxy/ProxySnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/proxy/ProxySnapExecutor.test.browser.ts
@@ -1,6 +1,6 @@
 import { MockPostMessageStream } from '@metamask/snaps-utils/test-utils';
 
-import { OffscreenSnapExecutor } from './OffscreenSnapExecutor';
+import { ProxySnapExecutor } from './ProxySnapExecutor';
 
 const MOCK_JOB_ID = 'job-id';
 const IFRAME_URL = `http://localhost:4568`;
@@ -56,11 +56,11 @@ async function getResponse(
   });
 }
 
-describe('OffscreenSnapExecutor', () => {
+describe('ProxySnapExecutor', () => {
   it('forwards messages to the iframe', async () => {
     const mockStream = new MockPostMessageStream();
 
-    OffscreenSnapExecutor.initialize(mockStream);
+    ProxySnapExecutor.initialize(mockStream);
 
     writeMessage(mockStream, {
       name: 'command',
@@ -86,7 +86,7 @@ describe('OffscreenSnapExecutor', () => {
   it('terminates the iframe', async () => {
     const mockStream = new MockPostMessageStream();
 
-    const executor = OffscreenSnapExecutor.initialize(mockStream);
+    const executor = ProxySnapExecutor.initialize(mockStream);
 
     // Send ping to ensure that the iframe is created.
     writeMessage(mockStream, {

--- a/packages/snaps-execution-environments/src/proxy/ProxySnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/proxy/ProxySnapExecutor.test.browser.ts
@@ -3,7 +3,6 @@ import { MockPostMessageStream } from '@metamask/snaps-utils/test-utils';
 import { ProxySnapExecutor } from './ProxySnapExecutor';
 
 const MOCK_JOB_ID = 'job-id';
-const IFRAME_URL = `http://localhost:4568`;
 
 /**
  * Write a message to the stream, wrapped with the job ID and frame URL.
@@ -18,9 +17,6 @@ function writeMessage(
   stream.write({
     jobId: MOCK_JOB_ID,
     data: message,
-    extra: {
-      frameUrl: IFRAME_URL,
-    },
   });
 }
 

--- a/packages/snaps-execution-environments/src/proxy/ProxySnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/proxy/ProxySnapExecutor.ts
@@ -1,10 +1,10 @@
 import type { BasePostMessageStream } from '@metamask/post-message-stream';
 import { WindowPostMessageStream } from '@metamask/post-message-stream';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import packageJson from '@metamask/snaps-execution-environments/package.json';
 import { createWindow, logError } from '@metamask/snaps-utils';
 import type { JsonRpcRequest } from '@metamask/utils';
 import { assert } from '@metamask/utils';
-
-import packageJson from '../../package.json';
 
 type ExecutorJob = {
   id: string;

--- a/packages/snaps-execution-environments/src/proxy/ProxySnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/proxy/ProxySnapExecutor.ts
@@ -30,6 +30,8 @@ const IFRAME_URL = `https://execution.metamask.io/${packageJson.version}/index.h
 export class ProxySnapExecutor {
   readonly #stream: BasePostMessageStream;
 
+  readonly #frameUrl: string;
+
   readonly jobs: Record<string, ExecutorJob> = {};
 
   /**
@@ -37,15 +39,17 @@ export class ProxySnapExecutor {
    * constructor.
    *
    * @param stream - The stream to use for communication.
+   * @param frameUrl - An optional URL for the iframe to use.
    * @returns The initialized executor.
    */
-  static initialize(stream: BasePostMessageStream) {
-    return new ProxySnapExecutor(stream);
+  static initialize(stream: BasePostMessageStream, frameUrl = IFRAME_URL) {
+    return new ProxySnapExecutor(stream, frameUrl);
   }
 
-  constructor(stream: BasePostMessageStream) {
+  constructor(stream: BasePostMessageStream, frameUrl: string) {
     this.#stream = stream;
     this.#stream.on('data', this.#onData.bind(this));
+    this.#frameUrl = frameUrl;
   }
 
   /**
@@ -91,7 +95,7 @@ export class ProxySnapExecutor {
    * @param jobId - The job ID.
    */
   async #initializeJob(jobId: string): Promise<ExecutorJob> {
-    const window = await createWindow(IFRAME_URL, jobId);
+    const window = await createWindow(this.#frameUrl, jobId);
     const jobStream = new WindowPostMessageStream({
       name: 'parent',
       target: 'child',

--- a/packages/snaps-execution-environments/src/proxy/ProxySnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/proxy/ProxySnapExecutor.ts
@@ -11,20 +11,19 @@ type ExecutorJob = {
 };
 
 /**
- * A snap executor using the Offscreen Documents API.
+ * A "proxy" snap executor that uses a level of indirection to execute snaps.
+ *
+ * Useful for multiple execution environments.
  *
  * This is not a traditional snap executor, as it does not execute snaps itself.
  * Instead, it creates an iframe window for each snap execution, and sends the
  * snap execution request to the iframe window. The iframe window is responsible
  * for executing the snap.
  *
- * Extensions can only have a single offscreen document, so this executor is
- * persisted between snap executions. The offscreen snap executor essentially
- * acts as a proxy between the extension and the iframe execution environment.
- *
- * @see https://developer.chrome.com/docs/extensions/reference/offscreen/
+ * This executor is persisted between snap executions. The executor essentially
+ * acts as a proxy between the client and the iframe execution environment.
  */
-export class OffscreenSnapExecutor {
+export class ProxySnapExecutor {
   readonly #stream: BasePostMessageStream;
 
   readonly jobs: Record<string, ExecutorJob> = {};
@@ -37,7 +36,7 @@ export class OffscreenSnapExecutor {
    * @returns The initialized executor.
    */
   static initialize(stream: BasePostMessageStream) {
-    return new OffscreenSnapExecutor(stream);
+    return new ProxySnapExecutor(stream);
   }
 
   constructor(stream: BasePostMessageStream) {

--- a/packages/snaps-execution-environments/tsconfig.build.json
+++ b/packages/snaps-execution-environments/tsconfig.build.json
@@ -3,10 +3,10 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist/types",
-    "rootDir": "./",
+    "rootDir": "./src",
     "typeRoots": ["../../node_modules/@types", "./node_modules/@types"]
   },
-  "include": ["./src", "package.json"],
+  "include": ["./src"],
   "exclude": [
     "**/*.test.ts",
     "**/*.test.browser.ts",

--- a/packages/snaps-execution-environments/tsconfig.build.json
+++ b/packages/snaps-execution-environments/tsconfig.build.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist/types",
-    "rootDir": "./src",
+    "rootDir": "./",
     "typeRoots": ["../../node_modules/@types", "./node_modules/@types"]
   },
   "include": ["./src", "package.json"],

--- a/packages/snaps-execution-environments/tsconfig.build.json
+++ b/packages/snaps-execution-environments/tsconfig.build.json
@@ -6,7 +6,7 @@
     "rootDir": "./src",
     "typeRoots": ["../../node_modules/@types", "./node_modules/@types"]
   },
-  "include": ["./src", "./src/openrpc.json"],
+  "include": ["./src", "package.json"],
   "exclude": [
     "**/*.test.ts",
     "**/*.test.browser.ts",

--- a/packages/snaps-execution-environments/tsconfig.json
+++ b/packages/snaps-execution-environments/tsconfig.json
@@ -7,7 +7,6 @@
   },
   "include": [
     "./src",
-    "./src/openrpc.json",
     "webpack.config.js",
     "scripts",
     "package.json"

--- a/packages/snaps-execution-environments/tsconfig.json
+++ b/packages/snaps-execution-environments/tsconfig.json
@@ -5,12 +5,7 @@
     "typeRoots": ["../../node_modules/@types", "./node_modules/@types"],
     "allowJs": true
   },
-  "include": [
-    "./src",
-    "webpack.config.js",
-    "scripts",
-    "package.json"
-  ],
+  "include": ["./src", "webpack.config.js", "scripts"],
   "references": [
     {
       "path": "../snaps-sdk"

--- a/packages/snaps-execution-environments/tsconfig.json
+++ b/packages/snaps-execution-environments/tsconfig.json
@@ -5,7 +5,13 @@
     "typeRoots": ["../../node_modules/@types", "./node_modules/@types"],
     "allowJs": true
   },
-  "include": ["./src", "./src/openrpc.json", "webpack.config.js", "scripts"],
+  "include": [
+    "./src",
+    "./src/openrpc.json",
+    "webpack.config.js",
+    "scripts",
+    "package.json"
+  ],
   "references": [
     {
       "path": "../snaps-sdk"


### PR DESCRIPTION
Moves most offscreen logic to a shared proxy executor and execution service that can be consumed by the offscreen executor. This is also useful for mobile. This PR is very similar to #2083 but targeting main to simplify the mobile PR.

This PR also removes the notion of a passed `frameUrl` in proxy executors. Instead they use a constructor argument that defaults to a hardcoded URL based on their version.