### PR TITLE
Handle unavailable registry more gracefully

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 91.05,
-  "functions": 96.56,
+  "branches": 90.82,
+  "functions": 96.57,
   "lines": 97.8,
   "statements": 97.46
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1234,7 +1234,11 @@ export class SnapController extends BaseController<
       result.status !== SnapsRegistryStatus.Verified
     ) {
       throw new Error(
-        `Cannot install version "${snapInfo.version}" of snap "${snapId}": The snap is not on the allowlist.`,
+        `Cannot install version "${snapInfo.version}" of snap "${snapId}": ${
+          result.status === SnapsRegistryStatus.Unavailable
+            ? 'The registry is temporarily unavailable.'
+            : 'The snap is not on the allowlist.'
+        }`,
       );
     }
   }

--- a/packages/snaps-controllers/src/snaps/registry/json.test.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.test.ts
@@ -267,7 +267,7 @@ describe('JsonSnapsRegistry', () => {
     });
   });
 
-  it('doesnt use existing state if existing state isnt sufficient', async () => {
+  it(`doesn't use existing state if existing state isn't sufficient`, async () => {
     fetchMock.mockResponse('', { status: 404 });
 
     const { messenger } = getRegistry({

--- a/packages/snaps-controllers/src/snaps/registry/json.test.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.test.ts
@@ -242,32 +242,15 @@ describe('JsonSnapsRegistry', () => {
     });
   });
 
-  it('returns unverified for unavailable database if failOnUnavailableRegistry is set to false', async () => {
+  it('uses existing state if registry is unavailable', async () => {
     fetchMock.mockResponse('', { status: 404 });
 
     const { messenger } = getRegistry({
-      failOnUnavailableRegistry: false,
-    });
-
-    const result = await messenger.call('SnapsRegistry:get', {
-      [MOCK_SNAP_ID]: {
-        version: '1.0.0' as SemVerVersion,
-        checksum: DEFAULT_SNAP_SHASUM,
+      refetchOnAllowlistMiss: true,
+      state: {
+        lastUpdated: 0,
+        database: MOCK_DATABASE,
       },
-    });
-
-    expect(result).toStrictEqual({
-      [MOCK_SNAP_ID]: {
-        status: SnapsRegistryStatus.Unverified,
-      },
-    });
-  });
-
-  it('does not verify the signature if no public key is provided', async () => {
-    fetchMock.mockResponse(JSON.stringify(MOCK_DATABASE));
-
-    const { messenger } = getRegistry({
-      publicKey: undefined,
     });
 
     const result = await messenger.call('SnapsRegistry:get', {
@@ -284,22 +267,51 @@ describe('JsonSnapsRegistry', () => {
     });
   });
 
-  it('throws for unavailable database by default', async () => {
+  it('doesnt use existing state if existing state isnt sufficient', async () => {
+    fetchMock.mockResponse('', { status: 404 });
+
+    const { messenger } = getRegistry({
+      refetchOnAllowlistMiss: true,
+      state: {
+        lastUpdated: 0,
+        database: MOCK_DATABASE,
+      },
+    });
+
+    const result = await messenger.call('SnapsRegistry:get', {
+      [MOCK_SNAP_ID]: {
+        version: '1.0.1' as SemVerVersion,
+        checksum: DEFAULT_SNAP_SHASUM,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      [MOCK_SNAP_ID]: {
+        status: SnapsRegistryStatus.Unavailable,
+      },
+    });
+  });
+
+  it('returns unavailable if the database is unavailable', async () => {
     fetchMock.mockResponse('', { status: 404 });
 
     const { messenger } = getRegistry();
 
-    await expect(
-      messenger.call('SnapsRegistry:get', {
-        [MOCK_SNAP_ID]: {
-          version: '1.0.0' as SemVerVersion,
-          checksum: DEFAULT_SNAP_SHASUM,
-        },
-      }),
-    ).rejects.toThrow('Snaps registry is unavailable, installation blocked.');
+    const result = await messenger.call('SnapsRegistry:get', {
+      [MOCK_SNAP_ID]: {
+        version: '1.0.0' as SemVerVersion,
+        checksum: DEFAULT_SNAP_SHASUM,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      [MOCK_SNAP_ID]: {
+        status: SnapsRegistryStatus.Unavailable,
+      },
+    });
   });
 
-  it('throws for unavailable signature', async () => {
+  it('returns unavailable if signature is unavailable', async () => {
     fetchMock
       .mockResponseOnce(JSON.stringify(MOCK_DATABASE))
       .mockResponseOnce('', {
@@ -308,17 +320,21 @@ describe('JsonSnapsRegistry', () => {
 
     const { messenger } = getRegistry();
 
-    await expect(
-      messenger.call('SnapsRegistry:get', {
-        [MOCK_SNAP_ID]: {
-          version: '1.0.0' as SemVerVersion,
-          checksum: DEFAULT_SNAP_SHASUM,
-        },
-      }),
-    ).rejects.toThrow('Snaps registry is unavailable, installation blocked.');
+    const result = await messenger.call('SnapsRegistry:get', {
+      [MOCK_SNAP_ID]: {
+        version: '1.0.0' as SemVerVersion,
+        checksum: DEFAULT_SNAP_SHASUM,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      [MOCK_SNAP_ID]: {
+        status: SnapsRegistryStatus.Unavailable,
+      },
+    });
   });
 
-  it('throws for invalid signature', async () => {
+  it('returns unavailable if signature is invalid', async () => {
     fetchMock
       .mockResponseOnce(JSON.stringify(MOCK_DATABASE))
       .mockResponseOnce(JSON.stringify(MOCK_SIGNATURE_FILE));
@@ -328,14 +344,18 @@ describe('JsonSnapsRegistry', () => {
         '0x034ca27b046507d1a9997bddc991b56d96b93d4adac3a96dfe01ce450bfb661455',
     });
 
-    await expect(
-      messenger.call('SnapsRegistry:get', {
-        [MOCK_SNAP_ID]: {
-          version: '1.0.0' as SemVerVersion,
-          checksum: DEFAULT_SNAP_SHASUM,
-        },
-      }),
-    ).rejects.toThrow('Snaps registry is unavailable, installation blocked.');
+    const result = await messenger.call('SnapsRegistry:get', {
+      [MOCK_SNAP_ID]: {
+        version: '1.0.0' as SemVerVersion,
+        checksum: DEFAULT_SNAP_SHASUM,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      [MOCK_SNAP_ID]: {
+        status: SnapsRegistryStatus.Unavailable,
+      },
+    });
   });
 
   describe('resolveVersion', () => {

--- a/packages/snaps-controllers/src/snaps/registry/registry.ts
+++ b/packages/snaps-controllers/src/snaps/registry/registry.ts
@@ -10,11 +10,11 @@ export type SnapsRegistryRequest = Record<SnapId, SnapsRegistryInfo>;
 export type SnapsRegistryMetadata =
   SnapsRegistryDatabase['verifiedSnaps'][SnapId]['metadata'];
 
-// TODO: Decide on names for these
 export enum SnapsRegistryStatus {
   Unverified = 0,
   Blocked = 1,
   Verified = 2,
+  Unavailable = 3,
 }
 
 export type SnapsRegistryResult = {


### PR DESCRIPTION
This PR makes a few changes to the registry controller implementation to attempt to handle an unavailable registry (e.g. invalid signature) more gracefully.

Instead of throwing when the registry fails to update or populate, we return `SnapsRegistryStatus.Unavailable`. This status is meant to indicate to the `SnapController` that we can't currently access the latest registry and thus our data might be out of date. For Snaps that don't require allowlisting, this shouldn't be a problem and they will still be installable. If a user is trying to install a Snap that does require allowlisting they are now greeted with a slightly better error message.