### PR TITLE
feat: add feature flag to disable platform

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 91.57,
-  "functions": 96.75,
-  "lines": 97.88,
-  "statements": 97.55
+  "branches": 91.59,
+  "functions": 96.76,
+  "lines": 97.89,
+  "statements": 97.57
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -908,6 +908,46 @@ describe('SnapController', () => {
     snapController.destroy();
   });
 
+  it('throws an error if the platform is disabled during installSnaps', async () => {
+    const controller = getSnapController(
+      getSnapControllerOptions({
+        getFeatureFlags: () => ({ disableSnaps: true }),
+      }),
+    );
+
+    await expect(
+      controller.installSnaps(MOCK_ORIGIN, {
+        [MOCK_SNAP_ID]: {},
+      }),
+    ).rejects.toThrow(
+      'The Snaps platform requires basic functionality to be used. Enable basic functionality in the settings to use the Snaps platform.',
+    );
+
+    controller.destroy();
+  });
+
+  it('throws an error if the platform is disabled during handleRequest', async () => {
+    const controller = getSnapController(
+      getSnapControllerOptions({
+        getFeatureFlags: () => ({ disableSnaps: true }),
+        state: getPersistedSnapsState(),
+      }),
+    );
+
+    await expect(
+      controller.handleRequest({
+        snapId: MOCK_SNAP_ID,
+        origin: MOCK_ORIGIN,
+        handler: HandlerType.OnRpcRequest,
+        request: { method: 'foo' },
+      }),
+    ).rejects.toThrow(
+      'The Snaps platform requires basic functionality to be used. Enable basic functionality in the settings to use the Snaps platform.',
+    );
+
+    controller.destroy();
+  });
+
   it('throws an error on invalid semver range during installSnaps', async () => {
     const controller = getSnapController();
 


### PR DESCRIPTION
Add `getFeatureFlags` constructor argument that can return dynamic feature flags at runtime, use the feature flag to assert whether the Snaps platform is allowed to run.

Closes https://github.com/MetaMask/MetaMask-planning/issues/2556