### PR TITLE
Publish `.browserslistrc` in CLI

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -194,7 +194,8 @@ gen_enforced_field(WorkspaceCwd, 'files', ['dist']) :-
   \+ is_example(WorkspaceCwd),
   \+ workspace_field(WorkspaceCwd, 'private', true),
   WorkspaceCwd \= '.',
-  WorkspaceCwd \= 'packages/snaps-jest'.
+  WorkspaceCwd \= 'packages/snaps-jest',
+  WorkspaceCwd \= 'packages/snaps-cli'.
 gen_enforced_field(WorkspaceCwd, 'files', ['dist', 'jest-preset.js']) :-
   WorkspaceCwd = 'packages/snaps-jest'.
 

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -14,7 +14,8 @@
       "require": "./dist/index.js",
       "types": "./dist/types/index.d.ts"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./browserslistrc": "./.browserslistrc"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -23,7 +24,8 @@
     "mm-snap": "./dist/main.js"
   },
   "files": [
-    "dist"
+    "dist",
+    ".browserslistrc"
   ],
   "scripts": {
     "build": "tsup --clean && yarn build:types && yarn build:chmod && yarn build:readme",


### PR DESCRIPTION
I accidentally removed `.browserslistrc` in the `tsup` refactor. This adds it back.