### PR TITLE
Use error wrappers in all examples

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -214,6 +214,8 @@ jobs:
       - run: yarn --immutable --immutable-cache
       - name: Install Google Chrome
         run: yarn install-chrome
+      - run: yarn workspace @metamask/snaps-sdk run build
+        if: ${{ matrix.package-name == '@metamask/snaps-cli' }}
       - run: yarn workspace ${{ matrix.package-name }} run test:ci
       - name: Get coverage folder
         id: get-coverage-folder
@@ -316,4 +318,5 @@ jobs:
           node-version-file: '.nvmrc'
           cache: yarn
       - run: yarn --immutable
+      - run: yarn workspace @metamask/snaps-sdk run build
       - run: yarn workspace @metamask/snaps-cli run test

--- a/packages/examples/packages/bip32/package.json
+++ b/packages/examples/packages/bip32/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@metamask/key-tree": "^9.0.0",
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.3.0",
     "@noble/ed25519": "^1.6.0",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6g87K+NnEehFnghqk0s8wWv6NnGkeaAAOq+eemGJndQ=",
+    "shasum": "8ab4U4VgNt1CNwLUmnANXyySVWy6MST2ywkXbK1/q54=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/src/index.ts
+++ b/packages/examples/packages/bip32/src/index.ts
@@ -1,4 +1,3 @@
-import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import {
   DialogType,
@@ -6,6 +5,9 @@ import {
   text,
   heading,
   copyable,
+  InvalidParamsError,
+  UserRejectedRequestError,
+  MethodNotFoundError,
 } from '@metamask/snaps-sdk';
 import {
   add0x,
@@ -46,9 +48,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       const { message, curve, ...params } = request.params as SignMessageParams;
 
       if (!message || typeof message !== 'string') {
-        throw rpcErrors.invalidParams({
-          message: `Invalid signature data: "${message}".`,
-        });
+        throw new InvalidParamsError(`Invalid signature data: "${message}".`);
       }
 
       const node = await getPrivateNode({ ...params, curve });
@@ -71,7 +71,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       });
 
       if (!approved) {
-        throw providerErrors.userRejectedRequest();
+        throw new UserRejectedRequestError();
       }
 
       if (curve === 'ed25519') {
@@ -95,10 +95,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       throw new Error(`Unsupported curve: ${String(curve)}.`);
     }
 
-    default: {
-      throw rpcErrors.methodNotFound({
-        data: { method: request.method },
-      });
-    }
+    default:
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/bip44/package.json
+++ b/packages/examples/packages/bip44/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@metamask/key-tree": "^9.0.0",
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.3.0",
     "@noble/bls12-381": "^1.2.0"

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "h9Unyy6nfIB+2Dri5Hn6fNMJEtEu6e4lmoBRk7SqGqY=",
+    "shasum": "6DBoUIrZECIq0rT8yj309Inh7p4GqUZdmqDEdVowCGs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6DBoUIrZECIq0rT8yj309Inh7p4GqUZdmqDEdVowCGs=",
+    "shasum": "hhQQ0zW2jmTR2pzXD3qr+q2WlhxzHZdjvhV7RmCCJ+k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/src/index.ts
+++ b/packages/examples/packages/bip44/src/index.ts
@@ -1,4 +1,3 @@
-import { rpcErrors, providerErrors } from '@metamask/rpc-errors';
 import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import {
   DialogType,
@@ -6,6 +5,8 @@ import {
   text,
   heading,
   copyable,
+  MethodNotFoundError,
+  UserRejectedRequestError,
 } from '@metamask/snaps-sdk';
 import { bytesToHex, stringToBytes } from '@metamask/utils';
 import { getPublicKey, sign } from '@noble/bls12-381';
@@ -58,7 +59,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       });
 
       if (!approved) {
-        throw providerErrors.userRejectedRequest();
+        throw new UserRejectedRequestError();
       }
 
       const newLocal = await sign(stringToBytes(message), privateKey);
@@ -66,8 +67,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
-      throw rpcErrors.methodNotFound({
-        data: { method: request.method },
-      });
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/browserify-plugin/package.json
+++ b/packages/examples/packages/browserify-plugin/package.json
@@ -29,7 +29,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "GDfl/OJepeU/Ms3q5ojSU1lRIu7mj01gV1uC2lctYG0=",
+    "shasum": "A3hd5c69jrirLCpvWB1g/JgPr99TOJBowhBlFuq1Nwg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "A3hd5c69jrirLCpvWB1g/JgPr99TOJBowhBlFuq1Nwg=",
+    "shasum": "jsLU4LfTnxcd6HxBnO0We83mboe2DGUVugwjyjMr/S4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/src/index.ts
+++ b/packages/examples/packages/browserify-plugin/src/index.ts
@@ -1,5 +1,4 @@
-import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the
@@ -21,9 +20,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       return 'Hello from Browserify!';
 
     default: {
-      throw rpcErrors.methodNotFound({
-        data: { method: request.method },
-      });
+      throw new MethodNotFoundError({ method: request.method });
     }
   }
 };

