### PR TITLE
fix: make `onUserInput` export optional

### DIFF
--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1567,6 +1567,47 @@ describe('BaseSnapExecutor', () => {
     });
   });
 
+  it('returns null if no onUserInput export is found', async () => {
+    const CODE = `
+      module.exports.onRpcRequest = () => {}
+    `;
+
+    const executor = new TestSnapExecutor();
+    await executor.executeSnap(1, MOCK_SNAP_ID, CODE, []);
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'OK',
+    });
+
+    const params = {
+      id: 'foo',
+      event: {
+        type: UserInputEventType.ButtonClickEvent,
+        name: 'bar',
+      },
+    };
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'snapRpc',
+      params: [
+        MOCK_SNAP_ID,
+        HandlerType.OnUserInput,
+        MOCK_ORIGIN,
+        { jsonrpc: '2.0', method: 'foo', params },
+      ],
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      id: 2,
+      jsonrpc: '2.0',
+      result: null,
+    });
+  });
+
   describe('lifecycle hooks', () => {
     const LIFECYCLE_HOOKS = [HandlerType.OnInstall, HandlerType.OnUpdate];
 

--- a/packages/snaps-utils/src/handlers.ts
+++ b/packages/snaps-utils/src/handlers.ts
@@ -98,7 +98,7 @@ export const SNAP_EXPORTS = {
   },
   [HandlerType.OnUserInput]: {
     type: HandlerType.OnUserInput,
-    required: true,
+    required: false,
     validator: (snapExport: unknown): snapExport is OnUserInputHandler => {
       return typeof snapExport === 'function';
     },


### PR DESCRIPTION
Snaps should not be required to to export `onUserInput` if they don't care to use it. This PR makes the export optional and uses existing functionality to return `null` if calls to the undefined export are detected.

Fixes #2364 