### PR TITLE
Add support for BIP-32-Ed25519 / CIP-3 key derivation

### DIFF
--- a/packages/examples/packages/bip32/package.json
+++ b/packages/examples/packages/bip32/package.json
@@ -30,7 +30,7 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/key-tree": "^9.0.0",
+    "@metamask/key-tree": "^9.1.0",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.3.0",
     "@noble/ed25519": "^1.6.0",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OQuxxP2wxKhjw8UnV1gmxF7p0xBJPjqDpZBPAopnTng=",
+    "shasum": "TRXRkxE2XflQwoOz9K7tXVk0D80XKI8+NVrxVx0poY8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/package.json
+++ b/packages/examples/packages/bip44/package.json
@@ -30,7 +30,7 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/key-tree": "^9.0.0",
+    "@metamask/key-tree": "^9.1.0",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.3.0",
     "@noble/bls12-381": "^1.2.0"

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VzcO1O0ZoxXGv/mrjeI8uKFb3Rzo1h+cmx3+BdyQVLQ=",
+    "shasum": "L9tWp7lXixx9ehd2wAVqDmYejKSDDR4P0q7D0EORqtU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
@@ -30,7 +30,7 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/key-tree": "^9.0.0",
+    "@metamask/key-tree": "^9.1.0",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.3.0",
     "@noble/hashes": "^1.3.1"

