### PR TITLE
fix: cache start promise

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 91.32,
+  "branches": 91.34,
   "functions": 96.58,
-  "lines": 97.85,
-  "statements": 97.52
+  "lines": 97.86,
+  "statements": 97.53
 }


### PR DESCRIPTION
Fixes a potential issue where requests could be sent to a Snap while it was installing that would error with "Snap is already being executed".

This is fixed by introducing a `startPromise` in the runtime which is cached while the Snap is starting.

I was unable to write a working unit test for this.