### PR TITLE
Allow `maxRequestTime` on `endowment:rpc`

### DIFF
--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -199,7 +199,7 @@ export const PermissionsStruct = type({
   ),
   'endowment:network-access': optional(object({})),
   'endowment:page-home': optional(HandlerCaveatsStruct),
-  'endowment:rpc': optional(RpcOriginsStruct),
+  'endowment:rpc': optional(assign(HandlerCaveatsStruct, RpcOriginsStruct)),
   'endowment:signature-insight': optional(
     assign(
       HandlerCaveatsStruct,


### PR DESCRIPTION
When implementing `maxRequestTime`, validation support for the property on `endowment:rpc` in the manifest was left out accidentally. This would cause problems when devs try to use `maxRequestTime` with the endowment permission. This PR fixes that by making the endowment use similar validation to the other handler endowments.

Fixes https://github.com/MetaMask/snaps/issues/2290