### PR TITLE
Add support for interactive UI to `onTransaction` and `onSignature`

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2223,7 +2223,7 @@ describe('SnapController', () => {
           },
         }),
       ).rejects.toThrow(
-        'Assertion failed: At path: foo -- Expected a value of type `never`, but received: `"bar"`.',
+        'Assertion failed: Expected the value to satisfy a union of `object | object`, but received: [object Object].',
       );
 
       snapController.destroy();
@@ -2398,7 +2398,7 @@ describe('SnapController', () => {
           },
         }),
       ).rejects.toThrow(
-        'Assertion failed: At path: foo -- Expected a value of type `never`, but received: `"bar"`.',
+        'Assertion failed: Expected the value to satisfy a union of `object | object`, but received: [object Object].',
       );
 
       snapController.destroy();
@@ -2626,7 +2626,7 @@ describe('SnapController', () => {
     snapController.destroy();
   });
 
-  it('gets the interface content if the result is an interface id', async () => {
+  it('gets the interface content if the result is an interface id for onHomePage', async () => {
     const rootMessenger = getControllerMessenger();
     const messenger = getSnapControllerMessenger(rootMessenger);
     const snapController = getSnapController(
@@ -2672,6 +2672,136 @@ describe('SnapController', () => {
       snapId: MOCK_SNAP_ID,
       origin: 'foo.com',
       handler: HandlerType.OnHomePage,
+      request: {
+        jsonrpc: '2.0',
+        method: ' ',
+        params: {},
+        id: 1,
+      },
+    });
+
+    expect(rootMessenger.call).toHaveBeenNthCalledWith(
+      5,
+      'SnapInterfaceController:getInterface',
+      MOCK_SNAP_ID,
+      'foo',
+    );
+    expect(result).toBe(handlerResponse);
+
+    snapController.destroy();
+  });
+
+  it('gets the interface content if the result is an interface id for onTransaction', async () => {
+    const rootMessenger = getControllerMessenger();
+    const messenger = getSnapControllerMessenger(rootMessenger);
+    const snapController = getSnapController(
+      getSnapControllerOptions({
+        messenger,
+        state: {
+          snaps: getPersistedSnapsState(),
+        },
+      }),
+    );
+
+    const handlerResponse = { id: 'foo' };
+
+    rootMessenger.registerActionHandler(
+      'PermissionController:getPermissions',
+      () => ({
+        [SnapEndowments.TransactionInsight]: {
+          caveats: null,
+          date: 1664187844588,
+          id: 'izn0WGUO8cvq_jqvLQuQP',
+          invoker: MOCK_SNAP_ID,
+          parentCapability: SnapEndowments.TransactionInsight,
+        },
+      }),
+    );
+
+    rootMessenger.registerActionHandler(
+      'SubjectMetadataController:getSubjectMetadata',
+      () => MOCK_SNAP_SUBJECT_METADATA,
+    );
+
+    rootMessenger.registerActionHandler(
+      'ExecutionService:handleRpcRequest',
+      async () => Promise.resolve(handlerResponse),
+    );
+
+    rootMessenger.registerActionHandler(
+      'SnapInterfaceController:getInterface',
+      () => ({ snapId: MOCK_SNAP_ID, state: {}, content: text('hello') }),
+    );
+
+    const result = await snapController.handleRequest({
+      snapId: MOCK_SNAP_ID,
+      origin: 'foo.com',
+      handler: HandlerType.OnTransaction,
+      request: {
+        jsonrpc: '2.0',
+        method: ' ',
+        params: {},
+        id: 1,
+      },
+    });
+
+    expect(rootMessenger.call).toHaveBeenNthCalledWith(
+      5,
+      'SnapInterfaceController:getInterface',
+      MOCK_SNAP_ID,
+      'foo',
+    );
+    expect(result).toBe(handlerResponse);
+
+    snapController.destroy();
+  });
+
+  it('gets the interface content if the result is an interface id for onSignature', async () => {
+    const rootMessenger = getControllerMessenger();
+    const messenger = getSnapControllerMessenger(rootMessenger);
+    const snapController = getSnapController(
+      getSnapControllerOptions({
+        messenger,
+        state: {
+          snaps: getPersistedSnapsState(),
+        },
+      }),
+    );
+
+    const handlerResponse = { id: 'foo' };
+
+    rootMessenger.registerActionHandler(
+      'PermissionController:getPermissions',
+      () => ({
+        [SnapEndowments.SignatureInsight]: {
+          caveats: null,
+          date: 1664187844588,
+          id: 'izn0WGUO8cvq_jqvLQuQP',
+          invoker: MOCK_SNAP_ID,
+          parentCapability: SnapEndowments.SignatureInsight,
+        },
+      }),
+    );
+
+    rootMessenger.registerActionHandler(
+      'SubjectMetadataController:getSubjectMetadata',
+      () => MOCK_SNAP_SUBJECT_METADATA,
+    );
+
+    rootMessenger.registerActionHandler(
+      'ExecutionService:handleRpcRequest',
+      async () => Promise.resolve(handlerResponse),
+    );
+
+    rootMessenger.registerActionHandler(
+      'SnapInterfaceController:getInterface',
+      () => ({ snapId: MOCK_SNAP_ID, state: {}, content: text('hello') }),
+    );
+
+    const result = await snapController.handleRequest({
+      snapId: MOCK_SNAP_ID,
+      origin: 'foo.com',
+      handler: HandlerType.OnSignature,
       request: {
         jsonrpc: '2.0',
         method: ' ',

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2938,10 +2938,9 @@ export class SnapController extends BaseController<
 
         await this.#triggerPhishingListUpdate();
 
-        validateComponentLinks(
-          result.content,
-          this.#checkPhishingList.bind(this),
-        );
+        const content = this.#getResponseContent(snapId, result);
+
+        validateComponentLinks(content, this.#checkPhishingList.bind(this));
         break;
       }
       case HandlerType.OnSignature: {
@@ -2953,10 +2952,9 @@ export class SnapController extends BaseController<
 
         await this.#triggerPhishingListUpdate();
 
-        validateComponentLinks(
-          result.content,
-          this.#checkPhishingList.bind(this),
-        );
+        const content = this.#getResponseContent(snapId, result);
+
+        validateComponentLinks(content, this.#checkPhishingList.bind(this));
         break;
       }
       case HandlerType.OnHomePage:

--- a/packages/snaps-sdk/src/types/handlers/signature.ts
+++ b/packages/snaps-sdk/src/types/handlers/signature.ts
@@ -111,10 +111,16 @@ export type OnSignatureHandler = (args: {
  * The response from a Snap's `onSignature` handler.
  *
  * @property component - A custom UI component, that will be shown in MetaMask.
+ * @property id - A Snap interface ID.
  * @property severity - The severity level of the content. Currently only one
  * level is supported: `critical`.
  */
-export type OnSignatureResponse = {
-  content: Component;
-  severity?: EnumToUnion<SeverityLevel>;
-};
+export type OnSignatureResponse =
+  | {
+      content: Component;
+      severity?: EnumToUnion<SeverityLevel>;
+    }
+  | {
+      id: string;
+      severity?: EnumToUnion<SeverityLevel>;
+    };

--- a/packages/snaps-sdk/src/types/handlers/transaction.ts
+++ b/packages/snaps-sdk/src/types/handlers/transaction.ts
@@ -107,10 +107,16 @@ export type OnTransactionHandler = (args: {
  * The response from a Snap's `onTransaction` handler.
  *
  * @property component - A custom UI component, that will be shown in MetaMask.
+ * @property id - A Snap interface ID.
  * @property severity - The severity level of the content. Currently only one
  * level is supported: `critical`.
  */
-export type OnTransactionResponse = {
-  content: Component;
-  severity?: EnumToUnion<SeverityLevel>;
-};
+export type OnTransactionResponse =
+  | {
+      content: Component;
+      severity?: EnumToUnion<SeverityLevel>;
+    }
+  | {
+      id: string;
+      severity?: EnumToUnion<SeverityLevel>;
+    };

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -2,5 +2,5 @@
   "branches": 96.05,
   "functions": 98.56,
   "lines": 98.63,
-  "statements": 95.2
+  "statements": 94.95
 }

--- a/packages/snaps-utils/src/handlers.ts
+++ b/packages/snaps-utils/src/handlers.ts
@@ -12,6 +12,7 @@ import type {
 } from '@metamask/snaps-sdk';
 import { SeverityLevel, ComponentStruct } from '@metamask/snaps-sdk';
 import {
+  assign,
   literal,
   nullable,
   object,
@@ -102,11 +103,29 @@ export const SNAP_EXPORTS = {
   },
 } as const;
 
-export const OnTransactionResponseStruct = nullable(
+export const OnTransactionSeverityResponseStruct = object({
+  severity: optional(literal(SeverityLevel.Critical)),
+});
+
+export const OnTransactionResponseWithIdStruct = assign(
+  OnTransactionSeverityResponseStruct,
+  object({
+    id: string(),
+  }),
+);
+
+export const OnTransactionResponseWithContentStruct = assign(
+  OnTransactionSeverityResponseStruct,
   object({
     content: ComponentStruct,
-    severity: optional(literal(SeverityLevel.Critical)),
   }),
+);
+
+export const OnTransactionResponseStruct = nullable(
+  union([
+    OnTransactionResponseWithContentStruct,
+    OnTransactionResponseWithIdStruct,
+  ]),
 );
 
 export const OnSignatureResponseStruct = OnTransactionResponseStruct;


### PR DESCRIPTION
This PR adds the ability to pass an interface id to the response of `onTransaction` and `onSignature`.

Fixes: #2124 #2125 