### PR TITLE
Optimise CLI Webpack configuration

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZjO2/vyI+gsEEsIWrloT+RXRpDiu90IJh8zk/geewkw=",
+    "shasum": "ALkwbuS0MFVTbJB0zQXPRdDmyis8TAfZayoVY0dDAow=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "JfQKetc6BTHCZdqd2yeKoJZvMG3qq51ATyr1B3A2Ni8=",
+    "shasum": "ivu8DqblrnqDucyKZQRFKcsT6uc7Vw+DsQJRJgIXn9Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "yWT12MR3BSCI14HKXyFQGp6RhG9s1hMgIRZiJCARYkc=",
+    "shasum": "nJN72lSBRDfROObGpijTtKtZjRSoWSTgbdo6/CScl1I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "IiaQ+vlnHF0JYKKVGd4/kMG+T50Dm7lCcrw2sDKftfQ=",
+    "shasum": "xBvDzo5oiGIbKEVGmzlI39BCzvh/l/nNkkAcOABQqoo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "uaVAErOHm4rPbUun4eo9xOmObQ2I20rF2IX7BRU57LA=",
+    "shasum": "wFgSmNho6eVxo+nEE2XlWRFVR8tLqKghhh86ozrwmAg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/errors/snap.manifest.json
+++ b/packages/examples/packages/errors/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "yHYVhtnHm6SonjnHmOYISrwKrySimS7p+jOISJsIi90=",
+    "shasum": "sAk9LVkXo2OI3rnOT+3/RToWgk5xT4IfJ0BJiQbbYjw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TU/R5DuCBfqVbdyRuyJztDjIYzupiVlijD5xvcuOZiU=",
+    "shasum": "m4jFP39tZIR1XMosUJ3u8YIfepiI9aRIMna3Hg8RlQQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "R6jyQ9MImF2Khms/DjvO8McPmjZAeUej2jbY8XOC49s=",
+    "shasum": "t9CVxyl+WB6UwtynS8zhgA76KWUmQUdGGP+E0Rj+fR0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "nB2XTMy/AC2QW5WWk2xL7Ed//hf/4IeSTdDIBtPZgSs=",
+    "shasum": "BLq144YW0hKG00k8SN3+7F9rKy6hggZVjjx9WkraNEI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vX3F2cUxbpH1b7HmBcqpp6h23iUWW7uwHR8lEmmKqL8=",
+    "shasum": "20Z28B/48X1gTo6V+RSFpx0BNs13lMwD8FE+NiDn18o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "rVaZdPjQO1y/11Oc54ud6nBId560CQZlUplvgWenQjI=",
+    "shasum": "rZXPzEYUFk5k8lG85JaR11U4wombdIZ8xM3go7dyhhg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "B9CP2TEbrD65sHO4WgdT6etbwwe9HVMG/EZE41Gclmk=",
+    "shasum": "YRGwMaOJHIRegfuR/LmMR+fs2pOi3Wg31Fh3Y/lOJfk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "eYnviy8NIYFFoq8LpNKK59QOB+dD43swieNvMTA4Vrc=",
+    "shasum": "Zul7ybCncDcgpTUpQNx0iTTvy97JNd0TIzM9QpzVROc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "nK1EKaUCdvw9Wq636V5wqYNtAle6tmuro090rO+YxLI=",
+    "shasum": "RVmSqvKdYxv4Ws0cCtkepbmXnQ+6Wj0pJ+/NR0WhqiI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "GvvGS+PSG/6uFDd7XBT3ZI7qsG+LE+rBoqOoVmB1Kq4=",
+    "shasum": "CF4xhZoqnfJt0pjTffWtNKNr8k4YDXh9ZuaszgPvoUU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8cgeiYi2GUhPWmOqquWCiadJPTbSLqo5LDUpAKLbUHA=",
+    "shasum": "tKAO/jlBp3BZubiu2HrD1idkHDIRPh7sAhOw+7htEN4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "pmtVK15TtC9vdrx/Tt+m6cipNVWcN4YrgXS4yl5YI3s=",
+    "shasum": "1ag+BcW+rfL1qTmpnMA+Sd0h57/sZoprFB4qMFXBmPE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "lqyeAE0sgCDYiga8uhb/2n7P8X2fEy8K32zTiFE2uv0=",
+    "shasum": "GFuYJnitc0nYDwAD8jhGyCw/Ufc5Ai9RbJbFWpydlFM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/name-lookup/snap.manifest.json
+++ b/packages/examples/packages/name-lookup/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "snZ/j7c61yFp0K0b77HAw0cLdQswUuqoJE+nVrrBK/A=",
+    "shasum": "ATVuf+9AUmlx48Lw3rcMQia6bf4UBg/M1SXL8FdG8t8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vUmPNRf1Bbf0MFTUDqrTv14PPpLqBnGQBiiEV3liNlI=",
+    "shasum": "7TGnfMZy7JaBMNhA62f6lmXWojpzMVSuSkxaKqfyPw0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "rXsyOrPqMBib+UpRgLzZbVtWpZdlLxv4ohvaa+WbSvs=",
+    "shasum": "QxqKMFGyTlsrrf7nDj/JlbQHDIF2l+eO2E5TttzMS64=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9/UzYulP10qM9PJ5Xc/bCgMEO6u6oX4GEkDzIjOPq/k=",
+    "shasum": "Rt8Li02ub7KWGSrpOkrf+P+mSZEYyUsLCQAln3LhYB0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hGq7EXkTWXrWuOOJrrlzshFjsKZZh91z5SOw+pmnYJg=",
+    "shasum": "s1ibpWtsuA2ku7WoMzpBHBFH+qQ1b2DI7as9fGPjDBY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZEfAOxy5Lid72lpfSfNeAY+68Fc3fVB8bNhYYCDLDng=",
+    "shasum": "eQZoypi/2K6+BnPVvcwOp3I8uwLKzbzLtAahPHVjOY0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
+++ b/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
@@ -12,7 +12,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/node_modules/swc-loader/index.js",
           "options": {
@@ -25,7 +25,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               },
             },
             "module": {
-              "type": "commonjs",
+              "type": "es6",
             },
             "sourceMaps": false,
             "sync": false,
