### PR TITLE
Fix issue installing non-allowlisted Snaps in allowlist mode

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 90.97,
+  "branches": 91.01,
   "functions": 96.56,
-  "lines": 97.78,
-  "statements": 97.44
+  "lines": 97.79,
+  "statements": 97.45
 }

--- a/packages/snaps-controllers/src/snaps/registry/json.test.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.test.ts
@@ -354,38 +354,38 @@ describe('JsonSnapsRegistry', () => {
       expect(result).toBe('1.0.0');
     });
 
-    it('throws if snap is not on the allowlist', async () => {
+    it('returns version range if snap is not on the allowlist', async () => {
       fetchMock
         .mockResponseOnce(
           JSON.stringify({ verifiedSnaps: {}, blockedSnaps: [] }),
         )
         .mockResponseOnce(JSON.stringify(MOCK_EMPTY_SIGNATURE_FILE));
 
+      const range = '^1.0.0' as SemVerRange;
       const { messenger } = getRegistry();
-      await expect(
-        messenger.call(
+      expect(
+        await messenger.call(
           'SnapsRegistry:resolveVersion',
           MOCK_SNAP_ID,
-          '^1.0.0' as SemVerRange,
+          range,
         ),
-      ).rejects.toThrow('The snap is not on the allowlist');
+      ).toBe(range);
     });
 
-    it('throws if resolved version is not on the allowlist', async () => {
+    it('returns version range if resolved version is not on the allowlist', async () => {
       fetchMock
         .mockResponseOnce(JSON.stringify(MOCK_DATABASE))
         .mockResponseOnce(JSON.stringify(MOCK_SIGNATURE_FILE));
 
+      const range = '^1.2.0' as SemVerRange;
       const { messenger } = getRegistry();
-      await expect(
-        messenger.call(
+      expect(
+        await messenger.call(
           'SnapsRegistry:resolveVersion',
           MOCK_SNAP_ID,
-          '^1.2.0' as SemVerRange,
+          range,
         ),
-      ).rejects.toThrow(
-        'No matching versions of the snap are on the allowlist',
-      );
+      ).toBe(range);
     });
 
     it('refetches the database on allowlist miss if configured', async () => {

--- a/packages/snaps-controllers/src/snaps/registry/json.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.ts
@@ -283,13 +283,12 @@ export class JsonSnapsRegistry extends BaseController<
   }
 
   /**
-   * Find an allowlisted version within a specified version range.
+   * Find an allowlisted version within a specified version range. Otherwise return the version range itself.
    *
    * @param snapId - The ID of the snap we are trying to resolve a version for.
    * @param versionRange - The version range.
    * @param refetch - An optional flag used to determine if we are refetching the registry.
-   * @returns An allowlisted version within the specified version range.
-   * @throws If an allowlisted version does not exist within the version range.
+   * @returns An allowlisted version within the specified version range if available otherwise returns the input version range.
    */
   async #resolveVersion(
     snapId: string,
@@ -304,7 +303,10 @@ export class JsonSnapsRegistry extends BaseController<
       return this.#resolveVersion(snapId, versionRange, true);
     }
 
-    assert(versions, 'The snap is not on the allowlist');
+    // If we cannot narrow down the version range we return the unaltered version range.
+    if (!versions) {
+      return versionRange;
+    }
 
     const targetVersion = getTargetVersion(
       Object.keys(versions) as SemVerVersion[],
@@ -316,10 +318,10 @@ export class JsonSnapsRegistry extends BaseController<
       return this.#resolveVersion(snapId, versionRange, true);
     }
 
-    assert(
-      targetVersion,
-      'No matching versions of the snap are on the allowlist',
-    );
+    // If we cannot narrow down the version range we return the unaltered version range.
+    if (!targetVersion) {
+      return versionRange;
+    }
 
     // A semver version is technically also a valid semver range.
     assertIsSemVerRange(targetVersion);


### PR DESCRIPTION
Fixes an issue installing non-allowlisted Snaps in allowlist mode. Previously we would fail if resolving a version range to an allowlisted version would fail. We cannot do this anymore as some Snaps may still be available for installation in allowlist mode without the version being on the allowlist. This PR alters the `resolveVersion` function to return the unaltered version range if it isn't possible to narrow down the version to install.

Snaps that require allowlisting will still fail in the `assertIsInstallAllowed` step which follows this step. This issue was not caught before testing in the extension since the SnapController tests run with a mocked registry.