### PR TITLE
feat: add dropdown component

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9wUdqSqbVJe+0aQ6y/LxGbJK0h4bVGVG8Y6gIAP5zyU=",
+    "shasum": "/iHYX1Nmt6RAkF7f6dGcOHK7GGzxhjiWKPz85B9AGAE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "/iHYX1Nmt6RAkF7f6dGcOHK7GGzxhjiWKPz85B9AGAE=",
+    "shasum": "GVN0FD0c4xnr+osY4rjRvF/KSGBgVC2fccbLwzGoFnk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9sGVcur+9HHb7S6RtXi2CYtGyGfazy4Up5wB4h0RuLs=",
+    "shasum": "j9j34JRDV5P98XgonRGfiqRSntlcaM4P53Z/S1g/XxA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9Ysf5NAslS75tHeB5y4T8SkAEChEx6m2Bf4bJdU6z84=",
+    "shasum": "9sGVcur+9HHb7S6RtXi2CYtGyGfazy4Up5wB4h0RuLs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "d8uw9NVVT/AWUsXjh+nwUOLaAtifQXT+sCJ0gTqPVjc=",
+    "shasum": "Rbm3Ojr+A+CYpapp0iQd90ZSyIDddc5LHNfjpp+6m00=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Rbm3Ojr+A+CYpapp0iQd90ZSyIDddc5LHNfjpp+6m00=",
+    "shasum": "AVhrthHcnFfQFZgbhwiIzjbqzRW7HWRiPKHkv+Fu+fA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "zsFF4XVvpIjSLdxQl/8LhwjGC24l2mRBtKZuKCV2jD0=",
+    "shasum": "2FquW6bL4OaB6c97+QdgLoVQCBZv22QanqtU+LzmndE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xWwHeCztUjPa8YIFoCtTKf77qJczDgWw3v89S6ZJXwI=",
+    "shasum": "zsFF4XVvpIjSLdxQl/8LhwjGC24l2mRBtKZuKCV2jD0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "tgk38f1RctSTY3valbyPvAWMltiFhlInsHywZH/Bq+A=",
+    "shasum": "IAkJ3r8AIaUfShFACWI9zzyRPDLyf4PbLEx4WbmVmc8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "IAkJ3r8AIaUfShFACWI9zzyRPDLyf4PbLEx4WbmVmc8=",
+    "shasum": "935lBT4lhnqdiUEnatcORNsAEjSfMRmMz0HT2KJK6yg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wBvHA1GYvp9HmWoYD4ZBMD84hfJRB5hB1qTS+HGaqiE=",
+    "shasum": "Ory0F194oSN15zWAVA5Dyvzpg2LFoWbi0ylfI2qLVz4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "dF33PfyAEyIG+0x/1ggNeCScROxGheANb3U4k63pz0I=",
+    "shasum": "wBvHA1GYvp9HmWoYD4ZBMD84hfJRB5hB1qTS+HGaqiE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "a1X+iXe4VL1J4AZNy0jkHrq0bY/Jnog9QZNdo2DfunA=",
+    "shasum": "4a7IfQp8AuCTx4BLTRow8IfZA0BArTuEb9CT8FLa3zE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7eaW1wlK1vuLEQoOyGfl4s6j7HvYwfN8lvhTim/ofUk=",
+    "shasum": "a1X+iXe4VL1J4AZNy0jkHrq0bY/Jnog9QZNdo2DfunA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "DYAfBoGmsxtJAY/473htgzk0a262nFgmdkhFcbfVQlA=",
+    "shasum": "0F0H8ZEQ0nLp60tV3h23pEPqEbt3eWfdEVxf2nFyIgo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0F0H8ZEQ0nLp60tV3h23pEPqEbt3eWfdEVxf2nFyIgo=",
+    "shasum": "25goBURWf+OrQTAgbwpuwN+TH/odY9fTHLDT/64oWvM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6aVCE+EKxHD9mcS5asPqN4ejs6mU3+rxd6qre4Hx4v8=",
+    "shasum": "iViByV12FW1bFiRXDvQBqpYH60a62WACXh3Z3lL+xlM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "iViByV12FW1bFiRXDvQBqpYH60a62WACXh3Z3lL+xlM=",
+    "shasum": "vj40D2zP2bG8E7+ADfp8htEhYGgP1Z+8ThcvjyEoyOk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "P+vBqlJolHAqbfdM9F7nGXjF/YR1bs+lthGTX4lwNX8=",
+    "shasum": "nY2+dap8Mtxzv5Hr9qNbkofQ3NpniVHb++BdfrfZlSQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "nY2+dap8Mtxzv5Hr9qNbkofQ3NpniVHb++BdfrfZlSQ=",
+    "shasum": "GHUM2ZesXFlhKOPU4mZ4Fty2qRln9aUuqHbVihttUKo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "HOT/KmUzzXrhnAI5PNYLapCB8kKoi9cE2ztzc8saaM4=",
+    "shasum": "x4KFuj9D0sfxdPCjcfjKHswhpZr8EtLTKA9jKeXD4M0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "x4KFuj9D0sfxdPCjcfjKHswhpZr8EtLTKA9jKeXD4M0=",
+    "shasum": "ExzexStVLaw/chL4NySLzoH0UAHpw8oSmf7PjP/P1fY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AmglwjCexdFOeMvg9m1QG/qCO7s0G3k1Wu1D8+5QBlM=",
+    "shasum": "FOe+60S6JcvSTyawpkPqd5ZsPmpqEWY1xG524iMMNKk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "rWABOhiFONdtEPQ6iFVw7XBVDswURwCNb2efK8oaBmE=",
+    "shasum": "AmglwjCexdFOeMvg9m1QG/qCO7s0G3k1Wu1D8+5QBlM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2riIfMwei7wEIb7WhllO7jFkYGNw/XWGjeUqaB6GyLU=",
+    "shasum": "ehTebDIqhb6jIhvvYnh8x6VLUmu9TmZLwGpWh5CmbMA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7dHD4QcAJrRiowUw2LKyJDvNxz/2WN9jDPajCuHLtcg=",
+    "shasum": "2riIfMwei7wEIb7WhllO7jFkYGNw/XWGjeUqaB6GyLU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Neb6FMQMVgpVVkDcKSCZxegtcplgebs2yw3uHxT3JCQ=",
+    "shasum": "NaByhc+fxmIG7PPdMjC6gH86rkKftx0/b3cwXc3XliA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "RSxzKtMDj8RukKcj1Nz+pHmUotDXvLhLJb7Uxfvm6q8=",
+    "shasum": "qyCrDHI8e9mx263r7hfaK8oEiiX468z6bxynzhUR8CE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2WrIpZaJtZdS9P0tcQn5pB5IvK61XLCArZVJtTRBfJo=",
+    "shasum": "RSxzKtMDj8RukKcj1Nz+pHmUotDXvLhLJb7Uxfvm6q8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "qyCrDHI8e9mx263r7hfaK8oEiiX468z6bxynzhUR8CE=",
+    "shasum": "Neb6FMQMVgpVVkDcKSCZxegtcplgebs2yw3uHxT3JCQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/src/components/InteractiveForm.tsx
+++ b/packages/examples/packages/interactive-ui/src/components/InteractiveForm.tsx
@@ -7,7 +7,7 @@ import {
   Form,
   Input,
   Dropdown,
-  DropdownOption,
+  Option,
 } from '@metamask/snaps-sdk/jsx';
 
 export const InteractiveForm: SnapComponent = () => {
@@ -20,9 +20,9 @@ export const InteractiveForm: SnapComponent = () => {
         </Field>
         <Field label="Example Dropdown">
           <Dropdown name="example-dropdown">
-            <DropdownOption value="option1">Option 1</DropdownOption>
-            <DropdownOption value="option2">Option 2</DropdownOption>
-            <DropdownOption value="option3">Option 3</DropdownOption>
+            <Option value="option1">Option 1</Option>
+            <Option value="option2">Option 2</Option>
+            <Option value="option3">Option 3</Option>
           </Dropdown>
         </Field>
         <Button type="submit" name="submit">

--- a/packages/examples/packages/interactive-ui/src/components/InteractiveForm.tsx
+++ b/packages/examples/packages/interactive-ui/src/components/InteractiveForm.tsx
@@ -6,6 +6,8 @@ import {
   Heading,
   Form,
   Input,
+  Dropdown,
+  DropdownOption,
 } from '@metamask/snaps-sdk/jsx';
 
 export const InteractiveForm: SnapComponent = () => {
@@ -16,6 +18,11 @@ export const InteractiveForm: SnapComponent = () => {
         <Field label="Example Input">
           <Input name="example-input" placeholder="Enter something..." />
         </Field>
+        <Dropdown name="example-dropdown">
+          <DropdownOption value="option1">Option 1</DropdownOption>
+          <DropdownOption value="option2">Option 2</DropdownOption>
+          <DropdownOption value="option3">Option 3</DropdownOption>
+        </Dropdown>
         <Button type="submit" name="submit">
           Submit
         </Button>

--- a/packages/examples/packages/interactive-ui/src/components/InteractiveForm.tsx
+++ b/packages/examples/packages/interactive-ui/src/components/InteractiveForm.tsx
@@ -18,11 +18,13 @@ export const InteractiveForm: SnapComponent = () => {
         <Field label="Example Input">
           <Input name="example-input" placeholder="Enter something..." />
         </Field>
-        <Dropdown name="example-dropdown">
-          <DropdownOption value="option1">Option 1</DropdownOption>
-          <DropdownOption value="option2">Option 2</DropdownOption>
-          <DropdownOption value="option3">Option 3</DropdownOption>
-        </Dropdown>
+        <Field label="Example Dropdown">
+          <Dropdown name="example-dropdown">
+            <DropdownOption value="option1">Option 1</DropdownOption>
+            <DropdownOption value="option2">Option 2</DropdownOption>
+            <DropdownOption value="option3">Option 3</DropdownOption>
+          </Dropdown>
+        </Field>
         <Button type="submit" name="submit">
           Submit
         </Button>

--- a/packages/examples/packages/interactive-ui/src/index.test.tsx
+++ b/packages/examples/packages/interactive-ui/src/index.test.tsx
@@ -43,12 +43,16 @@ describe('onRpcRequest', () => {
 
       await formScreen.typeInField('example-input', 'foobar');
 
+      await formScreen.selectInDropdown('example-dropdown', 'option3');
+
       await formScreen.clickElement('submit');
 
       const resultScreen = await response.getInterface();
 
       expect(resultScreen).toRender(
-        <Result values={{ 'example-input': 'foobar' }} />,
+        <Result
+          values={{ 'example-input': 'foobar', 'example-dropdown': 'option3' }}
+        />,
       );
       await resultScreen.ok();
 
@@ -72,7 +76,7 @@ describe('onRpcRequest', () => {
       const resultScreen = await response.getInterface();
 
       expect(resultScreen).toRender(
-        <Result values={{ 'example-input': '' }} />,
+        <Result values={{ 'example-input': '', 'example-dropdown': '' }} />,
       );
       await resultScreen.ok();
 
@@ -93,12 +97,16 @@ describe('onHomePage', () => {
 
     await formScreen.typeInField('example-input', 'foobar');
 
+    await formScreen.selectInDropdown('example-dropdown', 'option3');
+
     await formScreen.clickElement('submit');
 
     const resultScreen = response.getInterface();
 
     expect(resultScreen).toRender(
-      <Result values={{ 'example-input': 'foobar' }} />,
+      <Result
+        values={{ 'example-input': 'foobar', 'example-dropdown': 'option3' }}
+      />,
     );
   });
 });

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "GgSToaZ1ZQ2EAUsER9Ipz7JjXiP34tAh8yHlSeZnrIw=",
+    "shasum": "1CuOUFqC5G/wgBJDHUBk+xW9ATgBKFsXNtI9D9pO4aY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1CuOUFqC5G/wgBJDHUBk+xW9ATgBKFsXNtI9D9pO4aY=",
+    "shasum": "dMnmXtz6qjVPnvfPCjLI3jcU/TiR3gN6qhp/y0La5uI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "qRjdWlOFuznynW12exjTado0bOvmHuyD9tJ6EYllTfI=",
+    "shasum": "keNEs4pesk7bKOKVORmA3NGxxNZkt/Ikk+qssCXcNp4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "keNEs4pesk7bKOKVORmA3NGxxNZkt/Ikk+qssCXcNp4=",
+    "shasum": "IR1h1od8fD/rVtnohzFC8zz4XP3S+K/KOYcCR/V4hOU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ecGcLmxHbfbcggo+xXwKiKqn0jwvZpJBy9jzwbuhx14=",
+    "shasum": "+aiomcpwkr8LIVVaFUnHT1c8+30Ym8Fa6bqHa8ek+y0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+aiomcpwkr8LIVVaFUnHT1c8+30Ym8Fa6bqHa8ek+y0=",
+    "shasum": "Zh19stzSbkk4e0rl3mnZ69x6c1Ij+PEfJ3VGLcY1wEI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "MFFLgYGhSJlJ5I8JJsKcXFCI4UFYAbrGf+QNUMhvRGk=",
+    "shasum": "yqVsBhPZiHirCgF8KkdbvA5uMKdP4JsYipRTGFQ4kf8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "HoevSNqYDSD1M1rbAEDLdad/KnqdeJCR/qVQpXoRrfI=",
+    "shasum": "MFFLgYGhSJlJ5I8JJsKcXFCI4UFYAbrGf+QNUMhvRGk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hoY7FWJwVVeWRRz7u0VKyQTnMoLGLSa5aRfyDXPj9AM=",
+    "shasum": "VgVXeTn6yQ+gzvq8cSaz7zsBAxZ0xJPXNdTvQt71hVk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VgVXeTn6yQ+gzvq8cSaz7zsBAxZ0xJPXNdTvQt71hVk=",
+    "shasum": "ADZ5fA/qc6b9sLivha59OaZ8Q+/nvm2Br8QI8uTiMFQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "X4xkZ6Fea3Z1Ey6+nKyTFYe8oI5f8U0rOCZPIQdtqh8=",
+    "shasum": "K9QSwxnBwkz0Zf2tA8HWhNiuWJp6DGaD8UhgvtVtENE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "y+DckJzrDa6DAdy9g1K7sWK98XLi3b6byj6/SW+mvp0=",
+    "shasum": "X4xkZ6Fea3Z1Ey6+nKyTFYe8oI5f8U0rOCZPIQdtqh8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "QRgU12P+k4MbET92wLU6RpueK9KYZb3HGItOH8pdXqo=",
+    "shasum": "LmoEfrCUiEgeXglgfe6mSbMTJ+I3rm/Xst/YB861DZk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LmoEfrCUiEgeXglgfe6mSbMTJ+I3rm/Xst/YB861DZk=",
+    "shasum": "g/Wi1iKD5OHqHBMHGAZJxx9BXJK3DVpt7401DP5vxiA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4g1PLSrIvQDDD502ZqO13Nhm7V//Y2V2KVoNR9QZ/l8=",
+    "shasum": "3rJJn2lKBzyAgCn9J3m6XflIryIAT4qMqyhmGIL/tnE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "idx+4WZjLaansFM6HrxdUpXkhcr3EDknwrRF5xcDPL0=",
+    "shasum": "4g1PLSrIvQDDD502ZqO13Nhm7V//Y2V2KVoNR9QZ/l8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OozOdoPDn3miL7PzQHBhVDjbA8QULaNurUjXe8pEO5E=",
+    "shasum": "DR/Pwq0vy8L7T39CSGPYUCh8FdwzkcE9HiS0N14hLlQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "DR/Pwq0vy8L7T39CSGPYUCh8FdwzkcE9HiS0N14hLlQ=",
+    "shasum": "ta+iT3ThiGeJcfTy1DaDq5tOHJ6B7kweRWujb8hQzsc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3NBcGdsi/8Tw7mYaRS+hhHcLMDbfxZmz6AUJHSPEJ1k=",
+    "shasum": "txFjaexvEDCIGNF9zsGJzdfQp/iZ8eO0TMJGuEIXwOs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "txFjaexvEDCIGNF9zsGJzdfQp/iZ8eO0TMJGuEIXwOs=",
+    "shasum": "0cIQp4wDFLHahG8XiwmCcEcQc2ZiY0kBuOV0MBmc9yo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "DqHMyRiHljEYgKJZXJaYhFNCeXZAlc2sCjyI8+7Vgkg=",
+    "shasum": "WefCdzFcU9XNhTm4NK8o/s4XT/wXyj8RlRM7LA4bwsY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "WefCdzFcU9XNhTm4NK8o/s4XT/wXyj8RlRM7LA4bwsY=",
+    "shasum": "kSmphocy6yvQmcbeEAdVxF1WEEJw/wQbRyWEgViyYQo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "oo7KkCxPI9OXMaS+Ik9qdj4AulwiwTrSNCHtMe0WPP4=",
+    "shasum": "9xgQHlUd4veKe3luu7M8tVmuHw0ZOIjlQYKOIjN2LuU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9xgQHlUd4veKe3luu7M8tVmuHw0ZOIjlQYKOIjN2LuU=",
+    "shasum": "1IdcaOOx96qPQYfTZTRM7brevrP9jpCuxqxaGs0H+Bc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6Mbq9yf0IbE1to/tUfyDSOXq/37LJVqnYK8uKet0Q3U=",
+    "shasum": "1PbMUDBzJvOO4kM1VIMsnJCXbQT5A3vt9Hh3gboTsyo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "p6jcfAtN/r6hg314wA7Z9ihSAVP7+zm4KuZbB/Cu6+k=",
+    "shasum": "6Mbq9yf0IbE1to/tUfyDSOXq/37LJVqnYK8uKet0Q3U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "lHZY/AroUklVMhNzJtnn8mesBaNkSpu5PdIue+iBhqw=",
+    "shasum": "Eli9yqWMDpM34s1qfBJ5vjBZfkerVJqJyCvgp1Xsmoo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "zgVFc93FtIDmzDPyP80bN1gTPgIE+uhPrABgpoP83Gs=",
+    "shasum": "lHZY/AroUklVMhNzJtnn8mesBaNkSpu5PdIue+iBhqw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 91.55,
+  "branches": 91.57,
   "functions": 96.75,
   "lines": 97.88,
-  "statements": 97.56
+  "statements": 97.55
 }

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 91.54,
+  "branches": 91.55,
   "functions": 96.75,
   "lines": 97.88,
-  "statements": 97.55
+  "statements": 97.56
 }

--- a/packages/snaps-controllers/src/interface/utils.test.tsx
+++ b/packages/snaps-controllers/src/interface/utils.test.tsx
@@ -1,4 +1,13 @@
-import { Box, Button, Field, Form, Input, Text } from '@metamask/snaps-sdk/jsx';
+import {
+  Box,
+  Button,
+  Dropdown,
+  DropdownOption,
+  Field,
+  Form,
+  Input,
+  Text,
+} from '@metamask/snaps-sdk/jsx';
 
 import { assertNameIsUnique, constructState } from './utils';
 
@@ -220,6 +229,42 @@ describe('constructState', () => {
     const result = constructState({}, element);
     expect(result).toStrictEqual({
       foo: null,
+    });
+  });
+
+  it('supports root level dropdowns', () => {
+    const element = (
+      <Box>
+        <Dropdown name="foo" value="option2">
+          <DropdownOption value="option1">Option 1</DropdownOption>
+          <DropdownOption value="option2">Option 2</DropdownOption>
+        </Dropdown>
+      </Box>
+    );
+
+    const result = constructState({}, element);
+    expect(result).toStrictEqual({
+      foo: 'option2',
+    });
+  });
+
+  it('supports dropdowns in forms', () => {
+    const element = (
+      <Box>
+        <Form name="form">
+          <Field label="foo">
+            <Dropdown name="foo" value="option2">
+              <DropdownOption value="option1">Option 1</DropdownOption>
+              <DropdownOption value="option2">Option 2</DropdownOption>
+            </Dropdown>
+          </Field>
+        </Form>
+      </Box>
+    );
+
+    const result = constructState({}, element);
+    expect(result).toStrictEqual({
+      form: { foo: 'option2' },
     });
   });
 

--- a/packages/snaps-controllers/src/interface/utils.test.tsx
+++ b/packages/snaps-controllers/src/interface/utils.test.tsx
@@ -2,7 +2,7 @@ import {
   Box,
   Button,
   Dropdown,
-  DropdownOption,
+  Option,
   Field,
   Form,
   Input,
@@ -236,8 +236,8 @@ describe('constructState', () => {
     const element = (
       <Box>
         <Dropdown name="foo" value="option2">
-          <DropdownOption value="option1">Option 1</DropdownOption>
-          <DropdownOption value="option2">Option 2</DropdownOption>
+          <Option value="option1">Option 1</Option>
+          <Option value="option2">Option 2</Option>
         </Dropdown>
       </Box>
     );
@@ -254,8 +254,8 @@ describe('constructState', () => {
         <Form name="form">
           <Field label="foo">
             <Dropdown name="foo" value="option2">
-              <DropdownOption value="option1">Option 1</DropdownOption>
-              <DropdownOption value="option2">Option 2</DropdownOption>
+              <Option value="option1">Option 1</Option>
+              <Option value="option2">Option 2</Option>
             </Dropdown>
           </Field>
         </Form>

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -7,6 +7,7 @@ import type {
 } from '@metamask/snaps-sdk';
 import type {
   ButtonElement,
+  DropdownElement,
   FieldElement,
   InputElement,
   JSXElement,
@@ -54,7 +55,10 @@ export function assertNameIsUnique(state: InterfaceState, name: string) {
  * @param element - The input element.
  * @returns The input state.
  */
-function constructInputState(oldState: InterfaceState, element: InputElement) {
+function constructInputState(
+  oldState: InterfaceState,
+  element: InputElement | DropdownElement,
+) {
   return element.props.value ?? oldState[element.props.name] ?? null;
 }
 
@@ -68,7 +72,7 @@ function constructInputState(oldState: InterfaceState, element: InputElement) {
  */
 function constructFormInputState(
   oldState: InterfaceState,
-  component: InputElement,
+  component: InputElement | DropdownElement,
   form: string,
 ) {
   const oldFormState = oldState[form] as FormState;
@@ -160,6 +164,11 @@ export function constructState(
   }
 
   if (component.type === 'Input') {
+    assertNameIsUnique(newState, component.props.name);
+    newState[component.props.name] = constructInputState(oldState, component);
+  }
+
+  if (component.type === 'Dropdown') {
     assertNameIsUnique(newState, component.props.name);
     newState[component.props.name] = constructInputState(oldState, component);
   }

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -163,12 +163,7 @@ export function constructState(
     return newState;
   }
 
-  if (component.type === 'Input') {
-    assertNameIsUnique(newState, component.props.name);
-    newState[component.props.name] = constructInputState(oldState, component);
-  }
-
-  if (component.type === 'Dropdown') {
+  if (component.type === 'Input' || component.type === 'Dropdown') {
     assertNameIsUnique(newState, component.props.name);
     newState[component.props.name] = constructInputState(oldState, component);
   }

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -105,22 +105,11 @@ function getFieldInput(element: FieldElement) {
  */
 function constructFormState(
   oldState: InterfaceState,
-  component: FieldElement | ButtonElement | DropdownElement,
+  component: FieldElement | ButtonElement,
   form: string,
   newState: FormState,
 ): FormState {
   if (component.type === 'Button') {
-    return newState;
-  }
-
-  if (component.type === 'Dropdown') {
-    assertNameIsUnique(newState, component.props.name);
-
-    newState[component.props.name] = constructFormInputState(
-      oldState,
-      component,
-      form,
-    );
     return newState;
   }
 

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -105,11 +105,22 @@ function getFieldInput(element: FieldElement) {
  */
 function constructFormState(
   oldState: InterfaceState,
-  component: FieldElement | ButtonElement,
+  component: FieldElement | ButtonElement | DropdownElement,
   form: string,
   newState: FormState,
 ): FormState {
   if (component.type === 'Button') {
+    return newState;
+  }
+
+  if (component.type === 'Dropdown') {
+    assertNameIsUnique(newState, component.props.name);
+
+    newState[component.props.name] = constructFormInputState(
+      oldState,
+      component,
+      form,
+    );
     return newState;
   }
 

--- a/packages/snaps-jest/src/helpers.test.tsx
+++ b/packages/snaps-jest/src/helpers.test.tsx
@@ -403,6 +403,7 @@ describe('installSnap', () => {
         content: <Text>Hello, world!</Text>,
         clickElement: expect.any(Function),
         typeInField: expect.any(Function),
+        selectInDropdown: expect.any(Function),
         ok: expect.any(Function),
         cancel: expect.any(Function),
       });
@@ -461,6 +462,7 @@ describe('installSnap', () => {
         content: <Text>Hello, world!</Text>,
         clickElement: expect.any(Function),
         typeInField: expect.any(Function),
+        selectInDropdown: expect.any(Function),
         ok: expect.any(Function),
         cancel: expect.any(Function),
       });
@@ -518,6 +520,7 @@ describe('installSnap', () => {
         content: <Text>Hello, world!</Text>,
         clickElement: expect.any(Function),
         typeInField: expect.any(Function),
+        selectInDropdown: expect.any(Function),
         ok: expect.any(Function),
       });
 

--- a/packages/snaps-jest/src/internals/request.test.tsx
+++ b/packages/snaps-jest/src/internals/request.test.tsx
@@ -1,7 +1,7 @@
 import { SnapInterfaceController } from '@metamask/snaps-controllers';
 import type { SnapId } from '@metamask/snaps-sdk';
 import { UserInputEventType, button, input, text } from '@metamask/snaps-sdk';
-import { Dropdown, DropdownOption } from '@metamask/snaps-sdk/jsx';
+import { Dropdown, Option } from '@metamask/snaps-sdk/jsx';
 import { getJsxElementFromComponent, HandlerType } from '@metamask/snaps-utils';
 import { MOCK_SNAP_ID } from '@metamask/snaps-utils/test-utils';
 
@@ -345,8 +345,8 @@ describe('getInterfaceApi', () => {
 
     const content = (
       <Dropdown name="foo">
-        <DropdownOption value="option1">Option 1</DropdownOption>
-        <DropdownOption value="option2">Option 2</DropdownOption>
+        <Option value="option1">Option 1</Option>
+        <Option value="option2">Option 2</Option>
       </Dropdown>
     );
 

--- a/packages/snaps-jest/src/internals/request.test.tsx
+++ b/packages/snaps-jest/src/internals/request.test.tsx
@@ -1,6 +1,7 @@
 import { SnapInterfaceController } from '@metamask/snaps-controllers';
 import type { SnapId } from '@metamask/snaps-sdk';
 import { UserInputEventType, button, input, text } from '@metamask/snaps-sdk';
+import { Dropdown, DropdownOption } from '@metamask/snaps-sdk/jsx';
 import { getJsxElementFromComponent, HandlerType } from '@metamask/snaps-utils';
 import { MOCK_SNAP_ID } from '@metamask/snaps-utils/test-utils';
 
@@ -194,6 +195,7 @@ describe('getInterfaceApi', () => {
       content: getJsxElementFromComponent(content),
       clickElement: expect.any(Function),
       typeInField: expect.any(Function),
+      selectInDropdown: expect.any(Function),
     });
   });
 
@@ -223,6 +225,7 @@ describe('getInterfaceApi', () => {
       content: getJsxElementFromComponent(content),
       clickElement: expect.any(Function),
       typeInField: expect.any(Function),
+      selectInDropdown: expect.any(Function),
     });
   });
 
@@ -320,6 +323,59 @@ describe('getInterfaceApi', () => {
               type: UserInputEventType.InputChangeEvent,
               name: 'foo',
               value: 'bar',
+            },
+            id: expect.any(String),
+            context: null,
+          },
+        },
+      },
+    );
+  });
+
+  it('sends the request to the snap when using `selectInDropdown`', async () => {
+    const controllerMessenger = getRootControllerMessenger();
+
+    jest.spyOn(controllerMessenger, 'call');
+
+    // eslint-disable-next-line no-new
+    new SnapInterfaceController({
+      messenger:
+        getRestrictedSnapInterfaceControllerMessenger(controllerMessenger),
+    });
+
+    const content = (
+      <Dropdown name="foo">
+        <DropdownOption value="option1">Option 1</DropdownOption>
+        <DropdownOption value="option2">Option 2</DropdownOption>
+      </Dropdown>
+    );
+
+    const getInterface = await getInterfaceApi(
+      { content },
+      MOCK_SNAP_ID,
+      controllerMessenger,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const snapInterface = getInterface!();
+
+    await snapInterface.selectInDropdown('foo', 'option2');
+
+    expect(controllerMessenger.call).toHaveBeenNthCalledWith(
+      6,
+      'ExecutionService:handleRpcRequest',
+      MOCK_SNAP_ID,
+      {
+        origin: '',
+        handler: HandlerType.OnUserInput,
+        request: {
+          jsonrpc: '2.0',
+          method: ' ',
+          params: {
+            event: {
+              type: UserInputEventType.InputChangeEvent,
+              name: 'foo',
+              value: 'option2',
             },
             id: expect.any(String),
             context: null,

--- a/packages/snaps-jest/src/internals/request.ts
+++ b/packages/snaps-jest/src/internals/request.ts
@@ -16,6 +16,7 @@ import {
   getInterface,
   getNotifications,
   typeInField,
+  selectInDropdown,
 } from './simulation';
 import type { RunSagaFunction, Store } from './simulation';
 import type { RootControllerMessenger } from './simulation/controllers';
@@ -182,6 +183,16 @@ export async function getInterfaceApi(
         },
         typeInField: async (name, value) => {
           await typeInField(
+            controllerMessenger,
+            interfaceId,
+            content,
+            snapId,
+            name,
+            value,
+          );
+        },
+        selectInDropdown: async (name, value) => {
+          await selectInDropdown(
             controllerMessenger,
             interfaceId,
             content,

--- a/packages/snaps-jest/src/internals/simulation/interface.test.tsx
+++ b/packages/snaps-jest/src/internals/simulation/interface.test.tsx
@@ -13,7 +13,7 @@ import {
   Button,
   Text,
   Dropdown,
-  DropdownOption,
+  Option,
   Box,
   Input,
 } from '@metamask/snaps-sdk/jsx';
@@ -587,8 +587,8 @@ describe('selectInDropdown', () => {
 
     const content = (
       <Dropdown name="foo">
-        <DropdownOption value="option1">Option 1</DropdownOption>
-        <DropdownOption value="option2">Option 2</DropdownOption>
+        <Option value="option1">Option 1</Option>
+        <Option value="option2">Option 2</Option>
       </Dropdown>
     );
 
@@ -634,8 +634,8 @@ describe('selectInDropdown', () => {
   it('throws if selected option does not exist', async () => {
     const content = (
       <Dropdown name="foo">
-        <DropdownOption value="option1">Option 1</DropdownOption>
-        <DropdownOption value="option2">Option 2</DropdownOption>
+        <Option value="option1">Option 1</Option>
+        <Option value="option2">Option 2</Option>
       </Dropdown>
     );
 
@@ -860,8 +860,8 @@ describe('getInterface', () => {
 
     const content = (
       <Dropdown name="foo">
-        <DropdownOption value="option1">Option 1</DropdownOption>
-        <DropdownOption value="option2">Option 2</DropdownOption>
+        <Option value="option1">Option 1</Option>
+        <Option value="option2">Option 2</Option>
       </Dropdown>
     );
     const id = await interfaceController.createInterface(MOCK_SNAP_ID, content);

--- a/packages/snaps-jest/src/internals/simulation/interface.test.tsx
+++ b/packages/snaps-jest/src/internals/simulation/interface.test.tsx
@@ -625,6 +625,7 @@ describe('selectInDropdown', () => {
             value: 'option2',
           },
           id: interfaceId,
+          context: null,
         },
       },
     });
@@ -894,6 +895,7 @@ describe('getInterface', () => {
               value: 'option2',
             },
             id,
+            context: null,
           },
         },
       },

--- a/packages/snaps-jest/src/internals/simulation/interface.ts
+++ b/packages/snaps-jest/src/internals/simulation/interface.ts
@@ -461,7 +461,7 @@ export async function selectInDropdown(
     `The dropdown with the name "${name}" does not contain "${value}".`,
   );
 
-  const { state } = controllerMessenger.call(
+  const { state, context } = controllerMessenger.call(
     'SnapInterfaceController:getInterface',
     snapId,
     id,
@@ -488,6 +488,7 @@ export async function selectInDropdown(
           value,
         },
         id,
+        context,
       },
     },
   });

--- a/packages/snaps-jest/src/internals/simulation/interface.ts
+++ b/packages/snaps-jest/src/internals/simulation/interface.ts
@@ -7,7 +7,12 @@ import type {
 } from '@metamask/snaps-sdk';
 import { DialogType, UserInputEventType, assert } from '@metamask/snaps-sdk';
 import type { FormElement, JSXElement } from '@metamask/snaps-sdk/jsx';
-import { HandlerType, unwrapError, walkJsx } from '@metamask/snaps-utils';
+import {
+  HandlerType,
+  getJsxChildren,
+  unwrapError,
+  walkJsx,
+} from '@metamask/snaps-utils';
 import { hasProperty } from '@metamask/utils';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { type SagaIterator } from 'redux-saga';
@@ -416,6 +421,79 @@ export async function typeInField(
 }
 
 /**
+ * Type a value in an interface element.
+ *
+ * @param controllerMessenger - The controller messenger used to call actions.
+ * @param id - The interface ID.
+ * @param content - The interface Components.
+ * @param snapId - The Snap ID.
+ * @param name - The element name.
+ * @param value - The value to type in the element.
+ */
+export async function selectInDropdown(
+  controllerMessenger: RootControllerMessenger,
+  id: string,
+  content: JSXElement,
+  snapId: SnapId,
+  name: string,
+  value: string,
+) {
+  const result = getElement(content, name);
+
+  assert(
+    result !== undefined,
+    `Could not find an element in the interface with the name "${name}".`,
+  );
+
+  assert(
+    result.element.type === 'Dropdown',
+    `Expected an element of type "Dropdown", but found "${result.element.type}".`,
+  );
+
+  const options = getJsxChildren(result.element) as JSXElement[];
+  const selectedOption = options.find(
+    (option) =>
+      hasProperty(option.props, 'value') && option.props.value === value,
+  );
+
+  assert(
+    selectedOption !== undefined,
+    `The dropdown with the name "${name}" does not contain "${value}".`,
+  );
+
+  const { state } = controllerMessenger.call(
+    'SnapInterfaceController:getInterface',
+    snapId,
+    id,
+  );
+
+  const newState = mergeValue(state, name, value, result.form);
+
+  controllerMessenger.call(
+    'SnapInterfaceController:updateInterfaceState',
+    id,
+    newState,
+  );
+
+  await controllerMessenger.call('ExecutionService:handleRpcRequest', snapId, {
+    origin: '',
+    handler: HandlerType.OnUserInput,
+    request: {
+      jsonrpc: '2.0',
+      method: ' ',
+      params: {
+        event: {
+          type: UserInputEventType.InputChangeEvent,
+          name: result.element.props.name,
+          value,
+        },
+        id,
+      },
+    },
+  });
+}
+
+/**
  * Get a user interface object from a Snap.
  *
  * @param runSaga - A function to run a saga outside the usual Redux flow.
@@ -441,6 +519,16 @@ export function* getInterface(
     },
     typeInField: async (name: string, value: string) => {
       await typeInField(controllerMessenger, id, content, snapId, name, value);
+    },
+    selectInDropdown: async (name: string, value: string) => {
+      await selectInDropdown(
+        controllerMessenger,
+        id,
+        content,
+        snapId,
+        name,
+        value,
+      );
     },
   };
 

--- a/packages/snaps-jest/src/types.ts
+++ b/packages/snaps-jest/src/types.ts
@@ -96,6 +96,14 @@ export type SnapInterfaceActions = {
    * @param value - The value to type.
    */
   typeInField(name: string, value: string): Promise<void>;
+
+  /**
+   * Select an option with a value in a dropdown.
+   *
+   * @param name - The element name to type in.
+   * @param value - The value to type.
+   */
+  selectInDropdown(name: string, value: string): Promise<void>;
 };
 
 /**

--- a/packages/snaps-sdk/src/jsx/components/form/Dropdown.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Dropdown.ts
@@ -1,17 +1,19 @@
 import type { MaybeArray } from '../../component';
 import { createSnapComponent } from '../../component';
-import type { DropdownOptionElement } from './DropdownOption';
+import type { OptionElement } from './Option';
 
 /**
  * The props of the {@link Dropdown} component.
  *
  * @property name - The name of the dropdown. This is used to identify the
  * state in the form data.
+ * @property value - The selected value of the dropdown.
+ * @property children - The children of the dropdown.
  */
 type DropdownProps = {
   name: string;
   value?: string;
-  children: MaybeArray<DropdownOptionElement>;
+  children: MaybeArray<OptionElement>;
 };
 
 const TYPE = 'Dropdown';
@@ -23,12 +25,14 @@ const TYPE = 'Dropdown';
  * @param props - The props of the component.
  * @param props.name - The name of the dropdown field. This is used to identify the
  * state in the form data.
+ * @param props.value - The selected value of the dropdown.
+ * @param props.children - The children of the dropdown.
  * @returns A dropdown element.
  * @example
  * <Dropdown name="dropdown">
- *  <DropdownOption value="option1">Option 1</DropdownOption>
- *  <DropdownOption value="option2">Option 2</DropdownOption>
- *  <DropdownOption value="option3">Option 3</DropdownOption>
+ *  <Option value="option1">Option 1</Option>
+ *  <Option value="option2">Option 2</Option>
+ *  <Option value="option3">Option 3</Option>
  * </Dropdown>
  */
 export const Dropdown = createSnapComponent<DropdownProps, typeof TYPE>(TYPE);

--- a/packages/snaps-sdk/src/jsx/components/form/Dropdown.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Dropdown.ts
@@ -1,0 +1,42 @@
+import type { MaybeArray } from '../../component';
+import { createSnapComponent } from '../../component';
+import type { DropdownOptionElement } from './DropdownOption';
+
+// TODO: Add the `onChange` prop to the `InputProps` type.
+
+/**
+ * The props of the {@link Dropdown} component.
+ *
+ * @property name - The name of the dropdown. This is used to identify the
+ * state in the form data.
+ */
+type DropdownProps = {
+  name: string;
+  children: MaybeArray<DropdownOptionElement>;
+};
+
+const TYPE = 'Dropdown';
+
+/**
+ * A dropdown component, which is used to create a dropdown. This component
+ * can only be used as a child of the {@link Field} component.
+ *
+ * @param props - The props of the component.
+ * @param props.name - The name of the dropdown field. This is used to identify the
+ * state in the form data.
+ * @returns A dropdown element.
+ * @example
+ * <Dropdown name="dropdown">
+ *  <DropdownOption value="option1">Option 1</DropdownOption>
+ *  <DropdownOption value="option2">Option 2</DropdownOption>
+ *  <DropdownOption value="option3">Option 3</DropdownOption>
+ * </Dropdown>
+ */
+export const Dropdown = createSnapComponent<DropdownProps, typeof TYPE>(TYPE);
+
+/**
+ * A dropdown element.
+ *
+ * @see Dropdown
+ */
+export type DropdownElement = ReturnType<typeof Dropdown>;

--- a/packages/snaps-sdk/src/jsx/components/form/Dropdown.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Dropdown.ts
@@ -2,8 +2,6 @@ import type { MaybeArray } from '../../component';
 import { createSnapComponent } from '../../component';
 import type { DropdownOptionElement } from './DropdownOption';
 
-// TODO: Add the `onChange` prop to the `InputProps` type.
-
 /**
  * The props of the {@link Dropdown} component.
  *

--- a/packages/snaps-sdk/src/jsx/components/form/Dropdown.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Dropdown.ts
@@ -12,6 +12,7 @@ import type { DropdownOptionElement } from './DropdownOption';
  */
 type DropdownProps = {
   name: string;
+  value?: string;
   children: MaybeArray<DropdownOptionElement>;
 };
 

--- a/packages/snaps-sdk/src/jsx/components/form/DropdownOption.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/DropdownOption.ts
@@ -1,0 +1,43 @@
+import { createSnapComponent } from '../../component';
+
+// TODO: Add the `onChange` prop to the `InputProps` type.
+
+/**
+ * The props of the {@link Dropdown} component.
+ *
+ * @property value - The value of the dropdown option. This is used to populate the
+ * state in the form data.
+ */
+type DropdownOptionProps = {
+  value: string;
+  children: string;
+};
+
+const TYPE = 'DropdownOption';
+
+/**
+ * A dropdown option component, which is used to create a dropdown option. This component
+ * can only be used as a child of the {@link Dropdown} component.
+ *
+ * @param props - The props of the component.
+ * @param props.value - The value of the dropdown option. This is used to populate the
+ * state in the form data.
+ * @returns A dropdown option element.
+ * @example
+ * <Dropdown name="dropdown">
+ *  <DropdownOption value="option1">Option 1</DropdownOption>
+ *  <DropdownOption value="option2">Option 2</DropdownOption>
+ *  <DropdownOption value="option3">Option 3</DropdownOption>
+ * </Dropdown>
+ */
+export const DropdownOption = createSnapComponent<
+  DropdownOptionProps,
+  typeof TYPE
+>(TYPE);
+
+/**
+ * A dropdown element.
+ *
+ * @see Dropdown
+ */
+export type DropdownOptionElement = ReturnType<typeof DropdownOption>;

--- a/packages/snaps-sdk/src/jsx/components/form/DropdownOption.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/DropdownOption.ts
@@ -1,7 +1,5 @@
 import { createSnapComponent } from '../../component';
 
-// TODO: Add the `onChange` prop to the `InputProps` type.
-
 /**
  * The props of the {@link Dropdown} component.
  *

--- a/packages/snaps-sdk/src/jsx/components/form/Field.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/Field.test.tsx
@@ -1,8 +1,8 @@
 import { Button } from './Button';
 import { Dropdown } from './Dropdown';
-import { DropdownOption } from './DropdownOption';
 import { Field } from './Field';
 import { Input } from './Input';
+import { Option } from './Option';
 
 describe('Field', () => {
   it('renders a field element', () => {
@@ -93,8 +93,8 @@ describe('Field', () => {
     const result = (
       <Field label="Label">
         <Dropdown name="foo">
-          <DropdownOption value="option1">Option 1</DropdownOption>
-          <DropdownOption value="option2">Option 2</DropdownOption>
+          <Option value="option1">Option 1</Option>
+          <Option value="option2">Option 2</Option>
         </Dropdown>
       </Field>
     );
@@ -111,7 +111,7 @@ describe('Field', () => {
             name: 'foo',
             children: [
               {
-                type: 'DropdownOption',
+                type: 'Option',
                 key: null,
                 props: {
                   children: 'Option 1',
@@ -119,7 +119,7 @@ describe('Field', () => {
                 },
               },
               {
-                type: 'DropdownOption',
+                type: 'Option',
                 key: null,
                 props: {
                   children: 'Option 2',

--- a/packages/snaps-sdk/src/jsx/components/form/Field.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/Field.test.tsx
@@ -1,4 +1,6 @@
 import { Button } from './Button';
+import { Dropdown } from './Dropdown';
+import { DropdownOption } from './DropdownOption';
 import { Field } from './Field';
 import { Input } from './Input';
 
@@ -83,6 +85,50 @@ describe('Field', () => {
             },
           },
         ],
+      },
+    });
+  });
+
+  it('renders a dropdown element', () => {
+    const result = (
+      <Field label="Label">
+        <Dropdown name="foo">
+          <DropdownOption value="option1">Option 1</DropdownOption>
+          <DropdownOption value="option2">Option 2</DropdownOption>
+        </Dropdown>
+      </Field>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Field',
+      key: null,
+      props: {
+        label: 'Label',
+        children: {
+          type: 'Dropdown',
+          key: null,
+          props: {
+            name: 'foo',
+            children: [
+              {
+                type: 'DropdownOption',
+                key: null,
+                props: {
+                  children: 'Option 1',
+                  value: 'option1',
+                },
+              },
+              {
+                type: 'DropdownOption',
+                key: null,
+                props: {
+                  children: 'Option 2',
+                  value: 'option2',
+                },
+              },
+            ],
+          },
+        },
       },
     });
   });

--- a/packages/snaps-sdk/src/jsx/components/form/Field.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Field.ts
@@ -1,5 +1,6 @@
 import { createSnapComponent } from '../../component';
 import type { ButtonElement } from './Button';
+import type { DropdownElement } from './Dropdown';
 import type { InputElement } from './Input';
 
 /**
@@ -12,7 +13,7 @@ import type { InputElement } from './Input';
 export type FieldProps = {
   label?: string | undefined;
   error?: string | undefined;
-  children: [InputElement, ButtonElement] | InputElement;
+  children: [InputElement, ButtonElement] | InputElement | DropdownElement;
 };
 
 const TYPE = 'Field';

--- a/packages/snaps-sdk/src/jsx/components/form/Form.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Form.ts
@@ -1,8 +1,7 @@
-import type { DropdownElement } from '@metamask/snaps-sdk/jsx-runtime';
-
 import type { MaybeArray } from '../../component';
 import { createSnapComponent } from '../../component';
 import type { ButtonElement } from './Button';
+import type { DropdownElement } from './Dropdown';
 import type { FieldElement } from './Field';
 
 // TODO: Add `onSubmit` prop to the `FormProps` type.

--- a/packages/snaps-sdk/src/jsx/components/form/Form.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Form.ts
@@ -1,3 +1,5 @@
+import type { DropdownElement } from '@metamask/snaps-sdk/jsx-runtime';
+
 import type { MaybeArray } from '../../component';
 import { createSnapComponent } from '../../component';
 import type { ButtonElement } from './Button';
@@ -13,7 +15,7 @@ import type { FieldElement } from './Field';
  * the event handler.
  */
 type FormProps = {
-  children: MaybeArray<FieldElement | ButtonElement>;
+  children: MaybeArray<FieldElement | ButtonElement | DropdownElement>;
   name: string;
 };
 

--- a/packages/snaps-sdk/src/jsx/components/form/Form.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Form.ts
@@ -1,7 +1,6 @@
 import type { MaybeArray } from '../../component';
 import { createSnapComponent } from '../../component';
 import type { ButtonElement } from './Button';
-import type { DropdownElement } from './Dropdown';
 import type { FieldElement } from './Field';
 
 // TODO: Add `onSubmit` prop to the `FormProps` type.
@@ -14,7 +13,7 @@ import type { FieldElement } from './Field';
  * the event handler.
  */
 type FormProps = {
-  children: MaybeArray<FieldElement | ButtonElement | DropdownElement>;
+  children: MaybeArray<FieldElement | ButtonElement>;
   name: string;
 };
 

--- a/packages/snaps-sdk/src/jsx/components/form/Option.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Option.ts
@@ -5,13 +5,14 @@ import { createSnapComponent } from '../../component';
  *
  * @property value - The value of the dropdown option. This is used to populate the
  * state in the form data.
+ * @property children - The text to display.
  */
-type DropdownOptionProps = {
+type OptionProps = {
   value: string;
   children: string;
 };
 
-const TYPE = 'DropdownOption';
+const TYPE = 'Option';
 
 /**
  * A dropdown option component, which is used to create a dropdown option. This component
@@ -20,22 +21,20 @@ const TYPE = 'DropdownOption';
  * @param props - The props of the component.
  * @param props.value - The value of the dropdown option. This is used to populate the
  * state in the form data.
+ * @param props.children - The text to display.
  * @returns A dropdown option element.
  * @example
  * <Dropdown name="dropdown">
- *  <DropdownOption value="option1">Option 1</DropdownOption>
- *  <DropdownOption value="option2">Option 2</DropdownOption>
- *  <DropdownOption value="option3">Option 3</DropdownOption>
+ *  <Option value="option1">Option 1</Option>
+ *  <Option value="option2">Option 2</Option>
+ *  <Option value="option3">Option 3</Option>
  * </Dropdown>
  */
-export const DropdownOption = createSnapComponent<
-  DropdownOptionProps,
-  typeof TYPE
->(TYPE);
+export const Option = createSnapComponent<OptionProps, typeof TYPE>(TYPE);
 
 /**
  * A dropdown element.
  *
  * @see Dropdown
  */
-export type DropdownOptionElement = ReturnType<typeof DropdownOption>;
+export type OptionElement = ReturnType<typeof Option>;

--- a/packages/snaps-sdk/src/jsx/components/form/Option.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Option.ts
@@ -1,7 +1,7 @@
 import { createSnapComponent } from '../../component';
 
 /**
- * The props of the {@link Dropdown} component.
+ * The props of the {@link Option} component.
  *
  * @property value - The value of the dropdown option. This is used to populate the
  * state in the form data.
@@ -33,8 +33,8 @@ const TYPE = 'Option';
 export const Option = createSnapComponent<OptionProps, typeof TYPE>(TYPE);
 
 /**
- * A dropdown element.
+ * A dropdown option element.
  *
- * @see Dropdown
+ * @see Option
  */
 export type OptionElement = ReturnType<typeof Option>;

--- a/packages/snaps-sdk/src/jsx/components/form/index.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/index.ts
@@ -1,13 +1,13 @@
 import type { ButtonElement } from './Button';
 import type { DropdownElement } from './Dropdown';
-import type { DropdownOptionElement } from './DropdownOption';
 import type { FieldElement } from './Field';
 import type { FormElement } from './Form';
 import type { InputElement } from './Input';
+import type { OptionElement } from './Option';
 
 export * from './Button';
 export * from './Dropdown';
-export * from './DropdownOption';
+export * from './Option';
 export * from './Field';
 export * from './Form';
 export * from './Input';
@@ -18,4 +18,4 @@ export type StandardFormElement =
   | FieldElement
   | InputElement
   | DropdownElement
-  | DropdownOptionElement;
+  | OptionElement;

--- a/packages/snaps-sdk/src/jsx/components/form/index.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/index.ts
@@ -1,5 +1,6 @@
 import type { ButtonElement } from './Button';
 import type { DropdownElement } from './Dropdown';
+import type { DropdownOptionElement } from './DropdownOption';
 import type { FieldElement } from './Field';
 import type { FormElement } from './Form';
 import type { InputElement } from './Input';
@@ -16,4 +17,5 @@ export type StandardFormElement =
   | FormElement
   | FieldElement
   | InputElement
-  | DropdownElement;
+  | DropdownElement
+  | DropdownOptionElement;

--- a/packages/snaps-sdk/src/jsx/components/form/index.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/index.ts
@@ -1,9 +1,12 @@
 import type { ButtonElement } from './Button';
+import type { DropdownElement } from './Dropdown';
 import type { FieldElement } from './Field';
 import type { FormElement } from './Form';
 import type { InputElement } from './Input';
 
 export * from './Button';
+export * from './Dropdown';
+export * from './DropdownOption';
 export * from './Field';
 export * from './Form';
 export * from './Input';
@@ -12,4 +15,5 @@ export type StandardFormElement =
   | ButtonElement
   | FormElement
   | FieldElement
-  | InputElement;
+  | InputElement
+  | DropdownElement;

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -7,6 +7,8 @@ import {
   Button,
   Copyable,
   Divider,
+  Dropdown,
+  DropdownOption,
   Field,
   Form,
   Heading,
@@ -26,6 +28,7 @@ import {
   ButtonStruct,
   CopyableStruct,
   DividerStruct,
+  DropdownStruct,
   ElementStruct,
   FieldStruct,
   FormStruct,
@@ -204,6 +207,12 @@ describe('FieldStruct', () => {
     </Field>,
     <Field error="bar">
       <Input name="foo" type="text" />
+    </Field>,
+    <Field label="foo">
+      <Dropdown name="foo">
+        <DropdownOption value="option1">Option 1</DropdownOption>
+        <DropdownOption value="option2">Option 2</DropdownOption>
+      </Dropdown>
     </Field>,
   ])('validates a field element', (value) => {
     expect(is(value, FieldStruct)).toBe(true);
@@ -693,6 +702,37 @@ describe('SpinnerStruct', () => {
     </Row>,
   ])('does not validate "%p"', (value) => {
     expect(is(value, SpinnerStruct)).toBe(false);
+  });
+});
+
+describe('Dropdown', () => {
+  it.each([
+    <Dropdown name="foo">
+      <DropdownOption value="option1">Option 1</DropdownOption>
+      <DropdownOption value="option2">Option 2</DropdownOption>
+    </Dropdown>,
+  ])('validates a dropdown element', (value) => {
+    expect(is(value, DropdownStruct)).toBe(true);
+  });
+
+  it.each([
+    'foo',
+    42,
+    null,
+    undefined,
+    {},
+    [],
+    // @ts-expect-error - Invalid props.
+    <Spinner>foo</Spinner>,
+    <Text>foo</Text>,
+    <Box>
+      <Text>foo</Text>
+    </Box>,
+    <Row label="label">
+      <Image src="src" alt="alt" />
+    </Row>,
+  ])('does not validate "%p"', (value) => {
+    expect(is(value, DropdownStruct)).toBe(false);
   });
 });
 

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -8,7 +8,7 @@ import {
   Copyable,
   Divider,
   Dropdown,
-  DropdownOption,
+  Option,
   Field,
   Form,
   Heading,
@@ -210,8 +210,8 @@ describe('FieldStruct', () => {
     </Field>,
     <Field label="foo">
       <Dropdown name="foo">
-        <DropdownOption value="option1">Option 1</DropdownOption>
-        <DropdownOption value="option2">Option 2</DropdownOption>
+        <Option value="option1">Option 1</Option>
+        <Option value="option2">Option 2</Option>
       </Dropdown>
     </Field>,
   ])('validates a field element', (value) => {
@@ -708,8 +708,8 @@ describe('SpinnerStruct', () => {
 describe('Dropdown', () => {
   it.each([
     <Dropdown name="foo">
-      <DropdownOption value="option1">Option 1</DropdownOption>
-      <DropdownOption value="option2">Option 2</DropdownOption>
+      <Option value="option1">Option 1</Option>
+      <Option value="option2">Option 2</Option>
     </Dropdown>,
   ])('validates a dropdown element', (value) => {
     expect(is(value, DropdownStruct)).toBe(true);

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -165,7 +165,7 @@ export const FieldStruct: Describe<FieldElement> = element('Field', {
  * A struct for the {@link FormElement} type.
  */
 export const FormStruct: Describe<FormElement> = element('Form', {
-  children: maybeArray(nullUnion([FieldStruct, ButtonStruct, DropdownStruct])),
+  children: maybeArray(nullUnion([FieldStruct, ButtonStruct])),
   name: string(),
 });
 

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -129,15 +129,6 @@ export const InputStruct: Describe<InputElement> = element('Input', {
 });
 
 /**
- * A struct for the {@link FieldElement} type.
- */
-export const FieldStruct: Describe<FieldElement> = element('Field', {
-  label: optional(string()),
-  error: optional(string()),
-  children: nullUnion([tuple([InputStruct, ButtonStruct]), InputStruct]),
-});
-
-/**
  * A struct for the {@link DropdownOptionElement} type.
  */
 export const DropdownOptionStruct: Describe<DropdownOptionElement> = element(
@@ -154,6 +145,19 @@ export const DropdownOptionStruct: Describe<DropdownOptionElement> = element(
 export const DropdownStruct: Describe<DropdownElement> = element('Dropdown', {
   name: string(),
   children: maybeArray(DropdownOptionStruct),
+});
+
+/**
+ * A struct for the {@link FieldElement} type.
+ */
+export const FieldStruct: Describe<FieldElement> = element('Field', {
+  label: optional(string()),
+  error: optional(string()),
+  children: nullUnion([
+    tuple([InputStruct, ButtonStruct]),
+    InputStruct,
+    DropdownStruct,
+  ]),
 });
 
 /**
@@ -312,6 +316,7 @@ export const BoxChildStruct = nullUnion([
   RowStruct,
   SpinnerStruct,
   TextStruct,
+  DropdownStruct,
 ]);
 
 /**
@@ -341,6 +346,7 @@ export const JSXElementStruct: Describe<JSXElement> = nullUnion([
   SpinnerStruct,
   TextStruct,
   DropdownStruct,
+  DropdownOptionStruct,
 ]);
 
 /**

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -39,7 +39,7 @@ import type {
   CopyableElement,
   DividerElement,
   DropdownElement,
-  DropdownOptionElement,
+  OptionElement,
   FieldElement,
   FormElement,
   HeadingElement,
@@ -129,15 +129,12 @@ export const InputStruct: Describe<InputElement> = element('Input', {
 });
 
 /**
- * A struct for the {@link DropdownOptionElement} type.
+ * A struct for the {@link OptionElement} type.
  */
-export const DropdownOptionStruct: Describe<DropdownOptionElement> = element(
-  'DropdownOption',
-  {
-    value: string(),
-    children: string(),
-  },
-);
+export const OptionStruct: Describe<OptionElement> = element('Option', {
+  value: string(),
+  children: string(),
+});
 
 /**
  * A struct for the {@link DropdownElement} type.
@@ -145,7 +142,7 @@ export const DropdownOptionStruct: Describe<DropdownOptionElement> = element(
 export const DropdownStruct: Describe<DropdownElement> = element('Dropdown', {
   name: string(),
   value: optional(string()),
-  children: maybeArray(DropdownOptionStruct),
+  children: maybeArray(OptionStruct),
 });
 
 /**
@@ -347,7 +344,7 @@ export const JSXElementStruct: Describe<JSXElement> = nullUnion([
   SpinnerStruct,
   TextStruct,
   DropdownStruct,
-  DropdownOptionStruct,
+  OptionStruct,
 ]);
 
 /**

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -38,6 +38,8 @@ import type {
   ButtonElement,
   CopyableElement,
   DividerElement,
+  DropdownElement,
+  DropdownOptionElement,
   FieldElement,
   FormElement,
   HeadingElement,
@@ -136,10 +138,29 @@ export const FieldStruct: Describe<FieldElement> = element('Field', {
 });
 
 /**
+ * A struct for the {@link DropdownOptionElement} type.
+ */
+export const DropdownOptionStruct: Describe<DropdownOptionElement> = element(
+  'DropdownOption',
+  {
+    value: string(),
+    children: string(),
+  },
+);
+
+/**
+ * A struct for the {@link DropdownElement} type.
+ */
+export const DropdownStruct: Describe<DropdownElement> = element('Dropdown', {
+  name: string(),
+  children: maybeArray(DropdownOptionStruct),
+});
+
+/**
  * A struct for the {@link FormElement} type.
  */
 export const FormStruct: Describe<FormElement> = element('Form', {
-  children: maybeArray(nullUnion([FieldStruct, ButtonStruct])),
+  children: maybeArray(nullUnion([FieldStruct, ButtonStruct, DropdownStruct])),
   name: string(),
 });
 
@@ -319,6 +340,7 @@ export const JSXElementStruct: Describe<JSXElement> = nullUnion([
   RowStruct,
   SpinnerStruct,
   TextStruct,
+  DropdownStruct,
 ]);
 
 /**

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -144,6 +144,7 @@ export const DropdownOptionStruct: Describe<DropdownOptionElement> = element(
  */
 export const DropdownStruct: Describe<DropdownElement> = element('Dropdown', {
   name: string(),
+  value: optional(string()),
   children: maybeArray(DropdownOptionStruct),
 });
 


### PR DESCRIPTION
Adds support for a `Dropdown` component, that can be used on its own or as part of a `Field`.

```jsx
<Dropdown name="dropdown" value="option3">
  <DropdownOption value="option1">Option 1</DropdownOption>
  <DropdownOption value="option2">Option 2</DropdownOption>
  <DropdownOption value="option3">Option 3</DropdownOption>
</Dropdown>
```

Similarly to `Input`, it optionally uses `value` to determine the initial value/preselected dropdown item. This can also be used to control the input when re-rendering with `snap_updateInterface`. The dropdown will also trigger `InputChangeEvent` similarly to an `Input`.

This PR mostly adds validation and types for this new component as well as some handling for the form state. This will need a follow-up PR in the extension to complete integration. This PR also adds support for `selectInDropdown` to `snaps-jest` and uses this new component in the Interactive UI example Snap.

Progresses https://github.com/MetaMask/MetaMask-planning/issues/1575