### PR TITLE
fix: unintentionally low timeout value for proxy executors

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 91.37,
-  "functions": 96.71,
-  "lines": 97.84,
+  "branches": 91.4,
+  "functions": 96.72,
+  "lines": 97.85,
   "statements": 97.52
 }

--- a/packages/snaps-controllers/src/services/proxy/ProxyExecutionService.ts
+++ b/packages/snaps-controllers/src/services/proxy/ProxyExecutionService.ts
@@ -34,6 +34,7 @@ export class ProxyExecutionService extends AbstractExecutionService<string> {
     super({
       messenger,
       setupSnapProvider,
+      usePing: false,
     });
 
     this.#stream = stream;
@@ -67,6 +68,18 @@ export class ProxyExecutionService extends AbstractExecutionService<string> {
     const stream = new ProxyPostMessageStream({
       stream: this.#stream,
       jobId,
+    });
+
+    // Send a request and await any response before continuing
+    // This simulates the behaviour of non-proxy environments by effectively awaiting
+    // the load of the environment inside the proxy environment
+    // This assumes the proxy environment is already loaded before this function is called
+    await new Promise((resolve) => {
+      stream.once('data', resolve);
+      stream.write({
+        name: 'command',
+        data: { jsonrpc: '2.0', method: 'ping', id: nanoid() },
+      });
     });
 
     return { worker: jobId, stream };


### PR DESCRIPTION
Fixes a problem with proxy execution environments having unintentionally low timeout values. The assumption is that `initJob` resolves once the execution environment is perceived to be ready for requests and therefore we ping the execution env with a very low timeout to detect issues and fail early. However, `initJob` was resolving way before the actual proxy executor was ready. This problem can be fixed by effectively pinging the execution environment as part of the initialization process of proxy executors as this loads the proxy executor and doesn't resolve until the executor responds.

Fixes #2372 