### PR TITLE
Run cronjob example snap more often

### DIFF
--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "MlAIIlAjNj2pspgKe/SqU8UCoBJFbkhXxenNkP4hdpg=",
+    "shasum": "kTWgOF2hrQWTP3rRpgI2Zz7yiRPAUErzJoqbwPmQTd4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -21,7 +21,7 @@
     "endowment:cronjob": {
       "jobs": [
         {
-          "expression": "* * * * *",
+          "expression": "*/10 * * * * *",
           "request": {
             "method": "execute"
           }


### PR DESCRIPTION
Tweak cronjob example expression to run every 10 seconds, this makes testing it easier.