### PR TITLE
BREAKING: Disable source maps by default

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "WgSLbPzGSZkK+B2S/8JDBqt2UYlHZbSalplae2VbdAU=",
+    "shasum": "QSFl2gMVYB8vpB/cFlnXCNNi/d9FrYNP4rLOqNY6dMA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0AnxNHJv+JDG2ywdkfjtebHurhs9szsA6fykK1QNX2A=",
+    "shasum": "YJ3L2U/8vVAxhVma0Up4vCHRHCFWmJbVtZTgLrwUsEQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Tb65zln6DKNEwqgi30mB4M2UDBJdGhstKMqR/pEod+w=",
+    "shasum": "sv2nA4ghSNtJ/X+v5a0mseevW4supBSv1lW2ifgRr7I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "YYRsqVZi2Q1/qgdKebTwWYWQXoC97RnYJgxcixOYz7M=",
+    "shasum": "FyyIi50ZciVywbt+Mqq6uXeFGyrvmVxZoZ7PcEJ4HN0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "jmzjCN+L9MbXcd0wy8e/juwDpBZ6XLKwC+GpmMZw4LQ=",
+    "shasum": "6C/WHL3tog2KCybrsAn8kKs6ff/jpGs98YqiSRmyIq0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/errors/snap.manifest.json
+++ b/packages/examples/packages/errors/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+6PhrMOx+8qLUUig1UT6/uxr0tJcPLaCQ5zoQMHe+q8=",
+    "shasum": "yHYVhtnHm6SonjnHmOYISrwKrySimS7p+jOISJsIi90=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TMte8f7dN2rhK1QyGXC7SKz/Fe6U2y8KC0wmKPmnSII=",
+    "shasum": "iPSKLAHha7slKXycULWDEFukdnsUN44svh54UwN+PfI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "U8pyyFDJ3FfrYOUUG1KNwk4217xEm5P3I2Ar6R+OroM=",
+    "shasum": "WzJz80aWrAaRVDxBO3QuijwxlNfSBXaCsuSX2NzYw3U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7xElwRFNyXALD88h3C+/6DRekclQioHGStdxzqtexNY=",
+    "shasum": "IwH0dVg5Nj35EMSblUIZk+5JTyEVS+18LozwqMFd3vk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8Suc0upE1mK08r149VCYwu05mUwjwty/J14CNQOdqjI=",
+    "shasum": "O7/2QbXLnB1Y6Mwhd41qldPQWu8LugZHZQfiDg2YDk8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4XKIW+XQSrMNm4U4W8+CRk6Ob8mgnlz/1T40p0Y44YM=",
+    "shasum": "RABZLQsVw++ceVWu6WziPyyZWfLA/dkskOLGSG0Wrbk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "dCR5BCzxO9O+DdsajrXPa3nR0Wv7dsgUpXATuc0TyMg=",
+    "shasum": "9I+SLSNIzCFxIKAGMAQbQuUeSJNkPJc4mGmc25rLqo8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "nTpuyYRQ59S1Rm0AlhQymT+9kqMpDw8EbHnTqfinAvY=",
+    "shasum": "rOixy+uQEfnU0AfVmJi1dY2R7laPP/VKaYJFlo0txzE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Xctk2Kavq+W2+UjQZh5+eJHvyQldCQSGbGOs11DZjvk=",
+    "shasum": "BgiCbLwBUImrUY2jRtApDdP/8uVw7dfOp9uvVwxNON0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "QT9PTo6Qid2RAhG17Mk60tREkYWrH6xxLHEbUoI27VM=",
+    "shasum": "GSs2zxpSeeiUs0w3uuYS7b3K5eEuqyDN3mpXO7BNOsc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "UGYoI4aJxfURdL5XxjYCXiNDMB/w8xonQxGssEVWWls=",
+    "shasum": "n5mn1SsXj1hVgOc0weMmwEMVEStLYYu/pfAhMGIbF7w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "d76t6g00IJtcwQh/d6nHhp+hvK3SPDG1u55kb6Y/aQ0=",
+    "shasum": "2IJ+Uy5UALEDdYa57oi024k13H4Jn1YsR+fH5SUQATM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ypASfjRo21yfPon+thYpb5Ue+PXmrHiGW3HVFl4GD/E=",
+    "shasum": "UYM2R0zuW24ODQjTqnm+H+K6p3g/ae+Ml2EbyY5//Ok=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/name-lookup/snap.manifest.json
+++ b/packages/examples/packages/name-lookup/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "mnFLBYHzMpTmIdjvtO3JHGmecaqtcb4g/Tnz7VI7zV8=",
+    "shasum": "Ktg7ShpCp9QqnCzHa5GupDI8jlVJ4ZuMu5t8wsJnv2Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "WLRWcACt5POpPzzWLolnGmGLXkvB62K7tJHFAcxBrwc=",
+    "shasum": "tC8AzqPr6zKC9Zig+rOiKtN1foI1B9IWL7C/oPHMhAE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZN+z+9ZSFTok4R18mSx4I7pCwDVWWNGqJMX0t8vucRk=",
+    "shasum": "cp3fETtiBBloowVov0avNIkEq2zxQnyGq1ddqKfgjf4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5j6fnOtQLHXloXgqrlJzhqcbYu/QjbapTStxPNhyymQ=",
+    "shasum": "WAdPaw8Bhb7PoPru3P/wGmOBLAxWvKr8Dj3l9eqvIx4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "WAdPaw8Bhb7PoPru3P/wGmOBLAxWvKr8Dj3l9eqvIx4=",
+    "shasum": "5j6fnOtQLHXloXgqrlJzhqcbYu/QjbapTStxPNhyymQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AZ+z3h0cgmPyhUMqRcpcSrE45zE5qmyBf/DPbMave2I=",
+    "shasum": "LL77fwso1t8iWYHwl9iB6wAShC5FdrasenGxEfH7X2U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "s9SIn1ntTRZCkBEzQXrPk5GbHdBKXDtBdo10V/XLnWE=",
+    "shasum": "avAfBrcz61u72O627FXzvoEcUNvzm0BQuPSr01R0tBk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "V5yGxj/OvkdAjHz6MN0ardR3Sbf1A4OEEPrLbB/N8v4=",
+    "shasum": "wnkrJ/PwH+MZlRboaJaJ91TTr2/7tJ+X40HbErUMqYY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-cli/src/commands/build/implementation.test.ts
+++ b/packages/snaps-cli/src/commands/build/implementation.test.ts
@@ -118,10 +118,9 @@ describe('build', () => {
     );
 
     const output = await fs.readFile('/snap/output.js', 'utf8');
-    expect(output).toMatchInlineSnapshot(`
-      "(()=>{var e={67:e=>{e.exports.onRpcRequest=({request:e})=>{console.log("Hello, world!");const{method:r,id:o}=e;return r+o}}},r={};var o=function o(t){var s=r[t];if(void 0!==s)return s.exports;var n=r[t]={exports:{}};return e[t](n,n.exports,o),n.exports}(67),t=exports;for(var s in o)t[s]=o[s];o.__esModule&&Object.defineProperty(t,"__esModule",{value:!0})})();
-      //# sourceMappingURL=output.js.map"
-    `);
+    expect(output).toMatchInlineSnapshot(
+      `"(()=>{var e={67:e=>{e.exports.onRpcRequest=({request:e})=>{console.log("Hello, world!");const{method:r,id:o}=e;return r+o}}},r={};var o=function o(t){var s=r[t];if(void 0!==s)return s.exports;var n=r[t]={exports:{}};return e[t](n,n.exports,o),n.exports}(67),t=exports;for(var s in o)t[s]=o[s];o.__esModule&&Object.defineProperty(t,"__esModule",{value:!0})})();"`,
+    );
   });
 
   it('builds an unminimized snap bundle using Webpack', async () => {
@@ -186,8 +185,7 @@ describe('build', () => {
         if (__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, "__esModule", {
           value: true
         });
-      })();
-      //# sourceMappingURL=output.js.map"
+      })();"
     `);
   });
 

--- a/packages/snaps-cli/src/config.ts
+++ b/packages/snaps-cli/src/config.ts
@@ -532,7 +532,7 @@ const SnapsWebpackCustomizeWebpackConfigFunctionStruct =
 export const SnapsWebpackConfigStruct = object({
   bundler: literal('webpack'),
   input: defaulted(file(), resolve(process.cwd(), 'src/index.js')),
-  sourceMap: defaulted(union([boolean(), literal('inline')]), true),
+  sourceMap: defaulted(union([boolean(), literal('inline')]), false),
   evaluate: defaulted(boolean(), true),
 
   output: defaulted(

--- a/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
+++ b/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`getDefaultConfiguration returns the default Webpack configuration for the given CLI config 1`] = `
 {
-  "devtool": "source-map",
+  "devtool": false,
   "entry": "/foo/bar/src/index.js",
   "infrastructureLogging": {
     "level": "none",
@@ -27,7 +27,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "module": {
               "type": "commonjs",
             },
-            "sourceMaps": true,
+            "sourceMaps": false,
             "sync": false,
           },
         },
