### PR TITLE
Deploy multiple bundles to AWS

### DIFF
--- a/.github/workflows/publish-environment.yml
+++ b/.github/workflows/publish-environment.yml
@@ -34,4 +34,5 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - name: Deploy to `${{ inputs.destination_dir }}` directory of remote storage
         run: |
-          aws s3 cp ./packages/snaps-execution-environments/dist/browserify/iframe s3://${{ vars.AWS_BUCKET_NAME }}/${{ inputs.destination_dir }} --recursive --acl private
+          aws s3 cp ./packages/snaps-execution-environments/dist/browserify/iframe s3://${{ vars.AWS_BUCKET_NAME }}/iframe/${{ inputs.destination_dir }} --recursive --acl private
+          aws s3 cp ./packages/snaps-execution-environments/dist/browserify/webview s3://${{ vars.AWS_BUCKET_NAME }}/webview/${{ inputs.destination_dir }} --recursive --acl private

--- a/packages/snaps-execution-environments/src/proxy/ProxySnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/proxy/ProxySnapExecutor.ts
@@ -12,7 +12,7 @@ type ExecutorJob = {
   stream: WindowPostMessageStream;
 };
 
-const IFRAME_URL = `https://execution.metamask.io/${packageJson.version}/index.html`;
+const IFRAME_URL = `https://execution.metamask.io/iframe/${packageJson.version}/index.html`;
 
 /**
  * A "proxy" snap executor that uses a level of indirection to execute snaps.

--- a/packages/snaps-simulator/src/features/simulation/sagas.ts
+++ b/packages/snaps-simulator/src/features/simulation/sagas.ts
@@ -68,7 +68,7 @@ import {
   unrestrictedMethods,
 } from './snap-permissions';
 
-const DEFAULT_ENVIRONMENT_URL = `https://execution.metamask.io/${packageJson.version}/index.html`;
+const DEFAULT_ENVIRONMENT_URL = `https://execution.metamask.io/iframe/${packageJson.version}/index.html`;
 
 /**
  * The initialization saga is run on when the snap ID is changed and initializes the snaps execution environment.


### PR DESCRIPTION
Changes AWS deployment slightly to allow for deployment of both the iframe and webview bundles.

This means that the format of the AWS URLs changes from:
```
https://execution.metamask.io/%VERSION%/index.html
```
to
```
https://execution.metamask.io/iframe/%VERSION%/index.html
https://execution.metamask.io/webview/%VERSION%/index.html
```

To be merged once we are ready to publish the webview bundle.