### PR TITLE
Always create dynamic UI for returned content

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 91.24,
+  "branches": 91.4,
   "functions": 96.92,
-  "lines": 97.99,
-  "statements": 97.72
+  "lines": 98,
+  "statements": 97.73
 }

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 91.22,
+  "branches": 91.24,
   "functions": 96.92,
-  "lines": 97.94,
-  "statements": 97.67
+  "lines": 97.99,
+  "statements": 97.72
 }

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 91.17,
+  "branches": 91.22,
   "functions": 96.92,
-  "lines": 98,
-  "statements": 97.72
+  "lines": 97.94,
+  "statements": 97.67
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2347,6 +2347,60 @@ describe('SnapController', () => {
       snapController.destroy();
     });
 
+    it('throws if onTransaction return value is an invalid id', async () => {
+      const rootMessenger = getControllerMessenger();
+      const messenger = getSnapControllerMessenger(rootMessenger);
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(),
+          },
+        }),
+      );
+
+      const handlerResponse = { id: 'bar' };
+
+      rootMessenger.registerActionHandler(
+        'PermissionController:getPermissions',
+        () => ({
+          [SnapEndowments.TransactionInsight]: {
+            caveats: [{ type: SnapCaveatType.TransactionOrigin, value: false }],
+            date: 1664187844588,
+            id: 'izn0WGUO8cvq_jqvLQuQP',
+            invoker: MOCK_SNAP_ID,
+            parentCapability: SnapEndowments.TransactionInsight,
+          },
+        }),
+      );
+
+      rootMessenger.registerActionHandler(
+        'SubjectMetadataController:getSubjectMetadata',
+        () => MOCK_SNAP_SUBJECT_METADATA,
+      );
+
+      rootMessenger.registerActionHandler(
+        'ExecutionService:handleRpcRequest',
+        async () => Promise.resolve(handlerResponse),
+      );
+
+      await expect(
+        snapController.handleRequest({
+          snapId: MOCK_SNAP_ID,
+          origin: 'foo.com',
+          handler: HandlerType.OnTransaction,
+          request: {
+            jsonrpc: '2.0',
+            method: ' ',
+            params: {},
+            id: 1,
+          },
+        }),
+      ).rejects.toThrow("Interface with id 'bar' not found.");
+
+      snapController.destroy();
+    });
+
     it("doesn't throw if onTransaction return value is an id", async () => {
       const rootMessenger = getControllerMessenger();
       const messenger = getSnapControllerMessenger(rootMessenger);
@@ -2382,6 +2436,11 @@ describe('SnapController', () => {
       rootMessenger.registerActionHandler(
         'ExecutionService:handleRpcRequest',
         async () => Promise.resolve(handlerResponse),
+      );
+
+      rootMessenger.registerActionHandler(
+        'SnapInterfaceController:getInterface',
+        () => ({ snapId: MOCK_SNAP_ID, content: text('foo'), state: {} }),
       );
 
       const result = await snapController.handleRequest({
@@ -2517,6 +2576,60 @@ describe('SnapController', () => {
       ).rejects.toThrow(
         'Assertion failed: Expected the value to satisfy a union of `object | object`, but received: [object Object].',
       );
+
+      snapController.destroy();
+    });
+
+    it('throws if onSignature return value is an invalid id', async () => {
+      const rootMessenger = getControllerMessenger();
+      const messenger = getSnapControllerMessenger(rootMessenger);
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(),
+          },
+        }),
+      );
+
+      const handlerResponse = { id: 'bar' };
+
+      rootMessenger.registerActionHandler(
+        'PermissionController:getPermissions',
+        () => ({
+          [SnapEndowments.SignatureInsight]: {
+            caveats: [{ type: SnapCaveatType.SignatureOrigin, value: false }],
+            date: 1664187844588,
+            id: 'izn0WGUO8cvq_jqvLQuQP',
+            invoker: MOCK_SNAP_ID,
+            parentCapability: SnapEndowments.SignatureInsight,
+          },
+        }),
+      );
+
+      rootMessenger.registerActionHandler(
+        'SubjectMetadataController:getSubjectMetadata',
+        () => MOCK_SNAP_SUBJECT_METADATA,
+      );
+
+      rootMessenger.registerActionHandler(
+        'ExecutionService:handleRpcRequest',
+        async () => Promise.resolve(handlerResponse),
+      );
+
+      await expect(
+        snapController.handleRequest({
+          snapId: MOCK_SNAP_ID,
+          origin: 'foo.com',
+          handler: HandlerType.OnSignature,
+          request: {
+            jsonrpc: '2.0',
+            method: ' ',
+            params: {},
+            id: 1,
+          },
+        }),
+      ).rejects.toThrow("Interface with id 'bar' not found.");
 
       snapController.destroy();
     });
@@ -2738,6 +2851,60 @@ describe('SnapController', () => {
         },
       }),
     ).rejects.toThrow(`Invalid URL: The specified URL is not allowed.`);