@@ -143,7 +143,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 
 exports[`getDefaultConfiguration returns the default Webpack configuration for the given CLI config 2`] = `
 {
-  "devtool": "source-map",
+  "devtool": false,
   "entry": "/foo/bar/src/index.ts",
   "infrastructureLogging": {
     "level": "none",
@@ -168,7 +168,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "module": {
               "type": "commonjs",
             },
-            "sourceMaps": true,
+            "sourceMaps": false,
             "sync": false,
           },
         },
@@ -558,7 +558,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 
 exports[`getDefaultConfiguration returns the default Webpack configuration for the given CLI config 5`] = `
 {
-  "devtool": "source-map",
+  "devtool": false,
   "entry": "/foo/bar/src/index.js",
   "infrastructureLogging": {
     "level": "none",
@@ -583,7 +583,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "module": {
               "type": "commonjs",
             },
-            "sourceMaps": true,
+            "sourceMaps": false,
             "sync": false,
           },
         },
@@ -704,7 +704,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 
 exports[`getDefaultConfiguration returns the default Webpack configuration for the given CLI config 6`] = `
 {
-  "devtool": "source-map",
+  "devtool": false,
   "entry": "/foo/bar/src/index.js",
   "infrastructureLogging": {
     "level": "none",
@@ -729,7 +729,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "module": {
               "type": "commonjs",
             },
-            "sourceMaps": true,
+            "sourceMaps": false,
             "sync": false,
           },
         },
@@ -845,7 +845,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 
 exports[`getDefaultConfiguration returns the default Webpack configuration for the given CLI config 7`] = `
 {
-  "devtool": "source-map",
+  "devtool": false,
   "entry": "/foo/bar/src/index.js",
   "infrastructureLogging": {
     "level": "none",
@@ -870,7 +870,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "module": {
               "type": "commonjs",
             },
-            "sourceMaps": true,
+            "sourceMaps": false,
             "sync": false,
           },
         },
