### PR TITLE
Set `output.chunkFormat` to `commonjs` by default

### DIFF
--- a/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
+++ b/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
@@ -60,6 +60,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {
@@ -201,6 +202,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {
@@ -342,6 +344,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {
@@ -483,6 +486,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {
@@ -621,6 +625,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {
@@ -762,6 +767,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {
@@ -903,6 +909,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {
@@ -1044,6 +1051,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {
@@ -1193,6 +1201,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {
@@ -1342,6 +1351,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {
@@ -1492,6 +1502,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {
@@ -1633,6 +1644,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {
@@ -1774,6 +1786,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {
@@ -1924,6 +1937,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {
@@ -2077,6 +2091,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {
@@ -2211,6 +2226,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {
@@ -2345,6 +2361,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     ],
   },
   "output": {
+    "chunkFormat": "commonjs",
     "clean": false,
     "filename": "bundle.js",
     "library": {

--- a/packages/snaps-cli/src/webpack/config.ts
+++ b/packages/snaps-cli/src/webpack/config.ts
@@ -164,6 +164,16 @@ export async function getDefaultConfiguration(
          */
         type: 'commonjs',
       },
+
+      /**
+       * The chunk format. This tells Webpack how to export chunks. This is
+       * required because we use browserslist to target browsers, but Snaps are
+       * not fully compatible with browser APIs (such as `window` and
+       * `document`).
+       *
+       * @see https://webpack.js.org/configuration/output/#outputchunkformat
+       */
+      chunkFormat: 'commonjs',
     },
 
     /**


### PR DESCRIPTION
By default, Webpack will use `JsonpChunkLoadingRuntimeModule` to load chunks. This injects `document` into the Snap code, causing it to break. By setting `output.chunkFormat` to `commonjs`, we can disable `JsonpChunkLoadingRuntimeModule`.

More context here: https://github.com/MetaMask/snaps/discussions/2135