### PR TITLE
Fix update pull request workflow

### DIFF
--- a/.github/workflows/update-pull-request.yml
+++ b/.github/workflows/update-pull-request.yml
@@ -161,8 +161,7 @@ jobs:
         run: yarn --immutable
       - name: Build dependencies
         run: |
-          yarn build:source
-          yarn build:types
+          yarn build:ci
       - name: Update examples
         run: yarn build:examples
       - name: Cache examples


### PR DESCRIPTION
The update PR workflow previously builds the examples twice. We only need to build dependencies of the examples, so we can use `build:ci` instead. The Snaps CLI doesn't do type checking, so we can skip building those too.