### PR TITLE
Update example configurations

### DIFF
--- a/packages/examples/packages/bip32/snap.config.ts
+++ b/packages/examples/packages/bip32/snap.config.ts
@@ -7,12 +7,11 @@ const config: SnapConfig = {
   server: {
     port: 8001,
   },
-  polyfills: {
-    stream: true,
-  },
   stats: {
-    builtIns: false,
     buffer: false,
+    builtIns: {
+      ignore: ['crypto'],
+    },
   },
 };
 

--- a/packages/examples/packages/bip44/snap.config.ts
+++ b/packages/examples/packages/bip44/snap.config.ts
@@ -7,9 +7,11 @@ const config: SnapConfig = {
   server: {
     port: 8002,
   },
-  polyfills: {
-    buffer: true,
-    stream: true,
+  stats: {
+    buffer: false,
+    builtIns: {
+      ignore: ['crypto'],
+    },
   },
 };
 

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "G88Poc8uX2NVEqWnuOHZhEpt8TzD6fhOXbXZj2JGeSQ=",
+    "shasum": "nsCQTpHVQtjUTxAolBdau7xERxwz4OxKbyXth4kTiz8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.config.ts
+++ b/packages/examples/packages/dialogs/snap.config.ts
@@ -7,8 +7,8 @@ const config: SnapConfig = {
   server: {
     port: 8005,
   },
-  polyfills: {
-    stream: true,
+  stats: {
+    buffer: false,
   },
 };
 

--- a/packages/examples/packages/ethereum-provider/snap.config.ts
+++ b/packages/examples/packages/ethereum-provider/snap.config.ts
@@ -7,6 +7,9 @@ const config: SnapConfig = {
   server: {
     port: 8007,
   },
+  stats: {
+    buffer: false,
+  },
 };
 
 export default config;

--- a/packages/examples/packages/ethers-js/snap.config.ts
+++ b/packages/examples/packages/ethers-js/snap.config.ts
@@ -9,10 +9,11 @@ const config: SnapConfig = {
   server: {
     port: 8008,
   },
-  polyfills: {
-    crypto: true,
-    stream: true,
-    buffer: true,
+  stats: {
+    buffer: false,
+    builtIns: {
+      ignore: ['crypto'],
+    },
   },
   customizeWebpackConfig: (defaultConfig) =>
     merge(defaultConfig, {

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "N9i27+suBYwVHDzqQGtvafY55vHNCkcYAL7Fuw6wOz0=",
+    "shasum": "2gFUJsHPYeCR8WTdRtYSxyAuMG3n/IEUj1diV3F002k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.config.ts
+++ b/packages/examples/packages/get-entropy/snap.config.ts
@@ -7,8 +7,11 @@ const config: SnapConfig = {
   server: {
     port: 8009,
   },
-  polyfills: {
-    stream: true,
+  stats: {
+    buffer: false,
+    builtIns: {
+      ignore: ['crypto'],
+    },
   },
 };
 

--- a/packages/examples/packages/get-file/snap.config.ts
+++ b/packages/examples/packages/get-file/snap.config.ts
@@ -7,8 +7,8 @@ const config: SnapConfig = {
   server: {
     port: 8024,
   },
-  polyfills: {
-    stream: true,
+  stats: {
+    buffer: false,
   },
 };
 

--- a/packages/examples/packages/home-page/snap.config.ts
+++ b/packages/examples/packages/home-page/snap.config.ts
@@ -7,8 +7,8 @@ const config: SnapConfig = {
   server: {
     port: 8025,
   },
-  polyfills: {
-    stream: true,
+  stats: {
+    buffer: false,
   },
 };
 

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "GYviPuR6+daL3dTw5GNeb8alDHJYBmc6Jf0JEJVQ5ms=",
+    "shasum": "n5pi83PpGX4amRQqR9ij4oWARSt2bCJD3SyR5Bpu+Vw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/src/ui.ts
+++ b/packages/examples/packages/interactive-ui/src/ui.ts
@@ -10,9 +10,9 @@ import {
   panel,
   row,
   text,
+  assert,
 } from '@metamask/snaps-sdk';
 import type { Component, Transaction } from '@metamask/snaps-sdk';
-import assert from 'assert';
 
 import { decodeData } from './utils';
 

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.config.ts
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.config.ts
@@ -7,8 +7,8 @@ const config: SnapConfig = {
   server: {
     port: 8012,
   },
-  polyfills: {
-    stream: true,
+  stats: {
+    buffer: false,
   },
 };
 

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.config.ts
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.config.ts
@@ -7,8 +7,11 @@ const config: SnapConfig = {
   server: {
     port: 8011,
   },
-  polyfills: {
-    stream: true,
+  stats: {
+    buffer: false,
+    builtIns: {
+      ignore: ['crypto'],
+    },
   },
 };
 

--- a/packages/examples/packages/manage-state/snap.config.ts
+++ b/packages/examples/packages/manage-state/snap.config.ts
@@ -9,9 +9,6 @@ const config: SnapConfig = {
   stats: {
     buffer: false,
   },
-  polyfills: {
-    stream: true,
-  },
 };
 
 export default config;

--- a/packages/examples/packages/network-access/snap.config.ts
+++ b/packages/examples/packages/network-access/snap.config.ts
@@ -9,9 +9,6 @@ const config: SnapConfig = {
   stats: {
     buffer: false,
   },
-  polyfills: {
-    stream: true,
-  },
 };
 
 export default config;

--- a/packages/examples/packages/notifications/snap.config.ts
+++ b/packages/examples/packages/notifications/snap.config.ts
@@ -9,9 +9,6 @@ const config: SnapConfig = {
   stats: {
     buffer: false,
   },
-  polyfills: {
-    stream: true,
-  },
 };
 
 export default config;

--- a/packages/examples/packages/signature-insights/snap.config.ts
+++ b/packages/examples/packages/signature-insights/snap.config.ts
@@ -7,9 +7,6 @@ const config: SnapConfig = {
   server: {
     port: 8017,
   },
-  polyfills: {
-    stream: true,
-  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/transaction-insights/snap.config.ts
+++ b/packages/examples/packages/transaction-insights/snap.config.ts
@@ -9,9 +9,6 @@ const config: SnapConfig = {
   stats: {
     buffer: false,
   },
-  polyfills: {
-    stream: true,
-  },
 };
 
 export default config;


### PR DESCRIPTION
This updates the configuration of most example Snaps to reduce the number of warnings. Some examples also were using polyfills that were not needed anymore.