### PR TITLE
fix: disable top level await

### DIFF
--- a/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
+++ b/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
@@ -4,6 +4,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -164,6 +167,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.ts",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -324,6 +330,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": "inline-source-map",
   "entry": "/foo/bar/src/index.ts",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -484,6 +493,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": "source-map",
   "entry": "/foo/bar/src/index.ts",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -635,6 +647,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -803,6 +818,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -963,6 +981,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -1123,6 +1144,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -1291,6 +1315,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -1459,6 +1486,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -1604,6 +1634,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.ts",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -1773,6 +1806,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.ts",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -1933,6 +1969,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.ts",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -2093,6 +2132,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.ts",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -2262,6 +2304,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.ts",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -2431,6 +2476,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -2585,6 +2633,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.ts",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -2739,6 +2790,9 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.ts",
+  "experiments": {
+    "topLevelAwait": false,
+  },
   "infrastructureLogging": {
     "level": "none",
   },

--- a/packages/snaps-cli/src/webpack/config.ts
+++ b/packages/snaps-cli/src/webpack/config.ts
@@ -367,6 +367,23 @@ export async function getDefaultConfiguration(
     },
 
     /**
+     * The experiments configuration. This configures which Webpack
+     * experiments to enable/disable.
+     *
+     * @see https://webpack.js.org/configuration/experiments
+     */
+    experiments: {
+      /**
+       * Experimental support for top level await.
+       *
+       * This is unsupported in Snaps and therefore disabled.
+       *
+       * @see https://webpack.js.org/configuration/experiments/#experimentstoplevelawait
+       */
+      topLevelAwait: false,
+    },
+
+    /**
      * The performance configuration. This tells Webpack how to handle
      * performance hints.
      *


### PR DESCRIPTION
Disables `experiments.topLevelAwait` in the Webpack config. This was enabled by default in Webpack `5.83.0`, but is unsupported in Snaps.

With this flag disabled, trying to build a Snap with top level await will result in:
```
  • Module parse failed: The top-level-await experiment is not enabled (set experiments.topLevelAwait: true to enable it)
    File was processed with these loaders:
     * ../../node_modules/swc-loader/src/index.js
    You may need an additional loader to handle the result of these loaders.
    Error: The top-level-await experiment is not enabled (set experiments.topLevelAwait: true to enable it)
        at .../node_modules/webpack/lib/dependencies/HarmonyDetectionParserPlugin.js:68:11
        at Hook.eval [as call] (eval at create (.../node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:7:16)
        at Hook.CALL_DELEGATE [as _call] (.../node_modules/tapable/lib/Hook.js:14:14)
        at JavascriptParser.walkAwaitExpression (.../node_modules/webpack/lib/javascript/JavascriptParser.js:2893:29)
        at JavascriptParser.walkExpression (.../node_modules/webpack/lib/javascript/JavascriptParser.js:2820:10)
        at JavascriptParser.walkLeftRightExpression (.../node_modules/webpack/lib/javascript/JavascriptParser.js:3061:8)
        at JavascriptParser.walkLogicalExpression (.../node_modules/webpack/lib/javascript/JavascriptParser.js:3080:9)
        at JavascriptParser.walkExpression (.../node_modules/webpack/lib/javascript/JavascriptParser.js:2847:10)
        at JavascriptParser.walkVariableDeclaration (.../node_modules/webpack/lib/javascript/JavascriptParser.js:2638:33)
        at JavascriptParser.walkStatement (.../node_modules/webpack/lib/javascript/JavascriptParser.js:1930:10)
```

Previously the Snap would build successfully but fail running in the client.