### PR TITLE
Fix error message for invalid sizes

### DIFF
--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 96.17,
+  "branches": 96.19,
   "functions": 98.61,
   "lines": 98.69,
-  "statements": 94.3
+  "statements": 94.32
 }

--- a/packages/snaps-utils/src/structs.test.ts
+++ b/packages/snaps-utils/src/structs.test.ts
@@ -3,6 +3,7 @@ import { assert } from '@metamask/utils';
 import { bold, green, red } from 'chalk';
 import type { Struct } from 'superstruct';
 import superstruct, {
+  size,
   create,
   defaulted,
   is,
@@ -275,6 +276,24 @@ describe('getStructFailureMessage', () => {
       `Expected the value to be \`${green('"bar"')}\`, but received: ${red(
         '"foo"',
       )}.`,
+    );
+  });
+
+  it('returns a readable error for a string with the wrong size', () => {
+    const error = getStructError('', size(string(), 1, 5));
+    expect(getStructFailureMessage(size(string(), 1, 5), error)).toBe(
+      `Expected a string with a length between ${green('1')} and ${green(
+        '5',
+      )}, but received one with a length of ${red('0')}.`,
+    );
+  });
+
+  it('returns a readable error for an array with the wrong size', () => {
+    const error = getStructError([], size(array(), 1, 5));
+    expect(getStructFailureMessage(size(array(), 1, 5), error)).toBe(
+      `Expected an array with a length between ${green('1')} and ${green(
+        '5',
+      )}, but received one with a length of ${red('0')}.`,
     );
   });
 

--- a/packages/snaps-utils/src/structs.ts
+++ b/packages/snaps-utils/src/structs.ts
@@ -324,6 +324,22 @@ export function getStructFailureMessage<Type, Schema>(
     )}, received: ${received}.`;
   }
 
+  if (failure.refinement === 'size') {
+    const message = failure.message
+      .replace(
+        /length between `(\d+)` and `(\d+)`/u,
+        `length between ${color('$1', green, colorize)} and ${color(
+          '$2',
+          green,
+          colorize,
+        )},`,
+      )
+      .replace(/length of `(\d+)`/u, `length of ${color('$1', red, colorize)}`)
+      .replace(/a array/u, 'an array');
+
+    return `${prefix}${message}.`;
+  }
+
   return `${prefix}Expected a value of type ${color(
     failure.type,
     green,


### PR DESCRIPTION
`getStructFailureMessage` was previously returning confusing error messages for errors related to invalid sizes. This adds proper support for these messages.