### PR TITLE
Allow `null` in `FormSubmitEventStruct` form state

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "NVydltk67wE3e1uAxlmal62P2EcP+cMfsNZ66EyJ7O4=",
+    "shasum": "ex9+3FPBFm197iqqFpLT7+KKLZpGdnqrXwxizMgbB6w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cGgUQlMw+WDBaoWHvG4s/xaZO47vBrEp9sa+4DhBmTA=",
+    "shasum": "q+2CKuLIzEzZkFgCgB+WJSLpc6+I7o3RzurltqnqM4A=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6TN8dOxLJmaVCneGh9fMAmvNYvxvYJ+5lvj6c5I2dZY=",
+    "shasum": "jl1W8uKqeSlhfBbGDyiCgCm3AxnSBWZMRMqBFw8b9jk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8pImYekIrQ0oaGuxf8Lta25MPIq2td4KPEVQ8jWgos8=",
+    "shasum": "WL24OpD/6olDRY8R1Pd/bxAtmRk8z+huNk6rXE6E+/8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6jscZ6A0qMZUnPm6AxpTHXY++XeNFtkT9Pr1OkjSTyI=",
+    "shasum": "FDGAlp5hKbt1dkKFjgSV0RPl3vpHY6hz0s+hNHgGK/w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "J8ekYCK9+rqN9d6qBw85RomNqdXMbkB9s1eHnQkaABs=",
+    "shasum": "hO0YsQrTcKU6YAuxwBOEPNIssWs3f6GvecSCPWOu0ds=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2omN9u/lT2cXPZ3O6j4wG3W3HBn/6No9JxH4ncqUG6M=",
+    "shasum": "miP/5TlkFeW4Slz/t2jN4XMC1+VxI1uupHg86IEHUmY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "t6qrFcAL9Hw/7r7/Q4q1rSrFQ1FdWG+JaTDnLpBv9DM=",
+    "shasum": "O6/rl2sgxCPD1IiFbM+VL10bXthiFp3nJuMyAD3aXwQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "dHiE+9mYVkqNRma5GsZprTawv/bDUzcdbeciRzCmkhQ=",
+    "shasum": "UND77v81lE7TMxWXZvzD6wsD7jCRsFFhYyjePnBwBbs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "dTL+fLvEFKI0vtcRZ0ZGxU2menzmWl3rPuOwnsqNMIQ=",
+    "shasum": "pXhAXvfd96IJp5935S8XjyHdIJ7G3fG0rIfykvoNAHU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+jhsvzvvvNA8Gf1d8zGZT0de5KpYoZsLfiz0EowMK0g=",
+    "shasum": "8xZw7bkVD+WIkH1wQIGHi2Vv/kNTRsk+RT/2nYAshmc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+RC3pwNreHxiMjByPmX0vglQye6wRfdfqC3/Y20tnc8=",
+    "shasum": "ASDoD6KZ+AAXAm6XLnT2GLnqYGNWTXWWTWkv2vXY2is=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "SxUO9T9xJ/R+jHURdjaLvy0Wfq+6+7CkovvO0CB0wxY=",
+    "shasum": "NnBTEkmPwyO5U2Nj+7o1P1IIeONNGFWibQnRUel34DA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "opdcmTNMX2T252PmyJIM5ctTJvFr2OzddoIHYXMBgew=",
+    "shasum": "CuWON9Sznqj5jTXJt8jj4S4kYA15eZtYxo0RJirGlUA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/src/index.test.ts
+++ b/packages/examples/packages/interactive-ui/src/index.test.ts
@@ -88,6 +88,59 @@ describe('onRpcRequest', () => {
 
       expect(await response).toRespondWith(true);
     });
