### PR TITLE
Add signature insights to `test-snaps`

### DIFF
--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -47,6 +47,7 @@
     "@metamask/name-lookup-example-snap": "workspace:^",
     "@metamask/network-example-snap": "workspace:^",
     "@metamask/notification-example-snap": "workspace:^",
+    "@metamask/signature-insights-example-snap": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",
     "@metamask/utils": "^8.3.0",
     "@metamask/wasm-example-snap": "workspace:^",

--- a/packages/test-snaps/src/features/snaps/index.ts
+++ b/packages/test-snaps/src/features/snaps/index.ts
@@ -16,5 +16,6 @@ export * from './name-lookup';
 export * from './network-access';
 export * from './notifications';
 export * from './transaction-insights';
+export * from './signature-insights';
 export * from './updates';
 export * from './wasm';

--- a/packages/test-snaps/src/features/snaps/signature-insights/SignatureInsights.tsx
+++ b/packages/test-snaps/src/features/snaps/signature-insights/SignatureInsights.tsx
@@ -1,0 +1,20 @@
+import type { FunctionComponent } from 'react';
+
+import { Snap } from '../../../components';
+import {
+  SIGNATURE_INSIGHTS_SNAP_ID,
+  SIGNATURE_INSIGHTS_SNAP_PORT,
+  SIGNATURE_INSIGHTS_VERSION,
+} from './constants';
+
+export const SignatureInsights: FunctionComponent = () => {
+  return (
+    <Snap
+      name="Signature Insights Snap"
+      snapId={SIGNATURE_INSIGHTS_SNAP_ID}
+      port={SIGNATURE_INSIGHTS_SNAP_PORT}
+      version={SIGNATURE_INSIGHTS_VERSION}
+      testId="signature-insights"
+    />
+  );
+};

--- a/packages/test-snaps/src/features/snaps/signature-insights/constants.ts
+++ b/packages/test-snaps/src/features/snaps/signature-insights/constants.ts
@@ -1,0 +1,6 @@
+import packageJson from '@metamask/signature-insights-example-snap/package.json';
+
+export const SIGNATURE_INSIGHTS_SNAP_ID =
+  'npm:@metamask/signature-insights-example-snap';
+export const SIGNATURE_INSIGHTS_SNAP_PORT = 8017;
+export const SIGNATURE_INSIGHTS_VERSION = packageJson.version;

--- a/packages/test-snaps/src/features/snaps/signature-insights/index.ts
+++ b/packages/test-snaps/src/features/snaps/signature-insights/index.ts
@@ -1,0 +1,1 @@
+export * from './SignatureInsights';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5059,7 +5059,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/signature-insights-example-snap@workspace:packages/examples/packages/signature-insights":
+"@metamask/signature-insights-example-snap@workspace:^, @metamask/signature-insights-example-snap@workspace:packages/examples/packages/signature-insights":
   version: 0.0.0-use.local
   resolution: "@metamask/signature-insights-example-snap@workspace:packages/examples/packages/signature-insights"
   dependencies:
@@ -5875,6 +5875,7 @@ __metadata:
     "@metamask/network-example-snap": "workspace:^"
     "@metamask/notification-example-snap": "workspace:^"
     "@metamask/providers": ^14.0.2
+    "@metamask/signature-insights-example-snap": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
     "@metamask/utils": ^8.3.0
     "@metamask/wasm-example-snap": "workspace:^"


### PR DESCRIPTION
Added a section for the signature insights example snap. 

**Note:** This is merely for installation purposes when testing, but the e2e tests for signature insights in the extension will utilize the test-dapp.