### PR TITLE
Export `ProxySnapExecutor`

### DIFF
--- a/packages/snaps-execution-environments/src/index.ts
+++ b/packages/snaps-execution-environments/src/index.ts
@@ -1,0 +1,1 @@
+export * from './proxy';

--- a/packages/snaps-execution-environments/src/proxy/index.ts
+++ b/packages/snaps-execution-environments/src/proxy/index.ts
@@ -1,0 +1,1 @@
+export * from './ProxySnapExecutor';


### PR DESCRIPTION
Export `ProxySnapExecutor` to be used in the extension for the offscreen MV3 implementation.