### PR TITLE
Reduce executor bundle sizes

### DIFF
--- a/packages/snaps-execution-environments/lavamoat/browserify/iframe/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/iframe/policy.json
@@ -39,29 +39,15 @@
     },
     "@metamask/providers": {
       "globals": {
-        "CustomEvent": true,
-        "Event": true,
-        "addEventListener": true,
-        "chrome.runtime.connect": true,
-        "console": true,
-        "dispatchEvent": true,
-        "document.createElement": true,
-        "document.readyState": true,
-        "ethereum": "write",
-        "location.hostname": true,
-        "removeEventListener": true,
-        "web3": true
+        "console": true
       },
       "packages": {
         "@metamask/json-rpc-engine": true,
         "@metamask/object-multiplex": true,
         "@metamask/providers>@metamask/safe-event-emitter": true,
-        "@metamask/providers>detect-browser": true,
-        "@metamask/providers>extension-port-stream": true,
         "@metamask/providers>is-stream": true,
         "@metamask/providers>json-rpc-middleware-stream": true,
         "@metamask/rpc-errors": true,
-        "@metamask/utils": true,
         "eslint>fast-deep-equal": true,
         "readable-stream": true
       }
@@ -72,37 +58,6 @@
       },
       "packages": {
         "browserify>events": true
-      }
-    },
-    "@metamask/providers>detect-browser": {
-      "globals": {
-        "document": true,
-        "navigator": true
-      },
-      "packages": {
-        "browserify>process": true
-      }
-    },
-    "@metamask/providers>extension-port-stream": {
-      "packages": {
-        "@metamask/providers>extension-port-stream>readable-stream": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/providers>extension-port-stream>readable-stream": {
-      "globals": {
-        "AbortController": true,
-        "AggregateError": true,
-        "Blob": true,
-        "new": true,
-        "target": true
-      },
-      "packages": {
-        "@metamask/providers>extension-port-stream>readable-stream>abort-controller": true,
-        "browserify>buffer": true,
-        "browserify>events": true,
-        "browserify>process": true,
-        "browserify>string_decoder": true
       }
     },
     "@metamask/providers>json-rpc-middleware-stream": {

--- a/packages/snaps-execution-environments/lavamoat/browserify/node-process/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/node-process/policy.json
@@ -46,29 +46,15 @@
     },
     "@metamask/providers": {
       "globals": {
-        "CustomEvent": true,
-        "Event": true,
-        "addEventListener": true,
-        "chrome.runtime.connect": true,
-        "console": true,
-        "dispatchEvent": true,
-        "document.createElement": true,
-        "document.readyState": true,
-        "ethereum": "write",
-        "location.hostname": true,
-        "removeEventListener": true,
-        "web3": true
+        "console": true
       },
       "packages": {
         "@metamask/json-rpc-engine": true,
         "@metamask/object-multiplex": true,
         "@metamask/providers>@metamask/safe-event-emitter": true,
-        "@metamask/providers>detect-browser": true,
-        "@metamask/providers>extension-port-stream": true,
         "@metamask/providers>is-stream": true,
         "@metamask/providers>json-rpc-middleware-stream": true,
         "@metamask/rpc-errors": true,
-        "@metamask/utils": true,
         "eslint>fast-deep-equal": true,
         "readable-stream": true
       }
@@ -82,59 +68,6 @@
       },
       "packages": {
         "events": true
-      }
-    },
-    "@metamask/providers>detect-browser": {
-      "globals": {
-        "document": true,
-        "navigator": true,
-        "process": true
-      }
-    },
-    "@metamask/providers>extension-port-stream": {
-      "builtin": {
-        "buffer.Buffer": true
-      },
-      "packages": {
-        "@metamask/providers>extension-port-stream>readable-stream": true,
-        "buffer": true
-      }
-    },
-    "@metamask/providers>extension-port-stream>readable-stream": {
-      "builtin": {
-        "buffer.Blob": true,
-        "buffer.Buffer": true,
-        "events.EventEmitter": true,
-        "stream": true,
-        "string_decoder.StringDecoder": true
-      },
-      "globals": {
-        "AbortController": true,
-        "AggregateError": true,
-        "Blob": true,
-        "new": true,
-        "process.env.READABLE_STREAM": true,
-        "target": true
-      },
-      "packages": {
-        "@metamask/providers>extension-port-stream>readable-stream>abort-controller": true,
-        "browserify>process": true,
-        "buffer": true,
-        "events": true,
-        "stream": true,
-        "string_decoder": true
-      }
-    },
-    "@metamask/providers>extension-port-stream>readable-stream>abort-controller": {
-      "packages": {
-        "@metamask/providers>extension-port-stream>readable-stream>abort-controller>event-target-shim": true
-      }
-    },
-    "@metamask/providers>extension-port-stream>readable-stream>abort-controller>event-target-shim": {
-      "globals": {
-        "Event": true,
-        "EventTarget": true,
-        "console": true
       }
     },
     "@metamask/providers>json-rpc-middleware-stream": {
@@ -240,11 +173,6 @@
       },
       "packages": {
         "util": true
-      }
-    },
-    "browserify>process": {
-      "globals": {
-        "process": true
       }
     },
     "browserify>string_decoder": {

--- a/packages/snaps-execution-environments/lavamoat/browserify/node-thread/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/node-thread/policy.json
@@ -46,29 +46,15 @@
     },
     "@metamask/providers": {
       "globals": {
-        "CustomEvent": true,
-        "Event": true,
-        "addEventListener": true,
-        "chrome.runtime.connect": true,
-        "console": true,
-        "dispatchEvent": true,
-        "document.createElement": true,
-        "document.readyState": true,
-        "ethereum": "write",
-        "location.hostname": true,
-        "removeEventListener": true,
-        "web3": true
+        "console": true
       },
       "packages": {
         "@metamask/json-rpc-engine": true,
         "@metamask/object-multiplex": true,
         "@metamask/providers>@metamask/safe-event-emitter": true,
-        "@metamask/providers>detect-browser": true,
-        "@metamask/providers>extension-port-stream": true,
         "@metamask/providers>is-stream": true,
         "@metamask/providers>json-rpc-middleware-stream": true,
         "@metamask/rpc-errors": true,
-        "@metamask/utils": true,
         "eslint>fast-deep-equal": true,
         "readable-stream": true
       }
@@ -82,59 +68,6 @@
       },
       "packages": {
         "events": true
-      }
-    },
-    "@metamask/providers>detect-browser": {
-      "globals": {
-        "document": true,
-        "navigator": true,
-        "process": true
-      }
-    },
-    "@metamask/providers>extension-port-stream": {
-      "builtin": {
-        "buffer.Buffer": true
-      },
-      "packages": {
-        "@metamask/providers>extension-port-stream>readable-stream": true,
-        "buffer": true
-      }
-    },
-    "@metamask/providers>extension-port-stream>readable-stream": {
-      "builtin": {
-        "buffer.Blob": true,
-        "buffer.Buffer": true,
-        "events.EventEmitter": true,
-        "stream": true,
-        "string_decoder.StringDecoder": true
-      },
-      "globals": {
-        "AbortController": true,
-        "AggregateError": true,
-        "Blob": true,
-        "new": true,
-        "process.env.READABLE_STREAM": true,
-        "target": true
-      },
-      "packages": {
-        "@metamask/providers>extension-port-stream>readable-stream>abort-controller": true,
-        "browserify>process": true,
-        "buffer": true,
-        "events": true,
-        "stream": true,
-        "string_decoder": true
-      }
-    },
-    "@metamask/providers>extension-port-stream>readable-stream>abort-controller": {
-      "packages": {
-        "@metamask/providers>extension-port-stream>readable-stream>abort-controller>event-target-shim": true
-      }
-    },
-    "@metamask/providers>extension-port-stream>readable-stream>abort-controller>event-target-shim": {
-      "globals": {
-        "Event": true,
-        "EventTarget": true,
-        "console": true
       }
     },
     "@metamask/providers>json-rpc-middleware-stream": {
@@ -240,11 +173,6 @@
       },
       "packages": {
         "util": true
-      }
-    },
-    "browserify>process": {
-      "globals": {
-        "process": true
       }
     },
     "browserify>string_decoder": {

--- a/packages/snaps-execution-environments/lavamoat/browserify/worker-executor/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/worker-executor/policy.json
@@ -39,29 +39,15 @@
     },
     "@metamask/providers": {
       "globals": {
-        "CustomEvent": true,
-        "Event": true,
-        "addEventListener": true,
-        "chrome.runtime.connect": true,
-        "console": true,
-        "dispatchEvent": true,
-        "document.createElement": true,
-        "document.readyState": true,
-        "ethereum": "write",
-        "location.hostname": true,
-        "removeEventListener": true,
-        "web3": true
+        "console": true
       },
       "packages": {
         "@metamask/json-rpc-engine": true,
         "@metamask/object-multiplex": true,
         "@metamask/providers>@metamask/safe-event-emitter": true,
-        "@metamask/providers>detect-browser": true,
-        "@metamask/providers>extension-port-stream": true,
         "@metamask/providers>is-stream": true,
         "@metamask/providers>json-rpc-middleware-stream": true,
         "@metamask/rpc-errors": true,
-        "@metamask/utils": true,
         "eslint>fast-deep-equal": true,
         "readable-stream": true
       }
@@ -72,37 +58,6 @@
       },
       "packages": {
         "browserify>events": true
-      }
-    },
-    "@metamask/providers>detect-browser": {
-      "globals": {
-        "document": true,
-        "navigator": true
-      },
-      "packages": {
-        "browserify>process": true
-      }
-    },
-    "@metamask/providers>extension-port-stream": {
-      "packages": {
-        "@metamask/providers>extension-port-stream>readable-stream": true,
-        "browserify>buffer": true
-      }
-    },
-    "@metamask/providers>extension-port-stream>readable-stream": {
-      "globals": {
-        "AbortController": true,
-        "AggregateError": true,
-        "Blob": true,
-        "new": true,
-        "target": true
-      },
-      "packages": {
-        "@metamask/providers>extension-port-stream>readable-stream>abort-controller": true,
-        "browserify>buffer": true,
-        "browserify>events": true,
-        "browserify>process": true,
-        "browserify>string_decoder": true
       }
     },
     "@metamask/providers>json-rpc-middleware-stream": {

--- a/packages/snaps-execution-environments/lavamoat/build-system/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/build-system/policy.json
@@ -1101,6 +1101,47 @@
         "@metamask/object-multiplex>once>wrappy": true
       }
     },
