### PR TITLE
Fix VirtualFile import in browser contexts

### DIFF
--- a/packages/snaps-utils/src/bytes.ts
+++ b/packages/snaps-utils/src/bytes.ts
@@ -1,6 +1,6 @@
 import { stringToBytes } from '@metamask/utils';
 
-import { VirtualFile } from './virtual-file';
+import { VirtualFile } from './virtual-file/VirtualFile';
 
 /**
  * Convert a bytes-like input value to a Uint8Array.


### PR DESCRIPTION
This import previously brought in `fs` even in browser contexts. This was unintentional and can be easily fixed by correcting the import to be more narrow.