### PR TITLE
Add sizing limits for custom UI

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 91.01,
   "functions": 96.56,
-  "lines": 97.79,
-  "statements": 97.45
+  "lines": 97.8,
+  "statements": 97.46
 }

--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.test.ts
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.test.ts
@@ -125,7 +125,7 @@ describe('SnapInterfaceController', () => {
           MOCK_SNAP_ID,
           components,
         ),
-      ).rejects.toThrow('UI content is unreasonably large.');
+      ).rejects.toThrow('A Snap UI may not be larger than 250 kB.');
     });
 
     it('throws if text content is too large', async () => {
@@ -148,7 +148,7 @@ describe('SnapInterfaceController', () => {
           MOCK_SNAP_ID,
           components,
         ),
-      ).rejects.toThrow('UI text content is unreasonably large.');
+      ).rejects.toThrow('The text in a Snap UI may not be larger than 50 kB.');
     });
   });
 
@@ -368,7 +368,7 @@ describe('SnapInterfaceController', () => {
           id,
           newContent,
         ),
-      ).rejects.toThrow('UI content is unreasonably large.');
+      ).rejects.toThrow('A Snap UI may not be larger than 250 kB.');
     });
 
     it('throws if text content is too large', async () => {
@@ -401,7 +401,7 @@ describe('SnapInterfaceController', () => {
           id,
           newContent,
         ),
-      ).rejects.toThrow('UI text content is unreasonably large.');
+      ).rejects.toThrow('The text in a Snap UI may not be larger than 50 kB.');
     });
 
     it('throws if the interface does not exist', async () => {

--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.test.ts
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.test.ts
@@ -104,6 +104,52 @@ describe('SnapInterfaceController', () => {
         'foo.bar',
       );
     });
+
+    it('throws if UI content is too large', async () => {
+      const rootMessenger = getRootSnapInterfaceControllerMessenger();
+      const controllerMessenger = getRestrictedSnapInterfaceControllerMessenger(
+        rootMessenger,
+        false,
+      );
+
+      /* eslint-disable-next-line no-new */
+      new SnapInterfaceController({
+        messenger: controllerMessenger,
+      });
+
+      const components = panel([text('[foo](https://foo.bar)'.repeat(100000))]);
+
+      await expect(
+        rootMessenger.call(
+          'SnapInterfaceController:createInterface',
+          MOCK_SNAP_ID,
+          components,
+        ),
+      ).rejects.toThrow('UI content is unreasonably large.');
+    });
+
+    it('throws if text content is too large', async () => {
+      const rootMessenger = getRootSnapInterfaceControllerMessenger();
+      const controllerMessenger = getRestrictedSnapInterfaceControllerMessenger(
+        rootMessenger,
+        false,
+      );
+
+      /* eslint-disable-next-line no-new */
+      new SnapInterfaceController({
+        messenger: controllerMessenger,
+      });
+
+      const components = panel([text('[foo](https://foo.bar)'.repeat(2500))]);
+
+      await expect(
+        rootMessenger.call(
+          'SnapInterfaceController:createInterface',
+          MOCK_SNAP_ID,
+          components,
+        ),
+      ).rejects.toThrow('UI text content is unreasonably large.');
+    });
   });
 
   describe('getInterface', () => {
@@ -290,6 +336,72 @@ describe('SnapInterfaceController', () => {
         'PhishingController:testOrigin',
         'foo.bar',
       );
+    });
+
+    it('throws if UI content is too large', async () => {
+      const rootMessenger = getRootSnapInterfaceControllerMessenger();
+      const controllerMessenger =
+        getRestrictedSnapInterfaceControllerMessenger(rootMessenger);
+
+      /* eslint-disable-next-line no-new */
+      new SnapInterfaceController({
+        messenger: controllerMessenger,
+      });
+
+      const components = form({
+        name: 'foo',
+        children: [input({ name: 'bar' })],
+      });
+
+      const newContent = panel([text('[foo](https://foo.bar)'.repeat(100000))]);
+
+      const id = await rootMessenger.call(
+        'SnapInterfaceController:createInterface',
+        MOCK_SNAP_ID,
+        components,
+      );
+
+      await expect(
+        rootMessenger.call(
+          'SnapInterfaceController:updateInterface',
+          MOCK_SNAP_ID,
+          id,
+          newContent,
+        ),
+      ).rejects.toThrow('UI content is unreasonably large.');
+    });
+
+    it('throws if text content is too large', async () => {
+      const rootMessenger = getRootSnapInterfaceControllerMessenger();
+      const controllerMessenger =
+        getRestrictedSnapInterfaceControllerMessenger(rootMessenger);
+
+      /* eslint-disable-next-line no-new */
+      new SnapInterfaceController({
+        messenger: controllerMessenger,
+      });
+
+      const components = form({
+        name: 'foo',
+        children: [input({ name: 'bar' })],
+      });
+
+      const newContent = panel([text('[foo](https://foo.bar)'.repeat(2500))]);
+
+      const id = await rootMessenger.call(
+        'SnapInterfaceController:createInterface',
+        MOCK_SNAP_ID,
+        components,
+      );
+
+      await expect(
+        rootMessenger.call(
+          'SnapInterfaceController:updateInterface',
+          MOCK_SNAP_ID,
+          id,
+          newContent,
+        ),
+      ).rejects.toThrow('UI text content is unreasonably large.');
     });
 
     it('throws if the interface does not exist', async () => {

--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
@@ -14,8 +14,8 @@ import { nanoid } from 'nanoid';
 
 import { constructState } from './utils';
 
-const MAX_UI_CONTENT_SIZE = 256000; // 250 kb
-const MAX_TEXT_LENGTH = 51200; // 50 kb
+const MAX_UI_CONTENT_SIZE = 250_000; // 250 kb
+const MAX_TEXT_LENGTH = 50_000; // 50 kb
 
 const controllerName = 'SnapInterfaceController';
 
@@ -260,13 +260,18 @@ export class SnapInterfaceController extends BaseController<
   async #validateContent(content: Component) {
     const size = getJsonSize(content);
 
-    assert(size <= MAX_UI_CONTENT_SIZE, `A Snap UI may not be larger than ${MAX_UI_CONTENT_SIZE / 1000} kB.`);
+    assert(
+      size <= MAX_UI_CONTENT_SIZE,
+      `A Snap UI may not be larger than ${MAX_UI_CONTENT_SIZE / 1000} kB.`,
+    );
 
     const textSize = getTotalTextLength(content);
 
     assert(
       textSize <= MAX_TEXT_LENGTH,
-      'UI text content is unreasonably large.',
+      `The text in a Snap UI may not be larger than ${
+        MAX_TEXT_LENGTH / 1000
+      } kB.`,
     );
 
     await this.#triggerPhishingListUpdate();

--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
@@ -5,11 +5,17 @@ import type {
   TestOrigin,
 } from '@metamask/phishing-controller';
 import type { Component, InterfaceState, SnapId } from '@metamask/snaps-sdk';
-import { validateComponentLinks } from '@metamask/snaps-utils';
-import { assert } from '@metamask/utils';
+import {
+  getTotalTextLength,
+  validateComponentLinks,
+} from '@metamask/snaps-utils';
+import { assert, getJsonSize } from '@metamask/utils';
 import { nanoid } from 'nanoid';
 
 import { constructState } from './utils';
+
+const MAX_UI_CONTENT_SIZE = 256000; // 250 kb
+const MAX_TEXT_LENGTH = 51200; // 50 kb
 
 const controllerName = 'SnapInterfaceController';
 
@@ -252,6 +258,17 @@ export class SnapInterfaceController extends BaseController<
    * @param content - The components to verify.
    */
   async #validateContent(content: Component) {
+    const size = getJsonSize(content);
+
+    assert(size <= MAX_UI_CONTENT_SIZE, 'UI content is unreasonably large.');
+
+    const textSize = getTotalTextLength(content);
+
+    assert(
+      textSize <= MAX_TEXT_LENGTH,
+      'UI text content is unreasonably large.',
+    );
+
     await this.#triggerPhishingListUpdate();
 
     validateComponentLinks(content, this.#checkPhishingList.bind(this));

--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
@@ -260,7 +260,7 @@ export class SnapInterfaceController extends BaseController<
   async #validateContent(content: Component) {
     const size = getJsonSize(content);
 
-    assert(size <= MAX_UI_CONTENT_SIZE, 'UI content is unreasonably large.');
+    assert(size <= MAX_UI_CONTENT_SIZE, `A Snap UI may not be larger than ${MAX_UI_CONTENT_SIZE / 1000} kB.`);
 
     const textSize = getTotalTextLength(content);
 

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 96.4,
-  "functions": 98.62,
-  "lines": 98.73,
-  "statements": 94.45
+  "branches": 96.44,
+  "functions": 98.63,
+  "lines": 98.74,
+  "statements": 94.49
 }

--- a/packages/snaps-utils/src/ui.test.ts
+++ b/packages/snaps-utils/src/ui.test.ts
@@ -103,6 +103,12 @@ describe('getTotalTextLength', () => {
     ).toBe(9);
   });
 
+  it('calculates total length for nested text in rows', () => {
+    expect(
+      getTotalTextLength(panel([row('1', text('foo')), row('2', text('bar'))])),
+    ).toBe(6);
+  });
+
   it('ignores non text components', () => {
     expect(getTotalTextLength(panel([text('foo'), image('<svg />')]))).toBe(3);
   });

--- a/packages/snaps-utils/src/ui.test.ts
+++ b/packages/snaps-utils/src/ui.test.ts
@@ -1,6 +1,10 @@
-import { panel, text, row, address } from '@metamask/snaps-sdk';
+import { panel, text, row, address, image } from '@metamask/snaps-sdk';
 
-import { validateTextLinks, validateComponentLinks } from './ui';
+import {
+  validateTextLinks,
+  validateComponentLinks,
+  getTotalTextLength,
+} from './ui';
 
 describe('validateTextLinks', () => {
   it('passes for valid links', () => {
@@ -83,5 +87,23 @@ describe('validateComponentLinks', () => {
         isOnPhishingList,
       ),
     ).toThrow('Invalid URL: The specified URL is not allowed.');
+  });
+});
+
+describe('getTotalTextLength', () => {
+  it('calculates total length', () => {
+    expect(getTotalTextLength(text('foo'))).toBe(3);
+  });
+
+  it('calculates total length for nested text', () => {
+    expect(
+      getTotalTextLength(
+        panel([text('foo'), panel([text('bar'), text('baz')])]),
+      ),
+    ).toBe(9);
+  });
+
+  it('ignores non text components', () => {
+    expect(getTotalTextLength(panel([text('foo'), image('<svg />')]))).toBe(3);
   });
 });

--- a/packages/snaps-utils/src/ui.ts
+++ b/packages/snaps-utils/src/ui.ts
@@ -82,3 +82,27 @@ export function validateComponentLinks(
       break;
   }
 }
+
+/**
+ * Calculate the total length of all text in the component.
+ *
+ * @param component - A custom UI component.
+ * @returns The total length of all text components in the component.
+ */
+export function getTotalTextLength(component: Component): number {
+  const { type } = component;
+  if (type === NodeType.Panel) {
+    return component.children.reduce<number>(
+      // This is a bug in TypeScript: https://github.com/microsoft/TypeScript/issues/48313
+      // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+      (sum, node) => sum + getTotalTextLength(node),
+      0,
+    );
+  }
+
+  if (type === NodeType.Text) {
+    return component.value.length;
+  }
+
+  return 0;
+}

--- a/packages/snaps-utils/src/ui.ts
+++ b/packages/snaps-utils/src/ui.ts
@@ -91,18 +91,20 @@ export function validateComponentLinks(
  */
 export function getTotalTextLength(component: Component): number {
   const { type } = component;
-  if (type === NodeType.Panel) {
-    return component.children.reduce<number>(
-      // This is a bug in TypeScript: https://github.com/microsoft/TypeScript/issues/48313
-      // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-      (sum, node) => sum + getTotalTextLength(node),
-      0,
-    );
-  }
 
-  if (type === NodeType.Text) {
-    return component.value.length;
+  switch (type) {
+    case NodeType.Panel:
+      return component.children.reduce<number>(
+        // This is a bug in TypeScript: https://github.com/microsoft/TypeScript/issues/48313
+        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+        (sum, node) => sum + getTotalTextLength(node),
+        0,
+      );
+    case NodeType.Row:
+      return getTotalTextLength(component.value);
+    case NodeType.Text:
+      return component.value.length;
+    default:
+      return 0;
   }
-
-  return 0;
 }


### PR DESCRIPTION
Adds sizing limits for custom UI input. Previously these inputs were only validated to have the proper formatting.

This PR adds logic to validate that the UI components provided by the Snap are within reasonable length. Both the entire UI component object is serialized to JSON and validated that it's total size is less than 250 kb. Also the total text used in the UI component is validated to be less than 50 kb.