+    "@metamask/utils": {
+      "globals": {
+        "Buffer": true,
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/utils>@noble/hashes": true,
+        "@metamask/utils>@scure/base": true,
+        "@metamask/utils>pony-cause": true,
+        "@swc/cli>semver": true,
+        "eslint>debug": true,
+        "superstruct": true
+      }
+    },
+    "@metamask/utils>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@metamask/utils>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "@swc/cli>semver": {
+      "globals": {
+        "console.error": true,
+        "process": true
+      },
+      "packages": {
+        "@swc/cli>semver>lru-cache": true
+      }
+    },
+    "@swc/cli>semver>lru-cache": {
+      "packages": {
+        "@swc/cli>semver>lru-cache>yallist": true
+      }
+    },
     "@wdio/mocha-framework>mocha>supports-color": {
       "builtin": {
         "os.release": true,
@@ -2274,6 +2315,12 @@
     "readable-stream>util-deprecate": {
       "builtin": {
         "util.deprecate": true
+      }
+    },
+    "superstruct": {
+      "globals": {
+        "console.warn": true,
+        "define": true
       }
     },
     "terser": {

--- a/packages/snaps-execution-environments/scripts/build.js
+++ b/packages/snaps-execution-environments/scripts/build.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console, n/global-require */
+const { stringToBytes } = require('@metamask/utils');
 const {
   createResolvePath,
 } = require('babel-plugin-tsconfig-paths-module-resolver');
@@ -216,7 +217,11 @@ async function main() {
         await fs.writeFile(htmlPath, htmlFile);
       }
 
-      console.log('Finished', key);
+      const outputBytes = stringToBytes(outputBundle);
+
+      const outputSizeInKb = Math.round(outputBytes.byteLength / 1000);
+
+      console.log('Finished', key, `(${outputSizeInKb} KB)`);
       return buffer;
     }),
   );

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -1,8 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference path="../../../../node_modules/ses/types.d.ts" />
 import { createIdRemapMiddleware } from '@metamask/json-rpc-engine';
-import { StreamProvider } from '@metamask/providers';
 import type { RequestArguments } from '@metamask/providers/dist/BaseProvider';
+import { StreamProvider } from '@metamask/providers/dist/StreamProvider';
 import { errorCodes, rpcErrors, serializeError } from '@metamask/rpc-errors';
 import type { SnapsProvider } from '@metamask/snaps-sdk';
 import { getErrorData } from '@metamask/snaps-sdk';


### PR DESCRIPTION
Reduce executor bundle sizes by tweaking a `@metamask/providers` import.

Before:
```
Finished node-thread (933 KB)
Finished node-process (933 KB)
Finished iframe (491 KB)
Finished worker-executor (945 KB)
Finished worker-pool (320 KB)
```

After:
```
Finished node-thread (816 KB)
Finished node-process (816 KB)
Finished iframe (383 KB)
Finished worker-executor (837 KB)
Finished worker-pool (320 KB)
```

Strips about 100 KB of unused code from the bundle.