### PR TITLE
Use process execution service for network access example

### DIFF
--- a/packages/examples/packages/network-access/package.json
+++ b/packages/examples/packages/network-access/package.json
@@ -44,6 +44,7 @@
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
+    "@metamask/snaps-controllers": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",

--- a/packages/examples/packages/network-access/src/index.test.ts
+++ b/packages/examples/packages/network-access/src/index.test.ts
@@ -1,9 +1,12 @@
 import { expect } from '@jest/globals';
+import { NodeProcessExecutionService } from '@metamask/snaps-controllers';
 import { installSnap } from '@metamask/snaps-jest';
 
 describe('onRpcRequest', () => {
   it('throws an error if the requested method does not exist', async () => {
-    const { request } = await installSnap();
+    const { request } = await installSnap({
+      executionService: NodeProcessExecutionService,
+    });
 
     const response = await request({
       method: 'foo',
@@ -22,7 +25,9 @@ describe('onRpcRequest', () => {
 
   describe('fetch', () => {
     it('fetches a URL and returns the JSON response', async () => {
-      const { request } = await installSnap();
+      const { request } = await installSnap({
+        executionService: NodeProcessExecutionService,
+      });
 
       const url = 'https://dummyjson.com/http/200';
       const response = await request({

--- a/packages/examples/packages/network-access/tsconfig.json
+++ b/packages/examples/packages/network-access/tsconfig.json
@@ -16,6 +16,9 @@
     },
     {
       "path": "../../../snaps-cli"
+    },
+    {
+      "path": "../../../snaps-controllers"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4872,6 +4872,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-cli": "workspace:^"
+    "@metamask/snaps-controllers": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
     "@metamask/utils": ^8.3.0


### PR DESCRIPTION
This (hopefully) fixes the network access example E2Es sometimes getting stuck.