+
+    snapController.destroy();
+  });
+
+  it('throws if onHomePage return value is an invalid id', async () => {
+    const rootMessenger = getControllerMessenger();
+    const messenger = getSnapControllerMessenger(rootMessenger);
+    const snapController = getSnapController(
+      getSnapControllerOptions({
+        messenger,
+        state: {
+          snaps: getPersistedSnapsState(),
+        },
+      }),
+    );
+
+    const handlerResponse = { id: 'bar' };
+
+    rootMessenger.registerActionHandler(
+      'PermissionController:getPermissions',
+      () => ({
+        [SnapEndowments.HomePage]: {
+          caveats: null,
+          date: 1664187844588,
+          id: 'izn0WGUO8cvq_jqvLQuQP',
+          invoker: MOCK_SNAP_ID,
+          parentCapability: SnapEndowments.HomePage,
+        },
+      }),
+    );
+
+    rootMessenger.registerActionHandler(
+      'SubjectMetadataController:getSubjectMetadata',
+      () => MOCK_SNAP_SUBJECT_METADATA,
+    );
+
+    rootMessenger.registerActionHandler(
+      'ExecutionService:handleRpcRequest',
+      async () => Promise.resolve(handlerResponse),
+    );
+
+    await expect(
+      snapController.handleRequest({
+        snapId: MOCK_SNAP_ID,
+        origin: 'foo.com',
+        handler: HandlerType.OnHomePage,
+        request: {
+          jsonrpc: '2.0',
+          method: ' ',
+          params: {},
+          id: 1,
+        },
+      }),
+    ).rejects.toThrow("Interface with id 'bar' not found.");
 
     snapController.destroy();
   });

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -75,6 +75,7 @@ import {
   MOCK_BLOCK_NUMBER,
   MOCK_DAPP_SUBJECT_METADATA,
   MOCK_DAPPS_RPC_ORIGINS_PERMISSION,
+  MOCK_INTERFACE_ID,
   MOCK_KEYRING_ORIGINS_PERMISSION,
   MOCK_LIFECYCLE_HOOKS_PERMISSION,
   MOCK_ORIGIN_PERMISSIONS,
@@ -2211,11 +2212,10 @@ describe('SnapController', () => {
       );
 
       rootMessenger.registerActionHandler(
-        'PhishingController:testOrigin',
-        () => ({
-          result: true,
-          type: 'fuzzy',
-        }),
+        'SnapInterfaceController:createInterface',
+        () => {
+          throw new Error('Invalid URL: The specified URL is not allowed.');
+        },
       );
 
       await expect(
@@ -2342,7 +2342,7 @@ describe('SnapController', () => {
         },
       });
 
-      expect(result).toBe(handlerResponse);
+      expect(result).toStrictEqual({ id: MOCK_INTERFACE_ID });
 
       snapController.destroy();
     });
