### PR TITLE
Add connections diff calculations needed for Snap update

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 91.5,
-  "functions": 96.74,
-  "lines": 97.87,
-  "statements": 97.54
+  "branches": 91.54,
+  "functions": 96.75,
+  "lines": 97.88,
+  "statements": 97.55
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -121,6 +121,7 @@ import {
   type KeyDerivationOptions,
 } from '../types';
 import {
+  calculateConnectionsChange,
   fetchSnap,
   hasTimedOut,
   permissionsDiff,
@@ -2425,13 +2426,21 @@ export class SnapController extends BaseController<
       const { newPermissions, unusedPermissions, approvedPermissions } =
         this.#calculatePermissionsChange(snapId, processedPermissions);
 
+      const { newConnections, unusedConnections, approvedConnections } =
+        calculateConnectionsChange(
+          oldManifest.initialConnections ?? {},
+          manifest.initialConnections ?? {},
+        );
+
       this.#updateApproval(pendingApproval.id, {
-        connections: manifest.initialConnections ?? {},
         permissions: newPermissions,
         newVersion: manifest.version,
         newPermissions,
         approvedPermissions,
         unusedPermissions,
+        newConnections,
+        unusedConnections,
+        approvedConnections,
         loading: false,
       });
 

--- a/packages/snaps-controllers/src/utils.test.ts
+++ b/packages/snaps-controllers/src/utils.test.ts
@@ -14,7 +14,12 @@ import {
   MOCK_RPC_ORIGINS_PERMISSION,
   MOCK_SNAP_DIALOG_PERMISSION,
 } from './test-utils';
-import { getSnapFiles, permissionsDiff, setDiff } from './utils';
+import {
+  calculateConnectionsChange,
+  getSnapFiles,
+  permissionsDiff,
+  setDiff,
+} from './utils';
 
 describe('setDiff', () => {
   it('does nothing on empty type {}-B', () => {
@@ -178,5 +183,34 @@ describe('getSnapFiles', () => {
         value: 'bar',
       }),
     ]);
+  });
+});
+
+describe('calculateConnectionsChange', () => {
+  it('should properly calculate connection change based on the input data', () => {
+    const oldConnections = {
+      'npm:filsnap': {},
+      'https://snaps.metamask.io': {},
+      'https://metamask.github.io': {},
+    };
+    const newConnections = {
+      'https://snaps.metamask.io': {},
+      'https://portfolio.metamask.io': {},
+    };
+
+    expect(
+      calculateConnectionsChange(oldConnections, newConnections),
+    ).toStrictEqual({
+      newConnections: {
+        'https://portfolio.metamask.io': {},
+      },
+      unusedConnections: {
+        'npm:filsnap': {},
+        'https://metamask.github.io': {},
+      },
+      approvedConnections: {
+        'https://snaps.metamask.io': {},
+      },
+    });
   });
 });

--- a/packages/snaps-controllers/src/utils.ts
+++ b/packages/snaps-controllers/src/utils.ts
@@ -6,6 +6,7 @@ import {
   getValidatedLocalizationFiles,
   validateFetchedSnap,
 } from '@metamask/snaps-utils';
+import type { Json } from '@metamask/utils';
 import deepEqual from 'fast-deep-equal';
 
 import type { SnapLocation } from './snaps';
@@ -317,4 +318,30 @@ export async function fetchSnap(snapId: SnapId, location: SnapLocation) {
       `Failed to fetch snap "${snapId}": ${getErrorMessage(error)}.`,
     );
   }
+}
+
+/**
+ * Calculate change of initialConnections.
+ *
+ * @param oldConnectionsSet - Previously approved connections.
+ * @param desiredConnectionsSet - New connections.
+ * @returns Object containing newConnections, unusedConnections and approvedConnections.
+ */
+export function calculateConnectionsChange(
+  oldConnectionsSet: Record<string, Json>,
+  desiredConnectionsSet: Record<string, Json>,
+): {
+  newConnections: Record<string, Json>;
+  unusedConnections: Record<string, Json>;
+  approvedConnections: Record<string, Json>;
+} {
+  const newConnections = setDiff(desiredConnectionsSet, oldConnectionsSet);
+
+  const unusedConnections = setDiff(oldConnectionsSet, desiredConnectionsSet);
+
+  // It's a Set Intersection of oldConnections and desiredConnectionsSet
+  // oldConnections ∖ (oldConnections ∖ desiredConnectionsSet) ⟺ oldConnections ∩ desiredConnectionsSet
+  const approvedConnections = setDiff(oldConnectionsSet, unusedConnections);
+
+  return { newConnections, unusedConnections, approvedConnections };
 }

--- a/packages/snaps-utils/src/test-utils/snap.ts
+++ b/packages/snaps-utils/src/test-utils/snap.ts
@@ -23,6 +23,7 @@ export const getPersistedSnapObject = ({
   enabled = true,
   id = MOCK_SNAP_ID,
   initialPermissions = getSnapManifest().initialPermissions,
+  initialConnections = getSnapManifest().initialConnections,
   manifest = getSnapManifest(),
   sourceCode = DEFAULT_SNAP_BUNDLE,
   status = SnapStatus.Stopped,
@@ -38,6 +39,7 @@ export const getPersistedSnapObject = ({
   return {
     blocked,
     initialPermissions,
+    ...(initialConnections ? { initialConnections } : {}),
     id,
     version: version as SemVerVersion,
     manifest,


### PR DESCRIPTION
This PR adds additional logic for calculating difference of `initialConnections`. This is required so changes can be displayed in the UI for Snap update process.

New method is added to `SnapController` and integrated within Snap update handling functions.