### PR TITLE
Delete unencrypted state when uninstalling a Snap

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -6792,6 +6792,30 @@ describe('SnapController', () => {
 
       snapController.destroy();
     });
+
+    it('removes snap state', async () => {
+      const messenger = getSnapControllerMessenger();
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(),
+            snapStates: {
+              [MOCK_SNAP_ID]: 'foo',
+            },
+            unencryptedSnapStates: {
+              [MOCK_SNAP_ID]: 'bar',
+            },
+          },
+        }),
+      );
+
+      await snapController.removeSnap(MOCK_SNAP_ID);
+      expect(snapController.state.snapStates).toStrictEqual({});
+      expect(snapController.state.unencryptedSnapStates).toStrictEqual({});
+
+      snapController.destroy();
+    });
   });
 
   describe('enableSnap', () => {

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1638,6 +1638,7 @@ export class SnapController extends BaseController<
         this.update((state: any) => {
           delete state.snaps[snapId];
           delete state.snapStates[snapId];
+          delete state.unencryptedSnapStates[snapId];
         });
 
         // If the snap has been fully installed before, also emit snapUninstalled.


### PR DESCRIPTION
Unencrypted state is currently not deleted when uninstalling a Snap. I've fixed this, and also added a test to check this behaviour.