### PR TITLE
Add union creation util

### DIFF
--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 96.07,
-  "functions": 98.58,
+  "branches": 96.09,
+  "functions": 98.59,
   "lines": 98.67,
-  "statements": 94.22
+  "statements": 94.23
 }


### PR DESCRIPTION
This adds a `createUnion` which is a wrapper of the function introduced in #2161, but returns the (coerced) value after validation.