### PR TITLE
Add error text to input component

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4QSCSSjdmoszbfaqWG93OqdcEgxSG18SfYCZD6VPYu8=",
+    "shasum": "jXB7m0SEAB1g2n8E23KElZVG6cipIB8bk7tMInGTGHE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZF+ctvr/hsmxnvidH4OFY5t8Ai3fWEVXzzw6WJyBtVU=",
+    "shasum": "C9TwxeFksZjLcFlkiee3rwbU075F10AIBrxp2B1Vc3A=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cCmRsk5sCuZSLlObjR98fJvSrPIpduoNoG+ZzfLg9Fw=",
+    "shasum": "OltG2NDvqyXlQ63rnYbgs3E04Jkp7xDfoERPYjivJoI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LRROokJvEX/V+He6SJI2aZUHoSM9OhDiZLfRV5PP6+0=",
+    "shasum": "sJFkvJ7Hw/mL7nsUV2zacpbXagg/vbaWrlwx6m3kZv8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "s527n4Q5TFj9jO7gtWLgM9J+7V0D1wvk/LpZxEztrrw=",
+    "shasum": "BrtFgMRty4l3lFai0ZRzvsOMi+GD35wU2L8e4rC4Pzs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "uXxop+bRhDGtl6PtqkrjJcyne4LOl7Ua9Rg6Rjq/T4c=",
+    "shasum": "L5ZAAUcWucgTLY16I6pX7rzkhW/Am6eW8/6AtHQikuQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "DxuLKMcHp0jiFpxq20oihPQTq6fgdZK2CGEOEdvsRHg=",
+    "shasum": "c4TP0ESTAYG4AVILxhjNk8PfPNRZA+m1W+IF+8GIFiM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9mTY1UqSTzF65AM9pq7YrjlQTH2ZTuNUhEoJ08DgVc0=",
+    "shasum": "KZD5RWnfjvokfDoLsN3NDVZwmJ5VuhiBC9N8gOpLe48=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Cq6c06RWQkxYE98fkWPj4gaDXwLi+m4ARoFoZ6kfAVI=",
+    "shasum": "HAaFlDfI6+0VX5v5GtYliD2l8PRw74OgSidyU31hdYI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "O1cuod0X6zUqekz9v+hnCyUKbAAtQnI9cBeU5TnoAuQ=",
+    "shasum": "2ZO74x0nI5E7je1hVrWFRbsACAuN5XAu6NSyiSnMZ5s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "GGUVIcdMe69Pu/iT6GLl9PiT8muXyWeUM5xc3pd7rc0=",
+    "shasum": "qliiMjjWRT7RkwORjS15Uhyfo5AJo3gCUIC+/z4qB5Q=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hFISzpstpsaE+zpryvH7smbBTlItScL7mjKMPM04TMw=",
+    "shasum": "nPzGIoWTNhgD9GP8yM1jg8gQOR7LdDCXbfCiiQY6u6E=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "WGTtqvaGZY0J7d1nv4LIZiICOoIO+Zr0U+OjCBYTiEo=",
+    "shasum": "JaGuDtOA+RSa+rMvlvVgFG/oIy7o1BafN6WEIetbKqY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xf+z3LeFEICQeF3cXjCxPgWX6KofR7j/uXgzj4Xs5Dw=",
+    "shasum": "z6FH7b1/dv0jY5p7EQ2TclzPjDAb3LGdGybVCK6N3AQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "k/JXBG24WgKK2iyc0ZchWRmWUpv4N9wsdJw4Vm7MWKU=",
+    "shasum": "D9w45JEFlH+OlHKwOFPtNjBGX0d6rZPXMDnndk+zs0k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-sdk/src/ui/components/input.test.ts
+++ b/packages/snaps-sdk/src/ui/components/input.test.ts
@@ -10,6 +10,7 @@ describe('Input', () => {
         inputType: InputType.Text,
         placeholder: 'Type here...',
         label: 'Hello',
+        error: 'Invalid input',
       }),
     ).toStrictEqual({
       type: NodeType.Input,
@@ -18,6 +19,7 @@ describe('Input', () => {
       inputType: InputType.Text,
       placeholder: 'Type here...',
       label: 'Hello',
+      error: 'Invalid input',
     });
 
     expect(

--- a/packages/snaps-sdk/src/ui/components/input.ts
+++ b/packages/snaps-sdk/src/ui/components/input.ts
@@ -32,6 +32,7 @@ export const InputStruct = assign(
     ),
     placeholder: optional(string()),
     label: optional(string()),
+    error: optional(string()),
   }),
 );
 
@@ -44,6 +45,7 @@ export const InputStruct = assign(
  * @property inputType - An optional type, either `text`, `password` or `number`.
  * @property placeholder - An optional input placeholder.
  * @property label - An optional input label.
+ * @property error - An optional error text.
  */
 export type Input = Infer<typeof InputStruct>;
 
@@ -57,6 +59,7 @@ export type Input = Infer<typeof InputStruct>;
  * @param args.inputType - An optional type, either `text`, `password` or `number`.
  * @param args.placeholder - An optional input placeholder.
  * @param args.label - An optional input label.
+ * @param args.error - An optional error text.
  * @returns The input node as an object.
  * @example
  * const node = input('myInput');


### PR DESCRIPTION
Add an optional error text property to the input component. This lets Snaps provide feedback directly below input values:
![image](https://github.com/MetaMask/snaps/assets/1561200/7028618f-c74a-4a7b-8546-ca88a5400b02)
