### PR TITLE
Add multi install entry to test-snaps

### DIFF
--- a/packages/test-snaps/src/api.ts
+++ b/packages/test-snaps/src/api.ts
@@ -63,6 +63,8 @@ export type InstallSnapArgs = {
   version: string;
 };
 
+export type InstallSnapsArgs = Record<string, { version?: string }>;
+
 export type InstallSnapResult = Record<string, { error: JsonRpcError }>;
 
 export const baseApi = createApi({
@@ -114,14 +116,13 @@ export const baseApi = createApi({
             },
           },
         }),
-        transformResponse: (snaps: InstallSnapResult, _, { snapId }) => {
-          if (snaps[snapId].error) {
-            logError(snaps[snapId].error);
-            throw new Error(snaps[snapId].error.message);
-          }
-
-          return snaps;
-        },
+        invalidatesTags: [Tag.InstalledSnaps],
+      }),
+      installSnaps: build.mutation<InstallSnapResult, InstallSnapsArgs>({
+        query: (params) => ({
+          method: 'wallet_requestSnaps',
+          params,
+        }),
         invalidatesTags: [Tag.InstalledSnaps],
       }),
     };
@@ -136,4 +137,5 @@ export const {
   useLazyRequestQuery,
   useInvokeMutationMutation: useInvokeMutation,
   useInstallSnapMutation,
+  useInstallSnapsMutation,
 } = baseApi;

--- a/packages/test-snaps/src/features/snaps/index.ts
+++ b/packages/test-snaps/src/features/snaps/index.ts
@@ -15,6 +15,7 @@ export * from './images';
 export * from './json-rpc';
 export * from './lifecycle-hooks';
 export * from './manage-state';
+export * from './multi-install';
 export * from './name-lookup';
 export * from './network-access';
 export * from './notifications';

--- a/packages/test-snaps/src/features/snaps/multi-install/MultiInstall.tsx
+++ b/packages/test-snaps/src/features/snaps/multi-install/MultiInstall.tsx
@@ -1,0 +1,48 @@
+import { logError } from '@metamask/snaps-utils';
+import type { FunctionComponent } from 'react';
+import { Button, ButtonGroup } from 'react-bootstrap';
+
+import { useInstallSnapsMutation } from '../../../api';
+import { Snap } from '../../../components';
+import { getSnapId } from '../../../utils';
+import {
+  BIP_32_SNAP_ID,
+  BIP_32_PORT,
+  BIP_32_VERSION,
+} from '../bip32/constants';
+import {
+  BIP_44_SNAP_ID,
+  BIP_44_PORT,
+  BIP_44_VERSION,
+} from '../bip44/constants';
+
+export const MultiInstall: FunctionComponent = () => {
+  const [installSnaps, { isLoading }] = useInstallSnapsMutation();
+
+  const handleUpdate = () => {
+    installSnaps({
+      [getSnapId(BIP_32_SNAP_ID, BIP_32_PORT)]: { version: BIP_32_VERSION },
+      [getSnapId(BIP_44_SNAP_ID, BIP_44_PORT)]: { version: BIP_44_VERSION },
+    }).catch(logError);
+  };
+
+  return (
+    <Snap
+      name="Multi Install"
+      snapId={BIP_32_SNAP_ID}
+      version={BIP_32_VERSION}
+      testId="multi-install"
+      hideConnect={true}
+    >
+      <ButtonGroup>
+        <Button
+          disabled={isLoading}
+          onClick={handleUpdate}
+          id="multi-install-connect"
+        >
+          Install Snaps
+        </Button>
+      </ButtonGroup>
+    </Snap>
+  );
+};

--- a/packages/test-snaps/src/features/snaps/multi-install/MultiInstall.tsx
+++ b/packages/test-snaps/src/features/snaps/multi-install/MultiInstall.tsx
@@ -19,7 +19,7 @@ import {
 export const MultiInstall: FunctionComponent = () => {
   const [installSnaps, { isLoading }] = useInstallSnapsMutation();
 
-  const handleUpdate = () => {
+  const handleInstall = () => {
     installSnaps({
       [getSnapId(BIP_32_SNAP_ID, BIP_32_PORT)]: { version: BIP_32_VERSION },
       [getSnapId(BIP_44_SNAP_ID, BIP_44_PORT)]: { version: BIP_44_VERSION },
@@ -37,7 +37,7 @@ export const MultiInstall: FunctionComponent = () => {
       <ButtonGroup>
         <Button
           disabled={isLoading}
-          onClick={handleUpdate}
+          onClick={handleInstall}
           id="multi-install-connect"
         >
           Install Snaps

--- a/packages/test-snaps/src/features/snaps/multi-install/index.ts
+++ b/packages/test-snaps/src/features/snaps/multi-install/index.ts
@@ -1,0 +1,1 @@
+export * from './MultiInstall';


### PR DESCRIPTION
Adds an entry to test-snaps for installing multiple snaps at once, this is helpful for E2E testing.