### PR TITLE
Support new lines in CLI message formatting

### DIFF
--- a/packages/snaps-cli/src/webpack/utils.test.ts
+++ b/packages/snaps-cli/src/webpack/utils.test.ts
@@ -176,6 +176,22 @@ describe('formatText', () => {
     `);
   });
 
+  it('formats the text with new lines', () => {
+    expect(
+      formatText(
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam eget nulla mattis, sollicitudin enim tincidunt, vulputate libero.\nPellentesque neque sapien, lobortis eu elit in, suscipit aliquet augue.',
+        2,
+      ),
+    ).toMatchInlineSnapshot(`
+      "  Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit. Nam eget
+        nulla mattis, sollicitudin enim
+        tincidunt, vulputate libero.
+        Pellentesque neque sapien, lobortis eu
+        elit in, suscipit aliquet augue."
+    `);
+  });
+
   it('formats the text with a custom initial indentation', () => {
     process.stdout.columns = 40;
     expect(
@@ -191,6 +207,21 @@ describe('formatText', () => {
           tincidunt, vulputate libero.
           Pellentesque neque sapien, lobortis
           eu elit in, suscipit aliquet augue."
+    `);
+  });
+
+  it('indents the text if the terminal width is not set', () => {
+    // @ts-expect-error - According to the type, `columns` cannot be undefined.
+    process.stdout.columns = undefined;
+
+    expect(
+      formatText(
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam eget nulla mattis, sollicitudin enim tincidunt, vulputate libero.\nPellentesque neque sapien, lobortis eu elit in, suscipit aliquet augue.',
+        2,
+      ),
+    ).toMatchInlineSnapshot(`
+      "  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam eget nulla mattis, sollicitudin enim tincidunt, vulputate libero.
+        Pellentesque neque sapien, lobortis eu elit in, suscipit aliquet augue."
     `);
   });
 });

--- a/packages/snaps-cli/src/webpack/utils.ts
+++ b/packages/snaps-cli/src/webpack/utils.ts
@@ -298,27 +298,21 @@ export function getEnvironmentVariables(
 }
 
 /**
- * Format the given text to fit within the terminal width.
+ * Format the given line to fit within the terminal width.
  *
- * @param text - The text to format.
+ * @param line - The line to format.
  * @param indent - The indentation to use.
  * @param initialIndent - The initial indentation to use, i.e., the indentation
  * for the first line.
- * @returns The formatted text.
+ * @returns The formatted line.
  */
-export function formatText(
-  text: string,
-  indent: number,
-  initialIndent = indent,
-) {
+function formatLine(line: string, indent: number, initialIndent = indent) {
   const terminalWidth = process.stdout.columns;
   if (!terminalWidth) {
-    return text;
+    return `${' '.repeat(initialIndent)}${line}`;
   }
 
-  const words = text.split(' ');
-
-  const { formattedText: result } = words.reduce(
+  return line.split(' ').reduce(
     ({ formattedText, currentLineLength }, word, index) => {
       // `chalk` adds ANSI escape codes to the text, which are not visible
       // characters. We need to strip them to get the visible length of the
@@ -347,7 +341,30 @@ export function formatText(
       formattedText: ' '.repeat(initialIndent),
       currentLineLength: initialIndent,
     },
-  );
+  ).formattedText;
+}
 
-  return result;
+/**
+ * Format the given text to fit within the terminal width.
+ *
+ * @param text - The text to format.
+ * @param indent - The indentation to use.
+ * @param initialIndent - The initial indentation to use, i.e., the indentation
+ * for the first line.
+ * @returns The formatted text.
+ */
+export function formatText(
+  text: string,
+  indent: number,
+  initialIndent = indent,
+) {
+  const lines = text.split('\n');
+
+  // Apply formatting to each line separately and then join them.
+  return lines
+    .map((line, index) => {
+      const lineIndent = index === 0 ? initialIndent : indent;
+      return formatLine(line, indent, lineIndent);
+    })
+    .join('\n');
 }

--- a/packages/snaps-cli/src/webpack/utils.ts
+++ b/packages/snaps-cli/src/webpack/utils.ts
@@ -306,7 +306,7 @@ export function getEnvironmentVariables(
  * for the first line.
  * @returns The formatted line.
  */
-function formatLine(line: string, indent: number, initialIndent = indent) {
+function formatLine(line: string, indent: number, initialIndent: number) {
   const terminalWidth = process.stdout.columns;
   if (!terminalWidth) {
     return `${' '.repeat(initialIndent)}${line}`;


### PR DESCRIPTION
Strings containing new lines would not be indented previously. This fixes that.