### PR TITLE
[BREAKING] Add support for interactive UI to `snap_dialog`

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2940,7 +2940,7 @@ export class SnapController extends BaseController<
   }
 
   #assertInterfaceExists(snapId: SnapId, id: string) {
-    // This will throw if the interface is accessible, but we assert nevertheless.
+    // This will throw if the interface isn't accessible, but we assert nevertheless.
     assert(
       this.messagingSystem.call(
         'SnapInterfaceController:getInterface',

--- a/packages/snaps-jest/src/environment.ts
+++ b/packages/snaps-jest/src/environment.ts
@@ -3,6 +3,7 @@ import type {
   JestEnvironmentConfig,
 } from '@jest/environment';
 import type { AbstractExecutionService } from '@metamask/snaps-controllers';
+import type { SnapId } from '@metamask/snaps-sdk';
 import { assert, createModuleLogger } from '@metamask/utils';
 import type { Server } from 'http';
 import NodeEnvironment from 'jest-environment-node';
@@ -87,7 +88,7 @@ export class SnapsEnvironment extends NodeEnvironment {
     options: Partial<InstallSnapOptions<Service>> = {},
   ) {
     await this.#instance?.executionService.terminateAllSnaps();
-    this.#instance = await handleInstallSnap(snapId, options);
+    this.#instance = await handleInstallSnap(snapId as SnapId, options);
     return this.#instance;
   }
 

--- a/packages/snaps-jest/src/helpers.ts
+++ b/packages/snaps-jest/src/helpers.ts
@@ -1,4 +1,5 @@
 import type { AbstractExecutionService } from '@metamask/snaps-controllers';
+import type { SnapId } from '@metamask/snaps-sdk';
 import { HandlerType, logInfo } from '@metamask/snaps-utils';
 import { createModuleLogger } from '@metamask/utils';
 import { create } from 'superstruct';
@@ -38,9 +39,9 @@ function getOptions<
     typeof AbstractExecutionService
   >,
 >(
-  snapId: string | Partial<InstallSnapOptions<Service>> | undefined,
+  snapId: SnapId | Partial<InstallSnapOptions<Service>> | undefined,
   options: Partial<InstallSnapOptions<Service>>,
-): [string | undefined, Partial<InstallSnapOptions<Service>>] {
+): [SnapId | undefined, Partial<InstallSnapOptions<Service>>] {
   if (typeof snapId === 'object') {
     return [undefined, snapId];
   }
@@ -143,7 +144,7 @@ export async function installSnap<
     typeof AbstractExecutionService
   >,
 >(
-  snapId: string,
+  snapId: SnapId,
   options?: Partial<InstallSnapOptions<Service>>,
 ): Promise<Snap>;
 
@@ -184,7 +185,7 @@ export async function installSnap<
     typeof AbstractExecutionService
   >,
 >(
-  snapId?: string | Partial<InstallSnapOptions<Service>>,
+  snapId?: SnapId | Partial<InstallSnapOptions<Service>>,
   options: Partial<InstallSnapOptions<Service>> = {},
 ): Promise<Snap> {
   const resolvedOptions = getOptions(snapId, options);
@@ -193,6 +194,7 @@ export async function installSnap<
     store,
     executionService,
     runSaga,
+    controllerMessenger,
   } = await getEnvironment().installSnap(...resolvedOptions);
 
   const onTransaction = async (
@@ -211,6 +213,7 @@ export async function installSnap<
       store,
       executionService,
       runSaga,
+      controllerMessenger,
       handler: HandlerType.OnTransaction,
       request: {
         method: '',
@@ -230,6 +233,7 @@ export async function installSnap<
       snapId: installedSnapId,
       store,
       executionService,
+      controllerMessenger,
       runSaga,
       handler: HandlerType.OnCronjob,
       request,
@@ -244,6 +248,7 @@ export async function installSnap<
         snapId: installedSnapId,
         store,
         executionService,
+        controllerMessenger,
         runSaga,
         handler: HandlerType.OnRpcRequest,
         request,
@@ -265,6 +270,7 @@ export async function installSnap<
         snapId: installedSnapId,
         store,
         executionService,
+        controllerMessenger,
         runSaga,
         handler: HandlerType.OnSignature,
         request: {
@@ -287,6 +293,7 @@ export async function installSnap<
         snapId: installedSnapId,
         store,
         executionService,
+        controllerMessenger,
         runSaga,
         handler: HandlerType.OnHomePage,
         request: {

--- a/packages/snaps-jest/src/internals/request.test.ts
+++ b/packages/snaps-jest/src/internals/request.test.ts
@@ -8,7 +8,7 @@ import {
   getRestrictedSnapInterfaceControllerMessenger,
   getRootControllerMessenger,
 } from '../test-utils';
-import { handleRequest } from './request';
+import { getContentFromResult, handleRequest } from './request';
 import { handleInstallSnap } from './simulation';
 
 describe('handleRequest', () => {
@@ -124,5 +124,49 @@ describe('handleRequest', () => {
 
     await closeServer();
     await snap.executionService.terminateAllSnaps();
+  });
+});
+
+describe('getContentFromResult', () => {
+  it('gets the content from the SnapInterfaceController if the result contains an ID', async () => {
+    const controllerMessenger = getRootControllerMessenger();
+    const interfaceController = new SnapInterfaceController({
+      messenger:
+        getRestrictedSnapInterfaceControllerMessenger(controllerMessenger),
+    });
+
+    const snapId = 'foo' as SnapId;
+    const content = text('foo');
+
+    const id = await interfaceController.createInterface(snapId, content);
+
+    const result = getContentFromResult({ id }, snapId, controllerMessenger);
+
+    expect(result).toStrictEqual(content);
+  });
+
+  it('gets the content from the result if the result contains the content', () => {
+    const controllerMessenger = getRootControllerMessenger();
+
+    const snapId = 'foo' as SnapId;
+    const content = text('foo');
+
+    const result = getContentFromResult(
+      { content },
+      snapId,
+      controllerMessenger,
+    );
+
+    expect(result).toStrictEqual(content);
+  });
+
+  it('returns undefined if there is no content associated with the result', () => {
+    const controllerMessenger = getRootControllerMessenger();
+
+    const snapId = 'foo' as SnapId;
+
+    const result = getContentFromResult({}, snapId, controllerMessenger);
+
+    expect(result).toBeUndefined();
   });
 });

--- a/packages/snaps-jest/src/internals/request.ts
+++ b/packages/snaps-jest/src/internals/request.ts
@@ -2,7 +2,7 @@ import type { AbstractExecutionService } from '@metamask/snaps-controllers';
 import type { SnapId } from '@metamask/snaps-sdk';
 import type { HandlerType } from '@metamask/snaps-utils';
 import { unwrapError } from '@metamask/snaps-utils';
-import { getSafeJson, isPlainObject } from '@metamask/utils';
+import { getSafeJson, hasProperty, isPlainObject } from '@metamask/utils';
 import { nanoid } from '@reduxjs/toolkit';
 
 import type { RequestOptions, SnapRequest } from '../types';
@@ -67,7 +67,20 @@ export function handleRequest({
       const notifications = getNotifications(store.getState());
       store.dispatch(clearNotifications());
 
-      const content = isPlainObject(result) ? result.content : undefined;
+      let content;
+
+      if (isPlainObject(result) && hasProperty(result, 'id')) {
+        content = controllerMessenger.call(
+          'SnapInterfaceController:getInterface',
+          snapId,
+          result.id as string,
+        ).content;
+      }
+
+      if (isPlainObject(result) && hasProperty(result, 'content')) {
+        content = result.content;
+      }
+
       return {
         id: String(id),
         response: {

--- a/packages/snaps-jest/src/internals/request.ts
+++ b/packages/snaps-jest/src/internals/request.ts
@@ -103,7 +103,7 @@ export function handleRequest({
 }
 
 /**
- * Get the response content components either from the Snap interface Controller or the response object if there is some.
+ * Get the response content either from the SnapInterfaceController or the response object if there is one.
  *
  * @param result - The handler result object.
  * @param snapId - The Snap ID.

--- a/packages/snaps-jest/src/internals/simulation/controllers.test.ts
+++ b/packages/snaps-jest/src/internals/simulation/controllers.test.ts
@@ -11,6 +11,9 @@ import type { MiddlewareHooks } from './simulation';
 const MOCK_HOOKS: MiddlewareHooks = {
   getMnemonic: jest.fn(),
   getSnapFile: jest.fn(),
+  createInterface: jest.fn(),
+  updateInterface: jest.fn(),
+  getInterfaceState: jest.fn(),
 };
 
 describe('getControllers', () => {

--- a/packages/snaps-jest/src/internals/simulation/controllers.ts
+++ b/packages/snaps-jest/src/internals/simulation/controllers.ts
@@ -2,17 +2,25 @@ import type { ControllerMessenger } from '@metamask/base-controller';
 import type {
   CaveatSpecificationConstraint,
   PermissionSpecificationConstraint,
+  PermissionControllerActions,
+  SubjectMetadataControllerActions,
 } from '@metamask/permission-controller';
 import {
   PermissionController,
   SubjectMetadataController,
   SubjectType,
 } from '@metamask/permission-controller';
+import type {
+  ExecutionServiceActions,
+  SnapInterfaceControllerActions,
+  SnapInterfaceControllerAllowedActions,
+} from '@metamask/snaps-controllers';
 import {
   caveatSpecifications as snapsCaveatsSpecifications,
   endowmentCaveatSpecifications as snapsEndowmentCaveatSpecifications,
   processSnapPermissions,
 } from '@metamask/snaps-rpc-methods';
+import type { SnapId } from '@metamask/snaps-sdk';
 import type { SnapManifest } from '@metamask/snaps-utils';
 import { getSafeJson } from '@metamask/utils';
 
@@ -21,6 +29,18 @@ import { UNRESTRICTED_METHODS } from './methods/constants';
 import type { SimulationOptions } from './options';
 import type { MiddlewareHooks } from './simulation';
 import type { RunSagaFunction } from './store';
+
+export type RootControllerAllowedActions =
+  | SnapInterfaceControllerActions
+  | SnapInterfaceControllerAllowedActions
+  | PermissionControllerActions
+  | ExecutionServiceActions
+  | SubjectMetadataControllerActions;
+
+export type RootControllerMessenger = ControllerMessenger<
+  RootControllerAllowedActions,
+  any
+>;
 
 export type GetControllersOptions = {
   controllerMessenger: ControllerMessenger<any, any>;
@@ -68,10 +88,8 @@ export function getControllers(options: GetControllersOptions): Controllers {
  * @param options.options - Miscellaneous options.
  * @returns The permission controller for the Snap.
  */
-function getPermissionController({
-  controllerMessenger,
-  ...options
-}: GetControllersOptions) {
+function getPermissionController(options: GetControllersOptions) {
+  const { controllerMessenger } = options;
   const permissionSpecifications = getPermissionSpecifications(options);
   return new PermissionController({
     messenger: controllerMessenger.getRestricted({
@@ -105,7 +123,7 @@ function getPermissionController({
  * @param controllers.subjectMetadataController - The subject metadata controller.
  */
 export async function registerSnap(
-  snapId: string,
+  snapId: SnapId,
   manifest: SnapManifest,
   { permissionController, subjectMetadataController }: Controllers,
 ) {

--- a/packages/snaps-jest/src/internals/simulation/controllers.ts
+++ b/packages/snaps-jest/src/internals/simulation/controllers.ts
@@ -10,6 +10,7 @@ import {
   SubjectMetadataController,
   SubjectType,
 } from '@metamask/permission-controller';
+import { SnapInterfaceController } from '@metamask/snaps-controllers';
 import type {
   ExecutionServiceActions,
   SnapInterfaceControllerActions,
@@ -55,6 +56,7 @@ export type Controllers = {
     CaveatSpecificationConstraint
   >;
   subjectMetadataController: SubjectMetadataController;
+  interfaceController: SnapInterfaceController;
 };
 
 /**
@@ -72,11 +74,22 @@ export function getControllers(options: GetControllersOptions): Controllers {
     subjectCacheLimit: 100,
   });
 
+  const interfaceController = new SnapInterfaceController({
+    messenger: controllerMessenger.getRestricted({
+      name: 'SnapInterfaceController',
+      allowedActions: [
+        'PhishingController:maybeUpdateState',
+        'PhishingController:testOrigin',
+      ],
+    }),
+  });
+
   const permissionController = getPermissionController(options);
 
   return {
     permissionController,
     subjectMetadataController,
+    interfaceController,
   };
 }
 
@@ -125,7 +138,10 @@ function getPermissionController(options: GetControllersOptions) {
 export async function registerSnap(
   snapId: SnapId,
   manifest: SnapManifest,
-  { permissionController, subjectMetadataController }: Controllers,
+  {
+    permissionController,
+    subjectMetadataController,
+  }: Omit<Controllers, 'interfaceController'>,
 ) {
   subjectMetadataController.addSubjectMetadata({
     origin: snapId,

--- a/packages/snaps-jest/src/internals/simulation/methods/hooks/index.ts
+++ b/packages/snaps-jest/src/internals/simulation/methods/hooks/index.ts
@@ -3,3 +3,4 @@ export * from './get-locale';
 export * from './notifications';
 export * from './show-dialog';
 export * from './state';
+export * from './interface';

--- a/packages/snaps-jest/src/internals/simulation/methods/hooks/interface.test.ts
+++ b/packages/snaps-jest/src/internals/simulation/methods/hooks/interface.test.ts
@@ -1,0 +1,70 @@
+import { SnapInterfaceController } from '@metamask/snaps-controllers';
+import type { SnapId } from '@metamask/snaps-sdk';
+import { text } from '@metamask/snaps-sdk';
+
+import {
+  getRestrictedSnapInterfaceControllerMessenger,
+  getRootControllerMessenger,
+} from '../../../../test-utils';
+import {
+  getCreateInterfaceImplementation,
+  getGetInterfaceImplementation,
+} from './interface';
+
+describe('getCreateInterfaceImplementation', () => {
+  it('returns the implementation of the `createInterface` hook', async () => {
+    const controllerMessenger = getRootControllerMessenger();
+
+    const interfaceController = new SnapInterfaceController({
+      messenger:
+        getRestrictedSnapInterfaceControllerMessenger(controllerMessenger),
+    });
+
+    jest.spyOn(controllerMessenger, 'call');
+
+    const fn = getCreateInterfaceImplementation(controllerMessenger);
+
+    const snapId = 'foo' as SnapId;
+    const content = text('bar');
+
+    const id = await fn(snapId, content);
+
+    const result = interfaceController.getInterface(snapId, id);
+
+    expect(controllerMessenger.call).toHaveBeenCalledWith(
+      'SnapInterfaceController:createInterface',
+      snapId,
+      content,
+    );
+    expect(result.content).toStrictEqual(content);
+  });
+});
+
+describe('getGetInterfaceImplementation', () => {
+  it('returns the implementation of the `getInterface` hook', async () => {
+    const controllerMessenger = getRootControllerMessenger();
+
+    const interfaceController = new SnapInterfaceController({
+      messenger:
+        getRestrictedSnapInterfaceControllerMessenger(controllerMessenger),
+    });
+
+    jest.spyOn(controllerMessenger, 'call');
+
+    const fn = getGetInterfaceImplementation(controllerMessenger);
+
+    const snapId = 'foo' as SnapId;
+    const content = text('bar');
+
+    const id = await interfaceController.createInterface(snapId, content);
+
+    const result = fn(snapId, id);
+
+    expect(controllerMessenger.call).toHaveBeenCalledWith(
+      'SnapInterfaceController:getInterface',
+      snapId,
+      id,
+    );
+    expect(result).toStrictEqual({ content, state: {}, snapId });
+  });
+});

--- a/packages/snaps-jest/src/internals/simulation/methods/hooks/interface.ts
+++ b/packages/snaps-jest/src/internals/simulation/methods/hooks/interface.ts
@@ -1,0 +1,37 @@
+import type { Component, SnapId } from '@metamask/snaps-sdk';
+
+import type { RootControllerMessenger } from '../../controllers';
+
+/**
+ * Get the implementation of the `createInterface` hook.
+ *
+ * @param controllerMessenger - The controller messenger used to call actions.
+ * @returns The implementation of the `createInterface` hook.
+ */
+export function getCreateInterfaceImplementation(
+  controllerMessenger: RootControllerMessenger,
+) {
+  return async (snapId: SnapId, content: Component) =>
+    controllerMessenger.call(
+      'SnapInterfaceController:createInterface',
+      snapId,
+      content,
+    );
+}
+
+/**
+ * Get the implementation of the `getInterface` hook.
+ *
+ * @param controllerMessenger - The controller messenger used to call actions.
+ * @returns The implementation of the `getInterface` hook.
+ */
+export function getGetInterfaceImplementation(
+  controllerMessenger: RootControllerMessenger,
+) {
+  return (snapId: SnapId, id: string) =>
+    controllerMessenger.call(
+      'SnapInterfaceController:getInterface',
+      snapId,
+      id,
+    );
+}

--- a/packages/snaps-jest/src/internals/simulation/methods/hooks/show-dialog.test.ts
+++ b/packages/snaps-jest/src/internals/simulation/methods/hooks/show-dialog.test.ts
@@ -1,4 +1,4 @@
-import { DialogType, text } from '@metamask/snaps-sdk';
+import { DialogType } from '@metamask/snaps-sdk';
 import { MOCK_SNAP_ID } from '@metamask/snaps-utils/test-utils';
 
 import { getMockOptions } from '../../../../test-utils';
@@ -10,7 +10,7 @@ describe('getShowDialogImplementation', () => {
     const { store, runSaga } = createStore('password', getMockOptions());
     const fn = getShowDialogImplementation(runSaga);
 
-    const promise = fn(MOCK_SNAP_ID, DialogType.Alert, text('message'));
+    const promise = fn(MOCK_SNAP_ID, DialogType.Alert, 'foo');
     store.dispatch(resolveInterface('result'));
 
     expect(await promise).toBe('result');

--- a/packages/snaps-jest/src/internals/simulation/methods/hooks/show-dialog.ts
+++ b/packages/snaps-jest/src/internals/simulation/methods/hooks/show-dialog.ts
@@ -1,4 +1,4 @@
-import type { Component, DialogType } from '@metamask/snaps-sdk';
+import type { DialogType } from '@metamask/snaps-sdk';
 import type { SagaIterator } from 'redux-saga';
 import { put, take } from 'redux-saga/effects';
 
@@ -12,7 +12,7 @@ import { resolveInterface, setInterface, closeInterface } from '../../store';
  * @param _snapId - The ID of the Snap that created the dialog. This is ignored
  * because the simulator only supports one Snap.
  * @param type - The type of dialog to show.
- * @param content - The content to show in the dialog.
+ * @param id - The interface ID.
  * @param _placeholder - The placeholder text to show in the dialog. This is
  * not implemented yet.
  * @yields Sets the dialog in the store, waits for the user to resolve the
@@ -22,10 +22,10 @@ import { resolveInterface, setInterface, closeInterface } from '../../store';
 function* showDialogImplementation(
   _snapId: string,
   type: DialogType,
-  content: Component,
+  id: string,
   _placeholder?: string,
 ): SagaIterator<unknown> {
-  yield put(setInterface({ type, content }));
+  yield put(setInterface({ type, id }));
 
   // We use `take` to wait for `resolveUserInterface` to be dispatched, which
   // indicates that the user has resolved the dialog.

--- a/packages/snaps-jest/src/internals/simulation/methods/specifications.test.ts
+++ b/packages/snaps-jest/src/internals/simulation/methods/specifications.test.ts
@@ -17,6 +17,9 @@ import {
 const MOCK_HOOKS: MiddlewareHooks = {
   getMnemonic: jest.fn(),
   getSnapFile: jest.fn(),
+  createInterface: jest.fn(),
+  updateInterface: jest.fn(),
+  getInterfaceState: jest.fn(),
 };
 
 describe('resolve', () => {
@@ -40,6 +43,7 @@ describe('getPermissionSpecifications', () => {
         hooks: MOCK_HOOKS,
         runSaga: jest.fn(),
         options: getMockOptions(),
+        controllerMessenger: new ControllerMessenger(),
       }),
     ).toMatchInlineSnapshot(`
       {

--- a/packages/snaps-jest/src/internals/simulation/methods/specifications.ts
+++ b/packages/snaps-jest/src/internals/simulation/methods/specifications.ts
@@ -4,8 +4,10 @@ import {
   buildSnapEndowmentSpecifications,
   buildSnapRestrictedMethodSpecifications,
 } from '@metamask/snaps-rpc-methods';
+import type { SnapId } from '@metamask/snaps-sdk';
 import { DEFAULT_ENDOWMENTS } from '@metamask/snaps-utils';
 
+import type { RootControllerMessenger } from '../controllers';
 import type { SimulationOptions } from '../options';
 import type { RunSagaFunction } from '../store';
 import {
@@ -34,6 +36,7 @@ export type PermissionSpecificationsHooks = {
 };
 
 export type GetPermissionSpecificationsOptions = {
+  controllerMessenger: RootControllerMessenger;
   hooks: PermissionSpecificationsHooks;
   runSaga: RunSagaFunction;
   options: SimulationOptions;
@@ -64,6 +67,7 @@ export function asyncResolve(result?: unknown) {
  * Get the permission specifications for the Snap.
  *
  * @param options - The options.
+ * @param options.controllerMessenger - The controller messenger.
  * @param options.hooks - The hooks.
  * @param options.runSaga - The function to run a saga outside the usual Redux
  * flow.
@@ -71,6 +75,7 @@ export function asyncResolve(result?: unknown) {
  * @returns The permission specifications for the Snap.
  */
 export function getPermissionSpecifications({
+  controllerMessenger,
   hooks,
   runSaga,
   options,
@@ -100,6 +105,14 @@ export function getPermissionSpecifications({
       showInAppNotification: getShowInAppNotificationImplementation(runSaga),
       showNativeNotification: getShowNativeNotificationImplementation(runSaga),
       updateSnapState: getUpdateSnapStateMethodImplementation(runSaga),
+      createInterface: controllerMessenger.call.bind(
+        controllerMessenger,
+        'SnapInterfaceController:createInterface',
+      ),
+      getInterface: controllerMessenger.call.bind(
+        controllerMessenger,
+        'SnapInterfaceController:getInterface',
+      ),
     }),
   };
 }
@@ -113,7 +126,7 @@ export function getPermissionSpecifications({
  */
 export async function getEndowments(
   permissionController: GenericPermissionController,
-  snapId: string,
+  snapId: SnapId,
 ) {
   const allEndowments = await Object.keys(endowmentPermissionBuilders).reduce<
     Promise<string[]>

--- a/packages/snaps-jest/src/internals/simulation/methods/specifications.ts
+++ b/packages/snaps-jest/src/internals/simulation/methods/specifications.ts
@@ -4,7 +4,7 @@ import {
   buildSnapEndowmentSpecifications,
   buildSnapRestrictedMethodSpecifications,
 } from '@metamask/snaps-rpc-methods';
-import type { SnapId } from '@metamask/snaps-sdk';
+import type { SnapId, Component } from '@metamask/snaps-sdk';
 import { DEFAULT_ENDOWMENTS } from '@metamask/snaps-utils';
 
 import type { RootControllerMessenger } from '../controllers';
@@ -105,14 +105,18 @@ export function getPermissionSpecifications({
       showInAppNotification: getShowInAppNotificationImplementation(runSaga),
       showNativeNotification: getShowNativeNotificationImplementation(runSaga),
       updateSnapState: getUpdateSnapStateMethodImplementation(runSaga),
-      createInterface: controllerMessenger.call.bind(
-        controllerMessenger,
-        'SnapInterfaceController:createInterface',
-      ),
-      getInterface: controllerMessenger.call.bind(
-        controllerMessenger,
-        'SnapInterfaceController:getInterface',
-      ),
+      createInterface: async (snapId: SnapId, content: Component) =>
+        controllerMessenger.call(
+          'SnapInterfaceController:createInterface',
+          snapId,
+          content,
+        ),
+      getInterface: (snapId: SnapId, id: string) =>
+        controllerMessenger.call(
+          'SnapInterfaceController:getInterface',
+          snapId,
+          id,
+        ),
     }),
   };
 }

--- a/packages/snaps-jest/src/internals/simulation/methods/specifications.ts
+++ b/packages/snaps-jest/src/internals/simulation/methods/specifications.ts
@@ -4,7 +4,7 @@ import {
   buildSnapEndowmentSpecifications,
   buildSnapRestrictedMethodSpecifications,
 } from '@metamask/snaps-rpc-methods';
-import type { SnapId, Component } from '@metamask/snaps-sdk';
+import type { SnapId } from '@metamask/snaps-sdk';
 import { DEFAULT_ENDOWMENTS } from '@metamask/snaps-utils';
 
 import type { RootControllerMessenger } from '../controllers';
@@ -24,6 +24,8 @@ import {
   getShowNativeNotificationImplementation,
   encryptImplementation,
   decryptImplementation,
+  getCreateInterfaceImplementation,
+  getGetInterfaceImplementation,
 } from './hooks';
 
 export type PermissionSpecificationsHooks = {
@@ -105,18 +107,8 @@ export function getPermissionSpecifications({
       showInAppNotification: getShowInAppNotificationImplementation(runSaga),
       showNativeNotification: getShowNativeNotificationImplementation(runSaga),
       updateSnapState: getUpdateSnapStateMethodImplementation(runSaga),
-      createInterface: async (snapId: SnapId, content: Component) =>
-        controllerMessenger.call(
-          'SnapInterfaceController:createInterface',
-          snapId,
-          content,
-        ),
-      getInterface: (snapId: SnapId, id: string) =>
-        controllerMessenger.call(
-          'SnapInterfaceController:getInterface',
-          snapId,
-          id,
-        ),
+      createInterface: getCreateInterfaceImplementation(controllerMessenger),
+      getInterface: getGetInterfaceImplementation(controllerMessenger),
     }),
   };
 }

--- a/packages/snaps-jest/src/internals/simulation/simulation.ts
+++ b/packages/snaps-jest/src/internals/simulation/simulation.ts
@@ -11,7 +11,6 @@ import {
   detectSnapLocation,
   NodeThreadExecutionService,
   setupMultiplex,
-  SnapInterfaceController,
 } from '@metamask/snaps-controllers';
 import { getEncryptionKey } from '@metamask/snaps-rpc-methods';
 import type {
@@ -160,17 +159,6 @@ export async function handleInstallSnap<
   const controllerMessenger = new ControllerMessenger<any, any>();
 
   registerActions(controllerMessenger);
-
-  // eslint-disable-next-line no-new
-  new SnapInterfaceController({
-    messenger: controllerMessenger.getRestricted({
-      name: 'SnapInterfaceController',
-      allowedActions: [
-        'PhishingController:maybeUpdateState',
-        'PhishingController:testOrigin',
-      ],
-    }),
-  });
 
   // Set up controllers and JSON-RPC stack.
   const hooks = getHooks(options, snapFiles, snapId, controllerMessenger);

--- a/packages/snaps-jest/src/internals/simulation/simulation.ts
+++ b/packages/snaps-jest/src/internals/simulation/simulation.ts
@@ -11,14 +11,21 @@ import {
   detectSnapLocation,
   NodeThreadExecutionService,
   setupMultiplex,
+  SnapInterfaceController,
 } from '@metamask/snaps-controllers';
 import { getEncryptionKey } from '@metamask/snaps-rpc-methods';
-import type { AuxiliaryFileEncoding, SnapId } from '@metamask/snaps-sdk';
+import type {
+  SnapId,
+  AuxiliaryFileEncoding,
+  Component,
+  InterfaceState,
+} from '@metamask/snaps-sdk';
 import type { FetchedSnapFiles } from '@metamask/snaps-utils';
 import { logError } from '@metamask/snaps-utils';
 import type { Duplex } from 'readable-stream';
 import { pipeline } from 'readable-stream';
 
+import type { RootControllerMessenger } from './controllers';
 import { getControllers, registerSnap } from './controllers';
 import { getSnapFile } from './files';
 import { getEndowments } from './methods';
@@ -69,7 +76,7 @@ export type InstallSnapOptions<
     };
 
 export type InstalledSnap = {
-  snapId: string;
+  snapId: SnapId;
   store: Store;
   executionService: InstanceType<typeof AbstractExecutionService>;
   controllerMessenger: ControllerMessenger<ActionConstraint, EventConstraint>;
@@ -102,6 +109,9 @@ export type MiddlewareHooks = {
    * @returns A boolean flag signaling whether the client is locked.
    */
   getIsLocked: () => boolean;
+  createInterface: (content: Component) => Promise<string>;
+  updateInterface: (id: string, content: Component) => Promise<void>;
+  getInterfaceState: (id: string) => InterfaceState;
 };
 
 /**
@@ -123,7 +133,7 @@ export async function handleInstallSnap<
     typeof AbstractExecutionService
   >,
 >(
-  snapId: string,
+  snapId: SnapId,
   {
     executionService,
     executionServiceOptions,
@@ -137,7 +147,7 @@ export async function handleInstallSnap<
     allowLocal: true,
   });
 
-  const snapFiles = await fetchSnap(snapId as SnapId, location);
+  const snapFiles = await fetchSnap(snapId, location);
 
   // Create Redux store.
   const password = await getEncryptionKey({
@@ -147,10 +157,24 @@ export async function handleInstallSnap<
 
   const { store, runSaga } = createStore(password, options);
 
-  // Set up controllers and JSON-RPC stack.
-  const hooks = getHooks(options, snapFiles);
+  const controllerMessenger = new ControllerMessenger<any, any>();
 
-  const controllerMessenger = new ControllerMessenger();
+  registerActions(controllerMessenger);
+
+  // eslint-disable-next-line no-new
+  new SnapInterfaceController({
+    messenger: controllerMessenger.getRestricted({
+      name: 'SnapInterfaceController',
+      allowedActions: [
+        'PhishingController:maybeUpdateState',
+        'PhishingController:testOrigin',
+      ],
+    }),
+  });
+
+  // Set up controllers and JSON-RPC stack.
+  const hooks = getHooks(options, snapFiles, snapId, controllerMessenger);
+
   const { subjectMetadataController, permissionController } = getControllers({
     controllerMessenger,
     hooks,
@@ -216,11 +240,15 @@ export async function handleInstallSnap<
  *
  * @param options - The simulation options.
  * @param snapFiles - The Snap files.
+ * @param snapId - The Snap ID.
+ * @param controllerMessenger - The controller messenger.
  * @returns The hooks for the simulation.
  */
 export function getHooks(
   options: SimulationOptions,
   snapFiles: FetchedSnapFiles,
+  snapId: SnapId,
+  controllerMessenger: RootControllerMessenger,
 ): MiddlewareHooks {
   return {
     getMnemonic: async () =>
@@ -228,5 +256,40 @@ export function getHooks(
     getSnapFile: async (path: string, encoding: AuxiliaryFileEncoding) =>
       await getSnapFile(snapFiles.auxiliaryFiles, path, encoding),
     getIsLocked: () => false,
+    createInterface: async (...args) =>
+      controllerMessenger.call(
+        'SnapInterfaceController:createInterface',
+        snapId,
+        ...args,
+      ),
+    updateInterface: async (...args) =>
+      controllerMessenger.call(
+        'SnapInterfaceController:updateInterface',
+        snapId,
+        ...args,
+      ),
+    getInterfaceState: (...args) =>
+      controllerMessenger.call(
+        'SnapInterfaceController:getInterface',
+        snapId,
+        ...args,
+      ).state,
   };
+}
+
+/**
+ * Register mocked action handlers.
+ *
+ * @param controllerMessenger - The controller messenger.
+ */
+export function registerActions(controllerMessenger: RootControllerMessenger) {
+  controllerMessenger.registerActionHandler(
+    'PhishingController:maybeUpdateState',
+    async () => Promise.resolve(),
+  );
+
+  controllerMessenger.registerActionHandler(
+    'PhishingController:testOrigin',
+    () => ({ result: false, type: 'all' }),
+  );
 }

--- a/packages/snaps-jest/src/internals/simulation/store/ui.ts
+++ b/packages/snaps-jest/src/internals/simulation/store/ui.ts
@@ -1,4 +1,4 @@
-import type { DialogType, Component } from '@metamask/snaps-sdk';
+import type { DialogType } from '@metamask/snaps-sdk';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createAction, createSelector, createSlice } from '@reduxjs/toolkit';
 
@@ -6,7 +6,7 @@ import type { ApplicationState } from './store';
 
 export type Interface = {
   type: DialogType;
-  content: Component;
+  id: string;
 };
 
 export type UiState = {

--- a/packages/snaps-jest/src/test-utils/controller.ts
+++ b/packages/snaps-jest/src/test-utils/controller.ts
@@ -1,0 +1,44 @@
+import type { SnapInterfaceControllerAllowedActions } from '@metamask/snaps-controllers';
+import { MockControllerMessenger } from '@metamask/snaps-utils/test-utils';
+import type { RootControllerAllowedActions } from 'src/internals/simulation/controllers';
+
+export const getRootControllerMessenger = (mocked = true) => {
+  const messenger = new MockControllerMessenger<
+    RootControllerAllowedActions,
+    any
+  >();
+
+  if (mocked) {
+    messenger.registerActionHandler(
+      'PhishingController:maybeUpdateState',
+      async () => Promise.resolve(),
+    );
+
+    messenger.registerActionHandler('PhishingController:testOrigin', () => ({
+      result: false,
+      type: 'all',
+    }));
+  }
+
+  return messenger;
+};
+
+export const getRestrictedSnapInterfaceControllerMessenger = (
+  messenger: ReturnType<
+    typeof getRootControllerMessenger
+  > = getRootControllerMessenger(),
+) => {
+  const snapInterfaceControllerMessenger = messenger.getRestricted<
+    'SnapInterfaceController',
+    SnapInterfaceControllerAllowedActions['type'],
+    never
+  >({
+    name: 'SnapInterfaceController',
+    allowedActions: [
+      'PhishingController:testOrigin',
+      'PhishingController:maybeUpdateState',
+    ],
+  });
+
+  return snapInterfaceControllerMessenger;
+};

--- a/packages/snaps-jest/src/test-utils/controller.ts
+++ b/packages/snaps-jest/src/test-utils/controller.ts
@@ -1,6 +1,7 @@
 import type { SnapInterfaceControllerAllowedActions } from '@metamask/snaps-controllers';
 import { MockControllerMessenger } from '@metamask/snaps-utils/test-utils';
-import type { RootControllerAllowedActions } from 'src/internals/simulation/controllers';
+
+import type { RootControllerAllowedActions } from '../internals/simulation/controllers';
 
 export const getRootControllerMessenger = (mocked = true) => {
   const messenger = new MockControllerMessenger<

--- a/packages/snaps-jest/src/test-utils/index.ts
+++ b/packages/snaps-jest/src/test-utils/index.ts
@@ -2,3 +2,4 @@ export * from './jest';
 export * from './options';
 export * from './response';
 export * from './server';
+export * from './controller';

--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -10,7 +10,7 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 91.54,
+      branches: 91.42,
       functions: 97,
       lines: 97.53,
       statements: 97,

--- a/packages/snaps-rpc-methods/src/restricted/dialog.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/dialog.test.ts
@@ -20,9 +20,6 @@ describe('builder', () => {
       dialogBuilder.specificationBuilder({
         methodHooks: {
           showDialog: jest.fn(),
-          isOnPhishingList: jest.fn(),
-          maybeUpdatePhishingList: jest.fn(),
-          getInterface: jest.fn(),
           createInterface: jest.fn(),
         },
       }),
@@ -40,9 +37,6 @@ describe('implementation', () => {
   const getMockDialogHooks = () =>
     ({
       showDialog: jest.fn(),
-      isOnPhishingList: jest.fn(),
-      maybeUpdatePhishingList: jest.fn(),
-      getInterface: jest.fn(),
       createInterface: jest.fn().mockReturnValue('bar'),
     } as DialogMethodHooks);
 
@@ -68,13 +62,8 @@ describe('implementation', () => {
   });
 
   it('gets the interface data if an interface ID is passed', async () => {
-    const content = text('foo');
-
     const hooks = {
       showDialog: jest.fn(),
-      isOnPhishingList: jest.fn(),
-      maybeUpdatePhishingList: jest.fn(),
-      getInterface: jest.fn().mockReturnValue({ content, state: {} }),
       createInterface: jest.fn().mockReturnValue('bar'),
     };
 
@@ -89,7 +78,6 @@ describe('implementation', () => {
       },
     });
 
-    expect(hooks.getInterface).toHaveBeenCalledWith('foo', 'bar');
     expect(hooks.showDialog).toHaveBeenCalledTimes(1);
     expect(hooks.showDialog).toHaveBeenCalledWith(
       'foo',
@@ -324,26 +312,5 @@ describe('implementation', () => {
         );
       },
     );
-
-    it('rejects phishing links', async () => {
-      const implementation = getDialogImplementation({
-        showDialog: jest.fn(),
-        isOnPhishingList: () => true,
-        maybeUpdatePhishingList: jest.fn(),
-        getInterface: jest.fn(),
-        createInterface: jest.fn(),
-      });
-
-      await expect(
-        implementation({
-          context: { origin: 'foo' },
-          method: 'snap_dialog',
-          params: {
-            type: DialogType.Confirmation,
-            content: panel([heading('foo'), text('[bar](https://foo.bar)')]),
-          },
-        }),
-      ).rejects.toThrow('Invalid URL: The specified URL is not allowed.');
-    });
   });
 });

--- a/packages/snaps-rpc-methods/src/restricted/dialog.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/dialog.test.ts
@@ -286,7 +286,7 @@ describe('implementation', () => {
           params: value as any,
         }),
       ).rejects.toThrow(
-        /Invalid params: At path: .* -- Expected .*, but received: .*\./u,
+        /Invalid params: At path: .* — Expected a value of type .*, but received: .*\./u,
       );
     });
 
@@ -307,7 +307,7 @@ describe('implementation', () => {
             },
           }),
         ).rejects.toThrow(
-          /Invalid params: At path: placeholder -- Expected a string, but received: .*\./u,
+          /Invalid params: At path: .* — Expected a value of type .*, but received: .*\./u,
         );
       },
     );
@@ -327,7 +327,7 @@ describe('implementation', () => {
           },
         }),
       ).rejects.toThrow(
-        'Invalid params: At path: placeholder -- Expected a string with a length between `1` and `40` but received one with a length of `0`.',
+        'Invalid params: At path: placeholder — Expected a value of type string, but received: "".',
       );
     });
 

--- a/packages/snaps-rpc-methods/src/restricted/dialog.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/dialog.test.ts
@@ -327,7 +327,7 @@ describe('implementation', () => {
           },
         }),
       ).rejects.toThrow(
-        'Invalid params: At path: placeholder — Expected a value of type string, but received: "".',
+        'Invalid params: At path: placeholder — Expected a string with a length between 1 and 40, but received one with a length of 0.',
       );
     });
 

--- a/packages/snaps-rpc-methods/src/restricted/dialog.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/dialog.test.ts
@@ -307,7 +307,7 @@ describe('implementation', () => {
             },
           }),
         ).rejects.toThrow(
-          /Invalid params: At path: .* — Expected a value of type .*, but received: .*\./u,
+          /Invalid params: At path: placeholder — Expected a value of type string, but received: .*\./u,
         );
       },
     );
@@ -348,7 +348,7 @@ describe('implementation', () => {
             },
           }),
         ).rejects.toThrow(
-          'Invalid params: Alerts or confirmations may not specify a "placeholder" field.',
+          'Invalid params: Unknown key: placeholder, received: "foobar".',
         );
       },
     );

--- a/packages/snaps-rpc-methods/src/restricted/dialog.ts
+++ b/packages/snaps-rpc-methods/src/restricted/dialog.ts
@@ -38,7 +38,7 @@ type ShowDialog = (
   placeholder?: Placeholder,
 ) => Promise<null | boolean | string>;
 
-type CreateInterface = (snapId: string, content: Component) => string;
+type CreateInterface = (snapId: string, content: Component) => Promise<string>;
 
 export type DialogMethodHooks = {
   /**
@@ -210,7 +210,10 @@ export function getDialogImplementation({
         : undefined;
 
     if (hasProperty(validatedParams, 'content')) {
-      const id = createInterface(origin, validatedParams.content as Component);
+      const id = await createInterface(
+        origin,
+        validatedParams.content as Component,
+      );
       return showDialog(origin, validatedType, id, placeholder);
     }
 

--- a/packages/snaps-rpc-methods/src/restricted/dialog.ts
+++ b/packages/snaps-rpc-methods/src/restricted/dialog.ts
@@ -17,7 +17,7 @@ import {
   validateComponentLinks,
 } from '@metamask/snaps-utils';
 import type { InferMatching } from '@metamask/snaps-utils';
-import type { NonEmptyArray } from '@metamask/utils';
+import { hasProperty, type NonEmptyArray } from '@metamask/utils';
 import type { Infer, Struct } from 'superstruct';
 import {
   create,
@@ -31,7 +31,7 @@ import {
   union,
 } from 'superstruct';
 
-import { getParamsInterface, type MethodHooksObject } from '../utils';
+import { type MethodHooksObject } from '../utils';
 
 const methodName = 'snap_dialog';
 
@@ -243,12 +243,15 @@ export function getDialogImplementation({
     const validatedType = getValidatedType(params);
     const validatedParams = getValidatedParams(params, structs[validatedType]);
 
-    const { content, id } = getParamsInterface(
-      origin,
-      validatedParams,
-      getInterface,
-      createInterface,
-    );
+    let content, id;
+
+    if (hasProperty(validatedParams, 'id')) {
+      content = getInterface(origin, validatedParams.id as string).content;
+      id = validatedParams.id as string;
+    } else {
+      id = createInterface(origin, validatedParams.content);
+      content = validatedParams.content;
+    }
 
     await maybeUpdatePhishingList();
 

--- a/packages/snaps-rpc-methods/src/restricted/dialog.ts
+++ b/packages/snaps-rpc-methods/src/restricted/dialog.ts
@@ -235,6 +235,8 @@ export function getDialogImplementation({
       return showDialog(origin, validatedType, id, placeholder);
     }
 
+    // Verify that the passed interface ID is valid.
+    // This will throw if the interface ID is invalid (not created by the snap or doesn't exist)
     try {
       getInterface(origin, validatedParams.id);
     } catch (error) {

--- a/packages/snaps-rpc-methods/src/utils.test.ts
+++ b/packages/snaps-rpc-methods/src/utils.test.ts
@@ -1,14 +1,8 @@
-import { text } from '@metamask/snaps-sdk';
 import { SIP_6_MAGIC_VALUE } from '@metamask/snaps-utils';
 import { TEST_SECRET_RECOVERY_PHRASE_BYTES } from '@metamask/snaps-utils/test-utils';
 
 import { ENTROPY_VECTORS } from './__fixtures__';
-import {
-  deriveEntropy,
-  getNode,
-  getParamsInterface,
-  getPathPrefix,
-} from './utils';
+import { deriveEntropy, getNode, getPathPrefix } from './utils';
 
 describe('deriveEntropy', () => {
   it.each(ENTROPY_VECTORS)(
@@ -77,45 +71,5 @@ describe('getNode', () => {
         "publicKey": "0x00c9aaf347832dc3b1dbb7aab4f41e5e04c64446b819c0761571c27b9f90eacb27",
       }
     `);
-  });
-});
-
-describe('getParamsInterface', () => {
-  it('returns the content and creates a new interface if the params has them', () => {
-    const content = text('foo');
-    const id = 'foo';
-
-    const getInterface = jest.fn();
-    const createInterface = jest.fn().mockReturnValue(id);
-
-    const result = getParamsInterface(
-      'foo',
-      { content },
-      getInterface,
-      createInterface,
-    );
-
-    expect(result).toStrictEqual({ content, id });
-    expect(getInterface).not.toHaveBeenCalled();
-    expect(createInterface).toHaveBeenCalledWith('foo', content);
-  });
-
-  it('gets the content from the InterfaceController and returns the content and the id if the params contains an id', () => {
-    const params = { id: 'foo' };
-
-    const content = text('foo');
-    const getInterface = jest.fn().mockReturnValue({ content, state: {} });
-    const createInterface = jest.fn();
-
-    const result = getParamsInterface(
-      'foo',
-      params,
-      getInterface,
-      createInterface,
-    );
-
-    expect(result).toStrictEqual({ content, id: params.id });
-    expect(getInterface).toHaveBeenCalledWith('foo', params.id);
-    expect(createInterface).not.toHaveBeenCalled();
   });
 });

--- a/packages/snaps-rpc-methods/src/utils.test.ts
+++ b/packages/snaps-rpc-methods/src/utils.test.ts
@@ -1,8 +1,14 @@
+import { text } from '@metamask/snaps-sdk';
 import { SIP_6_MAGIC_VALUE } from '@metamask/snaps-utils';
 import { TEST_SECRET_RECOVERY_PHRASE_BYTES } from '@metamask/snaps-utils/test-utils';
 
 import { ENTROPY_VECTORS } from './__fixtures__';
-import { deriveEntropy, getNode, getPathPrefix } from './utils';
+import {
+  deriveEntropy,
+  getNode,
+  getParamsInterface,
+  getPathPrefix,
+} from './utils';
 
 describe('deriveEntropy', () => {
   it.each(ENTROPY_VECTORS)(
@@ -71,5 +77,45 @@ describe('getNode', () => {
         "publicKey": "0x00c9aaf347832dc3b1dbb7aab4f41e5e04c64446b819c0761571c27b9f90eacb27",
       }
     `);
+  });
+});
+
+describe('getParamsInterface', () => {
+  it('returns the content and creates a new interface if the params has them', () => {
+    const content = text('foo');
+    const id = 'foo';
+
+    const getInterface = jest.fn();
+    const createInterface = jest.fn().mockReturnValue(id);
+
+    const result = getParamsInterface(
+      'foo',
+      { content },
+      getInterface,
+      createInterface,
+    );
+
+    expect(result).toStrictEqual({ content, id });
+    expect(getInterface).not.toHaveBeenCalled();
+    expect(createInterface).toHaveBeenCalledWith('foo', content);
+  });
+
+  it('gets the content from the InterfaceController and returns the content and the id if the params contains an id', () => {
+    const params = { id: 'foo' };
+
+    const content = text('foo');
+    const getInterface = jest.fn().mockReturnValue({ content, state: {} });
+    const createInterface = jest.fn();
+
+    const result = getParamsInterface(
+      'foo',
+      params,
+      getInterface,
+      createInterface,
+    );
+
+    expect(result).toStrictEqual({ content, id: params.id });
+    expect(getInterface).toHaveBeenCalledWith('foo', params.id);
+    expect(createInterface).not.toHaveBeenCalled();
   });
 });

--- a/packages/snaps-rpc-methods/src/utils.ts
+++ b/packages/snaps-rpc-methods/src/utils.ts
@@ -4,7 +4,6 @@ import type {
   SLIP10PathNode,
 } from '@metamask/key-tree';
 import { SLIP10Node } from '@metamask/key-tree';
-import type { Component, InterfaceState } from '@metamask/snaps-sdk';
 import type { MagicValue } from '@metamask/snaps-utils';
 import type { Hex } from '@metamask/utils';
 import {
@@ -12,7 +11,6 @@ import {
   assert,
   concatBytes,
   createDataView,
-  hasProperty,
   stringToBytes,
 } from '@metamask/utils';
 import { keccak_256 as keccak256 } from '@noble/hashes/sha3';
@@ -210,31 +208,4 @@ export async function getNode({
         | SLIP10PathNode[]),
     ],
   });
-}
-
-/**
- * Get the interface data from the associated RPC Method params.
- *
- * @param snapId - The Snap ID.
- * @param params - The RPC Request params.
- * @param getInterface - The Interface Controller function to get the interface.
- * @param createInterface - The Interface Controller function to create the interface.
- * @returns An object with the inteface ID and the interface content.
- */
-export function getParamsInterface(
-  snapId: string,
-  params: { content: Component } | { id: string },
-  getInterface: (
-    snapId: string,
-    id: string,
-  ) => { content: Component; state: InterfaceState },
-  createInterface: (snapId: string, content: Component) => string,
-) {
-  if (hasProperty(params, 'id')) {
-    const { content } = getInterface(snapId, params.id as string);
-    return { id: params.id as string, content };
-  }
-
-  const id = createInterface(snapId, params.content);
-  return { id, content: params.content };
 }

--- a/packages/snaps-rpc-methods/src/utils.ts
+++ b/packages/snaps-rpc-methods/src/utils.ts
@@ -4,6 +4,7 @@ import type {
   SLIP10PathNode,
 } from '@metamask/key-tree';
 import { SLIP10Node } from '@metamask/key-tree';
+import type { Component, InterfaceState } from '@metamask/snaps-sdk';
 import type { MagicValue } from '@metamask/snaps-utils';
 import type { Hex } from '@metamask/utils';
 import {
@@ -11,6 +12,7 @@ import {
   assert,
   concatBytes,
   createDataView,
+  hasProperty,
   stringToBytes,
 } from '@metamask/utils';
 import { keccak_256 as keccak256 } from '@noble/hashes/sha3';
@@ -208,4 +210,31 @@ export async function getNode({
         | SLIP10PathNode[]),
     ],
   });
+}
+
+/**
+ * Get the interface data from the associated RPC Method params.
+ *
+ * @param snapId - The Snap ID.
+ * @param params - The RPC Request params.
+ * @param getInterface - The Interface Controller function to get the interface.
+ * @param createInterface - The Interface Controller function to create the interface.
+ * @returns An object with the inteface ID and the interface content.
+ */
+export function getParamsInterface(
+  snapId: string,
+  params: { content: Component } | { id: string },
+  getInterface: (
+    snapId: string,
+    id: string,
+  ) => { content: Component; state: InterfaceState },
+  createInterface: (snapId: string, content: Component) => string,
+) {
+  if (hasProperty(params, 'id')) {
+    const { content } = getInterface(snapId, params.id as string);
+    return { id: params.id as string, content };
+  }
+
+  const id = createInterface(snapId, params.content);
+  return { id, content: params.content };
 }

--- a/packages/snaps-sdk/src/types/methods/dialog.ts
+++ b/packages/snaps-sdk/src/types/methods/dialog.ts
@@ -20,42 +20,62 @@ export enum DialogType {
  *
  * @property type - The type of dialog. Must be `alert`.
  * @property content - The content to display in the dialog.
+ * @property id - The Snap interface ID.
  */
-export type AlertDialog = {
-  type: EnumToUnion<DialogType.Alert>;
-  content: Component;
-};
+export type AlertDialog =
+  | {
+      type: EnumToUnion<DialogType.Alert>;
+      content: Component;
+    }
+  | {
+      type: EnumToUnion<DialogType.Alert>;
+      id: string;
+    };
 
 /**
  * A confirmation dialog.
  *
  * @property type - The type of dialog. Must be `confirmation`.
  * @property content - The content to display in the dialog.
+ * @property id - The Snap interface ID.
  */
-export type ConfirmationDialog = {
-  type: EnumToUnion<DialogType.Confirmation>;
-  content: Component;
-};
+export type ConfirmationDialog =
+  | {
+      type: EnumToUnion<DialogType.Confirmation>;
+      content: Component;
+    }
+  | {
+      type: EnumToUnion<DialogType.Confirmation>;
+      id: string;
+    };
 
 /**
  * A prompt dialog.
  *
  * @property type - The type of dialog. Must be `prompt`.
  * @property content - The content to display in the dialog.
+ * @property id - The Snap interface ID.
  * @property placeholder - An optional placeholder text to display in the text
  * input.
  */
-export type PromptDialog = {
-  type: EnumToUnion<DialogType.Prompt>;
-  content: Component;
-  placeholder?: string;
-};
+export type PromptDialog =
+  | {
+      type: EnumToUnion<DialogType.Prompt>;
+      content: Component;
+      placeholder?: string;
+    }
+  | {
+      type: EnumToUnion<DialogType.Prompt>;
+      id: string;
+      placeholder?: string;
+    };
 
 /**
  * The request parameters for the `snap_dialog` method.
  *
  * @property type - The type of dialog to display.
  * @property content - The content to display in the dialog.
+ * @property id - The Snap interface ID.
  * @property placeholder - The placeholder text to display in the dialog. Only
  * applicable for the `prompt` dialog.
  */


### PR DESCRIPTION
This PR adds the ability to pass an interface id to the params of the `snap_dialog` RPC method. It also experiments a way to display better errors when they come from unions.

`snaps-jest` has also been updated to handle the intrerfaces ID.

Fixes: #2123 

BREAKING CHANGES:
- Now the `showDialog` hook expects an interface id.