--- a/packages/examples/packages/invoke-snap/packages/core-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/package.json
@@ -30,7 +30,7 @@
     "lint:dependencies": "depcheck"
   },
   "dependencies": {
-    "@metamask/key-tree": "^9.0.0",
+    "@metamask/key-tree": "^9.1.0",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/utils": "^8.3.0",
     "@noble/curves": "^1.1.0",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "GDWZSza7jjO8eLmEB/eZLcguLJivt7NZ14QM12HBqxA=",
+    "shasum": "w5YHaOqduw/AElLXKKw6rtilWmloVNWOuBUAThx0xn0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -44,7 +44,7 @@
     "@metamask/eth-json-rpc-middleware": "^12.1.0",
     "@metamask/json-rpc-engine": "^8.0.1",
     "@metamask/json-rpc-middleware-stream": "^7.0.1",
-    "@metamask/key-tree": "^9.0.0",
+    "@metamask/key-tree": "^9.1.0",
     "@metamask/permission-controller": "^9.0.2",
     "@metamask/snaps-controllers": "workspace:^",
     "@metamask/snaps-execution-environments": "workspace:^",

--- a/packages/snaps-rpc-methods/package.json
+++ b/packages/snaps-rpc-methods/package.json
@@ -39,7 +39,7 @@
     "build:ci": "tsup --clean"
   },
   "dependencies": {
-    "@metamask/key-tree": "^9.0.0",
+    "@metamask/key-tree": "^9.1.0",
     "@metamask/permission-controller": "^9.0.2",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.test.ts
@@ -137,5 +137,33 @@ describe('getBip32EntropyImplementation', () => {
         }
       `);
     });
+
+    it('derives a path using ed25519Bip32', async () => {
+      const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const getMnemonic = jest
+        .fn()
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES);
+
+      expect(
+        // @ts-expect-error Missing other required properties.
+        await getBip32EntropyImplementation({ getUnlockPromise, getMnemonic })({
+          params: {
+            path: ['m', "44'", "1'", "0'", "0'", "1'"],
+            curve: 'ed25519Bip32',
+          },
+        }),
+      ).toMatchInlineSnapshot(`
+        {
+          "chainCode": "0x8b46a12626641c1d3b888ea73a0474760bbf6530c189a987ad4be6403b2b7320",
+          "curve": "ed25519Bip32",
+          "depth": 5,
+          "index": 2147483649,
+          "masterFingerprint": 1587894111,
+          "parentFingerprint": 3236688876,
+          "privateKey": "0x88a59d7aa9fe82d8f98843ef474195178eb71956dee597252e7a5fbeebbc734e9b5bfdd17f82144a2bea78c8ab19bef26dc93f36e96eaa41453b65cb3daa1817",
+          "publicKey": "0xd91d18b4540a2f30341e8463d5f9b25b14fae9a236dcbea338b668a318bb0867",
+        }
+      `);
+    });
   });
 });

--- a/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.test.ts
@@ -101,6 +101,28 @@ describe('getBip32PublicKeyImplementation', () => {
       );
     });
 
+    it('derives the ed25519Bip32 public key from the path', async () => {
+      const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const getMnemonic = jest
+        .fn()
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES);
+
+      expect(
+        await getBip32PublicKeyImplementation({
+          getUnlockPromise,
+          getMnemonic,
+          // @ts-expect-error Missing other required properties.
+        })({
+          params: {
+            path: ['m', "44'", "1'", "0'", "0'", "1'"],
+            curve: 'ed25519Bip32',
+          },
+        }),
+      ).toMatchInlineSnapshot(
+        `"0xd91d18b4540a2f30341e8463d5f9b25b14fae9a236dcbea338b668a318bb0867"`,
+      );
+    });
+
     it('derives the compressed public key from the path', async () => {
       const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
       const getMnemonic = jest

--- a/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -13,11 +13,12 @@ import type {
 import {
   bip32entropy,
   Bip32PathStruct,
+  CurveStruct,
   SnapCaveatType,
 } from '@metamask/snaps-utils';
 import type { NonEmptyArray } from '@metamask/utils';
 import { assertStruct } from '@metamask/utils';
-import { boolean, enums, object, optional } from 'superstruct';
+import { boolean, object, optional } from 'superstruct';
 
 import type { MethodHooksObject } from '../utils';
 import { getNode } from '../utils';
@@ -53,7 +54,7 @@ type GetBip32PublicKeySpecification = ValidPermissionSpecification<{
 export const Bip32PublicKeyArgsStruct = bip32entropy(
   object({
     path: Bip32PathStruct,
-    curve: enums(['ed25519', 'secp256k1']),
+    curve: CurveStruct,
     compressed: optional(boolean()),
   }),
 );

--- a/packages/snaps-rpc-methods/src/utils.test.ts
+++ b/packages/snaps-rpc-methods/src/utils.test.ts
@@ -28,6 +28,17 @@ describe('getPathPrefix', () => {
   it('returns "slip10" for "ed25519"', () => {
     expect(getPathPrefix('ed25519')).toBe('slip10');
   });
+
+  it('returns "cip3" for "ed25519Bip32"', () => {
+    expect(getPathPrefix('ed25519Bip32')).toBe('cip3');
+  });
+
+  it('throws for an unknown curve', () => {
+    // @ts-expect-error Invalid curve.
+    expect(() => getPathPrefix('foo')).toThrow(
+      'Invalid branch reached. Should be detected during compilation.',
+    );
+  });
 });
 
 describe('getNode', () => {

--- a/packages/snaps-rpc-methods/src/utils.ts
+++ b/packages/snaps-rpc-methods/src/utils.ts
@@ -158,7 +158,7 @@ export async function deriveEntropy({
  *
  * - The Secp256k1 curve always uses the BIP-32 specification.
  * - The Ed25519 curve always uses the SLIP-10 specification.
- * - The BIP-32-Ed25519 curve always uses the SLIP-10 specification.
+ * - The BIP-32-Ed25519 curve always uses the CIP-3 specification.
  *
  * While this does not matter in most situations (no known case at the time of
  * writing), `key-tree` requires a specific specification to be used.
@@ -167,13 +167,16 @@ export async function deriveEntropy({
  * validated by this function.
  * @returns The path prefix, i.e., `bip32` or `slip10`.
  */
-export function getPathPrefix(curve: SupportedCurve): 'bip32' | 'slip10' {
+export function getPathPrefix(
+  curve: SupportedCurve,
+): 'bip32' | 'slip10' | 'cip3' {
   switch (curve) {
     case 'secp256k1':
       return 'bip32';
     case 'ed25519':
-    case 'ed25519Bip32':
       return 'slip10';
+    case 'ed25519Bip32':
+      return 'cip3';
     default:
       return assertExhaustive(curve);
   }
@@ -204,6 +207,7 @@ export async function getNode({
   path,
 }: GetNodeArgs) {
   const prefix = getPathPrefix(curve);
+
   return await SLIP10Node.fromDerivationPath({
     curve,
     derivationPath: [

--- a/packages/snaps-rpc-methods/src/utils.ts
+++ b/packages/snaps-rpc-methods/src/utils.ts
@@ -2,11 +2,13 @@ import type {
   HardenedBIP32Node,
   BIP32Node,
   SLIP10PathNode,
+  SupportedCurve,
 } from '@metamask/key-tree';
 import { SLIP10Node } from '@metamask/key-tree';
 import type { MagicValue } from '@metamask/snaps-utils';
 import type { Hex } from '@metamask/utils';
 import {
+  assertExhaustive,
   add0x,
   assert,
   concatBytes,
@@ -154,28 +156,31 @@ export async function deriveEntropy({
  * Get the path prefix to use for key derivation in `key-tree`. This assumes the
  * following:
  *
- * - The Secp256k1 curve always use the BIP-32 specification.
- * - The Ed25519 curve always use the SLIP-10 specification.
+ * - The Secp256k1 curve always uses the BIP-32 specification.
+ * - The Ed25519 curve always uses the SLIP-10 specification.
+ * - The BIP-32-Ed25519 curve always uses the SLIP-10 specification.
  *
  * While this does not matter in most situations (no known case at the time of
  * writing), `key-tree` requires a specific specification to be used.
  *
  * @param curve - The curve to get the path prefix for. The curve is NOT
  * validated by this function.
- * @returns The path prefix, i.e., `secp256k1` or `ed25519`.
+ * @returns The path prefix, i.e., `bip32` or `slip10`.
  */
-export function getPathPrefix(
-  curve: 'secp256k1' | 'ed25519',
-): 'bip32' | 'slip10' {
-  if (curve === 'secp256k1') {
-    return 'bip32';
+export function getPathPrefix(curve: SupportedCurve): 'bip32' | 'slip10' {
+  switch (curve) {
+    case 'secp256k1':
+      return 'bip32';
+    case 'ed25519':
+    case 'ed25519Bip32':
+      return 'slip10';
+    default:
+      return assertExhaustive(curve);
   }
-
-  return 'slip10';
 }
 
 type GetNodeArgs = {
-  curve: 'secp256k1' | 'ed25519';
+  curve: SupportedCurve;
   secretRecoveryPhrase: Uint8Array;
   path: string[];
 };

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -59,7 +59,7 @@
     "build:ci": "tsup --clean"
   },
   "dependencies": {
-    "@metamask/key-tree": "^9.0.0",
+    "@metamask/key-tree": "^9.1.0",
     "@metamask/providers": "^16.1.0",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/utils": "^8.3.0",

--- a/packages/snaps-sdk/src/types/permissions.test.ts
+++ b/packages/snaps-sdk/src/types/permissions.test.ts
@@ -42,6 +42,15 @@ describe('Bip32Entropy', () => {
 
     expectTypeOf(entropy).toMatchTypeOf<Bip32Entropy>();
   });
+
+  it('supports ed25519Bip32', () => {
+    const entropy = {
+      curve: 'ed25519Bip32' as const,
+      path: ['m', "44'"],
+    };
+
+    expectTypeOf(entropy).toMatchTypeOf<Bip32Entropy>();
+  });
 });
 
 describe('Bip44Entropy', () => {

--- a/packages/snaps-sdk/src/types/permissions.ts
+++ b/packages/snaps-sdk/src/types/permissions.ts
@@ -1,3 +1,4 @@
+import type { SupportedCurve } from '@metamask/key-tree';
 import type { JsonRpcRequest } from '@metamask/utils';
 
 import type { ChainId } from './caip';
@@ -22,7 +23,7 @@ export type NameLookupMatchers =
     };
 
 export type Bip32Entropy = {
-  curve: 'secp256k1' | 'ed25519';
+  curve: SupportedCurve;
   path: string[];
 };
 

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -34,7 +34,7 @@
     "@metamask/eth-json-rpc-middleware": "^12.1.0",
     "@metamask/json-rpc-engine": "^8.0.1",
     "@metamask/json-rpc-middleware-stream": "^7.0.1",
-    "@metamask/key-tree": "^9.0.0",
+    "@metamask/key-tree": "^9.1.0",
     "@metamask/permission-controller": "^9.0.2",
     "@metamask/snaps-controllers": "workspace:^",
     "@metamask/snaps-execution-environments": "workspace:^",

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -2,5 +2,5 @@
   "branches": 96.7,
   "functions": 98.72,
   "lines": 98.81,
-  "statements": 94.78
+  "statements": 94.79
 }

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -53,7 +53,7 @@
     "@babel/core": "^7.23.2",
     "@babel/types": "^7.23.0",
     "@metamask/base-controller": "^5.0.2",
-    "@metamask/key-tree": "^9.0.0",
+    "@metamask/key-tree": "^9.1.0",
     "@metamask/permission-controller": "^9.0.2",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/slip44": "^3.1.0",

--- a/packages/snaps-utils/src/derivation-path.test.ts
+++ b/packages/snaps-utils/src/derivation-path.test.ts
@@ -10,6 +10,12 @@ describe('getSnapDerivationPathName', () => {
     );
   });
 
+  it("returns a name from the hardcoded list starting with `1852'`, `1815'`", () => {
+    expect(
+      getSnapDerivationPathName(['m', `1852'`, `1815'`], 'ed25519Bip32'),
+    ).toBe('Cardano');
+  });
+
   it('returns a name from the SLIP44 list where applicable', () => {
     expect(
       getSnapDerivationPathName(['m', `44'`, `60'`, `0'`], 'secp256k1'),

--- a/packages/snaps-utils/src/derivation-paths.ts
+++ b/packages/snaps-utils/src/derivation-paths.ts
@@ -150,6 +150,11 @@ export const SNAPS_DERIVATION_PATHS: SnapsDerivationPath[] = [
     curve: 'ed25519',
     name: 'Vega',
   },
+  {
+    path: ['m', `1852'`, `1815'`],
+    curve: 'ed25519Bip32',
+    name: 'Cardano',
+  },
 ];
 
 /**

--- a/packages/snaps-utils/src/manifest/validation.test.ts
+++ b/packages/snaps-utils/src/manifest/validation.test.ts
@@ -6,6 +6,7 @@ import {
   Bip32EntropyStruct,
   Bip32PathStruct,
   createSnapManifest,
+  CurveStruct,
   EmptyObjectStruct,
   isSnapManifest,
   SnapIdsStruct,
@@ -78,6 +79,19 @@ describe('Bip32PathStruct', () => {
       expect(() => assert(path.split('/'), Bip32PathStruct)).toThrow(
         `The path "${path}" is not allowed for entropy derivation.`,
       );
+    },
+  );
+});
+
+describe('CurveStruct', () => {
+  it.each(['secp256k1', 'ed25519', 'ed25519Bip32'])('validates %p', (curve) => {
+    expect(is(curve, CurveStruct)).toBe(true);
+  });
+
+  it.each([1, '', 'asd', {}, null, undefined])(
+    'does not validate %p',
+    (curve) => {
+      expect(is(curve, CurveStruct)).toBe(false);
     },
   );
 });

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -111,7 +111,7 @@ export const bip32entropy = <
 export const Bip32EntropyStruct = bip32entropy(
   type({
     path: Bip32PathStruct,
-    curve: enums(['ed25519', 'secp256k1']),
+    curve: enums(['ed25519', 'secp256k1', 'ed25519Bip32']),
   }),
 );
 

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -1,3 +1,4 @@
+import type { SupportedCurve } from '@metamask/key-tree';
 import { isValidBIP32PathSegment } from '@metamask/key-tree';
 import type { EmptyObject, InitialPermissions } from '@metamask/snaps-sdk';
 import {
@@ -107,11 +108,17 @@ export const bip32entropy = <
     return true;
   });
 
+export const CurveStruct: Describe<SupportedCurve> = enums([
+  'ed25519',
+  'secp256k1',
+  'ed25519Bip32',
+]);
+
 // Used outside @metamask/snap-utils
 export const Bip32EntropyStruct = bip32entropy(
   type({
     path: Bip32PathStruct,
-    curve: enums(['ed25519', 'secp256k1', 'ed25519Bip32']),
+    curve: CurveStruct,
   }),
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3201,7 +3201,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereumjs/tx@npm:^4.1.2, @ethereumjs/tx@npm:^4.2.0":
+"@ethereumjs/tx@npm:^4.2.0":
   version: 4.2.0
   resolution: "@ethereumjs/tx@npm:4.2.0"
   dependencies:
@@ -3885,7 +3885,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/key-tree": ^9.0.0
+    "@metamask/key-tree": ^9.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -3925,7 +3925,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/key-tree": ^9.0.0
+    "@metamask/key-tree": ^9.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4086,7 +4086,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/key-tree": ^9.0.0
+    "@metamask/key-tree": ^9.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4142,7 +4142,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/key-tree": ^9.0.0
+    "@metamask/key-tree": ^9.1.0
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
@@ -4936,17 +4936,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/key-tree@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@metamask/key-tree@npm:9.0.0"
+"@metamask/key-tree@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "@metamask/key-tree@npm:9.1.0"
   dependencies:
-    "@metamask/scure-bip39": ^2.1.0
-    "@metamask/utils": ^6.0.1
-    "@noble/ed25519": ^1.6.0
-    "@noble/hashes": ^1.0.0
-    "@noble/secp256k1": ^1.5.5
+    "@metamask/scure-bip39": ^2.1.1
+    "@metamask/utils": ^8.3.0
+    "@noble/curves": ^1.2.0
+    "@noble/hashes": ^1.3.2
     "@scure/base": ^1.0.0
-  checksum: 5c81f07351ca59b37570d52edcc80d60424630b2a8403ed7149c3343c264878ac5d3fc0584a61635ea7ddda4a789295ded1247846606dc529d8e2fd42f6fc61a
+  checksum: 02709493f87c4cf8ebe3b81a47d3239d4d0b15fd73ac877047d0907652ff740d307966392f6f31d2f7871ab84315dddb4310edbf4edb976941a53d4e9ae04404
   languageName: node
   linkType: hard
 
@@ -5311,7 +5310,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/scure-bip39@npm:^2.1.0":
+"@metamask/scure-bip39@npm:^2.1.1":
   version: 2.1.1
   resolution: "@metamask/scure-bip39@npm:2.1.1"
   dependencies:
@@ -5695,7 +5694,7 @@ __metadata:
     "@metamask/eth-json-rpc-middleware": ^12.1.0
     "@metamask/json-rpc-engine": ^8.0.1
     "@metamask/json-rpc-middleware-stream": ^7.0.1
-    "@metamask/key-tree": ^9.0.0
+    "@metamask/key-tree": ^9.1.0
     "@metamask/permission-controller": ^9.0.2
     "@metamask/snaps-controllers": "workspace:^"
     "@metamask/snaps-execution-environments": "workspace:^"
@@ -5799,7 +5798,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/json-rpc-engine": ^8.0.1
-    "@metamask/key-tree": ^9.0.0
+    "@metamask/key-tree": ^9.1.0
     "@metamask/permission-controller": ^9.0.2
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/snaps-sdk": "workspace:^"
@@ -5842,7 +5841,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/key-tree": ^9.0.0
+    "@metamask/key-tree": ^9.1.0
     "@metamask/providers": ^16.1.0
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/utils": ^8.3.0
@@ -5894,7 +5893,7 @@ __metadata:
     "@metamask/eth-json-rpc-middleware": ^12.1.0
     "@metamask/json-rpc-engine": ^8.0.1
     "@metamask/json-rpc-middleware-stream": ^7.0.1
-    "@metamask/key-tree": ^9.0.0
+    "@metamask/key-tree": ^9.1.0
     "@metamask/permission-controller": ^9.0.2
     "@metamask/snaps-controllers": "workspace:^"
     "@metamask/snaps-execution-environments": "workspace:^"
@@ -5992,7 +5991,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/key-tree": ^9.0.0
+    "@metamask/key-tree": ^9.1.0
     "@metamask/permission-controller": ^9.0.2
     "@metamask/post-message-stream": ^8.0.0
     "@metamask/rpc-errors": ^6.2.1
@@ -6192,20 +6191,6 @@ __metadata:
     webpack-dev-server: ^4.15.1
   languageName: unknown
   linkType: soft
-
-"@metamask/utils@npm:^6.0.1":
-  version: 6.2.0
-  resolution: "@metamask/utils@npm:6.2.0"
-  dependencies:
-    "@ethereumjs/tx": ^4.1.2
-    "@noble/hashes": ^1.3.1
-    "@types/debug": ^4.1.7
-    debug: ^4.3.4
-    semver: ^7.3.8
-    superstruct: ^1.0.3
-  checksum: 0bc675358ecc09b3bc04da613d73666295d7afa51ff6b8554801585966900b24b8545bd93b8b2e9a17db867ebe421fe884baf3558ec4ca3199fa65504f677c1b
-  languageName: node
-  linkType: hard
 
 "@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.2.0, @metamask/utils@npm:^8.2.1, @metamask/utils@npm:^8.3.0":
   version: 8.4.0
@@ -6438,14 +6423,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:^1.0.0, @noble/hashes@npm:^1.1.2, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2":
+"@noble/hashes@npm:^1.1.2, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2":
   version: 1.4.0
   resolution: "@noble/hashes@npm:1.4.0"
   checksum: 8ba816ae26c90764b8c42493eea383716396096c5f7ba6bea559993194f49d80a73c081f315f4c367e51bd2d5891700bcdfa816b421d24ab45b41cb03e4f3342
   languageName: node
   linkType: hard
 
-"@noble/secp256k1@npm:1.7.1, @noble/secp256k1@npm:^1.5.5, @noble/secp256k1@npm:^1.7.1":
+"@noble/secp256k1@npm:1.7.1, @noble/secp256k1@npm:^1.7.1":
   version: 1.7.1
   resolution: "@noble/secp256k1@npm:1.7.1"
   checksum: d2301f1f7690368d8409a3152450458f27e54df47e3f917292de3de82c298770890c2de7c967d237eff9c95b70af485389a9695f73eb05a43e2bd562d18b18cb


### PR DESCRIPTION
This bumps `@metamask/key-tree` to `9.1.0` and applies some changes to support the new BIP-32-Ed25519 derivation.

Replaces #2400.