### PR TITLE
Add home page support to `snaps-jest`

### DIFF
--- a/packages/examples/packages/home-page/src/index.test.ts
+++ b/packages/examples/packages/home-page/src/index.test.ts
@@ -4,9 +4,9 @@ import { panel, text, heading } from '@metamask/snaps-sdk';
 
 describe('onHomePage', () => {
   it('returns custom UI', async () => {
-    const { renderHomePage } = await installSnap();
+    const { getHomePage } = await installSnap();
 
-    const response = await renderHomePage();
+    const response = await getHomePage();
 
     expect(response).toRender(
       panel([heading('Hello world!'), text('Welcome to my Snap home page!')]),

--- a/packages/examples/packages/home-page/src/index.test.ts
+++ b/packages/examples/packages/home-page/src/index.test.ts
@@ -1,17 +1,15 @@
 import { describe, it } from '@jest/globals';
+import { installSnap } from '@metamask/snaps-jest';
 import { panel, text, heading } from '@metamask/snaps-sdk';
 
-import { onHomePage } from '.';
-
-// The Snaps E2E testing framework doesn't currently support onHomePage, so we unit
-// test it instead.
 describe('onHomePage', () => {
   it('returns custom UI', async () => {
-    expect(await onHomePage()).toStrictEqual({
-      content: panel([
-        heading('Hello world!'),
-        text('Welcome to my Snap home page!'),
-      ]),
-    });
+    const { renderHomePage } = await installSnap();
+
+    const response = await renderHomePage();
+
+    expect(response).toRender(
+      panel([heading('Hello world!'), text('Welcome to my Snap home page!')]),
+    );
   });
 });

--- a/packages/snaps-jest/src/helpers.test.ts
+++ b/packages/snaps-jest/src/helpers.test.ts
@@ -645,6 +645,32 @@ describe('installSnap', () => {
     });
   });
 
+  describe('renderHomePage', () => {
+    it('sends a OnHomePage request and returns the result', async () => {
+      jest.spyOn(console, 'log').mockImplementation();
+
+      const { snapId, close: closeServer } = await getMockServer({
+        sourceCode: `
+          module.exports.onHomePage = async () => {
+            return { content: { type: 'text', value: 'Hello, world!' } };
+          };
+         `,
+      });
+
+      const { renderHomePage, close } = await installSnap(snapId);
+      const response = await renderHomePage();
+
+      expect(response).toStrictEqual(
+        expect.objectContaining({
+          content: { type: 'text', value: 'Hello, world!' },
+        }),
+      );
+
+      await close();
+      await closeServer();
+    });
+  });
+
   describe('mockJsonRpc', () => {
     it('mocks a JSON-RPC method', async () => {
       jest.spyOn(console, 'log').mockImplementation();

--- a/packages/snaps-jest/src/helpers.test.ts
+++ b/packages/snaps-jest/src/helpers.test.ts
@@ -645,7 +645,7 @@ describe('installSnap', () => {
     });
   });
 
-  describe('renderHomePage', () => {
+  describe('getHomePage', () => {
     it('sends a OnHomePage request and returns the result', async () => {
       jest.spyOn(console, 'log').mockImplementation();
 
@@ -657,8 +657,8 @@ describe('installSnap', () => {
          `,
       });
 
-      const { renderHomePage, close } = await installSnap(snapId);
-      const response = await renderHomePage();
+      const { getHomePage, close } = await installSnap(snapId);
+      const response = await getHomePage();
 
       expect(response).toStrictEqual(
         expect.objectContaining({

--- a/packages/snaps-jest/src/helpers.ts
+++ b/packages/snaps-jest/src/helpers.ts
@@ -241,7 +241,7 @@ export async function installSnap<
       });
     },
 
-    renderHomePage: async (): Promise<SnapResponse> => {
+    getHomePage: async (): Promise<SnapResponse> => {
       log('Rendering home page.');
 
       return handleRequest({

--- a/packages/snaps-jest/src/helpers.ts
+++ b/packages/snaps-jest/src/helpers.ts
@@ -241,6 +241,21 @@ export async function installSnap<
       });
     },
 
+    renderHomePage: async (): Promise<SnapResponse> => {
+      log('Rendering home page.');
+
+      return handleRequest({
+        snapId: installedSnapId,
+        store,
+        executionService,
+        runSaga,
+        handler: HandlerType.OnHomePage,
+        request: {
+          method: '',
+        },
+      });
+    },
+
     mockJsonRpc(mock: JsonRpcMockOptions) {
       log('Mocking JSON-RPC request %o.', mock);
 

--- a/packages/snaps-jest/src/types.ts
+++ b/packages/snaps-jest/src/types.ts
@@ -262,7 +262,7 @@ export type Snap = {
    *
    * @returns The response.
    */
-  renderHomePage(): Promise<SnapResponse>;
+  getHomePage(): Promise<SnapResponse>;
 
   /**
    * Mock a JSON-RPC request. This will cause the snap to respond with the

--- a/packages/snaps-jest/src/types.ts
+++ b/packages/snaps-jest/src/types.ts
@@ -256,6 +256,15 @@ export type Snap = {
   runCronjob(cronjob: CronjobOptions): SnapRequest;
 
   /**
+   * Makes a request to the snap to render the snaps home page.
+   *
+   * This method takes no arguments.
+   *
+   * @returns The response.
+   */
+  renderHomePage(): Promise<SnapResponse>;
+
+  /**
    * Mock a JSON-RPC request. This will cause the snap to respond with the
    * specified response when a request with the specified method is sent.
    *


### PR DESCRIPTION
Adds a `renderHomePage` helper to `snaps-jest`, allowing testing of snaps home pages.