### PR TITLE
Add union validation utils

### DIFF
--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 96.05,
-  "functions": 98.56,
-  "lines": 98.65,
-  "statements": 94.13
+  "branches": 96.07,
+  "functions": 98.58,
+  "lines": 98.67,
+  "statements": 94.22
 }

--- a/packages/snaps-utils/src/structs.test.ts
+++ b/packages/snaps-utils/src/structs.test.ts
@@ -26,6 +26,7 @@ import {
   getStructFromPath,
   getUnionStructNames,
   named,
+  validateUnion,
 } from './structs';
 
 /**
@@ -297,6 +298,50 @@ describe('getStructErrorMessage', () => {
 
     expect(getStructErrorMessage(struct, error.failures())).toBe(
       messages.map((message) => `  • ${message}`).join('\n'),
+    );
+  });
+});
+
+describe('validateUnion', () => {
+  it('throws a readable error if the type does not satisfy any of the expected types', () => {
+    const FooStruct = object({
+      type: literal('a'),
+      value: string(),
+    });
+
+    const BarStruct = object({
+      type: literal('b'),
+      value: number(),
+    });
+
+    const Union = union([FooStruct, BarStruct]);
+    expect(() =>
+      validateUnion({ type: 'c', value: 42 }, Union, 'type'),
+    ).toThrow(
+      `At path: ${bold('type')} — Expected the value to be one of: ${green(
+        '"a"',
+      )}, ${green('"b"')}, but received: ${red('"c"')}.`,
+    );
+  });
+
+  it('throws a readable error if the value does not satisfy the union type', () => {
+    const FooStruct = object({
+      type: literal('a'),
+      value: string(),
+    });
+
+    const BarStruct = object({
+      type: literal('b'),
+      value: number(),
+    });
+
+    const Union = union([FooStruct, BarStruct]);
+    expect(() =>
+      validateUnion({ type: 'a', value: 42 }, Union, 'type'),
+    ).toThrow(
+      `At path: ${bold('value')} — Expected a value of type ${green(
+        'string',
+      )}, but received: ${red('42')}.`,
     );
   });
 });

--- a/packages/snaps-utils/src/structs.ts
+++ b/packages/snaps-utils/src/structs.ts
@@ -1,8 +1,19 @@
-import { isObject } from '@metamask/utils';
+import { union } from '@metamask/snaps-sdk';
+import type { NonEmptyArray } from '@metamask/utils';
+import { assert, isObject } from '@metamask/utils';
 import { bold, green, red } from 'chalk';
 import { resolve } from 'path';
 import type { Failure } from 'superstruct';
-import { Struct, StructError, create, string, coerce } from 'superstruct';
+import {
+  is,
+  validate,
+  type as superstructType,
+  Struct,
+  StructError,
+  create,
+  string,
+  coerce,
+} from 'superstruct';
 import type { AnyStruct } from 'superstruct/dist/utils';
 
 import { indent } from './strings';
@@ -207,7 +218,7 @@ export function getUnionStructNames<Type, Schema>(
 }
 
 /**
- * Get a error prefix from a `superstruct` failure. This is useful for
+ * Get an error prefix from a `superstruct` failure. This is useful for
  * formatting the error message returned by `superstruct`.
  *
  * @param failure - The `superstruct` failure.
@@ -288,4 +299,69 @@ export function getStructErrorMessage<Type, Schema>(
   );
 
   return formattedFailures.join('\n');
+}
+
+/**
+ * Validate a union struct, and throw readable errors if the value does not
+ * satisfy the struct. This is useful for improving the error messages returned
+ * by `superstruct`.
+ *
+ * @param value - The value to validate.
+ * @param struct - The `superstruct` union struct to validate the value against.
+ * This struct must be a union of object structs, and must have at least one
+ * shared key to validate against.
+ * @param structKey - The key to validate against. This key must be present in
+ * all the object structs in the union struct, and is expected to be a literal
+ * value.
+ * @throws If the value does not satisfy the struct.
+ * @example
+ * const struct = union([
+ *   object({ type: literal('a'), value: string() }),
+ *   object({ type: literal('b'), value: number() }),
+ *   object({ type: literal('c'), value: boolean() }),
+ *   // ...
+ * ]);
+ *
+ * // At path: type — Expected the value to be one of: "a", "b", "c", but received: "d".
+ * validateUnion({ type: 'd', value: 'foo' }, struct, 'type');
+ *
+ * // At path: value — Expected a value of type string, but received: 42.
+ * validateUnion({ type: 'a', value: 42 }, struct, 'value');
+ */
+export function validateUnion<Type, Schema extends readonly Struct<any, any>[]>(
+  value: unknown,
+  struct: Struct<Type, Schema>,
+  structKey: keyof Type,
+) {
+  assert(struct.schema.length > 0, 'Expected a non-empty array of structs.');
+
+  const keyUnion = struct.schema.map(
+    (innerStruct) => innerStruct.schema[structKey],
+    // This is guaranteed to be a non-empty array by the assertion above. We
+    // need to cast it since `superstruct` requires a non-empty array of structs
+    // for the `union` struct.
+  ) as NonEmptyArray<Struct>;
+
+  const key = superstructType({
+    [structKey]: union(keyUnion),
+  });
+
+  const [keyError] = validate(value, key);
+  if (keyError) {
+    throw new Error(getStructFailureMessage(key, keyError.failures()[0]));
+  }
+
+  // At this point it's guaranteed that the value is an object, so we can safely
+  // cast it to a Record.
+  const objectValue = value as Record<PropertyKey, unknown>;
+  const objectStruct = struct.schema.find((innerStruct) =>
+    is(objectValue[structKey], innerStruct.schema[structKey]),
+  );
+
+  assert(objectStruct, 'Expected a struct to match the value.');
+
+  const [error] = validate(objectValue, objectStruct);
+  if (error) {
+    throw new Error(getStructFailureMessage(objectStruct, error.failures()[0]));
+  }
 }


### PR DESCRIPTION
This adds a `validateUnion` function, which can validate a union of objects (with at least one common property), and throw readable errors if validation fails.

For example, using the following structs:

```ts
const FooStruct = object({
  type: literal('a'),
  value: string(),
});

const BarStruct = object({
  type: literal('b'),
  value: number(),
});

const Union = union([FooStruct, BarStruct]);
```

We can use the `validateUnion` function with `type` as common property:

```ts
validateUnion(value, Union, 'type');
```

If the provided value does not have a valid type (i.e., it doesn't satisfy any of the objects in the union), the function throws:

> Error: At path: type — Expected the value to be one of: "a", "b", but received: "c".

If the type matches, but not the value (`{ type: 'b', value: 'foo' }`), the function throws:

> Error: At path: value -- Expected a number, but received: "foo".