--- a/packages/examples/packages/browserify-plugin/src/index.ts
+++ b/packages/examples/packages/browserify-plugin/src/index.ts
@@ -1,4 +1,7 @@
-import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import {
+  MethodNotFoundError,
+  type OnRpcRequestHandler,
+} from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the

--- a/packages/examples/packages/browserify/package.json
+++ b/packages/examples/packages/browserify/package.json
@@ -30,7 +30,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "95Quh+P0Twz147oYzCoirGX4cD//CznsElPR0o+Eg6g=",
+    "shasum": "YdcJWyqICGZig9C76bmjFzXj228WsHpfyQbpKFstk18=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "jjkP8lDWArcnVeNB1YyZuFf9JSLlGvbmsOtDWVMcURc=",
+    "shasum": "95Quh+P0Twz147oYzCoirGX4cD//CznsElPR0o+Eg6g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/src/index.ts
+++ b/packages/examples/packages/browserify/src/index.ts
@@ -1,5 +1,4 @@
-import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the
@@ -23,9 +22,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       return 'Hello from the MetaMask Snaps CLI using Browserify!';
 
     default: {
-      throw rpcErrors.methodNotFound({
-        data: { method: request.method },
-      });
+      throw new MethodNotFoundError({ method: request.method });
     }
   }
 };

--- a/packages/examples/packages/browserify/src/index.ts
+++ b/packages/examples/packages/browserify/src/index.ts
@@ -1,4 +1,7 @@
-import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import {
+  MethodNotFoundError,
+  type OnRpcRequestHandler,
+} from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the

--- a/packages/examples/packages/client-status/package.json
+++ b/packages/examples/packages/client-status/package.json
@@ -30,7 +30,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vBpEZ72bofDjez8+bFPLKZu/bFDZD+2qp1M4awO+AsA=",
+    "shasum": "AcXvYNa51+q0lmnxoA7JbDqs2GFChKSdOsZzNtQjs58=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AcXvYNa51+q0lmnxoA7JbDqs2GFChKSdOsZzNtQjs58=",
+    "shasum": "RdYraLfrwCrccsEbDUR9J7T8r+8+jAF9NtShsPkpqIY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/src/index.ts
+++ b/packages/examples/packages/client-status/src/index.ts
@@ -1,5 +1,4 @@
-import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the
@@ -21,10 +20,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
-      throw rpcErrors.methodNotFound({
-        data: {
-          method: request.method,
-        },
-      });
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/client-status/src/index.ts
+++ b/packages/examples/packages/client-status/src/index.ts
@@ -1,4 +1,7 @@
-import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import {
+  MethodNotFoundError,
+  type OnRpcRequestHandler,
+} from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the

--- a/packages/examples/packages/cronjobs/package.json
+++ b/packages/examples/packages/cronjobs/package.json
@@ -30,7 +30,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hXFQrGOJ+ScAdetboaVpVTv9jHS9ZbeGTSF6jQ8P8yM=",
+    "shasum": "OX8vhmU71QIHyYKPZC3PneMjgiEpB7/4+BxhIULLPCM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OX8vhmU71QIHyYKPZC3PneMjgiEpB7/4+BxhIULLPCM=",
+    "shasum": "cGr5IrUQn88gt4Et3hoG5p0hlcR1UwfsA3n6TJGh7kE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/src/index.ts
+++ b/packages/examples/packages/cronjobs/src/index.ts
@@ -1,6 +1,5 @@
-import { rpcErrors } from '@metamask/rpc-errors';
 import type { OnCronjobHandler } from '@metamask/snaps-sdk';
