### PR TITLE
Fix version on the signature insights example

### DIFF
--- a/packages/examples/packages/signature-insights/package.json
+++ b/packages/examples/packages/signature-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/signature-insights-example-snap",
-  "version": "2.1.0",
+  "version": "0.0.0",
   "description": "MetaMask example snap demonstrating the use of the Signature Insights API.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.0",
+  "version": "0.0.0",
   "description": "MetaMask example snap demonstrating the use of the Signature Insights API.",
   "proposedName": "Signature Insights Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "CgSdq4R6t33h6fOw5/Q0VAbmx/veJN6V5psyN2x5mHA=",
+    "shasum": "79WsMc0xmXW3Fi9pepRMAzxkYgv3bY535tYUe/rbh6s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
Sets the version of the signature insights example to `0.0.0` as it has not been released yet. Otherwise this blocks release.