### PR TITLE
Improve timeout handling

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 91.01,
+  "branches": 91.03,
   "functions": 96.56,
   "lines": 97.8,
   "statements": 97.46

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 91.03,
+  "branches": 91.05,
   "functions": 96.56,
   "lines": 97.8,
   "statements": 97.46

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -472,7 +472,7 @@ describe('SnapController', () => {
           id: 1,
         },
       }),
-    ).rejects.toThrow(/request timed out/u);
+    ).rejects.toThrow(`${snap.id} failed to respond to the request in time.`);
 
     expect(snapController.state.snaps[snap.id].status).toBe('crashed');
     snapController.destroy();
@@ -1141,7 +1141,7 @@ describe('SnapController', () => {
           id: 1,
         },
       }),
-    ).rejects.toThrow(/request timed out/u);
+    ).rejects.toThrow(`${snap.id} failed to respond to the request in time.`);
     expect(snapController.state.snaps[snap.id].status).toBe('crashed');
 
     snapController.destroy();
@@ -1226,7 +1226,7 @@ describe('SnapController', () => {
           id: 1,
         },
       }),
-    ).rejects.toThrow(/request timed out/u);
+    ).rejects.toThrow(`${snap.id} failed to respond to the request in time.`);
     expect(snapController.state.snaps[snap.id].status).toBe('crashed');
 
     snapController.destroy();
@@ -1401,7 +1401,7 @@ describe('SnapController', () => {
     const snapController = getSnapController(
       getSnapControllerOptions({
         messenger,
-        maxRequestTime: 50,
+        maxInitTime: 50,
         state: {
           snaps: getPersistedSnapsState(),
         },
@@ -1421,7 +1421,7 @@ describe('SnapController', () => {
     );
 
     await expect(snapController.startSnap(snap.id)).rejects.toThrow(
-      /request timed out/u,
+      `${snap.id} failed to start.`,
     );
 
     snapController.destroy();
@@ -1583,7 +1583,7 @@ describe('SnapController', () => {
           id: 1,
         },
       }),
-    ).rejects.toThrow(/request timed out/u);
+    ).rejects.toThrow(`${snap.id} failed to respond to the request in time.`);
     expect(snapController.state.snaps[snap.id].status).toBe('crashed');
 
     await snapController.removeSnap(snap.id);


### PR DESCRIPTION
This PR improves timeout handling in the SnapController and in the execution services, it makes a handful of changes:
- Adds a timeout of `2` seconds to the `ping` request, sent to the execution environment after boot. This lets us fail more immediately if the execution environment has loaded but is non-responsive (e.g. if the execution env is down, the iframe loads a Chrome failure page, which still counts as the iframe loading)
- Adds `maxInitTime` as a constructor argument allowing for better configuration of how long Snaps (and the execution environment) has in total to boot before timing out.
- Changes all of the error messaging around timeouts in an attempt to give more information than the previous vague error message: "The request timed out.".