### PR TITLE
fix: gracefully handle errors for multiple failing requests

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 91.47,
+  "branches": 91.49,
   "functions": 96.61,
-  "lines": 97.86,
+  "lines": 97.87,
   "statements": 97.53
 }


### PR DESCRIPTION
Fixes a problem where if multiple simultaneous requests were sent to a Snap that resulted in an error, termination would be attempted multiple times causing unintentional errors to be surfaced to the caller.

This is fixed by making sure `stopSnap` is only called once even if we have multiple pending requests for the Snap.