### PR TITLE
Bump `tar-stream`

### DIFF
--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -64,7 +64,7 @@
     "nanoid": "^3.1.31",
     "readable-stream": "^3.6.2",
     "readable-web-to-node-stream": "^3.0.2",
-    "tar-stream": "^3.1.6"
+    "tar-stream": "^3.1.7"
   },
   "devDependencies": {
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5317,7 +5317,7 @@ __metadata:
     readable-stream: ^3.6.2
     readable-web-to-node-stream: ^3.0.2
     rimraf: ^4.1.2
-    tar-stream: ^3.1.6
+    tar-stream: ^3.1.7
     ts-node: ^10.9.1
     typescript: ~4.8.4
     vite: ^4.3.9
@@ -21385,14 +21385,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-stream@npm:^3.0.0, tar-stream@npm:^3.1.5, tar-stream@npm:^3.1.6":
-  version: 3.1.6
-  resolution: "tar-stream@npm:3.1.6"
+"tar-stream@npm:^3.0.0, tar-stream@npm:^3.1.5, tar-stream@npm:^3.1.7":
+  version: 3.1.7
+  resolution: "tar-stream@npm:3.1.7"
   dependencies:
     b4a: ^1.6.4
     fast-fifo: ^1.2.0
     streamx: ^2.15.0
-  checksum: f3627f918581976e954ff03cb8d370551053796b82564f8c7ca8fac84c48e4d042026d0854fc222171a34ff9c682b72fae91be9c9b0a112d4c54f9e4f443e9c5
+  checksum: 6393a6c19082b17b8dcc8e7fd349352bb29b4b8bfe1075912b91b01743ba6bb4298f5ff0b499a3bbaf82121830e96a1a59d4f21a43c0df339e54b01789cb8cc6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bump `tar-stream` to the latest patch version as the patch includes a fix for a problem where tar headers would sometimes fail to decode depending on the stream performance.

This manifested as a snap installation failure.