### PR TITLE
fix: properly tear down partially initialized executors

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 91.49,
-  "functions": 96.61,
-  "lines": 97.87,
-  "statements": 97.53
+  "branches": 91.55,
+  "functions": 96.62,
+  "lines": 97.88,
+  "statements": 97.55
 }

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.ts
@@ -405,6 +405,11 @@ export abstract class AbstractExecutionService<WorkerType>
       }),
       remainingTime,
     );
+
+    if (result === hasTimedOut) {
+      throw new Error(`${snapId} failed to start.`);
+    }
+
     this.#createSnapHooks(snapId, job.id);
     return result as string;
   }

--- a/packages/snaps-controllers/src/services/ExecutionService.ts
+++ b/packages/snaps-controllers/src/services/ExecutionService.ts
@@ -21,7 +21,7 @@ export interface ExecutionService {
 export type SnapExecutionData = {
   snapId: string;
   sourceCode: string;
-  endowments?: Json;
+  endowments: Json;
 };
 
 export type SnapErrorJson = {

--- a/packages/snaps-controllers/src/services/iframe/IframeExecutionService.ts
+++ b/packages/snaps-controllers/src/services/iframe/IframeExecutionService.ts
@@ -2,7 +2,10 @@ import type { BasePostMessageStream } from '@metamask/post-message-stream';
 import { WindowPostMessageStream } from '@metamask/post-message-stream';
 import { createWindow } from '@metamask/snaps-utils';
 
-import type { Job, ExecutionServiceArgs } from '../AbstractExecutionService';
+import type {
+  ExecutionServiceArgs,
+  TerminateJobArgs,
+} from '../AbstractExecutionService';
 import { AbstractExecutionService } from '../AbstractExecutionService';
 
 type IframeExecutionEnvironmentServiceArgs = {
@@ -24,7 +27,7 @@ export class IframeExecutionService extends AbstractExecutionService<Window> {
     this.iframeUrl = iframeUrl;
   }
 
-  protected terminateJob(jobWrapper: Job<Window>): void {
+  protected terminateJob(jobWrapper: TerminateJobArgs<Window>): void {
     document.getElementById(jobWrapper.id)?.remove();
   }
 

--- a/packages/snaps-controllers/src/services/node-js/NodeProcessExecutionService.ts
+++ b/packages/snaps-controllers/src/services/node-js/NodeProcessExecutionService.ts
@@ -3,7 +3,7 @@ import { ProcessParentMessageStream } from '@metamask/post-message-stream';
 import type { ChildProcess } from 'child_process';
 import { fork } from 'child_process';
 
-import type { Job } from '..';
+import type { TerminateJobArgs } from '..';
 import { AbstractExecutionService } from '..';
 
 export class NodeProcessExecutionService extends AbstractExecutionService<ChildProcess> {
@@ -36,7 +36,7 @@ export class NodeProcessExecutionService extends AbstractExecutionService<ChildP
     return Promise.resolve({ worker, stream });
   }
 
-  protected terminateJob(jobWrapper: Job<ChildProcess>): void {
-    jobWrapper.worker.kill();
+  protected terminateJob(jobWrapper: TerminateJobArgs<ChildProcess>): void {
+    jobWrapper.worker?.kill();
   }
 }

--- a/packages/snaps-controllers/src/services/node-js/NodeThreadExecutionService.ts
+++ b/packages/snaps-controllers/src/services/node-js/NodeThreadExecutionService.ts
@@ -3,7 +3,7 @@ import { ThreadParentMessageStream } from '@metamask/post-message-stream';
 // eslint-disable-next-line @typescript-eslint/no-shadow
 import { Worker } from 'worker_threads';
 
-import type { Job } from '..';
+import type { TerminateJobArgs } from '..';
 import { AbstractExecutionService } from '..';
 
 export class NodeThreadExecutionService extends AbstractExecutionService<Worker> {
@@ -37,7 +37,9 @@ export class NodeThreadExecutionService extends AbstractExecutionService<Worker>
     return Promise.resolve({ worker, stream });
   }
 
-  protected async terminateJob(jobWrapper: Job<Worker>): Promise<void> {
-    await jobWrapper.worker.terminate();
+  protected async terminateJob(
+    jobWrapper: TerminateJobArgs<Worker>,
+  ): Promise<void> {
+    await jobWrapper.worker?.terminate();
   }
 }

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.test.ts
@@ -134,6 +134,7 @@ describe('OffscreenExecutionService', () => {
       await service.executeSnap({
         snapId: MOCK_SNAP_ID,
         sourceCode: DEFAULT_SNAP_BUNDLE,
+        endowments: [],
       }),
     ).toBe('OK');
 
@@ -141,6 +142,7 @@ describe('OffscreenExecutionService', () => {
       await service.executeSnap({
         snapId: MOCK_LOCAL_SNAP_ID,
         sourceCode: DEFAULT_SNAP_BUNDLE,
+        endowments: [],
       }),
     ).toBe('OK');
 
@@ -164,6 +166,7 @@ describe('OffscreenExecutionService', () => {
       await service.executeSnap({
         snapId: MOCK_SNAP_ID,
         sourceCode: DEFAULT_SNAP_BUNDLE,
+        endowments: [],
       }),
     ).toBe('OK');
 

--- a/packages/snaps-controllers/src/services/proxy/ProxyExecutionService.ts
+++ b/packages/snaps-controllers/src/services/proxy/ProxyExecutionService.ts
@@ -1,7 +1,10 @@
 import type { BasePostMessageStream } from '@metamask/post-message-stream';
 import { nanoid } from 'nanoid';
 
-import type { ExecutionServiceArgs, Job } from '../AbstractExecutionService';
+import type {
+  ExecutionServiceArgs,
+  TerminateJobArgs,
+} from '../AbstractExecutionService';
 import { AbstractExecutionService } from '../AbstractExecutionService';
 import { ProxyPostMessageStream } from '../ProxyPostMessageStream';
 
@@ -41,7 +44,7 @@ export class ProxyExecutionService extends AbstractExecutionService<string> {
    *
    * @param job - The job to terminate.
    */
-  protected async terminateJob(job: Job<string>) {
+  protected async terminateJob(job: TerminateJobArgs<string>) {
     // The `AbstractExecutionService` will have already closed the job stream,
     // so we write to the runtime stream directly.
     this.#stream.write({

--- a/packages/snaps-controllers/src/services/webview/WebViewExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/webview/WebViewExecutionService.test.ts
@@ -119,6 +119,7 @@ describe('WebViewExecutionService', () => {
       await service.executeSnap({
         snapId: MOCK_SNAP_ID,
         sourceCode: DEFAULT_SNAP_BUNDLE,
+        endowments: [],
       }),
     ).toBe('OK');
   });

--- a/packages/snaps-controllers/src/services/webworker/WebWorkerExecutionService.ts
+++ b/packages/snaps-controllers/src/services/webworker/WebWorkerExecutionService.ts
@@ -4,7 +4,10 @@ import { createWindow } from '@metamask/snaps-utils';
 import { assert } from '@metamask/utils';
 import { nanoid } from 'nanoid';
 
-import type { ExecutionServiceArgs, Job } from '../AbstractExecutionService';
+import type {
+  ExecutionServiceArgs,
+  TerminateJobArgs,
+} from '../AbstractExecutionService';
 import { AbstractExecutionService } from '../AbstractExecutionService';
 import { ProxyPostMessageStream } from '../ProxyPostMessageStream';
 
@@ -48,7 +51,7 @@ export class WebWorkerExecutionService extends AbstractExecutionService<string> 
    *
    * @param job - The job to terminate.
    */
-  protected async terminateJob(job: Job<string>) {
+  protected async terminateJob(job: TerminateJobArgs<string>) {
     // The `AbstractExecutionService` will have already closed the job stream,
     // so we write to the runtime stream directly.
     assert(this.#runtimeStream, 'Runtime stream not initialized.');

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -1535,38 +1535,6 @@ describe('SnapController', () => {
     await service.terminateAllSnaps();
   });
 
-  it('times out on stuck starting snap', async () => {
-    const rootMessenger = getControllerMessenger();
-    const messenger = getSnapControllerMessenger(rootMessenger);
-    const snapController = getSnapController(
-      getSnapControllerOptions({
-        messenger,
-        maxInitTime: 50,
-        state: {
-          snaps: getPersistedSnapsState(),
-        },
-      }),
-    );
-
-    const snap = snapController.getExpect(MOCK_SNAP_ID);
-
-    rootMessenger.registerActionHandler(
-      'ExecutionService:executeSnap',
-      async () => await sleep(100),
-    );
-
-    rootMessenger.registerActionHandler(
-      'PermissionController:hasPermission',
-      () => false,
-    );
-
-    await expect(snapController.startSnap(snap.id)).rejects.toThrow(
-      `${snap.id} failed to start.`,
-    );
-
-    snapController.destroy();
-  });
-
   it('gracefully throws for multiple failing requests', async () => {
     const sourceCode = `
     module.exports.onRpcRequest = async () => snap.request({ method: 'snap_dialog', params: null });

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2600,12 +2600,13 @@ export class SnapController extends BaseController<
 
     try {
       const runtime = this.#getRuntimeExpect(snapId);
-      const result = await withTimeout(
-        this.messagingSystem.call('ExecutionService:executeSnap', {
+      const result = await this.messagingSystem.call(
+        'ExecutionService:executeSnap',
+        {
           ...snapData,
           endowments: await this.#getEndowments(snapId),
-        }),
-        this.#maxInitTime,
+          timeout: this.#maxInitTime,
+        },
       );
 
       if (result === hasTimedOut) {

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -628,12 +628,6 @@ type SnapControllerArgs = {
   maxRequestTime?: number;
 
   /**
-   * The maximum amount of time a snap may take to initialize, including
-   * the time it takes for the execution environment to start.
-   */
-  maxInitTime?: number;
-
-  /**
    * The npm registry URL that will be used to fetch published snaps.
    */
   npmRegistryUrl?: string;
@@ -746,8 +740,6 @@ export class SnapController extends BaseController<
   // This property cannot be hash private yet because of tests.
   private readonly maxRequestTime: number;
 
-  #maxInitTime: number;
-
   #encryptor: ExportableKeyEncryptor;
 
   #getMnemonic: () => Promise<Uint8Array>;
@@ -776,7 +768,6 @@ export class SnapController extends BaseController<
     idleTimeCheckInterval = inMilliseconds(5, Duration.Second),
     maxIdleTime = inMilliseconds(30, Duration.Second),
     maxRequestTime = inMilliseconds(60, Duration.Second),
-    maxInitTime = inMilliseconds(60, Duration.Second),
     fetchFunction = globalThis.fetch.bind(globalThis),
     featureFlags = {},
     detectSnapLocation: detectSnapLocationFunction = detectSnapLocation,
@@ -834,7 +825,6 @@ export class SnapController extends BaseController<
     this.#idleTimeCheckInterval = idleTimeCheckInterval;
     this.#maxIdleTime = maxIdleTime;
     this.maxRequestTime = maxRequestTime;
-    this.#maxInitTime = maxInitTime;
     this.#detectSnapLocation = detectSnapLocationFunction;
     this.#encryptor = encryptor;
     this.#getMnemonic = getMnemonic;
@@ -2605,13 +2595,8 @@ export class SnapController extends BaseController<
         {
           ...snapData,
           endowments: await this.#getEndowments(snapId),
-          timeout: this.#maxInitTime,
         },
       );
-
-      if (result === hasTimedOut) {
-        throw new Error(`${snapId} failed to start.`);
-      }
 
       this.#transition(snapId, SnapStatusEvents.Start);
       // We treat the initialization of the snap as the first request, for idle timing purposes.

--- a/packages/snaps-controllers/src/snaps/Timer.test.ts
+++ b/packages/snaps-controllers/src/snaps/Timer.test.ts
@@ -19,6 +19,7 @@ describe('Timer', () => {
     expect(callback).not.toHaveBeenCalled();
     jest.advanceTimersByTime(500);
     expect(callback).toHaveBeenCalled();
+    expect(timer.remaining).toBe(0);
   });
 
   it('calls the callback', () => {
@@ -40,6 +41,7 @@ describe('Timer', () => {
     timer.cancel();
     jest.advanceTimersByTime(1000);
     expect(callback).not.toHaveBeenCalled();
+    expect(timer.remaining).toBe(1000);
   });
 
   it('works with +Infinity', () => {
@@ -144,6 +146,29 @@ describe('Timer', () => {
 
     jest.advanceTimersByTime(1000);
     expect(timer.status).toBe('finished');
+
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('updates remaining', () => {
+    const timer = new Timer(1000);
+    const callback = jest.fn();
+
+    expect(timer.remaining).toBe(1000);
+
+    timer.start(callback);
+
+    jest.advanceTimersByTime(200);
+
+    timer.pause();
+    expect(timer.remaining).toBe(800);
+
+    timer.resume();
+    expect(timer.status).toBe('running');
+
+    jest.advanceTimersByTime(800);
+    expect(timer.status).toBe('finished');
+    expect(timer.remaining).toBe(0);
 
     expect(callback).toHaveBeenCalled();
   });

--- a/packages/snaps-controllers/src/snaps/Timer.ts
+++ b/packages/snaps-controllers/src/snaps/Timer.ts
@@ -8,6 +8,7 @@ export class Timer {
     | {
         value: 'paused';
         remaining: number;
+        start: number;
         callback: () => void;
       }
     | {
@@ -17,7 +18,7 @@ export class Timer {
         start: number;
         timeout?: unknown;
       }
-    | { value: 'finished' };
+    | { value: 'finished'; remaining: number };
 
   /**
    * If `ms` is smaller or equal to zero (including -Infinity), the callback is added to the event loop and executed async immediately
@@ -37,6 +38,10 @@ export class Timer {
 
   get status(): TimerStatus {
     return this.state.value;
+  }
+
+  get remaining(): number {
+    return this.state.remaining;
   }
 
   /**
@@ -119,8 +124,11 @@ export class Timer {
       clearTimeout(this.state.timeout as any);
     }
 
-    const { callback } = this.state;
-    this.state = { value: 'finished' };
+    const { callback, start, remaining } = this.state;
+    this.state = {
+      value: 'finished',
+      remaining: remaining - (Date.now() - start),
+    };
 
     if (shouldCall) {
       callback();

--- a/packages/snaps-controllers/src/snaps/Timer.ts
+++ b/packages/snaps-controllers/src/snaps/Timer.ts
@@ -8,7 +8,6 @@ export class Timer {
     | {
         value: 'paused';
         remaining: number;
-        start: number;
         callback: () => void;
       }
     | {
@@ -124,10 +123,13 @@ export class Timer {
       clearTimeout(this.state.timeout as any);
     }
 
-    const { callback, start, remaining } = this.state;
+    const { callback, remaining } = this.state;
     this.state = {
       value: 'finished',
-      remaining: remaining - (Date.now() - start),
+      remaining:
+        this.state.value === 'running'
+          ? remaining - (Date.now() - this.state.start)
+          : remaining,
     };
 
     if (shouldCall) {


### PR DESCRIPTION
Refactor execution timeout logic to fix a problem where the execution worker would not be torn down correctly when failing to initialize. This PR also moves the entire initialization timeout logic to the `AbstractExecutionService`, simplifying the `SnapController`. Moving the timeout logic fixes problems where job initialization was not cancelled properly resulting in "Snap is already being executed", since execution of the async functions inside `AbstractExecutionService` would continue even after the timeout.

The ExecutionService gets an optional `maxInitTime` constructor argument that can be set to define init time for the specific service. This timeout value is spread between initiating the execution job and running the first execution of the Snap. If the execution environment fails to initiate we attempt to tear it down in case it has partially started (this is at least the case for iframes). We make sure that the timeout is applied to `initEnvStream` which has the smallest possible footprint and worry for side-effects. Additionally in case an error happens when terminating a Snap we catch that error an move on.