### PR TITLE
Remove usage of `Buffer` from `snaps-utils`

### DIFF
--- a/packages/snaps-execution-environments/lavamoat/browserify/iframe/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/iframe/policy.json
@@ -183,11 +183,6 @@
         "depcheck>semver>lru-cache>yallist": true
       }
     },
-    "external:../snaps-utils/src/icon.ts": {
-      "builtin": {
-        "buffer": true
-      }
-    },
     "readable-stream": {
       "packages": {
         "browserify>browser-resolve": true,

--- a/packages/snaps-execution-environments/lavamoat/browserify/node-process/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/node-process/policy.json
@@ -202,11 +202,6 @@
         "depcheck>semver>lru-cache>yallist": true
       }
     },
-    "external:../snaps-utils/src/icon.ts": {
-      "builtin": {
-        "buffer": true
-      }
-    },
     "istanbul-lib-report>supports-color>has-flag": {
       "globals": {
         "process.argv": true

--- a/packages/snaps-execution-environments/lavamoat/browserify/node-thread/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/node-thread/policy.json
@@ -202,11 +202,6 @@
         "depcheck>semver>lru-cache>yallist": true
       }
     },
-    "external:../snaps-utils/src/icon.ts": {
-      "builtin": {
-        "buffer": true
-      }
-    },
     "istanbul-lib-report>supports-color>has-flag": {
       "globals": {
         "process.argv": true

--- a/packages/snaps-execution-environments/lavamoat/browserify/policy-override.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/policy-override.json
@@ -1,9 +1,3 @@
 {
-  "resources": {
-    "external:../snaps-utils/src/icon.ts": {
-      "builtin": {
-        "buffer": true
-      }
-    }
-  }
+  "resources": {}
 }

--- a/packages/snaps-execution-environments/lavamoat/browserify/webview/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/webview/policy.json
@@ -129,11 +129,6 @@
         "depcheck>semver>lru-cache>yallist": true
       }
     },
-    "external:../snaps-utils/src/icon.ts": {
-      "builtin": {
-        "buffer": true
-      }
-    },
     "readable-stream": {
       "packages": {
         "browserify>browser-resolve": true,

--- a/packages/snaps-execution-environments/lavamoat/browserify/worker-executor/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/worker-executor/policy.json
@@ -183,11 +183,6 @@
         "depcheck>semver>lru-cache>yallist": true
       }
     },
-    "external:../snaps-utils/src/icon.ts": {
-      "builtin": {
-        "buffer": true
-      }
-    },
     "readable-stream": {
       "packages": {
         "browserify>browser-resolve": true,

--- a/packages/snaps-execution-environments/lavamoat/browserify/worker-pool/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/worker-pool/policy.json
@@ -129,11 +129,6 @@
         "depcheck>semver>lru-cache>yallist": true
       }
     },
-    "external:../snaps-utils/src/icon.ts": {
-      "builtin": {
-        "buffer": true
-      }
-    },
     "readable-stream": {
       "packages": {
         "browserify>browser-resolve": true,

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 96.44,
+  "branches": 96.47,
   "functions": 98.62,
   "lines": 98.74,
   "statements": 94.48

--- a/packages/snaps-utils/src/icon.test.ts
+++ b/packages/snaps-utils/src/icon.test.ts
@@ -30,6 +30,16 @@ describe('assertIsSnapIcon', () => {
     );
   });
 
+  it('asserts that the file is an appropriate size when the file is represented by a string', () => {
+    const icon = new VirtualFile({
+      value: '1'.repeat(SVG_MAX_BYTE_SIZE + 1),
+      path: 'foo.svg',
+    });
+    expect(() => assertIsSnapIcon(icon)).toThrow(
+      `The specified SVG icon exceeds the maximum size of ${SVG_MAX_BYTE_SIZE_TEXT}.`,
+    );
+  });
+
   it('asserts that the file is a valid SVG', () => {
     const icon = new VirtualFile({
       value: stringToBytes('foo'),

--- a/packages/snaps-utils/src/icon.ts
+++ b/packages/snaps-utils/src/icon.ts
@@ -1,5 +1,5 @@
 import { isSvg, parseSvg } from '@metamask/snaps-sdk';
-import { assert } from '@metamask/utils';
+import { assert, stringToBytes } from '@metamask/utils';
 
 import type { VirtualFile } from './virtual-file';
 
@@ -16,8 +16,13 @@ export const SVG_MAX_BYTE_SIZE_TEXT = `${Math.floor(
 export function assertIsSnapIcon(icon: VirtualFile) {
   assert(icon.path.endsWith('.svg'), 'Expected snap icon to end in ".svg".');
 
+  const byteLength =
+    typeof icon.value === 'string'
+      ? stringToBytes(icon.value).byteLength
+      : icon.value.byteLength;
+
   assert(
-    Buffer.byteLength(icon.value, 'utf8') <= SVG_MAX_BYTE_SIZE,
+    byteLength <= SVG_MAX_BYTE_SIZE,
     `The specified SVG icon exceeds the maximum size of ${SVG_MAX_BYTE_SIZE_TEXT}.`,
   );
 


### PR DESCRIPTION
Remove one usage of `Buffer` since the exported function is used in both in the browser and in the Node.js export.