### PR TITLE
fix: properly diff when using legacy UI with `toRender` matcher

### DIFF
--- a/packages/snaps-jest/src/matchers.ts
+++ b/packages/snaps-jest/src/matchers.ts
@@ -260,7 +260,7 @@ const toRenderLegacy: MatcherFunction<[expected: Component]> = function (
   // This is typed as `string | null`, but in practice it's always a string.
   // The function only returns `null` if both the expected and actual values
   // are numbers, bigints, or booleans, which is never the case here.
-  const difference = diff(actual, expectedElement) as string;
+  const difference = diff(expectedElement, content) as string;
 
   const message = pass
     ? () =>


### PR DESCRIPTION
This fixes two problems with diff outputs when using `toRender` with legacy UI:
- Firstly we had flipped actual and expected causing confusing output
- Secondly we were diffing not just the content but also the rest of the response object unnecessarily