### PR TITLE
fix(types): ensure types can be found when importer makes use of package.json's `exports` field

### DIFF
--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -10,7 +10,8 @@
     ".": {
       "browser": {
         "import": "./dist/esm/index.browser.js",
-        "require": "./dist/cjs/index.browser.js"
+        "require": "./dist/cjs/index.browser.js",
+        "types": "./dist/types/index.d.ts"
       },
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -13,7 +13,8 @@
         "require": "./dist/cjs/index.browser.js"
       },
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
     },
     "./test-utils": {
       "import": "./dist/esm/test-utils/index.js",


### PR DESCRIPTION
> the field [`typesVersions`] is not read in situations when [package.json "exports"](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports) are read

https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-typesversions