### PR TITLE
chore: unblock `eth_sendRawTransaction`

### DIFF
--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -2,5 +2,5 @@
   "branches": 80,
   "functions": 90.06,
   "lines": 90.76,
-  "statements": 90.13
+  "statements": 90.08
 }

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -2,5 +2,5 @@
   "branches": 80,
   "functions": 90.06,
   "lines": 90.76,
-  "statements": 90.08
+  "statements": 90.13
 }

--- a/packages/snaps-execution-environments/src/common/utils.ts
+++ b/packages/snaps-execution-environments/src/common/utils.ts
@@ -88,7 +88,6 @@ export const BLOCKED_RPC_METHODS = Object.freeze([
   'wallet_requestPermissions',
   'wallet_revokePermissions',
   // We disallow all of these confirmations for now, since the screens are not ready for Snaps.
-  'eth_sendRawTransaction',
   'eth_sendTransaction',
   'eth_sign',
   'eth_signTypedData',


### PR DESCRIPTION
Unblock `eth_sendRawTransaction` since it doesn't show a confirmation but is just a passthrough to the node for broadcasting a transaction.