### PR TITLE
Fix simulator build in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       contents: write
     uses: ./.github/workflows/publish-github-pages.yml
     with:
-      build_script: yarn workspace @metamask/snaps-simulator build:post-tsc
+      build_script: yarn workspace @metamask/snaps-simulator build
       publish_dir: ./packages/snaps-simulator/dist/webpack/main
       destination_dir: snaps-simulator/staging
     secrets:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -292,7 +292,7 @@ jobs:
       contents: write
     uses: ./.github/workflows/publish-github-pages.yml
     with:
-      build_script: yarn workspace @metamask/snaps-simulator build:post-tsc
+      build_script: yarn workspace @metamask/snaps-simulator build
       publish_dir: ./packages/snaps-simulator/dist/webpack/main
       destination_dir: snaps-simulator/${{ needs.is-simulator-release.outputs.SIMULATOR_VERSION }}
     secrets:
@@ -306,7 +306,7 @@ jobs:
       contents: write
     uses: ./.github/workflows/publish-github-pages.yml
     with:
-      build_script: yarn workspace @metamask/snaps-simulator build:post-tsc
+      build_script: yarn workspace @metamask/snaps-simulator build
       publish_dir: ./packages/snaps-simulator/dist/webpack/main
       destination_dir: snaps-simulator/latest
     secrets:


### PR DESCRIPTION
After the `tsup` refactor we removed `build:post-tsc`. This PR fixes a problem where this script was still in use in CI.