### PR TITLE
fix: correct validation for children of Box component

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AHkP73+F6K2QrntLGUCTzJHHd6S5IIO1PSKSSaE8xJk=",
+    "shasum": "4dOCGaoX1j+OZg4EVUWrwtuGZval0hf0uSTDUpL6OGM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "sc8Fxwl1RniWUSYvsFzUPViDl0JeJBPQD/q1YoCOBtc=",
+    "shasum": "jfMlNdZdqqc0W97lsuGx3nyUopRIjp67WXvqW1mnEmc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "IVfyi6wCd3P6SgXD0y6dUe5SClB8ZJMxSbcmYkzr7Sc=",
+    "shasum": "5c+KLOVBHhIzMeMdFPYQZNIHX0OI/dgi1mYv2D/5WB8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "II+ATIIZddsRIwDpHIo4RM03DXDmRnYt1OKeaqDli9o=",
+    "shasum": "lov9UzWhC5bjKvVqBzZbdwgkJVkSdVLMoPkjpg3vw2c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Z8sH/y+mC7F1+z8L1bWOJnMK1laux3YFFkhEutuSRmQ=",
+    "shasum": "3XKHfOmSygIhzrlybA+rvrLpFIBuRofaz9IiLHlGzuk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "io6c4pn3Jed5ZjOof5T/ALl19HsmxD67gE2tJZlU1Jo=",
+    "shasum": "AFBXBxUqzJe2Y/m52DFypWqSS9Y4uRFU1Fc/1RDZXGY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cZfPNoe+eKel73zZdQqx+nmi4tcBTF0D9F0PuFkKX/w=",
+    "shasum": "t5YI0US9RhMAsjOfzqGNburzaQagNg2j2q4HamDP76I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "c4bgWlnSU0Hd46OxipjNaIRGH9HEjzBUxSAR69aUH44=",
+    "shasum": "cTXs5WSTWF3EcAyY17TGxXnj7pHnEvm73S2Ggjy0vuo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2S3hBmK9hMrbADE4McrO67RtGIy80aeo3RMHex/wHQs=",
+    "shasum": "ds7zQq2RfNWr5c8g8AIoj/i6UM81HP4dnaLunR8Dbs8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "fohNenWt7KfTuR35R7nAQesng7XzkSPNv7m4o1hJKyI=",
+    "shasum": "+ro+OLp+QUy/JuDWOhgKLyBHkABQV3WwbcWXTrrZnsI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Oza+HOkkg5s0oTtcVbuQ3Q7DdSaxxi0TlzH/mooJrRs=",
+    "shasum": "uNy3t2aMQs11xHTYN44qP+EJgcd+D/A+HLjKLA/YA4o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8aX7nVuKl9OmJuMg8uLQSBTb1vr1vYH1uR0218lXoFE=",
+    "shasum": "eXviiGCf27NXpa/drwVnzm7giRRKt3ewoRpzbembkR0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "MT+0obK/uFBYKL5icuF5/LlBTf3JGeSZbzJp6btICAk=",
+    "shasum": "qirq7wCYvPIlH1ZccqWsmmiRbCJq1mEUegPG3AJWQBY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cTG6Wy66zBTmzBhspBFjLh2MceHIj9m8q2+hshuy3SQ=",
+    "shasum": "WCcrRcQpQpNuWEmyN5TQuX1ckpHF/5JIsdkgMLCvjO0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3IlIpZUnuz6c0mzyZoyaW7vS7ek157o45VkTiYBAdaw=",
+    "shasum": "+RiAww9tB7ZbSNnhFuaN3UO9VIYAICxwIT4X9c+XY5o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "MyDqL8bu5mPV+736quBpoiniZCbr3kDtE6hkt51Azj8=",
+    "shasum": "FgE3bkyOtLM+Xh3yWPkbfSUU1T8OFYSu4ViHzTr3ttg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "fGyV1PhRgLmvTML2qNZ6+GSgFXHlamFkJI0JWxGyucA=",
+    "shasum": "nGoSEdNAKM/q9mtRCfLyOaq9axv3zMNItVcHHK2t/5Q=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2rDSYeietN1dQb+5/Kn7u2tiQEsF6E3mWlhQDQnuuhs=",
+    "shasum": "LUIVyk3+RKCfl4/rLeAWrMsEeiByKUBHLpLJrG9ne4Q=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "HAhfBSOGy2x83I1UPVPL9leXlIUdcjeIcIqN6XiMD8k=",
+    "shasum": "IYn+DHmfYp5W8YSsGSj/Tp9jwde8pZPV3QMKBu3eyUg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Dk6CTYSmF4q47YeyEljBBOfRD6BZ5ZmYY6wYJ4wq9sM=",
+    "shasum": "PFeFk5Pj8mT2DfmeAvXHX465zgYipTbi0seGEsV59iU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VD5atDsEjUvIT67mviG9iA4pYCdx+NOzCaqWpk2PmqI=",
+    "shasum": "vs6lQZrLO6I/0cFIiXpYG+9UcGhNUVuvMQP1Krd8i44=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "iyyk7CujZcu9uvSqYldlG8vyEQsRPHvVxBhx6HzvYko=",
+    "shasum": "10nPm2qcs2YypKXV4y7yUGYsG74blyVBCt+DLZBhxpc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0lvur0+FFHpwyk0UDa5PSm1dlaU6cc5tHjolnIXubSc=",
+    "shasum": "gZi+6wk3FJAQtOxmcdqYGwZB0p+JRpzvkBzD7bbyEIQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Wm1CFfulkG3sDpGqdjGTPeNc2zGNvkp+f5fDTpJBBAo=",
+    "shasum": "TAFDZQTBk0VXOnyvQou54DLLd5Yo80X/gTE4FB30Oe8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6h9p4BqiZfXO7XWX6poBdolHnGmmVHcJ7VZQSXYnj9E=",
+    "shasum": "fsMOq+VpuKAGx56RLOMYMYkDMOrjJQYf9FRkQz2M53M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "bVKeVbm71whdh2FNlWVH+wbj5zmdhp0w/ecGhQkY66Y=",
+    "shasum": "y8qxSYdffr4P2Buu/VVM2ZBzB5HCOl6CX67LqKCcJMs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VvDw6fvpq23WFRLXfDWwosnmI72XaD4DCCBWlxHTebU=",
+    "shasum": "NpCJVa8aJ70ZlKLmdhtjJ4g4h39pgTEU2NTK031mnRk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "SE569UQhj3gTADqLeT4rzi7L+9rzxvn0Zy8p28hEzhE=",
+    "shasum": "0iiw8G58ip4VE7EQ1lxQePIWwPzZKZJimH99qA8xIkc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-sdk/src/jsx/index.ts
+++ b/packages/snaps-sdk/src/jsx/index.ts
@@ -4,6 +4,7 @@ export * from './jsx-runtime';
 export * from './jsx-dev-runtime';
 export {
   JSXElementStruct,
+  RootJSXElementStruct,
   isJSXElement,
   isJSXElementUnsafe,
   assertJSXElement,

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -437,6 +437,11 @@ describe('BoxStruct', () => {
         <Image src="src" alt="alt" />
       </Row>
     </Box>,
+    <Box>
+      <Field label="foo">
+        <Input name="foo" />
+      </Field>
+    </Box>,
   ])('does not validate "%p"', (value) => {
     expect(is(value, BoxStruct)).toBe(false);
   });

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -195,7 +195,7 @@ export const AddressStruct: Describe<AddressElement> = element('Address', {
 export const BoxStruct: Describe<BoxElement> = element('Box', {
   children: maybeArray(
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    nullable(lazy(() => JSXElementStruct)),
+    nullable(lazy(() => BoxChildStruct)),
   ) as unknown as Struct<MaybeArray<GenericSnapElement | null>, null>,
   direction: optional(nullUnion([literal('horizontal'), literal('vertical')])),
   alignment: optional(
@@ -269,6 +269,35 @@ export const RowStruct: Describe<RowElement> = element('Row', {
  * A struct for the {@link SpinnerElement} type.
  */
 export const SpinnerStruct: Describe<SpinnerElement> = element('Spinner');
+
+/**
+ * A subset of JSX elements that are allowed as children of the Box component.
+ * This set should include all components, except components that need to be nested
+ * in another component (e.g. Field must be contained in a Form).
+ */
+export const BoxChildStruct = nullUnion([
+  ButtonStruct,
+  InputStruct,
+  FormStruct,
+  BoldStruct,
+  ItalicStruct,
+  AddressStruct,
+  BoxStruct,
+  CopyableStruct,
+  DividerStruct,
+  HeadingStruct,
+  ImageStruct,
+  LinkStruct,
+  RowStruct,
+  SpinnerStruct,
+  TextStruct,
+]);
+
+/**
+ * For now, the allowed JSX elements at the root are the same as the allowed
+ * children of the Box component.
+ */
+export const RootJSXElementStruct = BoxChildStruct;
 
 /**
  * A struct for the {@link JSXElement} type.

--- a/packages/snaps-sdk/src/types/interface.ts
+++ b/packages/snaps-sdk/src/types/interface.ts
@@ -2,7 +2,7 @@ import type { Infer } from 'superstruct';
 import { nullable, record, string, union } from 'superstruct';
 
 import type { JSXElement } from '../jsx';
-import { JSXElementStruct } from '../jsx';
+import { RootJSXElementStruct } from '../jsx';
 import type { Component } from '../ui';
 import { ComponentStruct } from '../ui';
 
@@ -25,5 +25,5 @@ export type InterfaceState = Infer<typeof InterfaceStateStruct>;
 export type ComponentOrElement = Component | JSXElement;
 export const ComponentOrElementStruct = union([
   ComponentStruct,
-  JSXElementStruct,
+  RootJSXElementStruct,
 ]);


### PR DESCRIPTION
Fixes a problem where `Field` was allowed as a child of `Box` or as the content of a UI by itself. The implementation assumes elsewhere that `Field` is always a child of `Form` and so the validation should uphold that.

Note: We should revisit the decision to require `Field` always being a child of a `Form` later since it would make sense to allow `Box` within forms as well for positioning. But this requires a validation refactor.