### PR TITLE
fix: specify explicit type to prevent type issues at build

### DIFF
--- a/packages/snaps-utils/src/ui.tsx
+++ b/packages/snaps-utils/src/ui.tsx
@@ -5,8 +5,10 @@ import type {
   FieldElement,
   ItalicChildren,
   JSXElement,
+  LinkElement,
   MaybeArray,
   RowChildren,
+  StandardFormattingElement,
   TextChildren,
 } from '@metamask/snaps-sdk/jsx';
 import {
@@ -150,7 +152,9 @@ function getTextChildFromToken(token: Token): TextChildren {
  * @param value - The markdown string.
  * @returns The text children.
  */
-export function getTextChildren(value: string) {
+export function getTextChildren(
+  value: string,
+): (string | StandardFormattingElement | LinkElement)[] {
   const rootTokens = lexer(value, { gfm: false });
   const children: TextChildren = [];
 
@@ -165,7 +169,11 @@ export function getTextChildren(value: string) {
     }
   });
 
-  return children.filter((child) => child !== null);
+  return children.filter((child) => child !== null) as (
+    | string
+    | StandardFormattingElement
+    | LinkElement
+  )[];
 }
 
 /**


### PR DESCRIPTION
Our current declaration for `getTextChildren` are autogenerated since no explicit type is declared, however the generated type causes type errors since it directly reference the runtime:
```
export declare function getTextChildren(value: string): (string | import("@metamask/snaps-sdk/jsx-runtime").StandardFormattingElement | import("@metamask/snaps-sdk/jsx-runtime").SnapElement<import("@metamask/snaps-sdk/jsx-runtime").LinkProps, "Link"> | null)[];
```

We can work around this problem by specifying an explicit type declaration for the function.