### PR TITLE
fix: add missing TypeScript declarations for JSX entry points

### DIFF
--- a/packages/snaps-sdk/jsx-dev-runtime.d.ts
+++ b/packages/snaps-sdk/jsx-dev-runtime.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types/jsx/jsx-dev-runtime';

--- a/packages/snaps-sdk/jsx-runtime.d.ts
+++ b/packages/snaps-sdk/jsx-runtime.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types/jsx/jsx-runtime';

--- a/packages/snaps-sdk/jsx.d.ts
+++ b/packages/snaps-sdk/jsx.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types/jsx';

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -36,7 +36,10 @@
     "dist",
     "jsx.js",
     "jsx-dev-runtime.js",
-    "jsx-runtime.js"
+    "jsx-runtime.js",
+    "jsx.d.ts",
+    "jsx-dev-runtime.d.ts",
+    "jsx-runtime.d.ts"
   ],
   "scripts": {
     "test": "jest && yarn posttest",

--- a/packages/snaps-sdk/tsconfig.json
+++ b/packages/snaps-sdk/tsconfig.json
@@ -5,5 +5,12 @@
     "jsx": "react-jsx",
     "jsxImportSource": "@metamask/snaps-sdk"
   },
-  "include": ["./src", "package.json", "tsup.config.ts"]
+  "include": [
+    "./src",
+    "package.json",
+    "tsup.config.ts",
+    "jsx.d.ts",
+    "jsx-runtime.d.ts",
+    "jsx-dev-runtime.d.ts"
+  ]
 }


### PR DESCRIPTION
Add missing TypeScript declarations for JSX entry points that don't use the `exports`.