### PR TITLE
Make `getJsxChildren` return array of `JSXElement | string`

### DIFF
--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 96.69,
+  "branches": 96.7,
   "functions": 98.72,
   "lines": 98.81,
   "statements": 94.78

--- a/packages/snaps-utils/src/ui.test.tsx
+++ b/packages/snaps-utils/src/ui.test.tsx
@@ -734,7 +734,7 @@ describe('getJsxChildren', () => {
       </Box>
     );
 
-    expect(getJsxChildren(element)).toBe(element.props.children);
+    expect(getJsxChildren(element)).toStrictEqual(element.props.children);
   });
 
   it('returns the children of a JSX element with one child', () => {
@@ -752,6 +752,27 @@ describe('getJsxChildren', () => {
     const element = <Box />;
 
     expect(getJsxChildren(element)).toStrictEqual([]);
+  });
+
+  it('returns an empty array if the child is null', () => {
+    const element = <Box>{null}</Box>;
+
+    expect(getJsxChildren(element)).toStrictEqual([]);
+  });
+
+  it('removes null children from the array', () => {
+    const element = (
+      <Box>
+        <Text>Hello</Text>
+        {null}
+        <Text>World</Text>
+      </Box>
+    );
+
+    expect(getJsxChildren(element)).toStrictEqual([
+      <Text>Hello</Text>,
+      <Text>World</Text>,
+    ]);
   });
 });
 


### PR DESCRIPTION
To make `getJsxChildren` easier to use in practice, I've updated it to return an array of `JSXElement | string`, instead of the more generic `SnapNode`. It also filters nullish values now.