### PR TITLE
Use lexer for extraction of markdown links

### DIFF
--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -66,6 +66,7 @@
     "cron-parser": "^4.5.0",
     "fast-deep-equal": "^3.1.3",
     "fast-json-stable-stringify": "^2.1.0",
+    "marked": "^12.0.1",
     "rfdc": "^1.3.0",
     "semver": "^7.5.4",
     "ses": "^1.1.0",

--- a/packages/snaps-utils/src/ui.test.ts
+++ b/packages/snaps-utils/src/ui.test.ts
@@ -19,12 +19,72 @@ describe('validateTextLinks', () => {
     expect(() =>
       validateTextLinks('[](https://foo.bar)', () => false),
     ).not.toThrow();
+
+    expect(() =>
+      validateTextLinks('[[test]](https://foo.bar)', () => false),
+    ).not.toThrow();
+
+    expect(() =>
+      validateTextLinks('[test](https://foo.bar "foo bar baz")', () => false),
+    ).not.toThrow();
+
+    expect(() =>
+      validateTextLinks('<https://foo.bar>', () => false),
+    ).not.toThrow();
+
+    expect(() =>
+      validateTextLinks(
+        `[foo][1]
+         [1]: https://foo.bar`,
+        () => false,
+      ),
+    ).not.toThrow();
+
+    expect(() =>
+      validateTextLinks(
+        `[foo][1]
+         [1]: https://foo.bar "foo bar baz"`,
+        () => false,
+      ),
+    ).not.toThrow();
   });
 
   it('throws an error if an invalid link is found in text', () => {
     expect(() =>
       validateTextLinks('[test](http://foo.bar)', () => false),
     ).toThrow('Invalid URL: Protocol must be one of: https:, mailto:.');
+
+    expect(() =>
+      validateTextLinks('[[test]](http://foo.bar)', () => false),
+    ).toThrow('Invalid URL: Protocol must be one of: https:, mailto:.');
+
+    expect(() => validateTextLinks('<http://foo.bar>', () => false)).toThrow(
+      'Invalid URL: Protocol must be one of: https:, mailto:.',
+    );
+
+    expect(() =>
+      validateTextLinks('[test](http://foo.bar "foo bar baz")', () => false),
+    ).toThrow('Invalid URL: Protocol must be one of: https:, mailto:.');
+
+    expect(() =>
+      validateTextLinks(
+        `[foo][1]
+         [1]: http://foo.bar`,
+        () => false,
+      ),
+    ).toThrow('Invalid URL: Protocol must be one of: https:, mailto:.');
+
+    expect(() =>
+      validateTextLinks(
+        `[foo][1]
+         [1]: http://foo.bar "foo bar baz"`,
+        () => false,
+      ),
+    ).toThrow('Invalid URL: Protocol must be one of: https:, mailto:.');
+
+    expect(() => validateTextLinks('[test](#code)', () => false)).toThrow(
+      'Invalid URL: Unable to parse URL.',
+    );
 
     expect(() => validateTextLinks('[test](foo.bar)', () => false)).toThrow(
       'Invalid URL: Unable to parse URL.',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6008,6 +6008,7 @@ __metadata:
     istanbul-lib-report: ^3.0.0
     istanbul-reports: ^3.1.5
     jest: ^29.0.2
+    marked: ^12.0.1
     memfs: ^3.4.13
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
@@ -17206,6 +17207,15 @@ __metadata:
   version: 0.1.0
   resolution: "map-stream@npm:0.1.0"
   checksum: 38abbe4eb883888031e6b2fc0630bc583c99396be16b8ace5794b937b682a8a081f03e8b15bfd4914d1bc88318f0e9ac73ba3512ae65955cd449f63256ddb31d
+  languageName: node
+  linkType: hard
+
+"marked@npm:^12.0.1":
+  version: 12.0.1
+  resolution: "marked@npm:12.0.1"
+  bin:
+    marked: bin/marked.js
+  checksum: 35ebc6c4612fcc028a1cd6419321e336be5b29d3feb68dfd5aaa7fcddb399c7873cd3291d60daf342db3eede747757e4e18515f349f0ee7b84ec24254f3a4190
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Changes the implementation of the Markdown link extraction to use the lexer from `marked`.

For the actual rendering we use https://github.com/syntax-tree/mdast-util-from-markdown but since that is ESM-only I have chosen to use `marked` in this PR.