### PR TITLE
Add initialConnections to requestState

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 90.9,
+  "branches": 91.22,
   "functions": 96.58,
   "lines": 97.85,
   "statements": 97.52

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2386,6 +2386,7 @@ export class SnapController extends BaseController<
         this.#calculatePermissionsChange(snapId, processedPermissions);
 
       this.#updateApproval(pendingApproval.id, {
+        connections: manifest.initialConnections ?? {},
         permissions: newPermissions,
         newVersion: manifest.version,
         newPermissions,
@@ -2738,6 +2739,7 @@ export class SnapController extends BaseController<
       preinstalled,
 
       id: snapId,
+      initialConnections: manifest.result.initialConnections,
       initialPermissions: manifest.result.initialPermissions,
       manifest: manifest.result,
       status: this.#statusMachine.config.initial as StatusStates['value'],
@@ -2835,7 +2837,7 @@ export class SnapController extends BaseController<
     log(`Authorizing snap: ${snapId}`);
     const snapsState = this.state.snaps;
     const snap = snapsState[snapId];
-    const { initialPermissions } = snap;
+    const { initialPermissions, initialConnections } = snap;
 
     try {
       const processedPermissions = processSnapPermissions(initialPermissions);
@@ -2844,6 +2846,7 @@ export class SnapController extends BaseController<
 
       this.#updateApproval(pendingApproval.id, {
         loading: false,
+        connections: initialConnections ?? {},
         permissions: processedPermissions,
       });
 

--- a/packages/snaps-utils/src/snaps.ts
+++ b/packages/snaps-utils/src/snaps.ts
@@ -26,7 +26,11 @@ import validateNPMPackage from 'validate-npm-package-name';
 import { SnapCaveatType } from './caveats';
 import { checksumFiles } from './checksum';
 import type { LocalizationFile } from './localization';
-import type { SnapManifest, SnapPermissions } from './manifest/validation';
+import type {
+  InitialConnections,
+  SnapManifest,
+  SnapPermissions,
+} from './manifest/validation';
 import type { FetchedSnapFiles, SnapsPermissionRequest } from './types';
 import { SnapIdPrefixes, SnapValidationFailureReason, uri } from './types';
 import type { VirtualFile } from './virtual-file';
@@ -85,6 +89,10 @@ export type PersistedSnap = Snap;
  * A Snap as it exists in {@link SnapController} state.
  */
 export type Snap = TruncatedSnap & {
+  /**
+   * The initial connections of the Snap, optional, requested on installation.
+   */
+  initialConnections?: InitialConnections;
   /**
    * The initial permissions of the Snap, which will be requested when it is
    * installed.


### PR DESCRIPTION
This PR adds `initialConnections` specification from manifest to `requestState` object which is used on Snap installation or update process.

Related ticket: https://github.com/MetaMask/MetaMask-planning/issues/1895
Blocking: https://github.com/MetaMask/MetaMask-planning/issues/1895
