### PR TITLE
Validate that initial permissions type matches validation struct

### DIFF
--- a/packages/snaps-sdk/src/types/permissions.ts
+++ b/packages/snaps-sdk/src/types/permissions.ts
@@ -2,8 +2,7 @@ import type { JsonRpcRequest } from '@metamask/utils';
 
 import type { ChainId } from './caip';
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type EmptyObject = {};
+export type EmptyObject = Record<string, never>;
 
 export type Cronjob = {
   expression: string;

--- a/packages/snaps-sdk/src/types/permissions.ts
+++ b/packages/snaps-sdk/src/types/permissions.ts
@@ -2,12 +2,25 @@ import type { JsonRpcRequest } from '@metamask/utils';
 
 import type { ChainId } from './caip';
 
-export type EmptyObject = Record<string, never>;
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type EmptyObject = {};
 
 export type Cronjob = {
   expression: string;
   request: Omit<JsonRpcRequest, 'jsonrpc' | 'id'>;
 };
+
+export type NameLookupMatchers =
+  | {
+      tlds: string[];
+    }
+  | {
+      schemes: string[];
+    }
+  | {
+      tlds: string[];
+      schemes: string[];
+    };
 
 export type Bip32Entropy = {
   curve: 'secp256k1' | 'ed25519';
@@ -37,7 +50,7 @@ export type InitialPermissions = Partial<{
   };
   'endowment:name-lookup': {
     chains?: ChainId[];
-    matchers?: { tlds?: string[]; schemes?: string[] };
+    matchers?: NameLookupMatchers;
     maxRequestTime?: number;
   };
   'endowment:network-access': EmptyObject;

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -2,5 +2,5 @@
   "branches": 96.48,
   "functions": 98.64,
   "lines": 98.74,
-  "statements": 94.51
+  "statements": 94.52
 }

--- a/packages/snaps-utils/src/manifest/validation.test.ts
+++ b/packages/snaps-utils/src/manifest/validation.test.ts
@@ -6,6 +6,7 @@ import {
   Bip32EntropyStruct,
   Bip32PathStruct,
   createSnapManifest,
+  EmptyObjectStruct,
   isSnapManifest,
   SnapIdsStruct,
 } from './validation';
@@ -149,6 +150,16 @@ describe('SnapIdsStruct', () => {
       false,
     );
     expect(is({ fooBar: {} }, SnapIdsStruct)).toBe(false);
+  });
+});
+
+describe('EmptyObjectStruct', () => {
+  it('accepts an empty object', () => {
+    expect(is({}, EmptyObjectStruct)).toBe(true);
+  });
+
+  it('rejects non-empty objects', () => {
+    expect(is({ foo: 'bar' }, EmptyObjectStruct)).toBe(false);
   });
 });
 

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -175,9 +175,10 @@ export const HandlerCaveatsStruct = object({
 
 export type HandlerCaveats = Infer<typeof HandlerCaveatsStruct>;
 
-export const EmptyObjectStruct = optional(
-  object<EmptyObject>({}) as unknown as Struct<EmptyObject, null>,
-);
+export const EmptyObjectStruct = object<EmptyObject>({}) as unknown as Struct<
+  EmptyObject,
+  null
+>;
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export const PermissionsStruct: Describe<InitialPermissions> = type({
@@ -187,7 +188,7 @@ export const PermissionsStruct: Describe<InitialPermissions> = type({
       object({ jobs: CronjobSpecificationArrayStruct }),
     ),
   ),
-  'endowment:ethereum-provider': EmptyObjectStruct,
+  'endowment:ethereum-provider': optional(EmptyObjectStruct),
   'endowment:keyring': optional(
     assign(HandlerCaveatsStruct, KeyringOriginsStruct),
   ),
@@ -201,7 +202,7 @@ export const PermissionsStruct: Describe<InitialPermissions> = type({
       }),
     ),
   ),
-  'endowment:network-access': EmptyObjectStruct,
+  'endowment:network-access': optional(EmptyObjectStruct),
   'endowment:page-home': optional(HandlerCaveatsStruct),
   'endowment:rpc': optional(assign(HandlerCaveatsStruct, RpcOriginsStruct)),
   'endowment:signature-insight': optional(
@@ -220,11 +221,11 @@ export const PermissionsStruct: Describe<InitialPermissions> = type({
       }),
     ),
   ),
-  'endowment:webassembly': EmptyObjectStruct,
-  snap_dialog: EmptyObjectStruct,
-  snap_manageState: EmptyObjectStruct,
-  snap_manageAccounts: EmptyObjectStruct,
-  snap_notify: EmptyObjectStruct,
+  'endowment:webassembly': optional(EmptyObjectStruct),
+  snap_dialog: optional(EmptyObjectStruct),
+  snap_manageState: optional(EmptyObjectStruct),
+  snap_manageAccounts: optional(EmptyObjectStruct),
+  snap_notify: optional(EmptyObjectStruct),
   snap_getBip32Entropy: optional(SnapGetBip32EntropyPermissionsStruct),
   snap_getBip32PublicKey: optional(SnapGetBip32EntropyPermissionsStruct),
   snap_getBip44Entropy: optional(
@@ -234,8 +235,8 @@ export const PermissionsStruct: Describe<InitialPermissions> = type({
       Infinity,
     ),
   ),
-  snap_getEntropy: EmptyObjectStruct,
-  snap_getLocale: EmptyObjectStruct,
+  snap_getEntropy: optional(EmptyObjectStruct),
+  snap_getLocale: optional(EmptyObjectStruct),
   wallet_snap: optional(SnapIdsStruct),
 });
 /* eslint-enable @typescript-eslint/naming-convention */

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -1,5 +1,5 @@
 import { isValidBIP32PathSegment } from '@metamask/key-tree';
