### PR TITLE
Show Webpack compilation warnings in CLI

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ALkwbuS0MFVTbJB0zQXPRdDmyis8TAfZayoVY0dDAow=",
+    "shasum": "QOMVGPBlwfbeCdznshtkC/M7kmePZjFas2DghnuvAl4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ivu8DqblrnqDucyKZQRFKcsT6uc7Vw+DsQJRJgIXn9Y=",
+    "shasum": "xaeKgGBw7dxoyfQvHqVlmFP+dsbp8UyaHBD9cDqdTIQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "nJN72lSBRDfROObGpijTtKtZjRSoWSTgbdo6/CScl1I=",
+    "shasum": "5hpPoAqmyZB/I8WFfkmwL/AEcpVrmuDEvs6cVWRX95Q=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xBvDzo5oiGIbKEVGmzlI39BCzvh/l/nNkkAcOABQqoo=",
+    "shasum": "EZZGFdt4cijosfQJOtC/Ccn/gkBwgsIWR8rhLjPGpns=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wFgSmNho6eVxo+nEE2XlWRFVR8tLqKghhh86ozrwmAg=",
+    "shasum": "q5Cqe7Mk1UfaTOnxRAuZIxGbx2GBXYXQ+6mrXZFHWQI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "m4jFP39tZIR1XMosUJ3u8YIfepiI9aRIMna3Hg8RlQQ=",
+    "shasum": "Ra9HLlJ72RQZ8tZuQaKWmdgl3NtDntY44Xlwuu5oJTw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "t9CVxyl+WB6UwtynS8zhgA76KWUmQUdGGP+E0Rj+fR0=",
+    "shasum": "2rhguMIcxsk6FteTXJmU6KyxJQs/WalFIyN7VdeCuuE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "BLq144YW0hKG00k8SN3+7F9rKy6hggZVjjx9WkraNEI=",
+    "shasum": "mtog3tMv3eVyxuTeVViGVfhyFoaoUxJCmp1ebbAyKBw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "20Z28B/48X1gTo6V+RSFpx0BNs13lMwD8FE+NiDn18o=",
+    "shasum": "5nr1YbwY9W/ZSqRcM0PLPERnJN1/FLn+TKO1AVzwVA8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "YRGwMaOJHIRegfuR/LmMR+fs2pOi3Wg31Fh3Y/lOJfk=",
+    "shasum": "Mmq22si3G7gwXwk8tCyIRusRl1lYKcDqsc933BoJ+kk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Zul7ybCncDcgpTUpQNx0iTTvy97JNd0TIzM9QpzVROc=",
+    "shasum": "rgwfCQaNznfAyTzave1MWGmeYjrtN9QIDAiovln7K9A=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "RVmSqvKdYxv4Ws0cCtkepbmXnQ+6Wj0pJ+/NR0WhqiI=",
+    "shasum": "+SPhnfPu/KFVbNMst4xMgvrQIgyfLvvNEryLR02AF1Q=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "CF4xhZoqnfJt0pjTffWtNKNr8k4YDXh9ZuaszgPvoUU=",
+    "shasum": "vd8QnWyNewXHT0wtpJBk50H1yh+Kmv3A2RALNvSZrx4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1ag+BcW+rfL1qTmpnMA+Sd0h57/sZoprFB4qMFXBmPE=",
+    "shasum": "KwqpTiAM64yO+HGehTW1IYXxIDIRgUks2rzDVjWDKVY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "GFuYJnitc0nYDwAD8jhGyCw/Ufc5Ai9RbJbFWpydlFM=",
+    "shasum": "QOajRHcRuDh2kCI/ISixrdes7CEahvR2Ri5XSShj/oE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7TGnfMZy7JaBMNhA62f6lmXWojpzMVSuSkxaKqfyPw0=",
+    "shasum": "52p3c9ySoafFiZxlw1LBUS7ESRtZX2qHrcCpko1MG9M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "QxqKMFGyTlsrrf7nDj/JlbQHDIF2l+eO2E5TttzMS64=",
+    "shasum": "UNxqxiO92lBoQCUSpFO94e4B54TIxUYNXr5/AW9Ut4Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "eQZoypi/2K6+BnPVvcwOp3I8uwLKzbzLtAahPHVjOY0=",
+    "shasum": "L1fKCWbTIwGQYqmN0QW0QKsNEwfYMpQIWBrQbltpGNU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-cli/src/config.ts
+++ b/packages/snaps-cli/src/config.ts
@@ -562,11 +562,7 @@ export const SnapsWebpackConfigStruct = object({
     {},
   ),
 
-  environment: defaulted(record(string(), unknown()), {
-    NODE_DEBUG: false,
-    NODE_ENV: 'production',
-    DEBUG: false,
-  }),
+  environment: defaulted(record(string(), unknown()), {}),
 
   stats: defaulted(
     object({

--- a/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
+++ b/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
@@ -69,6 +69,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/foo/bar/dist",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -82,17 +85,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": false,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,
@@ -213,6 +211,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/foo/bar/dist",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -226,17 +227,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": true,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,
@@ -357,6 +353,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/foo/bar/dist",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -370,17 +369,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": false,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,
@@ -501,6 +495,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/foo/bar/dist",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -514,19 +511,13 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": false,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "FOO": "bar",
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.FOO": ""bar"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "FOO",
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,
@@ -642,6 +633,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/foo/bar/dist",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -655,17 +649,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": false,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,
@@ -786,6 +775,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/foo/bar/dist",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -799,17 +791,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": false,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,
@@ -930,6 +917,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/foo/bar/dist",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -943,17 +933,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": false,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,
@@ -1074,6 +1059,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/foo/bar/dist",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -1087,17 +1075,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": false,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,
@@ -1226,6 +1209,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/foo/bar/dist",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -1239,17 +1225,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": false,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,
@@ -1378,6 +1359,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/bar/baz",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -1391,17 +1375,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": false,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,
@@ -1531,6 +1510,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/bar/baz",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -1544,17 +1526,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": false,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,
@@ -1675,6 +1652,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/bar/baz",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -1688,17 +1668,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": false,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,
@@ -1819,6 +1794,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/bar/baz",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -1832,17 +1810,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": false,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,
@@ -1972,6 +1945,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/bar/baz",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -1985,17 +1961,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": false,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,
@@ -2128,6 +2099,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/foo/bar/dist",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -2141,17 +2115,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": false,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,
@@ -2265,6 +2234,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/foo/bar/dist",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -2278,17 +2250,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": false,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,
@@ -2402,6 +2369,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "path": "/foo/bar/dist",
     "publicPath": "/",
   },
+  "performance": {
+    "hints": false,
+  },
   "plugins": [
     SnapsWebpackPlugin {
       "options": {
@@ -2415,17 +2385,12 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         "verbose": false,
       },
     },
-    EnvironmentPlugin {
-      "defaultValues": {
-        "DEBUG": false,
-        "NODE_DEBUG": false,
-        "NODE_ENV": "production",
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
       },
-      "keys": [
-        "NODE_DEBUG",
-        "NODE_ENV",
-        "DEBUG",
-      ],
     },
     ProgressPlugin {
       "dependenciesCount": 10000,

--- a/packages/snaps-cli/src/webpack/config.ts
+++ b/packages/snaps-cli/src/webpack/config.ts
@@ -265,10 +265,10 @@ export async function getDefaultConfiguration(
       new SnapsStatsPlugin({ verbose: config.stats.verbose }, options.spinner),
 
       /**
-       * The `EnvironmentPlugin` is a Webpack plugin that adds environment
-       * variables to the bundle. We use it to add the `NODE_DEBUG`, `NODE_ENV`,
-       * and `DEBUG` environment variables, as well as any custom environment
-       * variables.
+       * The `DefinePlugin` is a Webpack plugin that adds static values to the
+       * bundle. We use it to add the `NODE_DEBUG`, `NODE_ENV`, and `DEBUG`
+       * environment variables, as well as any custom environment
+       * variables (as `process.env`).
        */
       new DefinePlugin(getEnvironmentVariables(config.environment)),
 

--- a/packages/snaps-cli/src/webpack/config.ts
+++ b/packages/snaps-cli/src/webpack/config.ts
@@ -337,6 +337,22 @@ export async function getDefaultConfiguration(
     },
 
     /**
+     * The performance configuration. This tells Webpack how to handle
+     * performance hints.
+     *
+     * @see https://webpack.js.org/configuration/performance/
+     */
+    performance: {
+      /**
+       * The hints to show. We set it to `false`, so that we don't get
+       * performance hints, as they are not relevant for Snaps.
+       *
+       * @see https://webpack.js.org/configuration/performance/#performancehints
+       */
+      hints: false,
+    },
+
+    /**
      * The infrastructure logging configuration. This tells Webpack how to
      * log messages.
      *

--- a/packages/snaps-cli/src/webpack/config.ts
+++ b/packages/snaps-cli/src/webpack/config.ts
@@ -3,7 +3,7 @@ import type { Ora } from 'ora';
 import { resolve } from 'path';
 import TerserPlugin from 'terser-webpack-plugin';
 import type { Configuration } from 'webpack';
-import { EnvironmentPlugin, ProgressPlugin, ProvidePlugin } from 'webpack';
+import { DefinePlugin, ProgressPlugin, ProvidePlugin } from 'webpack';
 
 import type { ProcessedWebpackConfig } from '../config';
 import {
@@ -16,6 +16,7 @@ import {
   BROWSERSLIST_FILE,
   getDefaultLoader,
   getDevTool,
+  getEnvironmentVariables,
   getFallbacks,
   getProgressHandler,
 } from './utils';
@@ -265,10 +266,11 @@ export async function getDefaultConfiguration(
 
       /**
        * The `EnvironmentPlugin` is a Webpack plugin that adds environment
-       * variables to the bundle. We use it to add the `NODE_ENV` and `DEBUG`
-       * environment variables.
+       * variables to the bundle. We use it to add the `NODE_DEBUG`, `NODE_ENV`,
+       * and `DEBUG` environment variables, as well as any custom environment
+       * variables.
        */
-      new EnvironmentPlugin(config.environment),
+      new DefinePlugin(getEnvironmentVariables(config.environment)),
 
       /**
        * The `ProgressPlugin` is a Webpack plugin that logs the progress of

--- a/packages/snaps-cli/src/webpack/loaders/wasm.test.ts
+++ b/packages/snaps-cli/src/webpack/loaders/wasm.test.ts
@@ -65,6 +65,7 @@ describe('loader', () => {
     // @ts-expect-error - We don't need to mock the entire `this` object.
     const result = await loader.bind({
       addDependency: jest.fn(),
+      resourcePath: join(__dirname, '__fixtures__', 'program.wasm'),
       // @ts-expect-error - The type of this function seems to be incorrect.
     })(source);
 

--- a/packages/snaps-cli/src/webpack/loaders/wasm.ts
+++ b/packages/snaps-cli/src/webpack/loaders/wasm.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-globals */
 
 import { assert } from '@metamask/utils';
+import { dirname, resolve } from 'path';
 import type { LoaderDefinitionFunction } from 'webpack';
 
 /**
@@ -95,8 +96,9 @@ const loader: LoaderDefinitionFunction = async function loader(
 
   // Add the WASM import as a dependency so that Webpack will watch it for
   // changes.
+  const path = dirname(this.resourcePath);
   for (const name of Object.keys(imports)) {
-    this.addDependency(name);
+    this.addDependency(resolve(path, name));
   }
 
   return `

--- a/packages/snaps-cli/src/webpack/plugins.ts
+++ b/packages/snaps-cli/src/webpack/plugins.ts
@@ -3,7 +3,6 @@ import { assert, hasProperty, isObject } from '@metamask/utils';
 import { dim, red, yellow } from 'chalk';
 import { isBuiltin } from 'module';
 import type { Ora } from 'ora';
-import type { WebpackError } from 'terser-webpack-plugin';
 import type {
   Compiler,
   ProvidePlugin,
@@ -129,7 +128,7 @@ export class SnapsStatsPlugin implements WebpackPluginInstance {
    * @param color - The color to use for the error message.
    * @returns The error message.
    */
-  #getStatsErrorMessage(statsError: StatsError | WebpackError, color = red) {
+  #getStatsErrorMessage(statsError: StatsError, color = red) {
     const baseMessage = this.options.verbose
       ? getErrorMessage(statsError)
       : statsError.message;

--- a/packages/snaps-cli/src/webpack/plugins.ts
+++ b/packages/snaps-cli/src/webpack/plugins.ts
@@ -3,6 +3,7 @@ import { assert, hasProperty, isObject } from '@metamask/utils';
 import { dim, red, yellow } from 'chalk';
 import { isBuiltin } from 'module';
 import type { Ora } from 'ora';
+import type { WebpackError } from 'terser-webpack-plugin';
 import type {
   Compiler,
   ProvidePlugin,
@@ -59,14 +60,14 @@ export class SnapsStatsPlugin implements WebpackPluginInstance {
         return;
       }
 
-      const { modules, time, errors } = stats.toJson();
+      const { modules, time, errors, warnings } = stats.toJson();
 
       assert(modules, 'Modules must be defined in stats.');
       assert(time, 'Time must be defined in stats.');
 
       if (errors?.length) {
         const formattedErrors = errors
-          .map(this.#getStatsErrorMessage.bind(this))
+          .map((statsError) => this.#getStatsErrorMessage(statsError))
           .join('\n\n');
 
         error(
@@ -86,13 +87,32 @@ export class SnapsStatsPlugin implements WebpackPluginInstance {
         return;
       }
 
-      info(
-        `Compiled ${modules.length} ${pluralize(
-          modules.length,
-          'file',
-        )} in ${time}ms.`,
-        this.#spinner,
-      );
+      if (warnings?.length) {
+        const formattedWarnings = warnings
+          .map((statsWarning) =>
+            this.#getStatsErrorMessage(statsWarning, yellow),
+          )
+          .join('\n\n');
+
+        warn(
+          `Compiled ${modules.length} ${pluralize(
+            modules.length,
+            'file',
+          )} in ${time}ms with ${warnings.length} ${pluralize(
+            warnings.length,
+            'warning',
+          )}.\n\n${formattedWarnings}\n`,
+          this.#spinner,
+        );
+      } else {
+        info(
+          `Compiled ${modules.length} ${pluralize(
+            modules.length,
+            'file',
+          )} in ${time}ms.`,
+          this.#spinner,
+        );
+      }
 
       if (compiler.watchMode) {
         // The spinner may be restarted by the watch plugin, outside of the
@@ -106,9 +126,10 @@ export class SnapsStatsPlugin implements WebpackPluginInstance {
    * Get the error message for the given stats error.
    *
    * @param statsError - The stats error.
+   * @param color - The color to use for the error message.
    * @returns The error message.
    */
-  #getStatsErrorMessage(statsError: StatsError) {
+  #getStatsErrorMessage(statsError: StatsError | WebpackError, color = red) {
     const baseMessage = this.options.verbose
       ? getErrorMessage(statsError)
       : statsError.message;
@@ -116,8 +137,8 @@ export class SnapsStatsPlugin implements WebpackPluginInstance {
     const [first, ...rest] = baseMessage.split('\n');
 
     return [
-      indent(red(`• ${first}`), 2),
-      ...rest.map((message) => indent(red(message), 4)),
+      indent(color(`• ${first}`), 2),
+      ...rest.map((message) => indent(color(message), 4)),
       statsError.details && indent(dim(statsError.details), 4),
     ]
       .filter(Boolean)

--- a/packages/snaps-cli/src/webpack/utils.test.ts
+++ b/packages/snaps-cli/src/webpack/utils.test.ts
@@ -10,6 +10,7 @@ import {
   getFallbacks,
   getProgressHandler,
   pluralize,
+  getEnvironmentVariables,
 } from './utils';
 
 describe('getDefaultLoader', () => {
@@ -125,5 +126,23 @@ describe('getFallbacks', () => {
     const fallbacks = getFallbacks(true);
 
     expect(fallbacks.fs).toBe(false);
+  });
+});
+
+describe('getEnvironmentVariables', () => {
+  it('returns the environment variables', () => {
+    const env = getEnvironmentVariables({
+      NODE_ENV: 'development',
+      API_URL: 'https://example.com',
+    });
+
+    expect(env).toMatchInlineSnapshot(`
+      {
+        "process.env.API_URL": ""https://example.com"",
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""development"",
+      }
+    `);
   });
 });

--- a/packages/snaps-cli/src/webpack/utils.ts
+++ b/packages/snaps-cli/src/webpack/utils.ts
@@ -271,3 +271,27 @@ export function getFallbacks(polyfills: ProcessedWebpackConfig['polyfills']): {
     ]),
   );
 }
+
+/**
+ * Get an object that can be used as environment variables for Webpack's
+ * `DefinePlugin`.
+ *
+ * @param environment - The environment object from the Snap config.
+ * @param defaults - The default environment variables.
+ * @returns The Webpack environment variables.
+ */
+export function getEnvironmentVariables(
+  environment: Record<string, unknown>,
+  defaults = {
+    NODE_DEBUG: 'false',
+    NODE_ENV: 'production',
+    DEBUG: 'false',
+  },
+) {
+  return Object.fromEntries(
+    Object.entries({
+      ...defaults,
+      ...environment,
+    }).map(([key, value]) => [`process.env.${key}`, JSON.stringify(value)]),
+  );
+}

--- a/packages/snaps-utils/src/post-process.ts
+++ b/packages/snaps-utils/src/post-process.ts
@@ -58,7 +58,7 @@ export type PostProcessedBundle = {
 };
 
 export enum PostProcessWarning {
-  UnsafeMathRandom = '`Math.random` was detected in the bundle. This is not a secure source of randomness.',
+  UnsafeMathRandom = '`Math.random` was detected in the Snap bundle. This is not a secure source of randomness, and should not be used in a secure context. Use `crypto.getRandomValues` instead.',
 }
 
 // The RegEx below consists of multiple groups joined by a boolean OR.

--- a/packages/snaps-webpack-plugin/src/plugin.test.ts
+++ b/packages/snaps-webpack-plugin/src/plugin.test.ts
@@ -155,7 +155,7 @@ describe('SnapsWebpackPlugin', () => {
     });
 
     expect(stats.toJson().warnings?.[0].message).toMatch(
-      `SnapsWebpackPlugin: Bundle Warning: Processing of the Snap bundle completed with warnings.\n${PostProcessWarning.UnsafeMathRandom}`,
+      PostProcessWarning.UnsafeMathRandom,
     );
   });
 

--- a/packages/snaps-webpack-plugin/src/plugin.ts
+++ b/packages/snaps-webpack-plugin/src/plugin.ts
@@ -84,13 +84,11 @@ export default class SnapsWebpackPlugin {
                 });
 
                 if (processed.warnings.length > 0) {
-                  compilation.warnings.push(
-                    new WebpackError(
-                      `${PLUGIN_NAME}: Bundle Warning: Processing of the Snap bundle completed with warnings.\n${processed.warnings.join(
-                        '\n',
-                      )}`,
-                    ),
+                  const webpackErrors = processed.warnings.map(
+                    (warning) => new WebpackError(warning),
                   );
+
+                  compilation.warnings.push(...webpackErrors);
                 }
 
                 const replacement = processed.sourceMap


### PR DESCRIPTION
Compilation warnings were previously ignored, potentially hiding important warnings from Webpack. This updates the Webpack config to show these warnings, and does some other changes to make warnings more readable.

Closes #2145.