### PR TITLE
Move `file` struct to CLI

### DIFF
--- a/packages/snaps-cli/src/config.ts
+++ b/packages/snaps-cli/src/config.ts
@@ -1,7 +1,6 @@
 import { literal, union } from '@metamask/snaps-sdk';
 import {
   createFromStruct,
-  file,
   indent,
   isFile,
   SnapsStructError,
@@ -35,6 +34,7 @@ import type { Configuration as WebpackConfiguration } from 'webpack';
 
 import { TranspilationModes } from './builders';
 import { ConfigError } from './errors';
+import { file } from './structs';
 import type { YargsArgs } from './types/yargs';
 import { CONFIG_FILE, TS_CONFIG_FILE } from './utils';
 

--- a/packages/snaps-cli/src/structs.test.ts
+++ b/packages/snaps-cli/src/structs.test.ts
@@ -1,0 +1,17 @@
+import { create, is } from 'superstruct';
+
+import { file } from './structs';
+
+describe('file', () => {
+  it('resolves a file path relative to the current working directory', () => {
+    jest.spyOn(process, 'cwd').mockReturnValue('/foo/bar');
+
+    expect(is('packages/snaps-utils/src/structs.test.ts', file())).toBe(true);
+    expect(create('packages/snaps-utils/src/structs.test.ts', file())).toBe(
+      '/foo/bar/packages/snaps-utils/src/structs.test.ts',
+    );
+    expect(create('/packages/snaps-utils/src/structs.test.ts', file())).toBe(
+      '/packages/snaps-utils/src/structs.test.ts',
+    );
+  });
+});

--- a/packages/snaps-cli/src/structs.test.ts
+++ b/packages/snaps-cli/src/structs.test.ts
@@ -3,11 +3,12 @@ import { create, is } from 'superstruct';
 
 import { file } from './structs';
 
+// Mock resolve so these tests work on Windows
+jest.mock('path', () => ({ resolve }));
+
 describe('file', () => {
   it('resolves a file path relative to the current working directory', () => {
     jest.spyOn(process, 'cwd').mockReturnValue('/foo/bar');
-    // Mock resolve so these tests work on Windows
-    jest.mock('path', () => ({ resolve }));
 
     expect(is('packages/snaps-utils/src/structs.test.ts', file())).toBe(true);
     expect(create('packages/snaps-utils/src/structs.test.ts', file())).toBe(

--- a/packages/snaps-cli/src/structs.test.ts
+++ b/packages/snaps-cli/src/structs.test.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'path/posix';
 import { create, is } from 'superstruct';
 
 import { file } from './structs';
@@ -5,6 +6,8 @@ import { file } from './structs';
 describe('file', () => {
   it('resolves a file path relative to the current working directory', () => {
     jest.spyOn(process, 'cwd').mockReturnValue('/foo/bar');
+    // Mock resolve so these tests work on Windows
+    jest.mock('path', () => ({ resolve }));
 
     expect(is('packages/snaps-utils/src/structs.test.ts', file())).toBe(true);
     expect(create('packages/snaps-utils/src/structs.test.ts', file())).toBe(

--- a/packages/snaps-cli/src/structs.ts
+++ b/packages/snaps-cli/src/structs.ts
@@ -1,0 +1,27 @@
+import { resolve } from 'path';
+import { coerce, string } from 'superstruct';
+
+/**
+ * A wrapper of `superstruct`'s `string` struct that coerces a value to a string
+ * and resolves it relative to the current working directory. This is useful
+ * for specifying file paths in a configuration file, as it allows the user to
+ * use both relative and absolute paths.
+ *
+ * @returns The `superstruct` struct, which validates that the value is a
+ * string, and resolves it relative to the current working directory.
+ * @example
+ * ```ts
+ * const config = struct({
+ *   file: file(),
+ *   // ...
+ * });
+ *
+ * const value = create({ file: 'path/to/file' }, config);
+ * console.log(value.file); // /process/cwd/path/to/file
+ * ```
+ */
+export function file() {
+  return coerce(string(), string(), (value) => {
+    return resolve(process.cwd(), value);
+  });
+}

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 96.44,
-  "functions": 98.63,
-  "lines": 98.74,
-  "statements": 94.49
+  "functions": 98.62,
+  "lines": 98.73,
+  "statements": 94.47
 }

--- a/packages/snaps-utils/src/structs.test.ts
+++ b/packages/snaps-utils/src/structs.test.ts
@@ -4,9 +4,7 @@ import { bold, green, red } from 'chalk';
 import type { Struct } from 'superstruct';
 import superstruct, {
   size,
-  create,
   defaulted,
-  is,
   number,
   object,
   string,
@@ -18,7 +16,6 @@ import superstruct, {
 import {
   arrayToGenerator,
   createFromStruct,
-  file,
   getError,
   getStructErrorMessage,
   getStructErrorPrefix,
@@ -45,20 +42,6 @@ function getStructError(value: unknown, struct: Struct<any>) {
 
   return error;
 }
-
-describe('file', () => {
-  it('resolves a file path relative to the current working directory', () => {
-    jest.spyOn(process, 'cwd').mockReturnValue('/foo/bar');
-
-    expect(is('packages/snaps-utils/src/structs.test.ts', file())).toBe(true);
-    expect(create('packages/snaps-utils/src/structs.test.ts', file())).toBe(
-      '/foo/bar/packages/snaps-utils/src/structs.test.ts',
-    );
-    expect(create('/packages/snaps-utils/src/structs.test.ts', file())).toBe(
-      '/packages/snaps-utils/src/structs.test.ts',
-    );
-  });
-});
 
 describe('named', () => {
   it('sets the struct name', () => {

--- a/packages/snaps-utils/src/structs.ts
+++ b/packages/snaps-utils/src/structs.ts
@@ -2,7 +2,6 @@ import { union } from '@metamask/snaps-sdk';
 import type { NonEmptyArray } from '@metamask/utils';
 import { assert, isObject } from '@metamask/utils';
 import { bold, green, red } from 'chalk';
-import { resolve } from 'path';
 import type { Failure } from 'superstruct';
 import {
   is,
@@ -11,8 +10,6 @@ import {
   Struct,
   StructError,
   create,
-  string,
-  coerce as superstructCoerce,
 } from 'superstruct';
 import type { AnyStruct } from 'superstruct/dist/utils';
 
@@ -66,31 +63,6 @@ function color(
   }
 
   return value;
-}
-
-/**
- * A wrapper of `superstruct`'s `string` struct that coerces a value to a string
- * and resolves it relative to the current working directory. This is useful
- * for specifying file paths in a configuration file, as it allows the user to
- * use both relative and absolute paths.
- *
- * @returns The `superstruct` struct, which validates that the value is a
- * string, and resolves it relative to the current working directory.
- * @example
- * ```ts
- * const config = struct({
- *   file: file(),
- *   // ...
- * });
- *
- * const value = create({ file: 'path/to/file' }, config);
- * console.log(value.file); // /process/cwd/path/to/file
- * ```
- */
-export function file() {
-  return superstructCoerce(string(), string(), (value) => {
-    return resolve(process.cwd(), value);
-  });
 }
 
 /**


### PR DESCRIPTION
Moves the `file` struct to the CLI package as it is the only place where it is currently in use.

Previously it was part of the `snaps-utils` and even included in the browser entrypoint. This PR moves it to avoid that problem.