### PR TITLE
Add images example to test-snaps page

### DIFF
--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -40,6 +40,7 @@
     "@metamask/get-entropy-example-snap": "workspace:^",
     "@metamask/get-file-example-snap": "workspace:^",
     "@metamask/home-page-example-snap": "workspace:^",
+    "@metamask/images-example-snap": "workspace:^",
     "@metamask/insights-example-snap": "workspace:^",
     "@metamask/interactive-ui-example-snap": "workspace:^",
     "@metamask/json-rpc-example-snap": "workspace:^",

--- a/packages/test-snaps/src/features/snaps/images/Images.tsx
+++ b/packages/test-snaps/src/features/snaps/images/Images.tsx
@@ -1,0 +1,20 @@
+import type { FunctionComponent } from 'react';
+
+import { Snap } from '../../../components';
+import { ShowImage, ShowQr } from './components';
+import { IMAGES_SNAP_ID, IMAGES_SNAP_PORT, IMAGES_VERSION } from './constants';
+
+export const Images: FunctionComponent = () => {
+  return (
+    <Snap
+      name="Images Snap"
+      snapId={IMAGES_SNAP_ID}
+      port={IMAGES_SNAP_PORT}
+      version={IMAGES_VERSION}
+      testId="images"
+    >
+      <ShowImage />
+      <ShowQr />
+    </Snap>
+  );
+};

--- a/packages/test-snaps/src/features/snaps/images/components/ShowImage.tsx
+++ b/packages/test-snaps/src/features/snaps/images/components/ShowImage.tsx
@@ -1,0 +1,24 @@
+import { logError } from '@metamask/snaps-utils';
+import type { FunctionComponent } from 'react';
+import { Button } from 'react-bootstrap';
+
+import { useInvokeMutation } from '../../../../api';
+import { getSnapId } from '../../../../utils';
+import { IMAGES_SNAP_ID, IMAGES_SNAP_PORT } from '../constants';
+
+export const ShowImage: FunctionComponent = () => {
+  const [invokeSnap, { isLoading }] = useInvokeMutation();
+
+  const handleShowImage = () => {
+    invokeSnap({
+      snapId: getSnapId(IMAGES_SNAP_ID, IMAGES_SNAP_PORT),
+      method: 'getCat',
+    }).catch(logError);
+  };
+
+  return (
+    <Button id="showImage" onClick={handleShowImage} disabled={isLoading}>
+      Show Image
+    </Button>
+  );
+};

--- a/packages/test-snaps/src/features/snaps/images/components/ShowQr.tsx
+++ b/packages/test-snaps/src/features/snaps/images/components/ShowQr.tsx
@@ -1,0 +1,53 @@
+import { logError } from '@metamask/snaps-utils';
+import type { FunctionComponent } from 'react';
+import { type ChangeEvent, type FormEvent, useState } from 'react';
+import { Button, Form } from 'react-bootstrap';
+
+import { useInvokeMutation } from '../../../../api';
+import { Result } from '../../../../components';
+import { getSnapId } from '../../../../utils';
+import { IMAGES_SNAP_ID, IMAGES_SNAP_PORT } from '../constants';
+
+export const ShowQr: FunctionComponent = () => {
+  const [data, setData] = useState('');
+  const [invokeSnap, { isLoading, error }] = useInvokeMutation();
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setData(event.target.value);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    invokeSnap({
+      snapId: getSnapId(IMAGES_SNAP_ID, IMAGES_SNAP_PORT),
+      method: 'getQrCode',
+      params: {
+        data,
+      },
+    }).catch(logError);
+  };
+
+  return (
+    <>
+      <Form onSubmit={handleSubmit} className="mt-3 mb-3">
+        <Form.Label>Message</Form.Label>
+        <Form.Control
+          type="text"
+          placeholder="Data"
+          value={data}
+          onChange={handleChange}
+          id="qrData"
+          className="mb-3"
+        />
+
+        <Button type="submit" id="getQrCode" disabled={isLoading}>
+          Show QR code
+        </Button>
+      </Form>
+      <Result>
+        <span id="getQrCodeResult">{JSON.stringify(error, null, 2)}</span>
+      </Result>
+    </>
+  );
+};

--- a/packages/test-snaps/src/features/snaps/images/components/index.ts
+++ b/packages/test-snaps/src/features/snaps/images/components/index.ts
@@ -1,0 +1,2 @@
+export * from './ShowImage';
+export * from './ShowQr';

--- a/packages/test-snaps/src/features/snaps/images/constants.ts
+++ b/packages/test-snaps/src/features/snaps/images/constants.ts
@@ -1,0 +1,5 @@
+import packageJson from '@metamask/images-example-snap/package.json';
+
+export const IMAGES_SNAP_ID = 'npm:@metamask/images-example-snap';
+export const IMAGES_SNAP_PORT = 8026;
+export const IMAGES_VERSION = packageJson.version;

--- a/packages/test-snaps/src/features/snaps/images/index.ts
+++ b/packages/test-snaps/src/features/snaps/images/index.ts
@@ -1,0 +1,1 @@
+export * from './Images';

--- a/packages/test-snaps/src/features/snaps/index.ts
+++ b/packages/test-snaps/src/features/snaps/index.ts
@@ -11,6 +11,7 @@ export * from './get-file';
 export * from './interactive-ui';
 export * from './localization';
 export * from './home-page';
+export * from './images';
 export * from './json-rpc';
 export * from './lifecycle-hooks';
 export * from './manage-state';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4536,7 +4536,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/images-example-snap@workspace:packages/examples/packages/images":
+"@metamask/images-example-snap@workspace:^, @metamask/images-example-snap@workspace:packages/examples/packages/images":
   version: 0.0.0-use.local
   resolution: "@metamask/images-example-snap@workspace:packages/examples/packages/images"
   dependencies:
@@ -5926,6 +5926,7 @@ __metadata:
     "@metamask/get-entropy-example-snap": "workspace:^"
     "@metamask/get-file-example-snap": "workspace:^"
     "@metamask/home-page-example-snap": "workspace:^"
+    "@metamask/images-example-snap": "workspace:^"
     "@metamask/insights-example-snap": "workspace:^"
     "@metamask/interactive-ui-example-snap": "workspace:^"
     "@metamask/json-rpc-example-snap": "workspace:^"


### PR DESCRIPTION
When debugging an issue, I noticed that there was no section on the test-snaps page for the images example, so I've added one.