### PR TITLE
Fix encryption key caching issues

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 91.22,
+  "branches": 91.26,
   "functions": 96.58,
   "lines": 97.85,
   "statements": 97.52

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 91.26,
+  "branches": 91.32,
   "functions": 96.58,
   "lines": 97.85,
   "statements": 97.52

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -7765,6 +7765,35 @@ describe('SnapController', () => {
 
       snapController.destroy();
     });
+
+    it(`returns null if the Snap has no state yet`, async () => {
+      const messenger = getSnapControllerMessenger();
+
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: {
+              [MOCK_SNAP_ID]: getPersistedSnapObject(),
+            },
+          },
+        }),
+      );
+
+      expect(
+        await messenger.call(
+          'SnapController:getSnapState',
+          MOCK_SNAP_ID,
+          false,
+        ),
+      ).toBeNull();
+
+      expect(
+        await messenger.call('SnapController:getSnapState', MOCK_SNAP_ID, true),
+      ).toBeNull();
+
+      snapController.destroy();
+    });
   });
 
   describe('SnapController:has', () => {

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1690,8 +1690,8 @@ export class SnapController extends BaseController<
       ? this.state.snapStates[snapId]
       : this.state.unencryptedSnapStates[snapId];
 
-    if (state === null) {
-      return state;
+    if (state === null || state === undefined) {
+      return null;
     }
 
     if (!encrypted) {

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -222,6 +222,11 @@ export interface SnapRuntimeData {
    * Cached encryption key used for state encryption.
    */
   encryptionKey: string | null;
+
+  /**
+   * Cached encryption salt used for state encryption.
+   */
+  encryptionSalt: string | null;
 }
 
 export type SnapError = {
@@ -1542,21 +1547,25 @@ export class SnapController extends BaseController<
    */
   async #getSnapEncryptionKey({
     snapId,
-    salt,
+    salt: passedSalt,
     useCache,
     keyMetadata,
   }: {
     snapId: SnapId;
-    salt: string;
+    salt?: string;
     useCache: boolean;
     keyMetadata?: KeyDerivationOptions;
-  }): Promise<unknown> {
+  }): Promise<{ key: unknown; salt: string }> {
     const runtime = this.#getRuntimeExpect(snapId);
 
-    if (runtime.encryptionKey && useCache) {
-      return this.#encryptor.importKey(runtime.encryptionKey);
+    if (runtime.encryptionKey && runtime.encryptionSalt && useCache) {
+      return {
+        key: await this.#encryptor.importKey(runtime.encryptionKey),
+        salt: runtime.encryptionSalt,
+      };
     }
 
+    const salt = passedSalt ?? this.#encryptor.generateSalt();
     const mnemonicPhrase = await this.#getMnemonic();
     const entropy = await getEncryptionEntropy({ snapId, mnemonicPhrase });
     const encryptionKey = await this.#encryptor.keyFromPassword(
@@ -1570,8 +1579,9 @@ export class SnapController extends BaseController<
     // Cache exported encryption key in runtime
     if (useCache) {
       runtime.encryptionKey = exportedKey;
+      runtime.encryptionSalt = salt;
     }
-    return encryptionKey;
+    return { key: encryptionKey, salt };
   }
 
   /**
@@ -1587,16 +1597,13 @@ export class SnapController extends BaseController<
       const parsed = parseJson<EncryptionResult>(state);
       const { salt, keyMetadata } = parsed;
       const useCache = this.#encryptor.isVaultUpdated(state);
-      const encryptionKey = await this.#getSnapEncryptionKey({
+      const { key } = await this.#getSnapEncryptionKey({
         snapId,
         salt,
         useCache,
         keyMetadata,
       });
-      const decryptedState = await this.#encryptor.decryptWithKey(
-        encryptionKey,
-        parsed,
-      );
+      const decryptedState = await this.#encryptor.decryptWithKey(key, parsed);
 
       assert(isValidJson(decryptedState));
 
@@ -1619,16 +1626,11 @@ export class SnapController extends BaseController<
    * @returns A string containing the encrypted JSON object.
    */
   async #encryptSnapState(snapId: SnapId, state: Record<string, Json>) {
-    const salt = this.#encryptor.generateSalt();
-    const encryptionKey = await this.#getSnapEncryptionKey({
+    const { key, salt } = await this.#getSnapEncryptionKey({
       snapId,
-      salt,
       useCache: true,
     });
-    const encryptedState = await this.#encryptor.encryptWithKey(
-      encryptionKey,
-      state,
-    );
+    const encryptedState = await this.#encryptor.encryptWithKey(key, state);
 
     encryptedState.salt = salt;
     return JSON.stringify(encryptedState);
@@ -3372,6 +3374,7 @@ export class SnapController extends BaseController<
       rpcHandler: null,
       installPromise: null,
       encryptionKey: null,
+      encryptionSalt: null,
       activeReferences: 0,
       pendingInboundRequests: [],
       pendingOutboundRequests: 0,


### PR DESCRIPTION
This PR fixes a few problems discovered when trying to integrate the new encryption caching mechanism.

When the Snap is initially installed, its state will be `undefined`. Thus, `getSnapState` needs to account for this when deciding when to return `null`, which is the normalized value we use for lack of state.

Also in our tests, the salt is always the same, so tests were passing, but in reality the salt changes every time `generateSalt` is called. For that reason, we cache the salt alongside the encryption key for a session.