### PR TITLE
Fix insight snap

### DIFF
--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "BHn/lh5WbcR61LkK6QnbXjkxMSdyKQZxNyKQ3qJVhP8=",
+    "shasum": "AZ+z3h0cgmPyhUMqRcpcSrE45zE5qmyBf/DPbMave2I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/src/index.ts
+++ b/packages/examples/packages/signature-insights/src/index.ts
@@ -49,7 +49,7 @@ export const onSignature: OnSignatureHandler = async ({ signature }) => {
       {},
     );
     return Object.entries(typeCount).map(([type, count]) =>
-      row(type, text(count)),
+      row(type, text(`${count}`)),
     );
   };
 


### PR DESCRIPTION
The snap is erroneously passing in a `number` to the `text` component, casting it into a string to fix.