### PR TITLE
feat!: Extract wallet_invokeSnap implementation into own middleware

### DIFF
--- a/packages/snaps-rpc-methods/src/index.ts
+++ b/packages/snaps-rpc-methods/src/index.ts
@@ -1,6 +1,6 @@
 export {
-  handlers as permittedMethods,
   createSnapsMethodMiddleware,
+  createSnapsMethodRemapMiddleware,
 } from './permitted';
 export type { PermittedRpcMethodHooks } from './permitted';
 export { SnapCaveatType } from '@metamask/snaps-utils';

--- a/packages/snaps-rpc-methods/src/permitted/handlers.ts
+++ b/packages/snaps-rpc-methods/src/permitted/handlers.ts
@@ -14,7 +14,6 @@ export const methodHandlers = {
   wallet_getAllSnaps: getAllSnapsHandler,
   wallet_getSnaps: getSnapsHandler,
   wallet_requestSnaps: requestSnapsHandler,
-  wallet_invokeSnap: invokeSnapSugarHandler,
   wallet_invokeKeyring: invokeKeyringHandler,
   snap_getClientStatus: getClientStatusHandler,
   snap_getFile: getFileHandler,
@@ -22,6 +21,9 @@ export const methodHandlers = {
   snap_updateInterface: updateInterfaceHandler,
   snap_getInterfaceState: getInterfaceStateHandler,
 };
-/* eslint-enable @typescript-eslint/naming-convention */
 
-export const handlers = Object.values(methodHandlers);
+// Methods that remap themselves to another method.
+export const methodRemapHandlers = {
+  wallet_invokeSnap: invokeSnapSugarHandler,
+};
+/* eslint-enable @typescript-eslint/naming-convention */

--- a/packages/snaps-rpc-methods/src/permitted/invokeSnapSugar.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/invokeSnapSugar.test.ts
@@ -36,11 +36,9 @@ describe('wallet_invokeSnap', () => {
         id: 'some-id',
         jsonrpc: '2.0',
         method: 'wallet_invokeSnap',
+        // @ts-expect-error - Invalid params.
         params: {
-          // @ts-expect-error - Invalid params.
           snapId: undefined,
-
-          // @ts-expect-error - Invalid params.
           request: [],
         },
       };

--- a/packages/snaps-rpc-methods/src/permitted/middleware.ts
+++ b/packages/snaps-rpc-methods/src/permitted/middleware.ts
@@ -4,14 +4,14 @@ import { logError } from '@metamask/snaps-utils';
 import type { Json, JsonRpcParams } from '@metamask/utils';
 
 import { selectHooks } from '../utils';
-import { methodHandlers } from './handlers';
+import { methodHandlers, methodRemapHandlers } from './handlers';
 
 /**
  * Creates a middleware that handles permitted snap RPC methods.
  *
  * @param isSnap - A flag that should indicate whether the requesting origin is a snap or not.
  * @param hooks - An object containing the hooks made available to the permitted RPC methods.
- * @returns The middleware.
+ * @returns The middleware function.
  */
 export function createSnapsMethodMiddleware(
   isSnap: boolean,
@@ -47,6 +47,30 @@ export function createSnapsMethodMiddleware(
       }
     }
 
+    return next();
+  };
+}
+
+/**
+ * Creates a middleware that handles Snap-related methods that are remapped to a different
+ * method. In other words, the actual implementation exists elsewhere.
+ *
+ * @param handlerMap - The map of method names to their handlers.
+ * @returns The middleware function.
+ */
+export function createSnapsMethodRemapMiddleware(
+  handlerMap = methodRemapHandlers,
+): JsonRpcMiddleware<JsonRpcParams, Json> {
+  return function methodRemapMiddleware(request, response, next, end) {
+    const handler = handlerMap[request.method as keyof typeof handlerMap];
+    if (handler) {
+      return (handler.implementation as JsonRpcMiddleware<JsonRpcParams, Json>)(
+        request,
+        response,
+        next,
+        end,
+      );
+    }
     return next();
   };
 }


### PR DESCRIPTION
We are moving our permission middleware ahead of all RPC method implementations in the extension (https://github.com/MetaMask/metamask-extension/pull/24472) and mobile (https://github.com/MetaMask/metamask-mobile/pull/9521). This breaks the current implementation of `wallet_invokeSnap`, which assumes that it's called before the permission middleware (which calls the implementation of `wallet_snap`, which is a restricted method).

This PR splits `wallet_invokeSnap` into its own middleware function. Since the method only transforms requests, and is not actually a method implementation, it can be placed ahead of the permission middleware. Also removes some apparently unused exports.