### PR TITLE
fix: correctly merge caveats when using initial connections

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -51,7 +51,7 @@ import {
   DEFAULT_SOURCE_PATH,
   DEFAULT_ICON_PATH,
 } from '@metamask/snaps-utils/test-utils';
-import type { SemVerRange, SemVerVersion } from '@metamask/utils';
+import type { SemVerRange, SemVerVersion, Json } from '@metamask/utils';
 import {
   assert,
   AssertionError,
@@ -4362,12 +4362,15 @@ describe('SnapController', () => {
         [snapId]: {},
       });
 
+      const existingCaveatValue = MOCK_WALLET_SNAP_PERMISSION.caveats?.[0]
+        .value as Record<string, Json>;
+
       expect(messenger.call).toHaveBeenCalledWith(
         'PermissionController:updateCaveat',
         'npm:filsnap',
         WALLET_SNAP_PERMISSION_KEY,
         SnapCaveatType.SnapIds,
-        expect.objectContaining({ [snapId]: {} }),
+        { ...existingCaveatValue, [snapId]: {} },
       );
 
       expect(messenger.call).toHaveBeenCalledWith(
@@ -4375,7 +4378,7 @@ describe('SnapController', () => {
         'https://snaps.metamask.io',
         WALLET_SNAP_PERMISSION_KEY,
         SnapCaveatType.SnapIds,
-        expect.objectContaining({ [snapId]: {} }),
+        { ...existingCaveatValue, [snapId]: {} },
       );
 
       snapController.destroy();
@@ -8495,7 +8498,6 @@ describe('SnapController', () => {
         SnapCaveatType.SnapIds,
         {
           [MOCK_LOCAL_SNAP_ID]: {},
-          foo: {},
           [`${MOCK_SNAP_ID}1`]: {},
           [`${MOCK_SNAP_ID}2`]: {},
           [`${MOCK_SNAP_ID}3`]: {},

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1894,7 +1894,7 @@ export class SnapController extends BaseController<
         origin,
         WALLET_SNAP_PERMISSION_KEY,
         SnapCaveatType.SnapIds,
-        { ...existingCaveat, [snapId]: {} },
+        { ...(existingCaveat.value as Record<string, Json>), [snapId]: {} },
       );
       return;
     }

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -201,7 +201,6 @@ export const MOCK_WALLET_SNAP_PERMISSION: PermissionConstraint = {
       value: {
         [MOCK_SNAP_ID]: {},
         [MOCK_LOCAL_SNAP_ID]: {},
-        foo: {},
         [`${MOCK_SNAP_ID}1`]: {},
         [`${MOCK_SNAP_ID}2`]: {},
         [`${MOCK_SNAP_ID}3`]: {},


### PR DESCRIPTION
Fixes a bug where we weren't correctly merging caveat values when using initial connections, since we were spreading the entire caveat and not just the value.