### PR TITLE
Disable network access E2E test

### DIFF
--- a/packages/examples/packages/network-access/src/index.test.ts
+++ b/packages/examples/packages/network-access/src/index.test.ts
@@ -24,7 +24,8 @@ describe('onRpcRequest', () => {
   });
 
   describe('fetch', () => {
-    it('fetches a URL and returns the JSON response', async () => {
+    // This test is disabled as it is flaky.
+    it.skip('fetches a URL and returns the JSON response', async () => {
       const { request } = await installSnap({
         executionService: NodeProcessExecutionService,
       });


### PR DESCRIPTION
Disables the network access E2E test since it is too flaky and often blocks CI 😞 