@@ -121,6 +121,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {
@@ -154,7 +156,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/node_modules/swc-loader/index.js",
           "options": {
@@ -167,7 +169,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               },
             },
             "module": {
-              "type": "commonjs",
+              "type": "es6",
             },
             "sourceMaps": false,
             "sync": false,
@@ -263,6 +265,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {
@@ -296,7 +300,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/node_modules/swc-loader/index.js",
           "options": {
@@ -309,7 +313,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               },
             },
             "module": {
-              "type": "commonjs",
+              "type": "es6",
             },
             "sourceMaps": true,
             "sync": false,
@@ -405,6 +409,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {
@@ -438,7 +444,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/node_modules/swc-loader/index.js",
           "options": {
@@ -451,7 +457,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               },
             },
             "module": {
-              "type": "commonjs",
+              "type": "es6",
             },
             "sourceMaps": true,
             "sync": false,
@@ -544,6 +550,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {
@@ -572,7 +580,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/node_modules/swc-loader/index.js",
           "options": {
@@ -585,7 +593,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               },
             },
             "module": {
-              "type": "commonjs",
+              "type": "es6",
             },
             "sourceMaps": false,
             "sync": false,
@@ -686,6 +694,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {
@@ -719,7 +729,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/node_modules/swc-loader/index.js",
           "options": {
@@ -732,7 +742,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               },
             },
             "module": {
-              "type": "commonjs",
+              "type": "es6",
             },
             "sourceMaps": false,
             "sync": false,
@@ -828,6 +838,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {
@@ -861,7 +873,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/node_modules/swc-loader/index.js",
           "options": {
@@ -874,7 +886,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               },
             },
             "module": {
-              "type": "commonjs",
+              "type": "es6",
             },
             "sourceMaps": false,
             "sync": false,
@@ -970,6 +982,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {
@@ -1003,7 +1017,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/node_modules/swc-loader/index.js",
           "options": {
@@ -1016,7 +1030,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               },
             },
             "module": {
-              "type": "commonjs",
+              "type": "es6",
             },
             "sourceMaps": false,
             "sync": false,
