### PR TITLE
Speed up eval-worker

### DIFF
--- a/packages/snaps-utils/src/eval-worker.ts
+++ b/packages/snaps-utils/src/eval-worker.ts
@@ -47,5 +47,3 @@ if (invalidExports.length > 0) {
   // eslint-disable-next-line no-console
   console.warn(`Invalid snap exports detected:\n${invalidExports.join('\n')}`);
 }
-
-setTimeout(() => process.exit(0), 1000); // Hack to ensure worker exits

--- a/packages/snaps-utils/src/eval-worker.ts
+++ b/packages/snaps-utils/src/eval-worker.ts
@@ -47,3 +47,7 @@ if (invalidExports.length > 0) {
   // eslint-disable-next-line no-console
   console.warn(`Invalid snap exports detected:\n${invalidExports.join('\n')}`);
 }
+
+// To ensure the worker exits we explicitly call exit here
+// If we didn't the eval would wait for timers set during Compartment eval
+process.exit(0);


### PR DESCRIPTION
Speed up eval-worker by removing hack to make it terminate after 1 second.

This moves the lowerbound for snap evaluation in the CLI from 1s to potentially milliseconds.