-import { panel, text, heading } from '@metamask/snaps-sdk';
+import { panel, text, heading, MethodNotFoundError } from '@metamask/snaps-sdk';
 
 /**
  * Handle cronjob execution requests from MetaMask. This handler handles one
@@ -31,10 +30,6 @@ export const onCronjob: OnCronjobHandler = async ({ request }) => {
         },
       });
     default:
-      throw rpcErrors.methodNotFound({
-        data: {
-          method: request.method,
-        },
-      });
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/dialogs/package.json
+++ b/packages/examples/packages/dialogs/package.json
@@ -30,7 +30,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "N2zhh1oUTEL5T4B+XYJz46f5ip9YEa9vTVnteSz8CC4=",
+    "shasum": "ipag4FRtdkJBJorSx5kyQ4+0i37b2EQH/aoq28zIvcc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ipag4FRtdkJBJorSx5kyQ4+0i37b2EQH/aoq28zIvcc=",
+    "shasum": "0EWOdxj1/tE41ruHFjRCOvD5GNYROKzwlrjya39HVVw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/src/index.ts
+++ b/packages/examples/packages/dialogs/src/index.ts
@@ -1,6 +1,5 @@
-import { rpcErrors } from '@metamask/rpc-errors';
 import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
-import { DialogType, panel, text, heading } from '@metamask/snaps-sdk';
+import { DialogType, panel, text, heading, MethodNotFoundError } from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the
@@ -71,10 +70,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       });
 
     default:
-      throw rpcErrors.methodNotFound({
-        data: {
-          method: request.method,
-        },
-      });
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/dialogs/src/index.ts
+++ b/packages/examples/packages/dialogs/src/index.ts
@@ -1,5 +1,11 @@
 import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
-import { DialogType, panel, text, heading, MethodNotFoundError } from '@metamask/snaps-sdk';
+import {
+  DialogType,
+  panel,
+  text,
+  heading,
+  MethodNotFoundError,
+} from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the

--- a/packages/examples/packages/ethereum-provider/package.json
+++ b/packages/examples/packages/ethereum-provider/package.json
@@ -30,7 +30,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.3.0"
   },

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7g/LtDd1foBy/f1eGIxdFI5jSzGidjTXewUiuvrlFdA=",
+    "shasum": "aOMvJu4RhWbR+7VyEdQA8axcIb42z0mLpGf7jLJcCf8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "aOMvJu4RhWbR+7VyEdQA8axcIb42z0mLpGf7jLJcCf8=",
+    "shasum": "lC5/FHnxWiHbzFNBHxyDYyo0fAn/SfZhh7g8m0BpoeM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/src/index.ts
+++ b/packages/examples/packages/ethereum-provider/src/index.ts
@@ -1,4 +1,7 @@
-import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import {
+  MethodNotFoundError,
+  type OnRpcRequestHandler,
+} from '@metamask/snaps-sdk';
 import type { Hex } from '@metamask/utils';
 import { assert, stringToBytes, bytesToHex } from '@metamask/utils';
 

--- a/packages/examples/packages/ethereum-provider/src/index.ts
+++ b/packages/examples/packages/ethereum-provider/src/index.ts
@@ -1,5 +1,4 @@
-import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import type { Hex } from '@metamask/utils';
 import { assert, stringToBytes, bytesToHex } from '@metamask/utils';
 
@@ -121,10 +120,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
-      throw rpcErrors.methodNotFound({
-        data: {
-          method: request.method,
-        },
-      });
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/ethers-js/package.json
+++ b/packages/examples/packages/ethers-js/package.json
@@ -30,7 +30,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^",
     "ethers": "^6.3.0"
   },

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "UbpOFJK8QM+jA23PsQFBI0TF/wfCfhkJ3PDIPMxMquc=",
+    "shasum": "5kmKjco5B1kA802FWjzh+W+h5f6nE/vDfVWZhd2e17U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "D/6w/eOgde9NmCfVoCnwLGDZSihAK7UNMHoj7llQKSU=",
+    "shasum": "UbpOFJK8QM+jA23PsQFBI0TF/wfCfhkJ3PDIPMxMquc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/src/index.ts
+++ b/packages/examples/packages/ethers-js/src/index.ts
@@ -1,5 +1,12 @@
 import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
-import { panel, heading, copyable, text, UserRejectedRequestError, MethodNotFoundError } from '@metamask/snaps-sdk';
+import {
+  panel,
+  heading,
+  copyable,
+  text,
+  UserRejectedRequestError,
+  MethodNotFoundError,
+} from '@metamask/snaps-sdk';
 import { Wallet } from 'ethers';
 
 import type { SignMessageParams } from './types';

--- a/packages/examples/packages/ethers-js/src/index.ts
+++ b/packages/examples/packages/ethers-js/src/index.ts
@@ -1,6 +1,5 @@
-import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
-import { panel, heading, copyable, text } from '@metamask/snaps-sdk';
+import { panel, heading, copyable, text, UserRejectedRequestError, MethodNotFoundError } from '@metamask/snaps-sdk';
 import { Wallet } from 'ethers';
 
 import type { SignMessageParams } from './types';
@@ -50,15 +49,13 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       });
 
       if (!result) {
-        throw providerErrors.userRejectedRequest();
+        throw new UserRejectedRequestError();
       }
 
       return wallet.signMessage(params.message);
     }
 
     default:
-      throw rpcErrors.methodNotFound({
-        data: { method: request.method },
-      });
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/get-entropy/package.json
+++ b/packages/examples/packages/get-entropy/package.json
@@ -30,7 +30,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.3.0",
     "@noble/bls12-381": "^1.2.0"

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "V6xn/HXuwCpDKZsHeX8yHWUbkW1cC1onClrZTU5kbIs=",
+    "shasum": "T49G0UC+Hv62pUMQD83VnOZ7vddgjc8dvV+9ZC6o2uM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "CrlL6w+qKhC0Zonm8KGeAHz4crnegl5IyAUBWMtobIo=",
+    "shasum": "V6xn/HXuwCpDKZsHeX8yHWUbkW1cC1onClrZTU5kbIs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/src/index.ts
+++ b/packages/examples/packages/get-entropy/src/index.ts
@@ -1,4 +1,3 @@
-import { rpcErrors, providerErrors } from '@metamask/rpc-errors';
 import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import {
   DialogType,
@@ -6,6 +5,8 @@ import {
   text,
   heading,
   copyable,
+  UserRejectedRequestError,
+  MethodNotFoundError,
 } from '@metamask/snaps-sdk';
 import { bytesToHex, stringToBytes } from '@metamask/utils';
 import { sign } from '@noble/bls12-381';
@@ -47,7 +48,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       });
 
       if (!approved) {
-        throw providerErrors.userRejectedRequest();
+        throw new UserRejectedRequestError();
       }
 
       const privateKey = await getEntropy(salt);
@@ -56,8 +57,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
-      throw rpcErrors.methodNotFound({
-        data: { method: request.method },
-      });
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/get-file/package.json
+++ b/packages/examples/packages/get-file/package.json
@@ -31,7 +31,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9T2t+DzkH3xJROpPsnq8AtXdlodTcsktjCPb6KPY4Vg=",
+    "shasum": "ie1wYA3UYL9R1CXYt47m2aDM4BKVYvRq3ciQeHbcVG8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Xe2a66BwZcahzZUIOV6ejRSX982QxSjhSIqWAPY+YVU=",
+    "shasum": "9T2t+DzkH3xJROpPsnq8AtXdlodTcsktjCPb6KPY4Vg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/src/index.ts
+++ b/packages/examples/packages/get-file/src/index.ts
@@ -1,5 +1,4 @@
-import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the
@@ -45,8 +44,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
-      throw rpcErrors.methodNotFound({
-        data: { method: request.method },
-      });
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/get-file/src/index.ts
+++ b/packages/examples/packages/get-file/src/index.ts
@@ -1,4 +1,7 @@
-import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import {
+  MethodNotFoundError,
+  type OnRpcRequestHandler,
+} from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "V/8JmQ8wclvOhR0UzGAHE5MrCHOsaOe26x7NwF0euXQ=",
+    "shasum": "tO3oJ/EasOvT1aoAsoOgxbDQZFI+6ol6Mh1NpACGYFI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "tO3oJ/EasOvT1aoAsoOgxbDQZFI+6ol6Mh1NpACGYFI=",
+    "shasum": "V/8JmQ8wclvOhR0UzGAHE5MrCHOsaOe26x7NwF0euXQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/package.json
+++ b/packages/examples/packages/images/package.json
@@ -30,7 +30,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^",
     "uqr": "^0.1.2"
   },

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "G8w1Dq52BAD6BnQB6sXCU74PoNGsbZPe73Bd8AczIOY=",
+    "shasum": "UKBWUM+VMGi3YPuP2zhT3fpfB5MgN7muuU2MBaW5964=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "j6DESLoBQHNUMM0XD2dLJ6vj/s/icJNw/5bFaHSB950=",
+    "shasum": "G8w1Dq52BAD6BnQB6sXCU74PoNGsbZPe73Bd8AczIOY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/src/index.ts
+++ b/packages/examples/packages/images/src/index.ts
@@ -1,4 +1,3 @@
-import { rpcErrors } from '@metamask/rpc-errors';
 import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import {
   DialogType,
@@ -6,6 +5,7 @@ import {
   image,
   panel,
   text,
+  MethodNotFoundError,
 } from '@metamask/snaps-sdk';
 import { renderSVG } from 'uqr';
 
@@ -75,8 +75,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
-      throw rpcErrors.methodNotFound({
-        data: { method: request.method },
-      });
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/interactive-ui/package.json
+++ b/packages/examples/packages/interactive-ui/package.json
@@ -30,7 +30,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.3.0"
   },

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "59cpZd9t58yrxzku0e1XEEnX2UB/zOG3rraPcADBs3Y=",
+    "shasum": "MP7yN+w1/v7go5f1gKqMIx6x1jpbyObknrR23jqrX6k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "MP7yN+w1/v7go5f1gKqMIx6x1jpbyObknrR23jqrX6k=",
+    "shasum": "mCZ19dCoi80l6PECQSPWS9xdJt2hqMOkY+WusVl0GRw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/src/index.ts
+++ b/packages/examples/packages/interactive-ui/src/index.ts
@@ -91,9 +91,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 
     default:
       throw new MethodNotFoundError({
-        data: {
-          method: request.method,
-        },
+        method: request.method,
       });
   }
 };

--- a/packages/examples/packages/interactive-ui/src/index.ts
+++ b/packages/examples/packages/interactive-ui/src/index.ts
@@ -1,4 +1,3 @@
-import { rpcErrors } from '@metamask/rpc-errors';
 import type {
   OnRpcRequestHandler,
   OnHomePageHandler,
@@ -9,6 +8,7 @@ import {
   UserInputEventType,
   ManageStateOperation,
   assert,
+  MethodNotFoundError,
 } from '@metamask/snaps-sdk';
 
 import {
@@ -90,7 +90,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
-      throw rpcErrors.methodNotFound({
+      throw new MethodNotFoundError({
         data: {
           method: request.method,
         },

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@metamask/key-tree": "^9.0.0",
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.3.0",
     "@noble/hashes": "^1.3.1"

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LK4kqwXOailBSJkprzDxkzSz72ZC+G2u4bwOU/h/kK4=",
+    "shasum": "gUO4bvlK1uPxl2aWXwTYGif4jnv7NXA8ouaNNaEtEFM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "gUO4bvlK1uPxl2aWXwTYGif4jnv7NXA8ouaNNaEtEFM=",
+    "shasum": "CdBl0Ngm1ky+yIy+sTaEZ0nqqu7fVH4c942C9VfekI0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/src/index.ts
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/src/index.ts
@@ -1,5 +1,8 @@
-import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import {
+  InvalidParamsError,
+  MethodNotFoundError,
+  type OnRpcRequestHandler,
+} from '@metamask/snaps-sdk';
 import { assert, stringToBytes } from '@metamask/utils';
 import { keccak_256 as keccak256 } from '@noble/hashes/sha3';
 
@@ -37,10 +40,9 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 
       assert(
         path[1] === `bip32:60'`,
-        rpcErrors.invalidParams({
-          message:
-            "This snap only supports the Ethereum mainnet. Please use the `bip32:60'` coin type.",
-        }),
+        new InvalidParamsError(
+          "This snap only supports the Ethereum mainnet. Please use the `bip32:60'` coin type.",
+        ),
       );
 
       const account = await snap.request({
@@ -75,8 +77,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
-      throw rpcErrors.methodNotFound({
-        data: { method: request.method },
-      });
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/invoke-snap/packages/core-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@metamask/key-tree": "^9.0.0",
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.3.0",
     "@noble/curves": "^1.1.0",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2BJWlCMx68q5XYjLG9Huixag1V4Uyrl+JeGcYN/6r9Y=",
+    "shasum": "KXg6RghBRko7eF8C58uKc8XycWzOsrOsZ4sM2J6Z71w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "KXg6RghBRko7eF8C58uKc8XycWzOsrOsZ4sM2J6Z71w=",
+    "shasum": "TiTLLMahR7au/Svbo96beqbpu8hMBfWT42TbGbMBEaA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/src/index.ts
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/src/index.ts
@@ -1,4 +1,3 @@
-import { rpcErrors, providerErrors } from '@metamask/rpc-errors';
 import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import {
   DialogType,
@@ -6,6 +5,8 @@ import {
   text,
   heading,
   copyable,
+  MethodNotFoundError,
+  UserRejectedRequestError,
 } from '@metamask/snaps-sdk';
 import { add0x, assert, hexToBytes } from '@metamask/utils';
 import { secp256k1 } from '@noble/curves/secp256k1';
@@ -68,7 +69,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       });
 
       if (!approved) {
-        throw providerErrors.userRejectedRequest();
+        throw new UserRejectedRequestError();
       }
 
       const signature = secp256k1.sign(
@@ -80,8 +81,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
-      throw rpcErrors.methodNotFound({
-        data: { method: request.method },
-      });
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/json-rpc/package.json
+++ b/packages/examples/packages/json-rpc/package.json
@@ -30,7 +30,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TcdGdRzlDmHXRh+YuNr28t+DxSM6fg0QgvuyoP7v5R8=",
+    "shasum": "Mx480HPDox0SqOZDi2mLTqawI7GYoh3X8/aAnPdHM7Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Mx480HPDox0SqOZDi2mLTqawI7GYoh3X8/aAnPdHM7Y=",
+    "shasum": "Njj3xVQ8Q8INYouSvtCFDS0P5LxGRCpL8DKG7Sqq/jg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/src/index.ts
+++ b/packages/examples/packages/json-rpc/src/index.ts
@@ -1,5 +1,4 @@
-import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the
@@ -59,10 +58,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
-      throw rpcErrors.methodNotFound({
-        data: {
-          method: request.method,
-        },
-      });
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/json-rpc/src/index.ts
+++ b/packages/examples/packages/json-rpc/src/index.ts
@@ -1,4 +1,7 @@
-import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import {
+  MethodNotFoundError,
+  type OnRpcRequestHandler,
+} from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AJ2WrMJafmZcGcKwcRvDHKD/lzwUuBiGbpXWW9HCRvo=",
+    "shasum": "FMHgDcOPDtPTfTMJuhJy71DMYhzZxsDYdpX4xfVXsJU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FMHgDcOPDtPTfTMJuhJy71DMYhzZxsDYdpX4xfVXsJU=",
+    "shasum": "AJ2WrMJafmZcGcKwcRvDHKD/lzwUuBiGbpXWW9HCRvo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/package.json
+++ b/packages/examples/packages/localization/package.json
@@ -31,7 +31,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3FbMrH9SY4ORrHAysFy2U4/d55U7eCvMPWF/qbQi9VU=",
+    "shasum": "HkEMOJcfQC+eYrIWPFYc4FtyQuNmJBS5MPGXu+luOS0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "HkEMOJcfQC+eYrIWPFYc4FtyQuNmJBS5MPGXu+luOS0=",
+    "shasum": "3Ww40u/9a7OvQuLhpyJrS2Mr1uha4tQZ5GoTXlmMgQM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/src/index.ts
+++ b/packages/examples/packages/localization/src/index.ts
@@ -1,5 +1,4 @@
-import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 import { getMessage } from './locales';
 
@@ -20,8 +19,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       return await getMessage('hello');
 
     default:
-      throw rpcErrors.methodNotFound({
-        data: { method: request.method },
-      });
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/localization/src/index.ts
+++ b/packages/examples/packages/localization/src/index.ts
@@ -1,4 +1,7 @@
-import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import {
+  MethodNotFoundError,
+  type OnRpcRequestHandler,
+} from '@metamask/snaps-sdk';
 
 import { getMessage } from './locales';
 

--- a/packages/examples/packages/manage-state/package.json
+++ b/packages/examples/packages/manage-state/package.json
@@ -30,7 +30,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "eEGWFgMCsUE2ExTUxL1tT47fpYVXltudfQ2cfeeSB/Q=",
+    "shasum": "GhEWeuSSjrBrsmDP+TZ93sumakRa0RpVyJZ57ltciBE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "GhEWeuSSjrBrsmDP+TZ93sumakRa0RpVyJZ57ltciBE=",
+    "shasum": "lL5sis3o0vmIktrwkwOWyrDt7nsAXMt3MKxIKtLdPcQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/src/index.ts
+++ b/packages/examples/packages/manage-state/src/index.ts
@@ -1,4 +1,7 @@
-import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import {
+  MethodNotFoundError,
+  type OnRpcRequestHandler,
+} from '@metamask/snaps-sdk';
 
 import type { BaseParams, SetStateParams } from './types';
 import { clearState, getState, setState } from './utils';

--- a/packages/examples/packages/manage-state/src/index.ts
+++ b/packages/examples/packages/manage-state/src/index.ts
@@ -1,5 +1,4 @@
-import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 import type { BaseParams, SetStateParams } from './types';
 import { clearState, getState, setState } from './utils';
@@ -51,10 +50,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
-      throw rpcErrors.methodNotFound({
-        data: {
-          method: request.method,
-        },
-      });
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/network-access/package.json
+++ b/packages/examples/packages/network-access/package.json
@@ -30,7 +30,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.3.0"
   },

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "SEdw1D71hdQpfnOBION11gKcPQZEcTUBAdRMCsgWq+U=",
+    "shasum": "LvpCxEC/9hgPo6a3IYAxRaWFLhAF5prULC5xLI+zsc8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OSZI05z4HSiilXgu+bQyjKbUdJEMWBnDLEX1+AESqAs=",
+    "shasum": "SEdw1D71hdQpfnOBION11gKcPQZEcTUBAdRMCsgWq+U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/src/index.ts
+++ b/packages/examples/packages/network-access/src/index.ts
@@ -1,5 +1,4 @@
-import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
 import { assert } from '@metamask/utils';
 
 import type { FetchParams } from './types';
@@ -46,10 +45,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
-      throw rpcErrors.methodNotFound({
-        data: {
-          method: request.method,
-        },
-      });
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/network-access/src/index.ts
+++ b/packages/examples/packages/network-access/src/index.ts
@@ -1,4 +1,7 @@
-import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import {
+  MethodNotFoundError,
+  type OnRpcRequestHandler,
+} from '@metamask/snaps-sdk';
 import { assert } from '@metamask/utils';
 
 import type { FetchParams } from './types';

--- a/packages/examples/packages/notifications/package.json
+++ b/packages/examples/packages/notifications/package.json
@@ -30,7 +30,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "dZB/j2sX42LBgSy7YLSBCfVerS18VoCTE95rHbO8ZuQ=",
+    "shasum": "ICgIJk9d4pav5vrH/+1EfEgpIf587GQHd47pngo7r1I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "tW8C+DzAdDnN1qryrtDErAgIsm76cMlgs5TI9MUH/R0=",
+    "shasum": "dZB/j2sX42LBgSy7YLSBCfVerS18VoCTE95rHbO8ZuQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/src/index.ts
+++ b/packages/examples/packages/notifications/src/index.ts
@@ -1,5 +1,4 @@
-import { rpcErrors } from '@metamask/rpc-errors';
-import { NotificationType } from '@metamask/snaps-sdk';
+import { MethodNotFoundError, NotificationType } from '@metamask/snaps-sdk';
 import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 /**
@@ -45,8 +44,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
       });
 
     default:
-      throw rpcErrors.methodNotFound({
-        data: { method: request.method },
-      });
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/rollup-plugin/package.json
+++ b/packages/examples/packages/rollup-plugin/package.json
@@ -30,7 +30,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4AhZwdLifuJG73BY2zQ+/tFxsdy6GJrjuMq5wpJAl/c=",
+    "shasum": "dunP3QcE1/cdYZE6IeFcbMfb++TuiX3HF02ZFb94IYw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "NOHjoM2O7h9o2F1pTOHj+y/Hxi7AgUE5DAD01Q+DCsA=",
+    "shasum": "4AhZwdLifuJG73BY2zQ+/tFxsdy6GJrjuMq5wpJAl/c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/src/index.ts
+++ b/packages/examples/packages/rollup-plugin/src/index.ts
@@ -1,5 +1,4 @@
-import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the
@@ -20,10 +19,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     case 'hello':
       return 'Hello from Rollup!';
 
-    default: {
-      throw rpcErrors.methodNotFound({
-        data: { method: request.method },
-      });
-    }
+    default:
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/rollup-plugin/src/index.ts
+++ b/packages/examples/packages/rollup-plugin/src/index.ts
@@ -1,4 +1,7 @@
-import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import {
+  MethodNotFoundError,
+  type OnRpcRequestHandler,
+} from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3FiXkxRZWJ/ZprhN86f08wfeym3zeZRmATdXkWc4O2g=",
+    "shasum": "4o53LPuk/bQ5liPZOgvkRjo8qMQhIMRD/hVwRFUfzrA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4o53LPuk/bQ5liPZOgvkRjo8qMQhIMRD/hVwRFUfzrA=",
+    "shasum": "3FiXkxRZWJ/ZprhN86f08wfeym3zeZRmATdXkWc4O2g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "x5KDoChPS3pUwoYmOi94B0/OzB9EuXK7YH1MQVYCLC0=",
+    "shasum": "0UnWFeXWEUJnbP7SMDDSeP5cG2ghBKphr3hA2thd3TI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0UnWFeXWEUJnbP7SMDDSeP5cG2ghBKphr3hA2thd3TI=",
+    "shasum": "x5KDoChPS3pUwoYmOi94B0/OzB9EuXK7YH1MQVYCLC0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/package.json
+++ b/packages/examples/packages/wasm/package.json
@@ -31,7 +31,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ST3YW54wjME1cCET3YsEh05hyEXBIKnI8zeCDltYHIc=",
+    "shasum": "Y+xkj0xUt84dxhfE8ZC2qSJOPB7L9YpDpEERoYnXO80=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Y+xkj0xUt84dxhfE8ZC2qSJOPB7L9YpDpEERoYnXO80=",
+    "shasum": "QRkMQoPdeXqIG3rcftFgeFcjJIeskXc8A5I+HkVV/MM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/src/index.ts
+++ b/packages/examples/packages/wasm/src/index.ts
@@ -1,5 +1,4 @@
-import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
 
 // This is only imported for its type. It is not used at runtime.
 // eslint-disable-next-line import/order
@@ -48,5 +47,5 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     return program[method](...params);
   }
 
-  throw rpcErrors.methodNotFound({ data: { method } });
+  throw new MethodNotFoundError({ method: request.method });
 };

--- a/packages/examples/packages/wasm/src/index.ts
+++ b/packages/examples/packages/wasm/src/index.ts
@@ -1,4 +1,7 @@
-import { MethodNotFoundError, type OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import {
+  MethodNotFoundError,
+  type OnRpcRequestHandler,
+} from '@metamask/snaps-sdk';
 
 // This is only imported for its type. It is not used at runtime.
 // eslint-disable-next-line import/order

--- a/packages/examples/packages/webpack-plugin/package.json
+++ b/packages/examples/packages/webpack-plugin/package.json
@@ -30,7 +30,6 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^"
   },
   "devDependencies": {

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2iObrsL3GjOnuVq2ioHBN9/5uezyE7LuQbjd/O1F8vI=",
+    "shasum": "SlOv3TFUXvECxiF0UzebngQL8MNENTo2X//5fwKODqc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "bmczkqXT/ZcYe69cZXEfC1nClZ0/F4XwCoLynMLhY8c=",
+    "shasum": "sECexIdXjQiIRCY0X/10UyuS5LTtzEbYaREFv7etDpk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "SlOv3TFUXvECxiF0UzebngQL8MNENTo2X//5fwKODqc=",
+    "shasum": "bmczkqXT/ZcYe69cZXEfC1nClZ0/F4XwCoLynMLhY8c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/src/index.ts
+++ b/packages/examples/packages/webpack-plugin/src/index.ts
@@ -1,5 +1,7 @@
-import { rpcErrors } from '@metamask/rpc-errors';
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
+import {
+  MethodNotFoundError,
+  type OnRpcRequestHandler,
+} from '@metamask/snaps-sdk';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the
@@ -20,10 +22,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     case 'hello':
       return 'Hello from Webpack!';
 
-    default: {
-      throw rpcErrors.methodNotFound({
-        data: { method: request.method },
-      });
-    }
+    default:
+      throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/webpack-plugin/webpack.config.ts
+++ b/packages/examples/packages/webpack-plugin/webpack.config.ts
@@ -35,7 +35,7 @@ const config: Configuration = {
     minimize: true,
     minimizer: [
       new TerserPlugin({
-        minify: TerserPlugin.swcMinify,
+        parallel: true,
       }),
     ],
   },

--- a/packages/snaps-cli/tsconfig.json
+++ b/packages/snaps-cli/tsconfig.json
@@ -13,7 +13,6 @@
   "references": [
     { "path": "../snaps-utils" },
     { "path": "../snaps-browserify-plugin" },
-    { "path": "../snaps-webpack-plugin" },
-    { "path": "../snaps-sdk" }
+    { "path": "../snaps-webpack-plugin" }
   ]
 }

--- a/packages/snaps-cli/tsconfig.json
+++ b/packages/snaps-cli/tsconfig.json
@@ -13,6 +13,7 @@
   "references": [
     { "path": "../snaps-utils" },
     { "path": "../snaps-browserify-plugin" },
-    { "path": "../snaps-webpack-plugin" }
+    { "path": "../snaps-webpack-plugin" },
+    { "path": "../snaps-sdk" }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3886,7 +3886,6 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/key-tree": ^9.0.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -3927,7 +3926,6 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/key-tree": ^9.0.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -3976,7 +3974,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4014,7 +4011,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-browserify-plugin": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4053,7 +4049,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4092,7 +4087,6 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/key-tree": ^9.0.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4149,7 +4143,6 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/key-tree": ^9.0.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4258,7 +4251,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4296,7 +4288,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4482,7 +4473,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4520,7 +4510,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4600,7 +4589,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4639,7 +4627,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4712,7 +4699,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4787,7 +4773,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4876,7 +4861,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4987,7 +4971,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -5024,7 +5007,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -5097,7 +5079,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-controllers": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
@@ -5136,7 +5117,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -5258,7 +5238,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-rollup-plugin": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -6228,7 +6207,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -6266,7 +6244,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
     "@metamask/snaps-webpack-plugin": "workspace:^"


### PR DESCRIPTION
Use error wrappers from the SDK in all examples, instead of recommending direct usage of `rpc-errors`.

Fixes #2041 