@@ -2386,11 +2386,10 @@ describe('SnapController', () => {
       );
 
       rootMessenger.registerActionHandler(
-        'PhishingController:testOrigin',
-        () => ({
-          result: true,
-          type: 'fuzzy',
-        }),
+        'SnapInterfaceController:createInterface',
+        () => {
+          throw new Error('Invalid URL: The specified URL is not allowed.');
+        },
       );
 
       await expect(
@@ -2517,7 +2516,7 @@ describe('SnapController', () => {
         },
       });
 
-      expect(result).toBe(handlerResponse);
+      expect(result).toStrictEqual({ id: MOCK_INTERFACE_ID });
 
       snapController.destroy();
     });
@@ -2666,11 +2665,10 @@ describe('SnapController', () => {
     );
 
     rootMessenger.registerActionHandler(
-      'PhishingController:testOrigin',
-      () => ({
-        result: true,
-        type: 'fuzzy',
-      }),
+      'SnapInterfaceController:createInterface',
+      () => {
+        throw new Error('Invalid URL: The specified URL is not allowed.');
+      },
     );
 
     await expect(
@@ -2739,7 +2737,7 @@ describe('SnapController', () => {
       },
     });
 
-    expect(result).toBe(handlerResponse);
+    expect(result).toStrictEqual({ id: MOCK_INTERFACE_ID });
 
     snapController.destroy();
   });

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2347,6 +2347,60 @@ describe('SnapController', () => {
       snapController.destroy();
     });
 
+    it("doesn't throw if onTransaction return value is an id", async () => {
+      const rootMessenger = getControllerMessenger();
+      const messenger = getSnapControllerMessenger(rootMessenger);
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(),
+          },
+        }),
+      );
+
+      const handlerResponse = { id: 'bar' };
+
+      rootMessenger.registerActionHandler(
+        'PermissionController:getPermissions',
+        () => ({
+          [SnapEndowments.TransactionInsight]: {
+            caveats: [{ type: SnapCaveatType.TransactionOrigin, value: false }],
+            date: 1664187844588,
+            id: 'izn0WGUO8cvq_jqvLQuQP',
+            invoker: MOCK_SNAP_ID,
+            parentCapability: SnapEndowments.TransactionInsight,
+          },
+        }),
+      );
+
+      rootMessenger.registerActionHandler(
+        'SubjectMetadataController:getSubjectMetadata',
+        () => MOCK_SNAP_SUBJECT_METADATA,
+      );
+
+      rootMessenger.registerActionHandler(
+        'ExecutionService:handleRpcRequest',
+        async () => Promise.resolve(handlerResponse),
+      );
+
+      const result = await snapController.handleRequest({
+        snapId: MOCK_SNAP_ID,
+        origin: 'foo.com',
+        handler: HandlerType.OnTransaction,
+        request: {
+          jsonrpc: '2.0',
+          method: ' ',
+          params: {},
+          id: 1,
+        },
+      });
+
+      expect(result).toStrictEqual({ id: 'bar' });
+
+      snapController.destroy();
+    });
+
     it('throws if onSignature handler returns a phishing link', async () => {
       const rootMessenger = getControllerMessenger();
       const messenger = getSnapControllerMessenger(rootMessenger);

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2898,6 +2898,13 @@ export class SnapController extends BaseController<
     return rpcHandler;
   }
 
+  /**
+   * Create a dynamic interface in the SnapInterfaceController.
+   *
+   * @param snapId - The snap ID.
+   * @param content - The initial interface content.
+   * @returns An identifier that can be used to identify the interface.
+   */
   async #createInterface(snapId: SnapId, content: Component): Promise<string> {
     return this.messagingSystem.call(
       'SnapInterfaceController:createInterface',
@@ -2906,6 +2913,14 @@ export class SnapController extends BaseController<
     );
   }
 
