### PR TITLE
Patch `@puppeteer/browsers`

### DIFF
--- a/.yarn/patches/@puppeteer-browsers-npm-1.7.0-203cb4f44b.patch
+++ b/.yarn/patches/@puppeteer-browsers-npm-1.7.0-203cb4f44b.patch
@@ -1,0 +1,104 @@
+diff --git a/lib/cjs/browser-data/chrome-headless-shell.js b/lib/cjs/browser-data/chrome-headless-shell.js
+index af555e4fb3294f7a48660f8d4a97ddf52dada0e5..c3b6a9f5860d08817869016dcef13eab3c63499a 100644
+--- a/lib/cjs/browser-data/chrome-headless-shell.js
++++ b/lib/cjs/browser-data/chrome-headless-shell.js
+@@ -35,7 +35,7 @@ function folder(platform) {
+             return 'win64';
+     }
+ }
+-function resolveDownloadUrl(platform, buildId, baseUrl = 'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing') {
++function resolveDownloadUrl(platform, buildId, baseUrl = 'https://storage.googleapis.com/chrome-for-testing-public') {
+     return `${baseUrl}/${resolveDownloadPath(platform, buildId).join('/')}`;
+ }
+ exports.resolveDownloadUrl = resolveDownloadUrl;
+diff --git a/lib/cjs/browser-data/chrome.js b/lib/cjs/browser-data/chrome.js
+index 6af4e6f63e55e83a00e5f5c557fc0dbb0bfc4865..9988779d2d307815776d6bcdd2a877af15f015cb 100644
+--- a/lib/cjs/browser-data/chrome.js
++++ b/lib/cjs/browser-data/chrome.js
+@@ -36,7 +36,7 @@ function folder(platform) {
+             return 'win64';
+     }
+ }
+-function resolveDownloadUrl(platform, buildId, baseUrl = 'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing') {
++function resolveDownloadUrl(platform, buildId, baseUrl = 'https://storage.googleapis.com/chrome-for-testing-public') {
+     return `${baseUrl}/${resolveDownloadPath(platform, buildId).join('/')}`;
+ }
+ exports.resolveDownloadUrl = resolveDownloadUrl;
+diff --git a/lib/cjs/browser-data/chromedriver.js b/lib/cjs/browser-data/chromedriver.js
+index f9ced6c4724e3cb3a3188989f1bab25b3aa4941b..faea49e7c8b1f4fa85acfae0d78a9a1a2a3c0a30 100644
+--- a/lib/cjs/browser-data/chromedriver.js
++++ b/lib/cjs/browser-data/chromedriver.js
+@@ -35,7 +35,7 @@ function folder(platform) {
+             return 'win64';
+     }
+ }
+-function resolveDownloadUrl(platform, buildId, baseUrl = 'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing') {
++function resolveDownloadUrl(platform, buildId, baseUrl = 'https://storage.googleapis.com/chrome-for-testing-public') {
+     return `${baseUrl}/${resolveDownloadPath(platform, buildId).join('/')}`;
+ }
+ exports.resolveDownloadUrl = resolveDownloadUrl;
+diff --git a/lib/cjs/install.d.ts b/lib/cjs/install.d.ts
+index 68fb99dff49e3c82b9dbd035343562ca8157a53d..5d9bd466c83458f6497a716ae6f6bbde444927c2 100644
+--- a/lib/cjs/install.d.ts
++++ b/lib/cjs/install.d.ts
+@@ -47,7 +47,7 @@ export interface InstallOptions {
+      *
+      * @defaultValue Either
+      *
+-     * - https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing or
++     * - https://storage.googleapis.com/chrome-for-testing-public or
+      * - https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central
+      *
+      */
+diff --git a/lib/esm/browser-data/chrome-headless-shell.js b/lib/esm/browser-data/chrome-headless-shell.js
+index cf45517bd6dbc1cdebd289b5e01db9a557c2822d..f8fd3d6362cd2e40f33df5fb4f30f7ec7f06d611 100644
+--- a/lib/esm/browser-data/chrome-headless-shell.js
++++ b/lib/esm/browser-data/chrome-headless-shell.js
+@@ -29,7 +29,7 @@ function folder(platform) {
+             return 'win64';
+     }
+ }
+-export function resolveDownloadUrl(platform, buildId, baseUrl = 'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing') {
++export function resolveDownloadUrl(platform, buildId, baseUrl = 'https://storage.googleapis.com/chrome-for-testing-public') {
+     return `${baseUrl}/${resolveDownloadPath(platform, buildId).join('/')}`;
+ }
+ export function resolveDownloadPath(platform, buildId) {
+diff --git a/lib/esm/browser-data/chrome.js b/lib/esm/browser-data/chrome.js
+index e550644bfc0893169feb46d884e1de01d10ccb12..87f8daec7b3e5d30790946149c51cae01278ecbc 100644
+--- a/lib/esm/browser-data/chrome.js
++++ b/lib/esm/browser-data/chrome.js
+@@ -30,7 +30,7 @@ function folder(platform) {
+             return 'win64';
+     }
+ }
+-export function resolveDownloadUrl(platform, buildId, baseUrl = 'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing') {
++export function resolveDownloadUrl(platform, buildId, baseUrl = 'https://storage.googleapis.com/chrome-for-testing-public') {
+     return `${baseUrl}/${resolveDownloadPath(platform, buildId).join('/')}`;
+ }
+ export function resolveDownloadPath(platform, buildId) {
+diff --git a/lib/esm/browser-data/chromedriver.js b/lib/esm/browser-data/chromedriver.js
+index a4504e4f2d9b361b393c013d3cb6ca325a346770..aa48aca65487921e04f735283a99218621682bdc 100644
+--- a/lib/esm/browser-data/chromedriver.js
++++ b/lib/esm/browser-data/chromedriver.js
+@@ -29,7 +29,7 @@ function folder(platform) {
+             return 'win64';
+     }
+ }
+-export function resolveDownloadUrl(platform, buildId, baseUrl = 'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing') {
++export function resolveDownloadUrl(platform, buildId, baseUrl = 'https://storage.googleapis.com/chrome-for-testing-public') {
+     return `${baseUrl}/${resolveDownloadPath(platform, buildId).join('/')}`;
+ }
+ export function resolveDownloadPath(platform, buildId) {
+diff --git a/lib/esm/install.d.ts b/lib/esm/install.d.ts
+index 68fb99dff49e3c82b9dbd035343562ca8157a53d..5d9bd466c83458f6497a716ae6f6bbde444927c2 100644
+--- a/lib/esm/install.d.ts
++++ b/lib/esm/install.d.ts
+@@ -47,7 +47,7 @@ export interface InstallOptions {
+      *
+      * @defaultValue Either
+      *
+-     * - https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing or
++     * - https://storage.googleapis.com/chrome-for-testing-public or
+      * - https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central
+      *
+      */

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "@babel/core": "patch:@babel/core@npm%3A7.23.2#./.yarn/patches/@babel-core-npm-7.23.2-b93f586907.patch",
     "@esbuild-plugins/node-modules-polyfill@^0.2.2": "patch:@esbuild-plugins/node-modules-polyfill@npm%3A0.2.2#./.yarn/patches/@esbuild-plugins-node-modules-polyfill-npm-0.2.2-f612681798.patch",
     "@lavamoat/lavapack@^6.1.0": "patch:@lavamoat/lavapack@npm%3A6.1.0#./.yarn/patches/@lavamoat-lavapack-npm-6.1.0-69c81c1923.patch",
+    "@puppeteer/browsers@1.4.6": "patch:@puppeteer/browsers@npm%3A1.7.0#./.yarn/patches/@puppeteer-browsers-npm-1.7.0-203cb4f44b.patch",
+    "@puppeteer/browsers@^1.6.0": "patch:@puppeteer/browsers@npm%3A1.7.0#./.yarn/patches/@puppeteer-browsers-npm-1.7.0-203cb4f44b.patch",
     "@types/glob@*": "patch:@types/glob@npm%3A7.1.4#./.yarn/patches/@types-glob-npm-7.1.4-d45247eaa2.patch",
     "@types/glob@^7.1.1": "patch:@types/glob@npm%3A7.1.4#./.yarn/patches/@types-glob-npm-7.1.4-d45247eaa2.patch",
     "@types/mocha@^10.0.1": "patch:@types/mocha@npm:10.0.1#.yarn/patches/@types-mocha-npm-10.0.1-7c94e9e170.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6409,29 +6409,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@puppeteer/browsers@npm:1.4.6":
-  version: 1.4.6
-  resolution: "@puppeteer/browsers@npm:1.4.6"
-  dependencies:
-    debug: 4.3.4
-    extract-zip: 2.0.1
-    progress: 2.0.3
-    proxy-agent: 6.3.0
-    tar-fs: 3.0.4
-    unbzip2-stream: 1.4.3
-    yargs: 17.7.1
-  peerDependencies:
-    typescript: ">= 4.7.4"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  bin:
-    browsers: lib/cjs/main-cli.js
-  checksum: 29569dd8a8a41737bb0dd40cce6279cfc8764afc6242d2f9d8ae610bed7e466fc77eeb27b9b3ac53dd04927a1a0e26389f282f6ba057210979b36ab455009d64
-  languageName: node
-  linkType: hard
-
-"@puppeteer/browsers@npm:^1.6.0":
+"@puppeteer/browsers@npm:1.7.0":
   version: 1.7.0
   resolution: "@puppeteer/browsers@npm:1.7.0"
   dependencies:
@@ -6445,6 +6423,23 @@ __metadata:
   bin:
     browsers: lib/cjs/main-cli.js
   checksum: 0a2aecc72fb94a8d94246188f94cfaad730d1d372b34df94ca51ff8a94596bf475a0fee162c317a768fa4b2a707bfa8afd582d594958f49e1019effadfe744b6
+  languageName: node
+  linkType: hard
+
+"@puppeteer/browsers@patch:@puppeteer/browsers@npm%3A1.7.0#./.yarn/patches/@puppeteer-browsers-npm-1.7.0-203cb4f44b.patch::locator=root%40workspace%3A.":
+  version: 1.7.0
+  resolution: "@puppeteer/browsers@patch:@puppeteer/browsers@npm%3A1.7.0#./.yarn/patches/@puppeteer-browsers-npm-1.7.0-203cb4f44b.patch::version=1.7.0&hash=bbbc7d&locator=root%40workspace%3A."
+  dependencies:
+    debug: 4.3.4
+    extract-zip: 2.0.1
+    progress: 2.0.3
+    proxy-agent: 6.3.0
+    tar-fs: 3.0.4
+    unbzip2-stream: 1.4.3
+    yargs: 17.7.1
+  bin:
+    browsers: lib/cjs/main-cli.js
+  checksum: d767c5c2e7278d8e4471f7ef027db36e73af19ff1955f943c8b0d18dcc71b44ef07569ab0c3ce0ba0038e4152c37c44f27e7435bccc768a0802f813dcde2a870
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Puppeteer is currently broken because Google Chrome moved to a new URL.

See puppeteer/puppeteer#11923.