### PR TITLE
Fix native notification example

### DIFF
--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "MV7VAvTwHITNDAKVY71bURgbuwxSegyMd/mTAwrjiSg=",
+    "shasum": "GKcy2dyT2VGscMJGEuZr/6n/J9aOAX1HIojxqUdGGP4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/src/index.test.ts
+++ b/packages/examples/packages/notifications/src/index.test.ts
@@ -49,7 +49,7 @@ describe('onRpcRequest', () => {
 
       expect(response).toRespondWith(null);
       expect(response).toSendNotification(
-        'Hello, Jest, from the browser!',
+        'Hello from the browser!',
         NotificationType.Native,
       );
     });

--- a/packages/examples/packages/notifications/src/index.ts
+++ b/packages/examples/packages/notifications/src/index.ts
@@ -10,16 +10,12 @@ import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
  *
  * @param params - The request parameters.
  * @param params.request - The JSON-RPC request object.
- * @param params.origin - The origin of the dapp that sent the request.
  * @returns The JSON-RPC response.
  * @see https://docs.metamask.io/snaps/reference/exports/#onrpcrequest
  * @see https://docs.metamask.io/snaps/reference/rpc-api/#wallet_invokesnap
  * @see https://docs.metamask.io/snaps/reference/rpc-api/#snap_notify
  */
-export const onRpcRequest: OnRpcRequestHandler = async ({
-  origin,
-  request,
-}) => {
+export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   switch (request.method) {
     case 'inApp':
       return await snap.request({
@@ -39,7 +35,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
           // We're using the `NotificationType` enum here, but you can also use
           // the string values directly, e.g. `type: 'native'`.
           type: NotificationType.Native,
-          message: `Hello, ${origin}, from the browser!`,
+          message: `Hello from the browser!`,
         },
       });
 


### PR DESCRIPTION
The native notification example message was too long and would fail when testing on test-snaps. This PR fixes that.