### PR TITLE
Rename snaps-jest APIs

### DIFF
--- a/packages/examples/packages/cronjobs/src/index.test.ts
+++ b/packages/examples/packages/cronjobs/src/index.test.ts
@@ -5,9 +5,9 @@ import { heading, panel, text } from '@metamask/snaps-sdk';
 describe('onCronjob', () => {
   describe('execute', () => {
     it('shows a dialog', async () => {
-      const { runCronjob } = await installSnap();
+      const { onCronjob } = await installSnap();
 
-      const request = runCronjob({
+      const request = onCronjob({
         // This would normally be called by the MetaMask extension, but to make
         // this testable, `@metamask/snaps-jest` exposes a `runCronjob` method.
         method: 'execute',

--- a/packages/examples/packages/home-page/src/index.test.ts
+++ b/packages/examples/packages/home-page/src/index.test.ts
@@ -4,9 +4,9 @@ import { panel, text, heading } from '@metamask/snaps-sdk';
 
 describe('onHomePage', () => {
   it('returns custom UI', async () => {
-    const { getHomePage } = await installSnap();
+    const { onHomePage } = await installSnap();
 
-    const response = await getHomePage();
+    const response = await onHomePage();
 
     expect(response).toRender(
       panel([heading('Hello world!'), text('Welcome to my Snap home page!')]),

--- a/packages/examples/packages/transaction-insights/src/index.test.ts
+++ b/packages/examples/packages/transaction-insights/src/index.test.ts
@@ -7,9 +7,9 @@ describe('onTransaction', () => {
   const TO_ADDRESS = '0x4bbeeb066ed09b7aed07bf39eee0460dfa261520';
 
   it('returns transaction insights for an ERC-20 transaction', async () => {
-    const { sendTransaction } = await installSnap();
+    const { onTransaction } = await installSnap();
 
-    const response = await sendTransaction({
+    const response = await onTransaction({
       from: FROM_ADDRESS,
       to: TO_ADDRESS,
       // This is not a valid ERC-20 transfer as all the values are zero, but it
@@ -27,9 +27,9 @@ describe('onTransaction', () => {
   });
 
   it('returns transaction insights for an ERC-721 transaction', async () => {
-    const { sendTransaction } = await installSnap();
+    const { onTransaction } = await installSnap();
 
-    const response = await sendTransaction({
+    const response = await onTransaction({
       from: FROM_ADDRESS,
       to: TO_ADDRESS,
       // This is not a valid ERC-721 transfer as all the values are zero, but it
@@ -47,9 +47,9 @@ describe('onTransaction', () => {
   });
 
   it('returns transaction insights for an ERC-1155 transaction', async () => {
-    const { sendTransaction } = await installSnap();
+    const { onTransaction } = await installSnap();
 
-    const response = await sendTransaction({
+    const response = await onTransaction({
       from: FROM_ADDRESS,
       to: TO_ADDRESS,
       // This is not a valid ERC-1155 transfer as all the values are zero, but
@@ -67,9 +67,9 @@ describe('onTransaction', () => {
   });
 
   it('returns transaction insights for an unknown transaction', async () => {
-    const { sendTransaction } = await installSnap();
+    const { onTransaction } = await installSnap();
 
-    const response = await sendTransaction({
+    const response = await onTransaction({
       from: FROM_ADDRESS,
       to: TO_ADDRESS,
       data: '0xabcdef1200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
@@ -85,9 +85,9 @@ describe('onTransaction', () => {
   });
 
   it('returns transaction insights for a transaction with no data', async () => {
-    const { sendTransaction } = await installSnap();
+    const { onTransaction } = await installSnap();
 
-    const response = await sendTransaction({
+    const response = await onTransaction({
       from: FROM_ADDRESS,
       to: TO_ADDRESS,
       data: '0x',

--- a/packages/snaps-jest/src/helpers.test.ts
+++ b/packages/snaps-jest/src/helpers.test.ts
@@ -657,8 +657,8 @@ describe('installSnap', () => {
          `,
       });
 
-      const { getHomePage, close } = await installSnap(snapId);
-      const response = await getHomePage();
+      const { onHomePage, close } = await installSnap(snapId);
+      const response = await onHomePage();
 
       expect(response).toStrictEqual(
         expect.objectContaining({

--- a/packages/snaps-jest/src/helpers.ts
+++ b/packages/snaps-jest/src/helpers.ts
@@ -15,7 +15,13 @@ import {
   addJsonRpcMock,
   removeJsonRpcMock,
 } from './internals/simulation/store/mocks';
-import type { JsonRpcMockOptions, Snap, SnapResponse } from './types';
+import type {
+  CronjobOptions,
+  JsonRpcMockOptions,
+  Snap,
+  SnapResponse,
+  TransactionOptions,
+} from './types';
 
 const log = createModuleLogger(rootLogger, 'helpers');
 
@@ -188,6 +194,47 @@ export async function installSnap<
     runSaga,
   } = await getEnvironment().installSnap(...resolvedOptions);
 
+  const onTransaction = async (
+    request: TransactionOptions,
+  ): Promise<SnapResponse> => {
+    log('Sending transaction %o.', request);
+
+    const {
+      origin: transactionOrigin,
+      chainId,
+      ...transaction
+    } = create(request, TransactionOptionsStruct);
+
+    return handleRequest({
+      snapId: installedSnapId,
+      store,
+      executionService,
+      runSaga,
+      handler: HandlerType.OnTransaction,
+      request: {
+        method: '',
+        params: {
+          chainId,
+          transaction,
+          transactionOrigin,
+        },
+      },
+    });
+  };
+
+  const onCronjob = (request: CronjobOptions) => {
+    log('Running cronjob %o.', options);
+
+    return handleRequest({
+      snapId: installedSnapId,
+      store,
+      executionService,
+      runSaga,
+      handler: HandlerType.OnCronjob,
+      request,
+    });
+  };
+
   return {
     request: (request) => {
       log('Sending request %o.', request);
@@ -202,46 +249,13 @@ export async function installSnap<
       });
     },
 
-    sendTransaction: async (request): Promise<SnapResponse> => {
-      log('Sending transaction %o.', request);
+    onTransaction,
+    sendTransaction: onTransaction,
 
-      const {
-        origin: transactionOrigin,
-        chainId,
-        ...transaction
-      } = create(request, TransactionOptionsStruct);
+    onCronjob,
+    runCronjob: onCronjob,
 
-      return handleRequest({
-        snapId: installedSnapId,
-        store,
-        executionService,
-        runSaga,
-        handler: HandlerType.OnTransaction,
-        request: {
-          method: '',
-          params: {
-            chainId,
-            transaction,
-            transactionOrigin,
-          },
-        },
-      });
-    },
-
-    runCronjob: (request) => {
-      log('Running cronjob %o.', options);
-
-      return handleRequest({
-        snapId: installedSnapId,
-        store,
-        executionService,
-        runSaga,
-        handler: HandlerType.OnCronjob,
-        request,
-      });
-    },
-
-    getHomePage: async (): Promise<SnapResponse> => {
+    onHomePage: async (): Promise<SnapResponse> => {
       log('Rendering home page.');
 
       return handleRequest({

--- a/packages/snaps-jest/src/types.ts
+++ b/packages/snaps-jest/src/types.ts
@@ -266,7 +266,7 @@ export type Snap = {
    * `endowment:cronjob` permission.
    * @returns The response promise, with extra {@link SnapRequestObject} fields.
    */
-  onCronjob(cronjob?: Partial<CronjobOptions>): Promise<SnapResponse>;
+  onCronjob(cronjob?: Partial<CronjobOptions>): SnapRequest;
 
   /**
    * Run a cronjob in the snap. This is similar to {@link request}, but the

--- a/packages/snaps-jest/src/types.ts
+++ b/packages/snaps-jest/src/types.ts
@@ -240,6 +240,19 @@ export type Snap = {
    * will be filled in with default values.
    * @returns The response.
    */
+  onTransaction(
+    transaction?: Partial<TransactionOptions>,
+  ): Promise<SnapResponse>;
+
+  /**
+   * Send a transaction to the snap.
+   *
+   * @param transaction - The transaction. This is similar to an Ethereum
+   * transaction object, but has an extra `origin` field. Any missing fields
+   * will be filled in with default values.
+   * @returns The response.
+   * @deprecated Use {@link onTransaction} instead.
+   */
   sendTransaction(
     transaction?: Partial<TransactionOptions>,
   ): Promise<SnapResponse>;
@@ -253,16 +266,26 @@ export type Snap = {
    * `endowment:cronjob` permission.
    * @returns The response promise, with extra {@link SnapRequestObject} fields.
    */
+  onCronjob(cronjob?: Partial<CronjobOptions>): Promise<SnapResponse>;
+
+  /**
+   * Run a cronjob in the snap. This is similar to {@link request}, but the
+   * request will be sent to the `onCronjob` method of the snap.
+   *
+   * @param cronjob - The cronjob request. This is similar to a JSON-RPC
+   * request, and is normally specified in the snap manifest, under the
+   * `endowment:cronjob` permission.
+   * @returns The response promise, with extra {@link SnapRequestObject} fields.
+   * @deprecated Use {@link onCronjob} instead.
+   */
   runCronjob(cronjob: CronjobOptions): SnapRequest;
 
   /**
-   * Makes a request to the snap to render the snaps home page.
-   *
-   * This method takes no arguments.
+   * Get the response from the snap's `onHomePage` method.
    *
    * @returns The response.
    */
-  getHomePage(): Promise<SnapResponse>;
+  onHomePage(): Promise<SnapResponse>;
 
   /**
    * Mock a JSON-RPC request. This will cause the snap to respond with the


### PR DESCRIPTION
With the exception of `request`, all APIs were renamed to match the name of the entry point in the Snap. This prevents confusing names like `sendSignature` (#2114) in the future.