@@ -1120,6 +1134,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {
@@ -1153,7 +1169,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/node_modules/swc-loader/index.js",
           "options": {
@@ -1166,7 +1182,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               },
             },
             "module": {
-              "type": "commonjs",
+              "type": "es6",
             },
             "sourceMaps": false,
             "sync": false,
@@ -1270,6 +1286,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {
@@ -1303,7 +1321,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/node_modules/swc-loader/index.js",
           "options": {
@@ -1316,7 +1334,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               },
             },
             "module": {
-              "type": "commonjs",
+              "type": "es6",
             },
             "sourceMaps": false,
             "sync": false,
@@ -1421,6 +1439,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {
@@ -1454,7 +1474,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/node_modules/swc-loader/index.js",
           "options": {
@@ -1467,7 +1487,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               },
             },
             "module": {
-              "type": "commonjs",
+              "type": "es6",
             },
             "sourceMaps": false,
             "sync": false,
@@ -1563,6 +1583,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {
@@ -1596,7 +1618,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/node_modules/swc-loader/index.js",
           "options": {
@@ -1609,7 +1631,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               },
             },
             "module": {
-              "type": "commonjs",
+              "type": "es6",
             },
             "sourceMaps": false,
             "sync": false,
@@ -1705,6 +1727,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {
@@ -1738,7 +1762,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/node_modules/swc-loader/index.js",
           "options": {
@@ -1751,7 +1775,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               },
             },
             "module": {
-              "type": "commonjs",
+              "type": "es6",
             },
             "sourceMaps": false,
             "sync": false,
@@ -1856,6 +1880,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {
@@ -1889,7 +1915,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/node_modules/swc-loader/index.js",
           "options": {
@@ -1902,7 +1928,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
               },
             },
             "module": {
-              "type": "commonjs",
+              "type": "es6",
             },
             "sourceMaps": false,
             "sync": false,