+  /**
+   * Transform a RPC request result if necessary.
+   *
+   * @param snapId - The snap ID of the snap that produced the result.
+   * @param handlerType - The handler type that produced the result.
+   * @param result - The result.
+   * @returns The transformed result if applicable, otherwise the original result.
+   */
   async #transformSnapRpcRequestResult(
     snapId: SnapId,
     handlerType: HandlerType,

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2930,15 +2930,11 @@ export class SnapController extends BaseController<
       case HandlerType.OnTransaction:
       case HandlerType.OnSignature:
       case HandlerType.OnHomePage: {
-        if (result === null) {
-          return result;
-        }
-
         // Since this type has been asserted earlier we can cast
-        const castResult = result as Record<string, Json>;
+        const castResult = result as Record<string, Json> | null;
 
         // If a handler returns static content, we turn it into a dynamic UI
-        if (hasProperty(castResult, 'content')) {
+        if (castResult && hasProperty(castResult, 'content')) {
           const { content, ...rest } = castResult;
 
           const id = await this.#createInterface(snapId, content as Component);

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -9,7 +9,7 @@ import type {
 import { SubjectType } from '@metamask/permission-controller';
 import { providerErrors } from '@metamask/rpc-errors';
 import { WALLET_SNAP_PERMISSION_KEY } from '@metamask/snaps-rpc-methods';
-import type { SnapId } from '@metamask/snaps-sdk';
+import { text, type SnapId } from '@metamask/snaps-sdk';
 import { SnapCaveatType } from '@metamask/snaps-utils';
 import {
   MockControllerMessenger,
@@ -28,6 +28,7 @@ import type {
 import type {
   SnapInterfaceControllerActions,
   SnapInterfaceControllerAllowedActions,
+  StoredInterface,
 } from '../interface/SnapInterfaceController';
 import type {
   AllowedActions,
@@ -316,6 +317,16 @@ export const getControllerMessenger = (registry = new MockSnapsRegistry()) => {
     async () => MOCK_INTERFACE_ID,
   );
 
+  messenger.registerActionHandler(
+    'SnapInterfaceController:getInterface',
+    (snapId, id) => {
+      if (id !== MOCK_INTERFACE_ID) {
+        throw new Error(`Interface with id '${id}' not found.`);
+      }
+      return { snapId, content: text('foo bar'), state: {} } as StoredInterface;
+    },
+  );
+
   jest.spyOn(messenger, 'call');
 
   return messenger;
@@ -390,6 +401,7 @@ export const getSnapControllerMessenger = (
       'SnapController:getFile',
       'SnapsRegistry:resolveVersion',
       'SnapInterfaceController:createInterface',
+      'SnapInterfaceController:getInterface',
     ],
   });
 

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -102,6 +102,8 @@ export const approvalControllerMock = new MockApprovalController();
 
 export const snapDialogPermissionKey = 'snap_dialog';
 
+export const MOCK_INTERFACE_ID = 'QovlAsV2Z3xLP5hsrVMsz';
+
 export const MOCK_SNAP_SUBJECT_METADATA: SubjectMetadata = {
   origin: MOCK_SNAP_ID,
   subjectType: SubjectType.Snap,
@@ -310,14 +312,9 @@ export const getControllerMessenger = (registry = new MockSnapsRegistry()) => {
   );
 
   messenger.registerActionHandler(
-    'PhishingController:maybeUpdateState',
-    async () => Promise.resolve(),
+    'SnapInterfaceController:createInterface',
+    async () => MOCK_INTERFACE_ID,
   );
-
-  messenger.registerActionHandler('PhishingController:testOrigin', () => ({
-    result: false,
-    type: 'all',
-  }));
 
   jest.spyOn(messenger, 'call');
 
@@ -392,6 +389,7 @@ export const getSnapControllerMessenger = (
       'SnapController:revokeDynamicPermissions',
       'SnapController:getFile',
       'SnapsRegistry:resolveVersion',
+      'SnapInterfaceController:createInterface',
     ],
   });
 


### PR DESCRIPTION
This PR makes changes to always create dynamic UI for returned static content from handlers. It introduces a `transformSnapRpcRequestResult` function that can be used in the future for any transformation needed for snap results before returning them.

This removes the need for the `SnapController` to handle phishing detection and extended validation of the UI. The `SnapInterfaceController` now manages this for all handler types and inputs.

This PR also adds an assertion to check that returned interface ids are valid.