+
+    it('lets users input nothing', async () => {
+      const { request } = await installSnap();
+
+      const response = request({
+        method: 'dialog',
+      });
+
+      const startScreen = await response.getInterface();
+      assert(startScreen.type === 'confirmation');
+
+      expect(startScreen).toRender(
+        panel([
+          heading('Interactive UI Example Snap'),
+          button({ value: 'Update UI', name: 'update' }),
+        ]),
+      );
+
+      await startScreen.clickElement('update');
+
+      const formScreen = await response.getInterface();
+
+      expect(formScreen).toRender(
+        panel([
+          heading('Interactive UI Example Snap'),
+          form({
+            name: 'example-form',
+            children: [
+              input({
+                name: 'example-input',
+                placeholder: 'Enter something...',
+              }),
+              button('Submit', ButtonType.Submit, 'submit'),
+            ],
+          }),
+        ]),
+      );
+
+      await formScreen.clickElement('submit');
+
+      const resultScreen = await response.getInterface();
+
+      expect(resultScreen).toRender(
+        panel([
+          heading('Interactive UI Example Snap'),
+          text('The submitted value is:'),
+          copyable(''),
+        ]),
+      );
+      await resultScreen.ok();
+
+      expect(await response).toRespondWith(true);
+    });
   });
 
   describe('getState', () => {

--- a/packages/examples/packages/interactive-ui/src/index.ts
+++ b/packages/examples/packages/interactive-ui/src/index.ts
@@ -186,6 +186,6 @@ export const onUserInput: OnUserInputHandler = async ({ id, event }) => {
     event.name === 'example-form'
   ) {
     const inputValue = event.value['example-input'];
-    await showResult(id, inputValue);
+    await showResult(id, inputValue ?? '');
   }
 };

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Idgne76ryW6QCf5Of8LZ+629vqkbLidCV6SmG3JZ7Iw=",
+    "shasum": "y3GdAX1pLkqY8Otlirf4SSQQXxte3qRLmvZEQJR/Yag=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "p2DDVeRmZ1peIJOSFP/mkzIX+8TUj8R0Rrh+6cgB1bA=",
+    "shasum": "dDj68iayGsdRVYT/mE8lKEh6Jihoh/etW+ppbAbyYQA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "lhPQ91mCD7n9r0yiA/KxP/olypotYlAbGauZTTUHh2w=",
+    "shasum": "AsKG87SRdGV6xeJVjT+OranYxEM6YyJz4XLVAPFDcEQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "BXlcBtRno7GhLlq0cqal08ALFJa9G+DP/a1Ad7cTUKY=",
+    "shasum": "PUJ46lEhp4Cvr6fkIhlr7hCJvjZGgsmpEubMrdnNTeA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vO4Ep4ZPZCfGukm9uw9WvvoMoojZ77/3Q2ajMNNCHQA=",
+    "shasum": "294hRqYtFbkho4eU2gc+amfn6OiUXXjhtMOQMGbgF/I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "f9PoXGMUUbGJtHHvKt715/pvWiHR3KogkfWAV07itaM=",
+    "shasum": "744MKon7/xMQ6JJyV6K8PANnf7WXWkKLz06oQhszMqA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "t4cfOsg8zpOverDV5ZdNKovQFhg2wDLZM+nYq6qmddA=",
+    "shasum": "ncWlW87GtmR4X97s0HHLcutUShbjk1wB3Jx1hFFCq80=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "uLxnaoy3UvlSqkAVwSa1s3YRDmle0CLeeD6obROqNK4=",
+    "shasum": "DDhpMR4WnEVF6S+bUOAhBZhrMTrY877EtPFJH5/61EQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "k5EwY5zY9GlI4F1hmtCOlMNjjqCspAs7DcNayoCB+J4=",
+    "shasum": "NOD8o7g47PyStwKZc/2yvDC82WRARyLJVX22CmwmXto=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8vwJeiNQLkL9YZxlLrfL6tK7Vd3cITEax5aSm6xiDlU=",
+    "shasum": "3ksEl1GxJVWbtkGeXfHIF5OCu1uqialcTetE/3nmLrg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "76NEiG+oW2yBCnvjY9TAjkitGYBfZ9hipf+i2l2e8uE=",
+    "shasum": "bjeONcTKE7AQKC1lRgIPC/TusPoq1n4DCRtGT42MLck=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "n4JE2r3hx1TX4nWT6BelHRyaNJnW5Q3b3pMMLHvSPb0=",
+    "shasum": "AfJMAwhmPMfxswVoRr+wtYe381fuZ5yOeuk+LKJilF8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7bFmVf6LL/1xCUX5IuY/W039IkfdCdEhrMylr8pi6uo=",
+    "shasum": "vQlLJfewN8oCDFFtJ660My9bphqC8Q8QXeWG9GNzxX8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-sdk/src/types/handlers/user-input.ts
+++ b/packages/snaps-sdk/src/types/handlers/user-input.ts
@@ -2,6 +2,7 @@ import type { Infer } from 'superstruct';
 import {
   assign,
   literal,
+  nullable,
   object,
   optional,
   record,
@@ -40,7 +41,7 @@ export const FormSubmitEventStruct = assign(
   GenericEventStruct,
   object({
     type: literal(UserInputEventType.FormSubmitEvent),
-    value: record(string(), string()),
+    value: record(string(), nullable(string())),
     name: string(),
   }),
 );
@@ -68,7 +69,7 @@ export const UserInputEventStruct = union([
  * @property value - The value associated with the event. Only available when an {@link UserInputEventType.FormSubmitEvent} is fired.
  * It contains the form values submitted.
  */
-type UserInputEvent = Infer<typeof UserInputEventStruct>;
+export type UserInputEvent = Infer<typeof UserInputEventStruct>;
 
 /**
  * The `onUserInput` handler. This is called when an user input event is fired in the UI.


### PR DESCRIPTION
Fixes an unintentional issue where null was disallowed in `FormSubmitEventStruct.value`. This value represents the form state and `null` is intended to be used as a lack of value. This also fixes a problem where Snaps would error if a user tried to submit an empty form field.