@@ -2007,6 +2033,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {
@@ -2040,7 +2068,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/loaders/browserify",
           "options": {
@@ -2147,6 +2175,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {
@@ -2175,7 +2205,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/loaders/browserify",
           "options": {
@@ -2282,6 +2312,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {
@@ -2310,7 +2342,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "rules": [
       {
         "exclude": /node_modules/u,
-        "test": /\\\\\\.\\[tj\\]sx\\?\\$/u,
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|ts\\)\\$/u,
         "use": {
           "loader": "/foo/bar/loaders/browserify",
           "options": {
@@ -2417,6 +2449,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
   "resolve": {
     "extensions": [
       ".js",
+      ".mjs",
+      ".cjs",
       ".ts",
     ],
     "fallback": {

--- a/packages/snaps-cli/src/webpack/config.ts
+++ b/packages/snaps-cli/src/webpack/config.ts
@@ -185,7 +185,7 @@ export async function getDefaultConfiguration(
     module: {
       rules: [
         {
-          test: /\.[tj]sx?$/u,
+          test: /\.(js|mjs|cjs|ts)$/u,
           exclude: /node_modules/u,
           use: await getDefaultLoader(config),
         },
@@ -220,10 +220,10 @@ export async function getDefaultConfiguration(
      */
     resolve: {
       /**
-       * The extensions to resolve. We set it to resolve `.js` and `.ts`
+       * The extensions to resolve. We set it to resolve `.(c|m)?js` and `.ts`
        * files.
        */
-      extensions: ['.js', '.ts'],
+      extensions: ['.js', '.mjs', '.cjs', '.ts'],
 
       /**
        * The fallback options. This tells Webpack how to handle imports that

--- a/packages/snaps-cli/src/webpack/utils.ts
+++ b/packages/snaps-cli/src/webpack/utils.ts
@@ -137,7 +137,9 @@ export async function getDefaultLoader({
       module: {
         /**
          * This tells SWC to output ES6 modules. This will allow Webpack to
-         * optimize the output code better.
+         * optimize the output code better. Snaps don't support ES6 however, so
+         * the output code will be transpiled to CommonJS by Webpack later in
+         * the build process.
          *
          * @see https://swc.rs/docs/configuration/modules#es6
          */

--- a/packages/snaps-cli/src/webpack/utils.ts
+++ b/packages/snaps-cli/src/webpack/utils.ts
@@ -139,7 +139,7 @@ export async function getDefaultLoader({
          * This tells SWC to output ES6 modules. This will allow Webpack to
          * optimize the output code better.
          *
-         * @see https://swc.rs/docs/configuration/modules#commonjs
+         * @see https://swc.rs/docs/configuration/modules#es6
          */
         type: 'es6',
       },

--- a/packages/snaps-cli/src/webpack/utils.ts
+++ b/packages/snaps-cli/src/webpack/utils.ts
@@ -136,12 +136,12 @@ export async function getDefaultLoader({
        */
       module: {
         /**
-         * This tells SWC to output CommonJS modules. MetaMask Snaps
-         * doesn't support ES modules yet, so this is necessary.
+         * This tells SWC to output ES6 modules. This will allow Webpack to
+         * optimize the output code better.
          *
          * @see https://swc.rs/docs/configuration/modules#commonjs
          */
-        type: 'commonjs',
+        type: 'es6',
       },
 
       env: {


### PR DESCRIPTION
SWC was previously configured to output CJS, which means any imports would be transpiled to `require`. This means that any dependencies would also be loaded as CJS, even though an ESM version may be available. By changing SWC to output ES6 code and not transpiling any imports, Webpack loads potentially more ESM code which can be better optimised and tree-shaken.

Below are the old and new file sizes of the examples. For some examples, this change reduces the file size by 70%.

<details>
<summary>Before this change</summary>

```
272K    ./bip32/dist/bundle.js
344K    ./bip44/dist/bundle.js
312K    ./browserify-plugin/dist/bundle.js
136K    ./browserify/dist/bundle.js
104K    ./client-status/dist/bundle.js
152K    ./cronjobs/dist/bundle.js
156K    ./dialogs/dist/bundle.js
4.0K    ./errors/dist/bundle.js
108K    ./ethereum-provider/dist/bundle.js
1.1M    ./ethers-js/dist/bundle.js
200K    ./get-entropy/dist/bundle.js
104K    ./get-file/dist/bundle.js
152K    ./home-page/dist/bundle.js
164K    ./images/dist/bundle.js
104K    ./json-rpc/dist/bundle.js
152K    ./lifecycle-hooks/dist/bundle.js
108K    ./localization/dist/bundle.js
156K    ./manage-state/dist/bundle.js
4.0K    ./name-lookup/dist/bundle.js
104K    ./network-access/dist/bundle.js
152K    ./notifications/dist/bundle.js
104K    ./rollup-plugin/dist/bundle.js
156K    ./signature-insights/dist/bundle.js
152K    ./transaction-insights/dist/bundle.js
108K    ./wasm/dist/bundle.js
104K    ./webpack-plugin/dist/bundle.js
4.6M    total
```

</details>

<details>
  <summary>After this change</summary>

```
256K    ./bip32/dist/bundle.js
324K    ./bip44/dist/bundle.js
312K    ./browserify-plugin/dist/bundle.js
136K    ./browserify/dist/bundle.js
104K    ./client-status/dist/bundle.js
136K    ./cronjobs/dist/bundle.js
136K    ./dialogs/dist/bundle.js
4.0K    ./errors/dist/bundle.js
108K    ./ethereum-provider/dist/bundle.js
300K    ./ethers-js/dist/bundle.js
176K    ./get-entropy/dist/bundle.js
104K    ./get-file/dist/bundle.js
 36K    ./home-page/dist/bundle.js
152K    ./images/dist/bundle.js
104K    ./json-rpc/dist/bundle.js
 36K    ./lifecycle-hooks/dist/bundle.js
104K    ./localization/dist/bundle.js
104K    ./manage-state/dist/bundle.js
4.0K    ./name-lookup/dist/bundle.js
104K    ./network-access/dist/bundle.js
104K    ./notifications/dist/bundle.js
104K    ./rollup-plugin/dist/bundle.js
 36K    ./signature-insights/dist/bundle.js
 36K    ./transaction-insights/dist/bundle.js
104K    ./wasm/dist/bundle.js
104K    ./webpack-plugin/dist/bundle.js
3.2M    total
```

</details>