### PR TITLE
Fix regex for HTML comment tokens

### DIFF
--- a/packages/snaps-utils/src/post-process.test.ts
+++ b/packages/snaps-utils/src/post-process.test.ts
@@ -173,6 +173,21 @@ describe('postProcessBundle', () => {
     `);
   });
 
+  it('breaks up HTML comment terminators in string literals with alternative comment end', () => {
+    const code = `
+      const foo = '<!-- bar --!>';
+    `;
+
+    const processedCode = postProcessBundle(code);
+    expect(processedCode).toMatchInlineSnapshot(`
+      {
+        "code": "const foo = "<!" + "--" + " bar " + "--" + "!" + ">";",
+        "sourceMap": null,
+        "warnings": [],
+      }
+    `);
+  });
+
   it('breaks up `import()` in string literals', () => {
     const code = `
       const foo = 'foo bar import() baz';
@@ -199,6 +214,21 @@ describe('postProcessBundle', () => {
     expect(processedCode).toMatchInlineSnapshot(`
       {
         "code": "const foo = \`\${"<!"}\${"--"} bar \${"--"}\${">"} \${"<!" + "--" + " baz " + "--" + ">"} \${qux}\`;",
+        "sourceMap": null,
+        "warnings": [],
+      }
+    `);
+  });
+
+  it('breaks up HTML comment terminators in template literals with alternative comment end', () => {
+    const code = `
+      const foo = \`<!-- bar --> \${'<!-- baz --!>'} \${qux}\`;
+    `;
+
+    const processedCode = postProcessBundle(code);
+    expect(processedCode).toMatchInlineSnapshot(`
+      {
+        "code": "const foo = \`\${"<!"}\${"--"} bar \${"--"}\${">"} \${"<!" + "--" + " baz " + "--" + "!" + ">"} \${qux}\`;",
         "sourceMap": null,
         "warnings": [],
       }

--- a/packages/snaps-utils/src/post-process.ts
+++ b/packages/snaps-utils/src/post-process.ts
@@ -64,7 +64,7 @@ export enum PostProcessWarning {
 // The RegEx below consists of multiple groups joined by a boolean OR.
 // Each part consists of two groups which capture a part of each string
 // which needs to be split up, e.g., `<!--` is split into `<!` and `--`.
-const TOKEN_REGEX = /(<!)(--)|(--)(>)|(import)(\(.*?\))/gu;
+const TOKEN_REGEX = /(<!)(--)|(--)(>)|(--)(!)(>)|(import)(\(.*?\))/gu;
 
 // An empty template element, i.e., a part of a template literal without any
 // value ("").


### PR DESCRIPTION
Address code scanning alert by altering the regex for HTML comment tokens used in the post processing step. Apparently `--!>` is a valid way to end an HTML comment 🤯 

Fixes https://github.com/MetaMask/snaps/security/code-scanning/1