### PR TITLE
fix: instantiate preinstalled snaps on cleanup

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 91.44,
-  "functions": 96.72,
-  "lines": 97.85,
+  "functions": 96.73,
+  "lines": 97.86,
   "statements": 97.53
 }

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 91.4,
+  "branches": 91.44,
   "functions": 96.72,
   "lines": 97.85,
-  "statements": 97.52
+  "statements": 97.53
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1778,7 +1778,9 @@ export class SnapController extends BaseController<
     });
 
     // We want to remove all snaps & permissions, except for preinstalled snaps
-    this.#handlePreinstalledSnaps(this.#preinstalledSnaps);
+    if (this.#preinstalledSnaps) {
+      this.#handlePreinstalledSnaps(this.#preinstalledSnaps);
+    }
   }
 
   /**

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1777,9 +1777,15 @@ export class SnapController extends BaseController<
       state.snapStates = {};
     });
 
+    this.#snapsRuntimeData.clear();
+
     // We want to remove all snaps & permissions, except for preinstalled snaps
     if (this.#preinstalledSnaps) {
       this.#handlePreinstalledSnaps(this.#preinstalledSnaps);
+
+      Object.values(this.state?.snaps).forEach((snap) =>
+        this.#setupRuntime(snap.id),
+      );
     }
   }
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -758,7 +758,7 @@ export class SnapController extends BaseController<
     StatusStates
   >;
 
-  #preinstalledSnaps: PreinstalledSnap[] = [];
+  #preinstalledSnaps: PreinstalledSnap[] | null;
 
   constructor({
     closeAllConnections,

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -647,7 +647,7 @@ type SnapControllerArgs = {
   /**
    * A list of snaps to be preinstalled into the SnapController state on initialization.
    */
-  preinstalledSnaps?: PreinstalledSnap[];
+  preinstalledSnaps?: PreinstalledSnap[] | null;
 
   /**
    * A utility object containing functions required for state encryption.
@@ -773,7 +773,7 @@ export class SnapController extends BaseController<
     fetchFunction = globalThis.fetch.bind(globalThis),
     featureFlags = {},
     detectSnapLocation: detectSnapLocationFunction = detectSnapLocation,
-    preinstalledSnaps,
+    preinstalledSnaps = null,
     encryptor,
     getMnemonic,
   }: SnapControllerArgs) {
@@ -830,6 +830,7 @@ export class SnapController extends BaseController<
     this.#detectSnapLocation = detectSnapLocationFunction;
     this.#encryptor = encryptor;
     this.#getMnemonic = getMnemonic;
+    this.#preinstalledSnaps = preinstalledSnaps;
     this._onUnhandledSnapError = this._onUnhandledSnapError.bind(this);
     this._onOutboundRequest = this._onOutboundRequest.bind(this);
     this._onOutboundResponse = this._onOutboundResponse.bind(this);
@@ -877,9 +878,8 @@ export class SnapController extends BaseController<
     this.#initializeStateMachine();
     this.#registerMessageHandlers();
 
-    if (preinstalledSnaps) {
-      this.#preinstalledSnaps = preinstalledSnaps;
-      this.#handlePreinstalledSnaps(preinstalledSnaps);
+    if (this.#preinstalledSnaps) {
+      this.#handlePreinstalledSnaps(this.#preinstalledSnaps);
     }
 
     Object.values(this.state?.snaps ?? {}).forEach((snap) =>

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -758,6 +758,8 @@ export class SnapController extends BaseController<
     StatusStates
   >;
 
+  #preinstalledSnaps: PreinstalledSnap[] = [];
+
   constructor({
     closeAllConnections,
     messenger,
@@ -876,6 +878,7 @@ export class SnapController extends BaseController<
     this.#registerMessageHandlers();
 
     if (preinstalledSnaps) {
+      this.#preinstalledSnaps = preinstalledSnaps;
       this.#handlePreinstalledSnaps(preinstalledSnaps);
     }
 
@@ -1773,6 +1776,9 @@ export class SnapController extends BaseController<
       state.snaps = {};
       state.snapStates = {};
     });
+
+    // We want to remove all snaps & permissions, except for preinstalled snaps
+    this.#handlePreinstalledSnaps(this.#preinstalledSnaps);
   }
 
   /**


### PR DESCRIPTION
Preinstalled snaps should not be cleaned up. This ensures they are saved and have the correct permissions when a cleanup is performed.

This comes from testing with Extensions PreInstalled snaps. As a user is setting up a new wallet, the SnapController will have its state cleared.
https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/metamask-controller.js#L3780

Due to this, any Snap calls made using preinstalled snaps will fail with:
`Snap "npm:<SNAP_ID>" is not permitted to use "endowment:rpc"`