-import type { InitialPermissions } from '@metamask/snaps-sdk';
+import type { EmptyObject, InitialPermissions } from '@metamask/snaps-sdk';
 import {
   assertStruct,
   ChecksumStruct,
@@ -175,6 +175,10 @@ export const HandlerCaveatsStruct = object({
 
 export type HandlerCaveats = Infer<typeof HandlerCaveatsStruct>;
 
+export const EmptyObjectStruct = optional(
+  object<EmptyObject>({}) as unknown as Struct<EmptyObject, null>,
+);
+
 /* eslint-disable @typescript-eslint/naming-convention */
 export const PermissionsStruct: Describe<InitialPermissions> = type({
   'endowment:cronjob': optional(
@@ -183,7 +187,7 @@ export const PermissionsStruct: Describe<InitialPermissions> = type({
       object({ jobs: CronjobSpecificationArrayStruct }),
     ),
   ),
-  'endowment:ethereum-provider': optional(object({})),
+  'endowment:ethereum-provider': EmptyObjectStruct,
   'endowment:keyring': optional(
     assign(HandlerCaveatsStruct, KeyringOriginsStruct),
   ),
@@ -197,7 +201,7 @@ export const PermissionsStruct: Describe<InitialPermissions> = type({
       }),
     ),
   ),
-  'endowment:network-access': optional(object({})),
+  'endowment:network-access': EmptyObjectStruct,
   'endowment:page-home': optional(HandlerCaveatsStruct),
   'endowment:rpc': optional(assign(HandlerCaveatsStruct, RpcOriginsStruct)),
   'endowment:signature-insight': optional(
@@ -216,11 +220,11 @@ export const PermissionsStruct: Describe<InitialPermissions> = type({
       }),
     ),
   ),
-  'endowment:webassembly': optional(object({})),
-  snap_dialog: optional(object({})),
-  snap_manageState: optional(object({})),
-  snap_manageAccounts: optional(object({})),
-  snap_notify: optional(object({})),
+  'endowment:webassembly': EmptyObjectStruct,
+  snap_dialog: EmptyObjectStruct,
+  snap_manageState: EmptyObjectStruct,
+  snap_manageAccounts: EmptyObjectStruct,
+  snap_notify: EmptyObjectStruct,
   snap_getBip32Entropy: optional(SnapGetBip32EntropyPermissionsStruct),
   snap_getBip32PublicKey: optional(SnapGetBip32EntropyPermissionsStruct),
   snap_getBip44Entropy: optional(
@@ -230,8 +234,8 @@ export const PermissionsStruct: Describe<InitialPermissions> = type({
       Infinity,
     ),
   ),
-  snap_getEntropy: optional(object({})),
-  snap_getLocale: optional(object({})),
+  snap_getEntropy: EmptyObjectStruct,
+  snap_getLocale: EmptyObjectStruct,
   wallet_snap: optional(SnapIdsStruct),
 });
 /* eslint-enable @typescript-eslint/naming-convention */

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -8,7 +8,7 @@ import {
   inMilliseconds,
   Duration,
 } from '@metamask/utils';
-import type { Infer, Struct } from 'superstruct';
+import type { Describe, Infer, Struct } from 'superstruct';
 import {
   array,
   boolean,
@@ -176,7 +176,7 @@ export const HandlerCaveatsStruct = object({
 export type HandlerCaveats = Infer<typeof HandlerCaveatsStruct>;
 
 /* eslint-disable @typescript-eslint/naming-convention */
-export const PermissionsStruct = type({
+export const PermissionsStruct: Describe<InitialPermissions> = type({
   'endowment:cronjob': optional(
     assign(
       HandlerCaveatsStruct,


### PR DESCRIPTION
By using Superstruct's `Describe` type, we can validate that a struct is assignable to a type. In this case, we make sure that the validation struct in `snaps-utils` matches the type in `snaps-sdk`. I had to make a small change to the type to get validation to pass.