@@ -986,7 +986,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 
 exports[`getDefaultConfiguration returns the default Webpack configuration for the given CLI config 8`] = `
 {
-  "devtool": "source-map",
+  "devtool": false,
   "entry": "/foo/bar/src/index.js",
   "infrastructureLogging": {
     "level": "none",
@@ -1011,7 +1011,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "module": {
               "type": "commonjs",
             },
-            "sourceMaps": true,
+            "sourceMaps": false,
             "sync": false,
           },
         },
@@ -1135,7 +1135,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 
 exports[`getDefaultConfiguration returns the default Webpack configuration for the given CLI config 9`] = `
 {
-  "devtool": "source-map",
+  "devtool": false,
   "entry": "/foo/bar/src/index.js",
   "infrastructureLogging": {
     "level": "none",
@@ -1160,7 +1160,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "module": {
               "type": "commonjs",
             },
-            "sourceMaps": true,
+            "sourceMaps": false,
             "sync": false,
           },
         },
@@ -1284,7 +1284,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 
 exports[`getDefaultConfiguration returns the default Webpack configuration for the given CLI config and options 1`] = `
 {
-  "devtool": "source-map",
+  "devtool": false,
   "entry": "/foo/bar/src/index.ts",
   "infrastructureLogging": {
     "level": "none",
@@ -1309,7 +1309,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "module": {
               "type": "commonjs",
             },
-            "sourceMaps": true,
+            "sourceMaps": false,
             "sync": false,
           },
         },
@@ -1434,7 +1434,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 
 exports[`getDefaultConfiguration returns the default Webpack configuration for the given CLI config and options 2`] = `
 {
-  "devtool": "source-map",
+  "devtool": false,
   "entry": "/foo/bar/src/index.ts",
   "infrastructureLogging": {
     "level": "none",
@@ -1459,7 +1459,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "module": {
               "type": "commonjs",
             },
-            "sourceMaps": true,
+            "sourceMaps": false,
             "sync": false,
           },
         },
@@ -1575,7 +1575,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 
 exports[`getDefaultConfiguration returns the default Webpack configuration for the given CLI config and options 3`] = `
 {
-  "devtool": "source-map",
+  "devtool": false,
   "entry": "/foo/bar/src/index.ts",
   "infrastructureLogging": {
     "level": "none",
@@ -1600,7 +1600,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "module": {
               "type": "commonjs",
             },
-            "sourceMaps": true,
+            "sourceMaps": false,
             "sync": false,
           },
         },
@@ -1716,7 +1716,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 
 exports[`getDefaultConfiguration returns the default Webpack configuration for the given CLI config and options 4`] = `
 {
-  "devtool": "source-map",
+  "devtool": false,
   "entry": "/foo/bar/src/index.ts",
   "infrastructureLogging": {
     "level": "none",
@@ -1741,7 +1741,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "module": {
               "type": "commonjs",
             },
-            "sourceMaps": true,
+            "sourceMaps": false,
             "sync": false,
           },
         },
@@ -1866,7 +1866,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 
 exports[`getDefaultConfiguration returns the default Webpack configuration for the given CLI config and options 5`] = `
 {
-  "devtool": "source-map",
+  "devtool": false,
   "entry": "/foo/bar/src/index.ts",
   "infrastructureLogging": {
     "level": "none",
@@ -1891,7 +1891,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
             "module": {
               "type": "commonjs",
             },
-            "sourceMaps": true,
+            "sourceMaps": false,
             "sync": false,
           },
         },


### PR DESCRIPTION
Disables source maps by default in the CLI, speeding up the build process for devs that don't need source maps (most currently do not with snaps).