### PR TITLE
refactor!(snaps-rpc-methods): Use hooks in `wallet_invokeSnap` instead of remapping the request to `wallet_snap`

### DIFF
--- a/packages/snaps-rpc-methods/src/permitted/invokeSnapSugar.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/invokeSnapSugar.test.ts
@@ -23,7 +23,7 @@ describe('wallet_invokeSnap', () => {
         jsonrpc: jsonrpc2,
       } as PendingJsonRpcResponse<InvokeSnapResult>);
 
-    it('invokes snap with next()', async () => {
+    it('invokes snap using hook', async () => {
       const params = {
         snapId: 'npm:@metamask/example-snap',
         request: { method: 'hello' },

--- a/packages/snaps-rpc-methods/src/permitted/invokeSnapSugar.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/invokeSnapSugar.test.ts
@@ -3,61 +3,68 @@ import type {
   JsonRpcEngineNextCallback,
 } from '@metamask/json-rpc-engine';
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { InvokeSnapParams } from '@metamask/snaps-sdk';
-import type { JsonRpcRequest } from '@metamask/utils';
+import type { InvokeSnapParams, InvokeSnapResult } from '@metamask/snaps-sdk';
+import type { PendingJsonRpcResponse } from '@metamask/utils';
+import { assertIsJsonRpcSuccess, jsonrpc2 } from '@metamask/utils';
 
 import { getValidatedParams, invokeSnapSugar } from './invokeSnapSugar';
 
 describe('wallet_invokeSnap', () => {
   describe('invokeSnapSugar', () => {
-    it('invokes snap with next()', () => {
-      const req: JsonRpcRequest<InvokeSnapParams> = {
+    const getMockRpcRequest = (params: InvokeSnapParams) => ({
+      id: 'some-id',
+      jsonrpc: jsonrpc2,
+      method: 'wallet_invokeSnap',
+      params,
+    });
+    const getMockRpcResponse = () =>
+      ({
         id: 'some-id',
-        jsonrpc: '2.0',
-        method: 'wallet_invokeSnap',
-        params: {
-          snapId: 'npm:@metamask/example-snap',
-          request: { method: 'hello' },
-        },
+        jsonrpc: jsonrpc2,
+      } as PendingJsonRpcResponse<InvokeSnapResult>);
+
+    it('invokes snap with next()', async () => {
+      const params = {
+        snapId: 'npm:@metamask/example-snap',
+        request: { method: 'hello' },
       };
-      const _res: unknown = {};
-      const next: JsonRpcEngineNextCallback = jest
-        .fn()
-        .mockResolvedValueOnce(true);
+      const req = getMockRpcRequest({ ...params });
+      const res = getMockRpcResponse();
+      const next: JsonRpcEngineNextCallback = jest.fn();
       const end: JsonRpcEngineEndCallback = jest.fn();
+      const invokeSnap = jest.fn().mockResolvedValue(true);
 
-      invokeSnapSugar(req, _res, next, end);
+      await invokeSnapSugar(req, res, next, end, { invokeSnap });
 
-      expect(next).toHaveBeenCalledTimes(1);
+      assertIsJsonRpcSuccess(res);
+      expect(next).not.toHaveBeenCalled();
+      expect(invokeSnap).toHaveBeenCalledTimes(1);
+      expect(invokeSnap).toHaveBeenCalledWith({ ...params });
+      expect(end).toHaveBeenCalledTimes(1);
     });
 
-    it('ends with an error if params are invalid', () => {
-      const req: JsonRpcRequest<InvokeSnapParams> = {
-        id: 'some-id',
-        jsonrpc: '2.0',
-        method: 'wallet_invokeSnap',
-        params: {
-          // @ts-expect-error - Invalid params.
-          snapId: undefined,
-
-          // @ts-expect-error - Invalid params.
-          request: [],
-        },
-      };
-      const _res: unknown = {};
-      const next: JsonRpcEngineNextCallback = jest
-        .fn()
-        .mockResolvedValueOnce(true);
+    it('ends with an error if params are invalid', async () => {
+      const req = getMockRpcRequest({
+        // @ts-expect-error Intentional destructive testing
+        snapId: undefined,
+        // @ts-expect-error Intentional destructive testing
+        request: [],
+      });
+      const res = getMockRpcResponse();
+      const next: JsonRpcEngineNextCallback = jest.fn();
       const end: JsonRpcEngineEndCallback = jest.fn();
+      const invokeSnap = jest.fn();
 
-      invokeSnapSugar(req, _res, next, end);
+      await invokeSnapSugar(req, res, next, end, { invokeSnap });
 
+      expect(next).not.toHaveBeenCalled();
+      expect(end).toHaveBeenCalledTimes(1);
       expect(end).toHaveBeenCalledWith(
         rpcErrors.invalidParams({
           message: 'Must specify a valid snap ID.',
         }),
       );
-      expect(next).not.toHaveBeenCalled();
+      expect(invokeSnap).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Supersedes: #2398

We are moving our permission middleware ahead of all RPC method implementations in the extension (https://github.com/MetaMask/metamask-extension/pull/24472) and mobile (https://github.com/MetaMask/metamask-mobile/pull/9521). This breaks the current implementation of `wallet_invokeSnap`, which assumes that it's called before the permission middleware (which calls the implementation of `wallet_snap`, which is a restricted method).

This PR refactors `wallet_invokeSnap` to use an `invokeSnap()` hook, intended to be `PermissionController.executeRestrictedMethod()` bound to the requesting origin and `'wallet_snap'`.