### PR TITLE
Disable GitHub flavored Markdown when lexing

### DIFF
--- a/packages/snaps-utils/src/ui.test.ts
+++ b/packages/snaps-utils/src/ui.test.ts
@@ -58,6 +58,12 @@ describe('validateTextLinks', () => {
     ).not.toThrow();
   });
 
+  it('passes for non-links', () => {
+    expect(() =>
+      validateTextLinks('Hello **http://localhost:3000**', () => false),
+    ).not.toThrow();
+  });
+
   it('throws an error if an invalid link is found in text', () => {
     expect(() =>
       validateTextLinks('[test](http://foo.bar)', () => false),
@@ -76,17 +82,12 @@ describe('validateTextLinks', () => {
     ).toThrow('Invalid URL: Protocol must be one of: https:, mailto:.');
 
     expect(() =>
-      validateTextLinks(
-        `[foo][1]
-         [1]: http://foo.bar`,
-        () => false,
-      ),
+      validateTextLinks('[foo][1]\n\n[1]: http://foo.bar', () => false),
     ).toThrow('Invalid URL: Protocol must be one of: https:, mailto:.');
 
     expect(() =>
       validateTextLinks(
-        `[foo][1]
-         [1]: http://foo.bar "foo bar baz"`,
+        `[foo][1]\n\n[1]: http://foo.bar "foo bar baz"`,
         () => false,
       ),
     ).toThrow('Invalid URL: Protocol must be one of: https:, mailto:.');

--- a/packages/snaps-utils/src/ui.ts
+++ b/packages/snaps-utils/src/ui.ts
@@ -13,7 +13,7 @@ const ALLOWED_PROTOCOLS = ['https:', 'mailto:'];
  * @returns A list of URLs linked to in the string.
  */
 function getMarkdownLinks(text: string) {
-  const tokens = lexer(text);
+  const tokens = lexer(text, { gfm: false });
   const links: (Tokens.Link | Tokens.Generic)[] = [];
 
   // Walk the lexed tokens and collect all link tokens


### PR DESCRIPTION
`marked` has GitHub flavored Markdown enabled by default, but we don't support GitHub flavored Markdown in the UI. This makes the validation stricter than it needs to be. This PR fixes that by disabling GitHub flavored Markdown when lexing.