### PR TITLE
Reintroduce `DecompressionStream`

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 90.88,
-  "functions": 96.59,
-  "lines": 97.83,
-  "statements": 97.53
+  "branches": 90.77,
+  "functions": 96.6,
+  "lines": 97.84,
+  "statements": 97.54
 }

--- a/packages/snaps-controllers/src/snaps/location/npm.test.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.test.ts
@@ -189,6 +189,74 @@ describe('NpmLocation', () => {
     expect(location.version).toBe(templateSnapVersion);
   });
 
+  it('falls back to zlib if DecompressionStream is unavailable', async () => {
+    // @ts-expect-error Deleting DecompressionStream for testing reasons
+    delete globalThis.DecompressionStream;
+
+    const { version: templateSnapVersion } = JSON.parse(
+      (
+        await readFile(require.resolve('@metamask/template-snap/package.json'))
+      ).toString('utf8'),
+    );
+
+    const customFetchMock = jest.fn();
+
+    customFetchMock.mockResolvedValue({
+      ok: true,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      headers: new Headers({ 'content-length': '5477' }),
+      body: Readable.toWeb(
+        createReadStream(
+          path.resolve(
+            __dirname,
+            `../../../test/fixtures/metamask-template-snap-${templateSnapVersion}.tgz`,
+          ),
+        ),
+      ),
+    } as any);
+
+    const tarballUrl = `https://registry.npmjs.org/@metamask/template-snap/-/template-snap-${templateSnapVersion}.tgz`;
+
+    const location = new NpmLocation(new URL('npm:@metamask/template-snap'), {
+      versionRange: templateSnapVersion,
+      fetch: customFetchMock as typeof fetch,
+    });
+
+    const manifest = await location.manifest();
+    const sourceCode = (
+      await location.fetch(manifest.result.source.location.npm.filePath)
+    ).toString();
+    assert(manifest.result.source.location.npm.iconPath);
+    const svgIcon = (
+      await location.fetch(manifest.result.source.location.npm.iconPath)
+    ).toString();
+
+    expect(customFetchMock).toHaveBeenCalledTimes(1);
+    expect(customFetchMock).toHaveBeenNthCalledWith(1, tarballUrl);
+
+    expect(manifest.result).toStrictEqual(
+      JSON.parse(
+        (
+          await readFile(
+            require.resolve('@metamask/template-snap/snap.manifest.json'),
+          )
+        ).toString('utf8'),
+      ),
+    );
+
+    expect(sourceCode).toStrictEqual(
+      (
+        await readFile(
+          require.resolve('@metamask/template-snap/dist/bundle.js'),
+        )
+      ).toString('utf8'),
+    );
+
+    expect(svgIcon?.startsWith('<svg') && svgIcon.endsWith('</svg>')).toBe(
+      true,
+    );
+  });
+
   it('throws if fetch fails', async () => {
     fetchMock.mockResponse(async () => ({ status: 404, body: 'Not found' }));
     const location = new NpmLocation(new URL('npm:@metamask/template-snap'));


### PR DESCRIPTION
We now know that the NPM fetching problems were caused by a bug in `tar-stream` and unrelated to our usage of `DecompressionStream`. Therefore we can reintroduce it for improved performance.