### PR TITLE
ci: Bump CodeCov action

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -2,6 +2,9 @@ name: Build, Lint, and Test
 
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: true
 
 jobs:
   prepare:
@@ -254,9 +257,10 @@ jobs:
           pattern: coverage-*
           merge-multiple: true
       - name: Upload coverage results
-        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+        uses: codecov/codecov-action@6d798873df2b1b8e5846dba6fb86631229fbcb17
         with:
           files: packages/**/coverage-final.json
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-e2e:
     name: E2E Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
     name: Build, lint, and test
     needs: check-workflows
     uses: ./.github/workflows/build-lint-test.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   publish-staging-simulator:
     name: Publish Snaps Simulator to `staging` folder


### PR DESCRIPTION
Bump CodeCov to latest version and add upload token secret to fix issues publishing code coverage.