### PR TITLE
Add support for `ed25519Bip32` to the BIP-32 example snap

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -38,6 +38,14 @@
           "0'"
         ],
         "curve": "ed25519"
+      },
+      {
+        "path": [
+          "m",
+          "44'",
+          "0'"
+        ],
+        "curve": "ed25519Bip32"
       }
     ],
     "snap_getBip32PublicKey": [

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "GVN0FD0c4xnr+osY4rjRvF/KSGBgVC2fccbLwzGoFnk=",
+    "shasum": "VTYKPC0W5V/eIRyWm3BWx596kB2yHcAtduJKwfZM9mg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/src/index.test.ts
+++ b/packages/examples/packages/bip32/src/index.test.ts
@@ -160,6 +160,38 @@ describe('onRpcRequest', () => {
       );
     });
 
+    it('signs a message for the given BIP-32 path using ed25519Bip32', async () => {
+      const { request } = await installSnap();
+
+      const response = request({
+        method: 'signMessage',
+        params: {
+          path: ['m', "44'", "0'"],
+          curve: 'ed25519Bip32',
+          message: 'Hello, world!',
+        },
+      });
+
+      const ui = await response.getInterface();
+      expect(ui).toRender(
+        panel([
+          heading('Signature request'),
+          text(
+            `Do you want to ed25519Bip32 sign "Hello, world!" with the following public key?`,
+          ),
+          copyable(
+            '0x2c3ac523b470dead7981df46c93d894ed4381e94c23aa1ec3806a320ff8ceb42',
+          ),
+        ]),
+      );
+
+      await ui.ok();
+
+      expect(await response).toRespondWith(
+        '0x5c01bf4c314a74d3feb27b261637837740e167cf3261fe0bc89dcdbf97888276be030a84298087c031141c1093647768de5b35c1154ec485cb08373a72574902',
+      );
+    });
+
     it('throws an error when rejecting the signature request', async () => {
       const { request } = await installSnap();
 

--- a/packages/examples/packages/bip32/src/index.ts
+++ b/packages/examples/packages/bip32/src/index.ts
@@ -54,7 +54,11 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       const node = await getPrivateNode({ ...params, curve });
 
       assert(node.privateKey);
-      assert(curve === 'ed25519' || curve === 'secp256k1');
+      assert(
+        curve === 'ed25519' ||
+          curve === 'ed25519bip32' ||
+          curve === 'secp256k1',
+      );
 
       const approved = await snap.request({
         method: 'snap_dialog',
@@ -75,6 +79,14 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       }
 
       if (curve === 'ed25519') {
+        const signed = await signEd25519(
+          stringToBytes(message),
+          remove0x(node.privateKey),
+        );
+        return bytesToHex(signed);
+      }
+
+      if (curve === 'ed25519bip32') {
         const signed = await signEd25519(
           stringToBytes(message),
           remove0x(node.privateKey),

--- a/packages/examples/packages/bip32/src/index.ts
+++ b/packages/examples/packages/bip32/src/index.ts
@@ -56,7 +56,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       assert(node.privateKey);
       assert(
         curve === 'ed25519' ||
-          curve === 'ed25519bip32' ||
+          curve === 'ed25519Bip32' ||
           curve === 'secp256k1',
       );
 
@@ -86,7 +86,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
         return bytesToHex(signed);
       }
 
-      if (curve === 'ed25519bip32') {
+      if (curve === 'ed25519Bip32') {
         const signed = await signEd25519(
           stringToBytes(message),
           remove0x(node.privateKey),

--- a/packages/examples/packages/bip32/src/index.ts
+++ b/packages/examples/packages/bip32/src/index.ts
@@ -81,7 +81,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       if (curve === 'ed25519' || curve === 'ed25519Bip32') {
         const signed = await signEd25519(
           stringToBytes(message),
-          remove0x(node.privateKey),
+          remove0x(node.privateKey).slice(0, 64),
         );
         return bytesToHex(signed);
       }

--- a/packages/examples/packages/bip32/src/index.ts
+++ b/packages/examples/packages/bip32/src/index.ts
@@ -78,15 +78,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
         throw new UserRejectedRequestError();
       }
 
-      if (curve === 'ed25519') {
-        const signed = await signEd25519(
-          stringToBytes(message),
-          remove0x(node.privateKey),
-        );
-        return bytesToHex(signed);
-      }
-
-      if (curve === 'ed25519Bip32') {
+      if (curve === 'ed25519' || curve === 'ed25519Bip32') {
         const signed = await signEd25519(
           stringToBytes(message),
           remove0x(node.privateKey),

--- a/packages/examples/packages/bip32/src/types.ts
+++ b/packages/examples/packages/bip32/src/types.ts
@@ -46,5 +46,5 @@ export type SignMessageParams = {
   /**
    * The curve used to derive the account.
    */
-  curve: 'secp256k1' | 'ed25519';
+  curve: 'secp256k1' | 'ed25519' | 'ed25519bip32';
 };

--- a/packages/examples/packages/bip32/src/types.ts
+++ b/packages/examples/packages/bip32/src/types.ts
@@ -13,7 +13,7 @@ export type GetBip32PublicKeyParams = {
   /**
    * The curve used to derive the account.
    */
-  curve: 'secp256k1' | 'ed25519';
+  curve: 'secp256k1' | 'ed25519' | 'ed25519Bip32';
 
   /**
    * Whether to return the public key in compressed form.
@@ -46,5 +46,5 @@ export type SignMessageParams = {
   /**
    * The curve used to derive the account.
    */
-  curve: 'secp256k1' | 'ed25519' | 'ed25519bip32';
+  curve: 'secp256k1' | 'ed25519' | 'ed25519Bip32';
 };

--- a/packages/test-snaps/src/features/snaps/bip32/BIP32.tsx
+++ b/packages/test-snaps/src/features/snaps/bip32/BIP32.tsx
@@ -16,6 +16,7 @@ export const BIP32: FunctionComponent = () => {
       <PublicKey />
       <SignMessage curve="secp256k1" />
       <SignMessage curve="ed25519" />
+      <SignMessage curve="ed25519Bip32" />
     </Snap>
   );
 };

--- a/packages/test-snaps/src/features/snaps/bip32/components/SignMessage.tsx
+++ b/packages/test-snaps/src/features/snaps/bip32/components/SignMessage.tsx
@@ -9,7 +9,7 @@ import { getSnapId } from '../../../../utils';
 import { BIP_32_PORT, BIP_32_SNAP_ID } from '../constants';
 
 export type SignMessageProps = {
-  curve: 'secp256k1' | 'ed25519';
+  curve: 'secp256k1' | 'ed25519' | 'ed25519Bip32';
 };
 
 export const SignMessage: FunctionComponent<SignMessageProps> = ({ curve }) => {


### PR DESCRIPTION
Add support for the `ed25519Bip32` curve to the BIP-32 example Snap for E2E testing purposes.