### PR TITLE
feat: add accounts chain API

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -4975,7 +4975,7 @@ describe('SnapController', () => {
           [MOCK_SNAP_ID]: {},
         }),
       ).rejects.toThrow(
-        'A snap must request at least one of the following permissions: endowment:rpc, endowment:transaction-insight, endowment:cronjob, endowment:name-lookup, endowment:lifecycle-hooks, endowment:keyring, endowment:page-home, endowment:signature-insight.',
+        'A snap must request at least one of the following permissions: endowment:rpc, endowment:transaction-insight, endowment:cronjob, endowment:name-lookup, endowment:lifecycle-hooks, endowment:keyring, endowment:page-home, endowment:signature-insight, endowment:accounts-chain.',
       );
 
       controller.destroy();

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 80,
+  "branches": 80.13,
   "functions": 90.06,
   "lines": 90.76,
   "statements": 90.13

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1449,6 +1449,39 @@ describe('BaseSnapExecutor', () => {
     });
   });
 
+  it('supports onAccountsChainRequest export', async () => {
+    const CODE = `
+      module.exports.onAccountsChainRequest = ({ request }) => request.params[0];
+    `;
+
+    const executor = new TestSnapExecutor();
+    await executor.executeSnap(1, MOCK_SNAP_ID, CODE, []);
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'OK',
+    });
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'snapRpc',
+      params: [
+        MOCK_SNAP_ID,
+        HandlerType.OnAccountsChainRequest,
+        MOCK_ORIGIN,
+        { jsonrpc: '2.0', method: 'foo', params: ['bar'] },
+      ],
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      id: 2,
+      jsonrpc: '2.0',
+      result: 'bar',
+    });
+  });
+
   it('supports onHomePage export', async () => {
     const CODE = `
       module.exports.onHomePage = () => ({ content: { type: 'panel', children: [] }});

--- a/packages/snaps-execution-environments/src/common/commands.ts
+++ b/packages/snaps-execution-environments/src/common/commands.ts
@@ -76,6 +76,7 @@ export function getHandlerArguments(
     }
     case HandlerType.OnRpcRequest:
     case HandlerType.OnKeyringRequest:
+    case HandlerType.OnAccountsChainRequest:
       return { origin, request };
 
     case HandlerType.OnCronjob:

--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -10,7 +10,7 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 91.21,
+      branches: 90.95,
       functions: 96.96,
       lines: 97.51,
       statements: 96.97,

--- a/packages/snaps-rpc-methods/src/endowments/accounts-chain.test.ts
+++ b/packages/snaps-rpc-methods/src/endowments/accounts-chain.test.ts
@@ -1,0 +1,143 @@
+import { PermissionType, SubjectType } from '@metamask/permission-controller';
+import { SnapCaveatType } from '@metamask/snaps-utils';
+
+import {
+  getAccountsChainCaveatMapper,
+  getAccountsChainCaveatOrigins,
+  accountsChainCaveatSpecifications,
+  accountsChainEndowmentBuilder,
+} from './accounts-chain';
+import { SnapEndowments } from './enum';
+
+describe('endowment:accounts-chain', () => {
+  it('builds the expected permission specification', () => {
+    const specification = accountsChainEndowmentBuilder.specificationBuilder(
+      {},
+    );
+    expect(specification).toStrictEqual({
+      permissionType: PermissionType.Endowment,
+      targetName: SnapEndowments.AccountsChain,
+      endowmentGetter: expect.any(Function),
+      allowedCaveats: [
+        SnapCaveatType.KeyringOrigin,
+        SnapCaveatType.MaxRequestTime,
+      ],
+      subjectTypes: [SubjectType.Snap],
+      validator: expect.any(Function),
+    });
+  });
+
+  describe('validator', () => {
+    it('throws if the caveat is not a single "keyringOrigin"', () => {
+      const specification = accountsChainEndowmentBuilder.specificationBuilder(
+        {},
+      );
+
+      expect(() =>
+        specification.validator({
+          // @ts-expect-error Missing other required permission types.
+          caveats: undefined,
+        }),
+      ).toThrow('Expected the following caveats: "keyringOrigin".');
+
+      expect(() =>
+        // @ts-expect-error Missing other required permission types.
+        specification.validator({
+          caveats: [{ type: 'foo', value: 'bar' }],
+        }),
+      ).toThrow(
+        'Expected the following caveats: "keyringOrigin", "maxRequestTime", received "foo".',
+      );
+
+      expect(() =>
+        // @ts-expect-error Missing other required permission types.
+        specification.validator({
+          caveats: [
+            { type: 'keyringOrigin', value: { allowedOrgins: ['foo.com'] } },
+            { type: 'keyringOrigin', value: { allowedOrgins: ['bar.com'] } },
+          ],
+        }),
+      ).toThrow('Duplicate caveats are not allowed.');
+    });
+  });
+});
+
+describe('getKeyringCaveatMapper', () => {
+  it('maps a value to a caveat', () => {
+    expect(
+      getAccountsChainCaveatMapper({ allowedOrigins: ['foo.com'] }),
+    ).toStrictEqual({
+      caveats: [
+        {
+          type: SnapCaveatType.KeyringOrigin,
+          value: { allowedOrigins: ['foo.com'] },
+        },
+      ],
+    });
+  });
+});
+
+describe('getAccountsChainCaveatOrigins', () => {
+  it('returns the origins from the caveat', () => {
+    expect(
+      // @ts-expect-error Missing other required permission types.
+      getAccountsChainCaveatOrigins({
+        caveats: [
+          {
+            type: SnapCaveatType.KeyringOrigin,
+            value: { allowedOrigins: ['foo.com'] },
+          },
+        ],
+      }),
+    ).toStrictEqual({ allowedOrigins: ['foo.com'] });
+  });
+
+  it('throws if the caveat is not a single "rpcOrigin"', () => {
+    expect(() =>
+      // @ts-expect-error Missing other required permission types.
+      getAccountsChainCaveatOrigins({
+        caveats: [{ type: 'foo', value: 'bar' }],
+      }),
+    ).toThrow('Assertion failed.');
+
+    expect(() =>
+      // @ts-expect-error Missing other required permission types.
+      getAccountsChainCaveatOrigins({
+        caveats: [
+          { type: 'keyringOrigin', value: { allowedOrigins: ['foo.com'] } },
+          { type: 'keyringOrigin', value: { allowedOrigins: ['foo.com'] } },
+        ],
+      }),
+    ).toThrow('Assertion failed.');
+  });
+});
+
+describe('keyringCaveatSpecifications', () => {
+  describe('validator', () => {
+    it('throws if the caveat values are invalid', () => {
+      expect(() =>
+        accountsChainCaveatSpecifications[
+          SnapCaveatType.KeyringOrigin
+        ].validator?.(
+          // @ts-expect-error Missing value type.
+          {
+            type: SnapCaveatType.KeyringOrigin,
+          },
+        ),
+      ).toThrow('Invalid keyring origins: Expected a plain object.');
+
+      expect(() =>
+        accountsChainCaveatSpecifications[
+          SnapCaveatType.KeyringOrigin
+        ].validator?.({
+          type: SnapCaveatType.KeyringOrigin,
+          value: {
+            foo: 'bar',
+          },
+        }),
+      ).toThrow(
+        'Invalid keyring origins: At path: foo -- Expected a value of type `never`, but received: `"bar"`.',
+      );
+    });
+  });
+});

--- a/packages/snaps-rpc-methods/src/endowments/accounts-chain.test.ts
+++ b/packages/snaps-rpc-methods/src/endowments/accounts-chain.test.ts
@@ -4,7 +4,6 @@ import { SnapCaveatType } from '@metamask/snaps-utils';
 import {
   getAccountsChainCaveatMapper,
   getAccountsChainCaveatOrigins,
-  accountsChainCaveatSpecifications,
   accountsChainEndowmentBuilder,
 } from './accounts-chain';
 import { SnapEndowments } from './enum';
@@ -20,6 +19,7 @@ describe('endowment:accounts-chain', () => {
       endowmentGetter: expect.any(Function),
       allowedCaveats: [
         SnapCaveatType.KeyringOrigin,
+        SnapCaveatType.ChainIds,
         SnapCaveatType.MaxRequestTime,
       ],
       subjectTypes: [SubjectType.Snap],
@@ -109,35 +109,5 @@ describe('getAccountsChainCaveatOrigins', () => {
         ],
       }),
     ).toThrow('Assertion failed.');
-  });
-});
-
-describe('keyringCaveatSpecifications', () => {
-  describe('validator', () => {
-    it('throws if the caveat values are invalid', () => {
-      expect(() =>
-        accountsChainCaveatSpecifications[
-          SnapCaveatType.KeyringOrigin
-        ].validator?.(
-          // @ts-expect-error Missing value type.
-          {
-            type: SnapCaveatType.KeyringOrigin,
-          },
-        ),
-      ).toThrow('Invalid keyring origins: Expected a plain object.');
-
-      expect(() =>
-        accountsChainCaveatSpecifications[
-          SnapCaveatType.KeyringOrigin
-        ].validator?.({
-          type: SnapCaveatType.KeyringOrigin,
-          value: {
-            foo: 'bar',
-          },
-        }),
-      ).toThrow(
-        'Invalid keyring origins: At path: foo -- Expected a value of type `never`, but received: `"bar"`.',
-      );
-    });
   });
 });

--- a/packages/snaps-rpc-methods/src/endowments/accounts-chain.ts
+++ b/packages/snaps-rpc-methods/src/endowments/accounts-chain.ts
@@ -11,7 +11,7 @@ import { PermissionType, SubjectType } from '@metamask/permission-controller';
 import type { KeyringOrigins } from '@metamask/snaps-utils';
 import { SnapCaveatType } from '@metamask/snaps-utils';
 import type { Json, NonEmptyArray } from '@metamask/utils';
-import { assert, isObject } from '@metamask/utils';
+import { isObject } from '@metamask/utils';
 
 import { createGenericPermissionValidator } from './caveats';
 import { SnapEndowments } from './enum';
@@ -92,8 +92,6 @@ export function getAccountsChainCaveatMapper(
       value: { allowedOrigins: value.allowedOrigins },
     });
   }
-
-  assert(caveats.length >= 2);
 
   return { caveats: caveats as NonEmptyArray<CaveatConstraint> };
 }

--- a/packages/snaps-rpc-methods/src/endowments/accounts-chain.ts
+++ b/packages/snaps-rpc-methods/src/endowments/accounts-chain.ts
@@ -1,0 +1,133 @@
+import type {
+  Caveat,
+  CaveatConstraint,
+  EndowmentGetterParams,
+  PermissionConstraint,
+  PermissionSpecificationBuilder,
+  PermissionValidatorConstraint,
+  ValidPermissionSpecification,
+} from '@metamask/permission-controller';
+import { PermissionType, SubjectType } from '@metamask/permission-controller';
+import type { KeyringOrigins } from '@metamask/snaps-utils';
+import { SnapCaveatType } from '@metamask/snaps-utils';
+import type { Json, NonEmptyArray } from '@metamask/utils';
+import { assert, isObject } from '@metamask/utils';
+
+import { createGenericPermissionValidator } from './caveats';
+import { SnapEndowments } from './enum';
+
+const permissionName = SnapEndowments.AccountsChain;
+
+type AccountsChainEndowmentSpecification = ValidPermissionSpecification<{
+  permissionType: PermissionType.Endowment;
+  targetName: typeof permissionName;
+  endowmentGetter: (_options?: EndowmentGetterParams) => undefined;
+  allowedCaveats: Readonly<NonEmptyArray<string>> | null;
+  validator: PermissionValidatorConstraint;
+  subjectTypes: readonly SubjectType[];
+}>;
+
+/**
+ * `endowment:accounts-chain` returns nothing; it is intended to be used as a flag
+ * by the client to detect whether the Snap supports the Accounts Chain API.
+ *
+ * @param _builderOptions - Optional specification builder options.
+ * @returns The specification for the accounts chain endowment.
+ */
+const specificationBuilder: PermissionSpecificationBuilder<
+  PermissionType.Endowment,
+  any,
+  AccountsChainEndowmentSpecification
+> = (_builderOptions?: unknown) => {
+  return {
+    permissionType: PermissionType.Endowment,
+    targetName: permissionName,
+    allowedCaveats: [
+      SnapCaveatType.KeyringOrigin,
+      SnapCaveatType.ChainIds,
+      SnapCaveatType.MaxRequestTime,
+    ],
+    endowmentGetter: (_getterOptions?: EndowmentGetterParams) => undefined,
+    validator: createGenericPermissionValidator([
+      { type: SnapCaveatType.KeyringOrigin },
+      { type: SnapCaveatType.ChainIds },
+      { type: SnapCaveatType.MaxRequestTime, optional: true },
+    ]),
+    subjectTypes: [SubjectType.Snap],
+  };
+};
+
+export const accountsChainEndowmentBuilder = Object.freeze({
+  targetName: permissionName,
+  specificationBuilder,
+} as const);
+
+/**
+ * Map a raw value from the `initialPermissions` to a caveat specification.
+ * Note that this function does not do any validation, that's handled by the
+ * PermissionsController when the permission is requested.
+ *
+ * @param value - The raw value from the `initialPermissions`.
+ * @returns The caveat specification.
+ */
+export function getAccountsChainCaveatMapper(
+  value: Json,
+): Pick<PermissionConstraint, 'caveats'> {
+  if (!value || !isObject(value) || Object.keys(value).length === 0) {
+    return { caveats: null };
+  }
+
+  const caveats = [];
+
+  if (value.chains) {
+    caveats.push({
+      type: SnapCaveatType.ChainIds,
+      value: value.chains,
+    });
+  }
+
+  if (value.allowedOrigins) {
+    caveats.push({
+      type: SnapCaveatType.KeyringOrigin,
+      value: { allowedOrigins: value.allowedOrigins },
+    });
+  }
+
+  assert(caveats.length >= 2);
+
+  return { caveats: caveats as NonEmptyArray<CaveatConstraint> };
+}
+
+/**
+ * Getter function to get the {@link KeyringOrigins} caveat value from a
+ * permission.
+ *
+ * @param permission - The permission to get the caveat value from.
+ * @returns The caveat value.
+ */
+export function getAccountsChainCaveatOrigins(
+  permission?: PermissionConstraint,
+): KeyringOrigins | null {
+  const caveat = permission?.caveats?.find(
+    (permCaveat) => permCaveat.type === SnapCaveatType.KeyringOrigin,
+  ) as Caveat<string, KeyringOrigins> | undefined;
+
+  return caveat ? caveat.value : null;
+}
+
+/**
+ * Getter function to get the {@link ChainIds} caveat value from a
+ * permission.
+ *
+ * @param permission - The permission to get the caveat value from.
+ * @returns The caveat value.
+ */
+export function getAccountsChainCaveatChainIds(
+  permission?: PermissionConstraint,
+): string[] | null {
+  const caveat = permission?.caveats?.find(
+    (permCaveat) => permCaveat.type === SnapCaveatType.ChainIds,
+  ) as Caveat<string, string[]> | undefined;
+
+  return caveat ? caveat.value : null;
+}

--- a/packages/snaps-rpc-methods/src/endowments/enum.ts
+++ b/packages/snaps-rpc-methods/src/endowments/enum.ts
@@ -10,4 +10,5 @@ export enum SnapEndowments {
   LifecycleHooks = 'endowment:lifecycle-hooks',
   Keyring = 'endowment:keyring',
   HomePage = 'endowment:page-home',
+  AccountsChain = 'endowment:accounts-chain',
 }

--- a/packages/snaps-rpc-methods/src/endowments/index.ts
+++ b/packages/snaps-rpc-methods/src/endowments/index.ts
@@ -59,6 +59,7 @@ export const endowmentPermissionBuilders = {
   [nameLookupEndowmentBuilder.targetName]: nameLookupEndowmentBuilder,
   [lifecycleHooksEndowmentBuilder.targetName]: lifecycleHooksEndowmentBuilder,
   [keyringEndowmentBuilder.targetName]: keyringEndowmentBuilder,
+  [accountsChainEndowmentBuilder.targetName]: accountsChainEndowmentBuilder,
   [homePageEndowmentBuilder.targetName]: homePageEndowmentBuilder,
   [signatureInsightEndowmentBuilder.targetName]:
     signatureInsightEndowmentBuilder,

--- a/packages/snaps-rpc-methods/src/endowments/index.ts
+++ b/packages/snaps-rpc-methods/src/endowments/index.ts
@@ -3,6 +3,10 @@ import { HandlerType } from '@metamask/snaps-utils';
 import type { Json } from '@metamask/utils';
 
 import {
+  getAccountsChainCaveatMapper,
+  accountsChainEndowmentBuilder,
+} from './accounts-chain';
+import {
   createMaxRequestTimeMapper,
   getMaxRequestTimeCaveatMapper,
   maxRequestTimeCaveatSpecifications,
@@ -88,6 +92,9 @@ export const endowmentCaveatMappers: Record<
   [keyringEndowmentBuilder.targetName]: createMaxRequestTimeMapper(
     getKeyringCaveatMapper,
   ),
+  [accountsChainEndowmentBuilder.targetName]: createMaxRequestTimeMapper(
+    getAccountsChainCaveatMapper,
+  ),
   [signatureInsightEndowmentBuilder.targetName]: createMaxRequestTimeMapper(
     getSignatureInsightCaveatMapper,
   ),
@@ -106,6 +113,8 @@ export const handlerEndowments: Record<HandlerType, string | null> = {
   [HandlerType.OnKeyringRequest]: keyringEndowmentBuilder.targetName,
   [HandlerType.OnHomePage]: homePageEndowmentBuilder.targetName,
   [HandlerType.OnSignature]: signatureInsightEndowmentBuilder.targetName,
+  [HandlerType.OnAccountsChainRequest]:
+    accountsChainEndowmentBuilder.targetName,
   [HandlerType.OnUserInput]: null,
 };
 

--- a/packages/snaps-rpc-methods/src/permitted/handlers.ts
+++ b/packages/snaps-rpc-methods/src/permitted/handlers.ts
@@ -4,6 +4,7 @@ import { getClientStatusHandler } from './getClientStatus';
 import { getFileHandler } from './getFile';
 import { getInterfaceStateHandler } from './getInterfaceState';
 import { getSnapsHandler } from './getSnaps';
+import { invokeAccountSnapHandler } from './invokeAccountsSnap';
 import { invokeKeyringHandler } from './invokeKeyring';
 import { invokeSnapSugarHandler } from './invokeSnapSugar';
 import { requestSnapsHandler } from './requestSnaps';
@@ -16,6 +17,7 @@ export const methodHandlers = {
   wallet_requestSnaps: requestSnapsHandler,
   wallet_invokeSnap: invokeSnapSugarHandler,
   wallet_invokeKeyring: invokeKeyringHandler,
+  wallet_invokeAccountsSnap: invokeAccountSnapHandler,
   snap_getClientStatus: getClientStatusHandler,
   snap_getFile: getFileHandler,
   snap_createInterface: createInterfaceHandler,

--- a/packages/snaps-rpc-methods/src/permitted/invokeAccountsSnap.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/invokeAccountsSnap.test.ts
@@ -1,0 +1,357 @@
+import { JsonRpcEngine } from '@metamask/json-rpc-engine';
+import { rpcErrors } from '@metamask/rpc-errors';
+import type { InvokeKeyringParams } from '@metamask/snaps-sdk';
+import { AccountsSnapHandlerType } from '@metamask/snaps-sdk';
+import { HandlerType } from '@metamask/snaps-utils';
+import { MOCK_SNAP_ID, getSnapObject } from '@metamask/snaps-utils/test-utils';
+import type {
+  JsonRpcRequest,
+  JsonRpcFailure,
+  JsonRpcSuccess,
+} from '@metamask/utils';
+
+import { invokeAccountSnapHandler } from './invokeAccountsSnap';
+
+describe('wallet_invokeAccountsSnap', () => {
+  describe('invokeKeyringHandler', () => {
+    it('has the expected shape', () => {
+      expect(invokeAccountSnapHandler).toMatchObject({
+        methodNames: ['wallet_invokeAccountsSnap'],
+        implementation: expect.any(Function),
+        hookNames: {
+          getSnap: true,
+          handleSnapRpcRequest: true,
+          hasPermission: true,
+        },
+      });
+    });
+  });
+  describe('invokeKeyringImplementation', () => {
+    // Mirror the origin middleware in the extension
+    const createOriginMiddleware =
+      (origin: string) =>
+      (request: any, _response: unknown, next: () => void, _end: unknown) => {
+        request.origin = origin;
+        next();
+      };
+
+    const getMockHooks = () =>
+      ({
+        getSnap: jest.fn(),
+        hasPermission: jest.fn(),
+        handleSnapRpcRequest: jest.fn(),
+        getAllowedKeyringMethods: jest.fn(),
+      } as any);
+
+    it('invokes the snap and returns the result', async () => {
+      const { implementation } = invokeAccountSnapHandler;
+
+      const hooks = getMockHooks();
+
+      hooks.hasPermission.mockImplementation(() => true);
+      hooks.getSnap.mockImplementation(() => getSnapObject());
+      hooks.handleSnapRpcRequest.mockImplementation(() => 'bar');
+      hooks.getAllowedKeyringMethods.mockImplementation(() => ['foo']);
+
+      const engine = new JsonRpcEngine();
+      engine.push(createOriginMiddleware('metamask.io'));
+      engine.push((req, res, next, end) => {
+        const result = implementation(
+          req as JsonRpcRequest<InvokeKeyringParams>,
+          res,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = (await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'wallet_invokeAccountsSnap',
+        params: {
+          snapId: MOCK_SNAP_ID,
+          request: { method: 'foo' },
+          type: AccountsSnapHandlerType.Keyring,
+        },
+      })) as JsonRpcSuccess<string>;
+
+      expect(response.result).toBe('bar');
+      expect(hooks.handleSnapRpcRequest).toHaveBeenCalledWith({
+        handler: HandlerType.OnKeyringRequest,
+        request: { method: 'foo' },
+        snapId: MOCK_SNAP_ID,
+      });
+    });
+
+    it('fails if invoking the snap fails', async () => {
+      const { implementation } = invokeAccountSnapHandler;
+
+      const hooks = getMockHooks();
+
+      hooks.hasPermission.mockImplementation(() => true);
+      hooks.getSnap.mockImplementation(() => getSnapObject());
+      hooks.handleSnapRpcRequest.mockImplementation(() => {
+        throw rpcErrors.invalidRequest({
+          message: 'Failed to start snap.',
+        });
+      });
+      hooks.getAllowedKeyringMethods.mockImplementation(() => ['foo']);
+
+      const engine = new JsonRpcEngine();
+      engine.push(createOriginMiddleware('metamask.io'));
+      engine.push((req, res, next, end) => {
+        const result = implementation(
+          req as JsonRpcRequest<InvokeKeyringParams>,
+          res,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = (await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'wallet_invokeAccountsSnap',
+        params: {
+          snapId: MOCK_SNAP_ID,
+          request: { method: 'foo' },
+          type: AccountsSnapHandlerType.Keyring,
+        },
+      })) as JsonRpcFailure;
+
+      expect(response.error).toStrictEqual({
+        ...rpcErrors
+          .invalidRequest({
+            message: 'Failed to start snap.',
+          })
+          .serialize(),
+        stack: expect.any(String),
+      });
+    });
+
+    it('fails if origin is not authorized to call the method', async () => {
+      const { implementation } = invokeAccountSnapHandler;
+
+      const hooks = getMockHooks();
+
+      hooks.hasPermission.mockImplementation(() => true);
+      hooks.getSnap.mockImplementation(() => getSnapObject());
+      hooks.handleSnapRpcRequest.mockImplementation(() => {
+        throw rpcErrors.invalidRequest({
+          message: 'Failed to start snap.',
+        });
+      });
+      hooks.getAllowedKeyringMethods.mockImplementation(() => ['bar']);
+
+      const engine = new JsonRpcEngine();
+      engine.push(createOriginMiddleware('metamask.io'));
+      engine.push((req, res, next, end) => {
+        const result = implementation(
+          req as JsonRpcRequest<InvokeKeyringParams>,
+          res,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = (await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'wallet_invokeAccountsSnap',
+        params: {
+          snapId: MOCK_SNAP_ID,
+          request: { method: 'foo' },
+          type: AccountsSnapHandlerType.Keyring,
+        },
+      })) as JsonRpcFailure;
+
+      expect(response.error).toStrictEqual({
+        ...rpcErrors
+          .invalidRequest({
+            message:
+              'The origin "metamask.io" is not allowed to invoke the method "foo".',
+          })
+          .serialize(),
+        stack: expect.any(String),
+      });
+    });
+
+    it("fails if the request doesn't have a method name", async () => {
+      const { implementation } = invokeAccountSnapHandler;
+
+      const hooks = getMockHooks();
+
+      hooks.hasPermission.mockImplementation(() => true);
+      hooks.getSnap.mockImplementation(() => getSnapObject());
+      hooks.handleSnapRpcRequest.mockImplementation(() => {
+        throw rpcErrors.invalidRequest({
+          message: 'Failed to start snap.',
+        });
+      });
+      hooks.getAllowedKeyringMethods.mockImplementation(() => ['foo']);
+
+      const engine = new JsonRpcEngine();
+      engine.push(createOriginMiddleware('metamask.io'));
+      engine.push((req, res, next, end) => {
+        const result = implementation(
+          req as JsonRpcRequest<InvokeKeyringParams>,
+          res,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = (await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'wallet_invokeAccountsSnap',
+        params: {
+          snapId: MOCK_SNAP_ID,
+          request: { something: 'foo' },
+          type: AccountsSnapHandlerType.Keyring,
+        },
+      })) as JsonRpcFailure;
+
+      expect(response.error).toStrictEqual({
+        ...rpcErrors
+          .invalidRequest({ message: 'The request must have a method.' })
+          .serialize(),
+        stack: expect.any(String),
+      });
+    });
+
+    it("fails if the origin doesn't have the permission to invoke the snap", async () => {
+      const { implementation } = invokeAccountSnapHandler;
+
+      const hooks = getMockHooks();
+
+      hooks.hasPermission.mockImplementation(() => false);
+
+      const engine = new JsonRpcEngine();
+      engine.push(createOriginMiddleware('metamask.io'));
+      engine.push((req, res, next, end) => {
+        const result = implementation(
+          req as JsonRpcRequest<InvokeKeyringParams>,
+          res,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = (await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'wallet_invokeAccountsSnap',
+        params: {
+          snapId: MOCK_SNAP_ID,
+          request: { method: 'foo' },
+          type: AccountsSnapHandlerType.Keyring,
+        },
+      })) as JsonRpcFailure;
+
+      expect(response.error).toStrictEqual({
+        ...rpcErrors
+          .invalidRequest({
+            message: `The snap "${MOCK_SNAP_ID}" is not connected to "metamask.io". Please connect before invoking the snap.`,
+          })
+          .serialize(),
+        stack: expect.any(String),
+      });
+    });
+
+    it('fails if the snap is not installed', async () => {
+      const { implementation } = invokeAccountSnapHandler;
+
+      const hooks = getMockHooks();
+
+      hooks.hasPermission.mockImplementation(() => true);
+      hooks.getSnap.mockImplementation(() => undefined);
+
+      const engine = new JsonRpcEngine();
+      engine.push(createOriginMiddleware('metamask.io'));
+      engine.push((req, res, next, end) => {
+        const result = implementation(
+          req as JsonRpcRequest<InvokeKeyringParams>,
+          res,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = (await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'wallet_invokeAccountsSnap',
+        params: {
+          snapId: MOCK_SNAP_ID,
+          request: { method: 'foo' },
+          type: AccountsSnapHandlerType.Keyring,
+        },
+      })) as JsonRpcFailure;
+
+      expect(response.error).toStrictEqual({
+        ...rpcErrors
+          .invalidRequest({
+            message: `The snap "${MOCK_SNAP_ID}" is not installed. Please install it first, before invoking the snap.`,
+          })
+          .serialize(),
+        stack: expect.any(String),
+      });
+    });
+
+    it('fails if params are invalid', async () => {
+      const { implementation } = invokeAccountSnapHandler;
+
+      const hooks = getMockHooks();
+
+      const engine = new JsonRpcEngine();
+      engine.push((req, res, next, end) => {
+        const result = implementation(
+          req as JsonRpcRequest<InvokeKeyringParams>,
+          res,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = (await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'wallet_invokeAccountsSnap',
+        params: {
+          request: [],
+        },
+      })) as JsonRpcFailure;
+
+      expect(response.error).toStrictEqual({
+        ...rpcErrors
+          .invalidParams({
+            message: 'Must specify a valid snap ID.',
+          })
+          .serialize(),
+        stack: expect.any(String),
+      });
+    });
+  });
+});

--- a/packages/snaps-rpc-methods/src/permitted/invokeAccountsSnap.ts
+++ b/packages/snaps-rpc-methods/src/permitted/invokeAccountsSnap.ts
@@ -2,9 +2,8 @@ import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
 import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
 import type {
-  InvokeKeyringParams,
-  InvokeKeyringResult,
-  InvokeSnapParams,
+  InvokeAccountsSnapParams,
+  InvokeAccountsSnapResult,
 } from '@metamask/snaps-sdk';
 import { AccountsSnapHandlerType } from '@metamask/snaps-sdk';
 import type { Snap, SnapRpcHookArgs } from '@metamask/snaps-utils';
@@ -15,7 +14,7 @@ import { hasProperty, type Json } from '@metamask/utils';
 import type { MethodHooksObject } from '../utils';
 import { getValidatedParams } from './invokeSnapSugar';
 
-const hookNames: MethodHooksObject<InvokeKeyringHooks> = {
+const hookNames: MethodHooksObject<InvokeAccountsSnapHooks> = {
   hasPermission: true,
   handleSnapRpcRequest: true,
   getSnap: true,
@@ -26,16 +25,16 @@ const hookNames: MethodHooksObject<InvokeKeyringHooks> = {
  * `wallet_invokeAccountsSnap` invokes an account Snap.
  */
 export const invokeAccountSnapHandler: PermittedHandlerExport<
-  InvokeKeyringHooks,
-  InvokeSnapParams,
-  InvokeKeyringResult
+  InvokeAccountsSnapHooks,
+  InvokeAccountsSnapParams,
+  InvokeAccountsSnapResult
 > = {
   methodNames: ['wallet_invokeAccountsSnap'],
   implementation: invokeAccountSnapImplementation,
   hookNames,
 };
 
-export type InvokeKeyringHooks = {
+export type InvokeAccountsSnapHooks = {
   hasPermission: (permissionName: string) => boolean;
 
   handleSnapRpcRequest: ({
@@ -72,8 +71,8 @@ const HANDLER_MAP = Object.freeze({
  * @returns Nothing.
  */
 async function invokeAccountSnapImplementation(
-  req: JsonRpcRequest<InvokeKeyringParams>,
-  res: PendingJsonRpcResponse<InvokeKeyringResult>,
+  req: JsonRpcRequest<InvokeAccountsSnapParams>,
+  res: PendingJsonRpcResponse<InvokeAccountsSnapResult>,
   _next: unknown,
   end: JsonRpcEngineEndCallback,
   {
@@ -81,11 +80,11 @@ async function invokeAccountSnapImplementation(
     hasPermission,
     getSnap,
     getAllowedKeyringMethods,
-  }: InvokeKeyringHooks,
+  }: InvokeAccountsSnapHooks,
 ): Promise<void> {
-  let params: InvokeSnapParams;
+  let params: InvokeAccountsSnapParams;
   try {
-    params = getValidatedParams(req.params);
+    params = getValidatedParams(req.params) as InvokeAccountsSnapParams;
   } catch (error) {
     return end(error);
   }

--- a/packages/snaps-rpc-methods/src/permitted/invokeAccountsSnap.ts
+++ b/packages/snaps-rpc-methods/src/permitted/invokeAccountsSnap.ts
@@ -1,0 +1,153 @@
+import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
+import type { PermittedHandlerExport } from '@metamask/permission-controller';
+import { rpcErrors } from '@metamask/rpc-errors';
+import type {
+  InvokeKeyringParams,
+  InvokeKeyringResult,
+  InvokeSnapParams,
+} from '@metamask/snaps-sdk';
+import { AccountsSnapHandlerType } from '@metamask/snaps-sdk';
+import type { Snap, SnapRpcHookArgs } from '@metamask/snaps-utils';
+import { HandlerType, WALLET_SNAP_PERMISSION_KEY } from '@metamask/snaps-utils';
+import type { PendingJsonRpcResponse, JsonRpcRequest } from '@metamask/utils';
+import { hasProperty, type Json } from '@metamask/utils';
+
+import type { MethodHooksObject } from '../utils';
+import { getValidatedParams } from './invokeSnapSugar';
+
+const hookNames: MethodHooksObject<InvokeKeyringHooks> = {
+  hasPermission: true,
+  handleSnapRpcRequest: true,
+  getSnap: true,
+  getAllowedKeyringMethods: true,
+};
+
+/**
+ * `wallet_invokeAccountsSnap` invokes an account Snap.
+ */
+export const invokeAccountSnapHandler: PermittedHandlerExport<
+  InvokeKeyringHooks,
+  InvokeSnapParams,
+  InvokeKeyringResult
+> = {
+  methodNames: ['wallet_invokeAccountsSnap'],
+  implementation: invokeAccountSnapImplementation,
+  hookNames,
+};
+
+export type InvokeKeyringHooks = {
+  hasPermission: (permissionName: string) => boolean;
+
+  handleSnapRpcRequest: ({
+    snapId,
+    handler,
+    request,
+  }: Omit<SnapRpcHookArgs, 'origin'> & { snapId: string }) => Promise<unknown>;
+
+  getSnap: (snapId: string) => Snap | undefined;
+
+  getAllowedKeyringMethods: () => string[];
+};
+
+const HANDLER_MAP = Object.freeze({
+  [AccountsSnapHandlerType.Keyring]: HandlerType.OnKeyringRequest,
+  [AccountsSnapHandlerType.Chain]: HandlerType.OnAccountsChainRequest,
+});
+
+/**
+ * The `wallet_invokeAccountsSnap` method implementation.
+ * Invokes onKeyringRequest or onAccountsChainRequest if the snap requested is installed and connected to the dapp.
+ *
+ * @param req - The JSON-RPC request object.
+ * @param res - The JSON-RPC response object.
+ * @param _next - The `json-rpc-engine` "next" callback. Not used by this
+ * function.
+ * @param end - The `json-rpc-engine` "end" callback.
+ * @param hooks - The RPC method hooks.
+ * @param hooks.handleSnapRpcRequest - Invokes a snap with a given RPC request.
+ * @param hooks.hasPermission - Checks whether a given origin has a given permission.
+ * @param hooks.getSnap - Gets information about a given snap.
+ * @param hooks.getAllowedKeyringMethods - Get the list of allowed Keyring
+ * methods for a given origin.
+ * @returns Nothing.
+ */
+async function invokeAccountSnapImplementation(
+  req: JsonRpcRequest<InvokeKeyringParams>,
+  res: PendingJsonRpcResponse<InvokeKeyringResult>,
+  _next: unknown,
+  end: JsonRpcEngineEndCallback,
+  {
+    handleSnapRpcRequest,
+    hasPermission,
+    getSnap,
+    getAllowedKeyringMethods,
+  }: InvokeKeyringHooks,
+): Promise<void> {
+  let params: InvokeSnapParams;
+  try {
+    params = getValidatedParams(req.params);
+  } catch (error) {
+    return end(error);
+  }
+
+  // We expect the MM middleware stack to always add the origin to requests
+  const { origin } = req as JsonRpcRequest & { origin: string };
+  const { snapId, request, type } = params;
+
+  if (!origin || !hasPermission(WALLET_SNAP_PERMISSION_KEY)) {
+    return end(
+      rpcErrors.invalidRequest({
+        message: `The snap "${snapId}" is not connected to "${origin}". Please connect before invoking the snap.`,
+      }),
+    );
+  }
+
+  const handler = HANDLER_MAP[type];
+
+  if (!handler) {
+    return end(
+      rpcErrors.invalidParams({
+        message: `The handler type "${type}" does not exist.`,
+      }),
+    );
+  }
+
+  if (!getSnap(snapId)) {
+    return end(
+      rpcErrors.invalidRequest({
+        message: `The snap "${snapId}" is not installed. Please install it first, before invoking the snap.`,
+      }),
+    );
+  }
+
+  if (!hasProperty(request, 'method') || typeof request.method !== 'string') {
+    return end(
+      rpcErrors.invalidRequest({
+        message: 'The request must have a method.',
+      }),
+    );
+  }
+
+  if (type === AccountsSnapHandlerType.Keyring) {
+    const allowedMethods = getAllowedKeyringMethods();
+    if (!allowedMethods.includes(request.method)) {
+      return end(
+        rpcErrors.invalidRequest({
+          message: `The origin "${origin}" is not allowed to invoke the method "${request.method}".`,
+        }),
+      );
+    }
+  }
+
+  try {
+    res.result = (await handleSnapRpcRequest({
+      snapId,
+      request,
+      handler,
+    })) as Json;
+  } catch (error) {
+    return end(error);
+  }
+
+  return end();
+}

--- a/packages/snaps-rpc-methods/src/permitted/invokeKeyring.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/invokeKeyring.test.ts
@@ -1,11 +1,10 @@
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
-import { rpcErrors } from '@metamask/rpc-errors';
 import type { InvokeKeyringParams } from '@metamask/snaps-sdk';
-import { HandlerType } from '@metamask/snaps-utils';
-import { MOCK_SNAP_ID, getSnapObject } from '@metamask/snaps-utils/test-utils';
+import { AccountsSnapHandlerType } from '@metamask/snaps-sdk';
+import { MOCK_SNAP_ID } from '@metamask/snaps-utils/test-utils';
 import type {
-  JsonRpcRequest,
   JsonRpcFailure,
+  JsonRpcRequest,
   JsonRpcSuccess,
 } from '@metamask/utils';
 
@@ -18,28 +17,16 @@ describe('wallet_invokeKeyring', () => {
         methodNames: ['wallet_invokeKeyring'],
         implementation: expect.any(Function),
         hookNames: {
-          getSnap: true,
-          handleSnapRpcRequest: true,
-          hasPermission: true,
+          invokeAccountSnap: true,
         },
       });
     });
   });
-  describe('invokeKeyringImplementation', () => {
-    // Mirror the origin middleware in the extension
-    const createOriginMiddleware =
-      (origin: string) =>
-      (request: any, _response: unknown, next: () => void, _end: unknown) => {
-        request.origin = origin;
-        next();
-      };
 
+  describe('invokeKeyringImplementation', () => {
     const getMockHooks = () =>
       ({
-        getSnap: jest.fn(),
-        hasPermission: jest.fn(),
-        handleSnapRpcRequest: jest.fn(),
-        getAllowedKeyringMethods: jest.fn(),
+        invokeAccountSnap: jest.fn(),
       } as any);
 
     it('invokes the snap and returns the result', async () => {
@@ -47,13 +34,9 @@ describe('wallet_invokeKeyring', () => {
 
       const hooks = getMockHooks();
 
-      hooks.hasPermission.mockImplementation(() => true);
-      hooks.getSnap.mockImplementation(() => getSnapObject());
-      hooks.handleSnapRpcRequest.mockImplementation(() => 'bar');
-      hooks.getAllowedKeyringMethods.mockImplementation(() => ['foo']);
+      hooks.invokeAccountSnap.mockImplementation(() => 'bar');
 
       const engine = new JsonRpcEngine();
-      engine.push(createOriginMiddleware('metamask.io'));
       engine.push((req, res, next, end) => {
         const result = implementation(
           req as JsonRpcRequest<InvokeKeyringParams>,
@@ -73,244 +56,19 @@ describe('wallet_invokeKeyring', () => {
         params: {
           snapId: MOCK_SNAP_ID,
           request: { method: 'foo' },
+          type: AccountsSnapHandlerType.Keyring,
         },
       })) as JsonRpcSuccess<string>;
 
       expect(response.result).toBe('bar');
-      expect(hooks.handleSnapRpcRequest).toHaveBeenCalledWith({
-        handler: HandlerType.OnKeyringRequest,
+      expect(hooks.invokeAccountSnap).toHaveBeenCalledWith({
         request: { method: 'foo' },
         snapId: MOCK_SNAP_ID,
+        type: AccountsSnapHandlerType.Keyring,
       });
     });
 
-    it('fails if invoking the snap fails', async () => {
-      const { implementation } = invokeKeyringHandler;
-
-      const hooks = getMockHooks();
-
-      hooks.hasPermission.mockImplementation(() => true);
-      hooks.getSnap.mockImplementation(() => getSnapObject());
-      hooks.handleSnapRpcRequest.mockImplementation(() => {
-        throw rpcErrors.invalidRequest({
-          message: 'Failed to start snap.',
-        });
-      });
-      hooks.getAllowedKeyringMethods.mockImplementation(() => ['foo']);
-
-      const engine = new JsonRpcEngine();
-      engine.push(createOriginMiddleware('metamask.io'));
-      engine.push((req, res, next, end) => {
-        const result = implementation(
-          req as JsonRpcRequest<InvokeKeyringParams>,
-          res,
-          next,
-          end,
-          hooks,
-        );
-
-        result?.catch(end);
-      });
-
-      const response = (await engine.handle({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'wallet_invokeKeyring',
-        params: {
-          snapId: MOCK_SNAP_ID,
-          request: { method: 'foo' },
-        },
-      })) as JsonRpcFailure;
-
-      expect(response.error).toStrictEqual({
-        ...rpcErrors
-          .invalidRequest({
-            message: 'Failed to start snap.',
-          })
-          .serialize(),
-        stack: expect.any(String),
-      });
-    });
-
-    it('fails if origin is not authorized to call the method', async () => {
-      const { implementation } = invokeKeyringHandler;
-
-      const hooks = getMockHooks();
-
-      hooks.hasPermission.mockImplementation(() => true);
-      hooks.getSnap.mockImplementation(() => getSnapObject());
-      hooks.handleSnapRpcRequest.mockImplementation(() => {
-        throw rpcErrors.invalidRequest({
-          message: 'Failed to start snap.',
-        });
-      });
-      hooks.getAllowedKeyringMethods.mockImplementation(() => ['bar']);
-
-      const engine = new JsonRpcEngine();
-      engine.push(createOriginMiddleware('metamask.io'));
-      engine.push((req, res, next, end) => {
-        const result = implementation(
-          req as JsonRpcRequest<InvokeKeyringParams>,
-          res,
-          next,
-          end,
-          hooks,
-        );
-
-        result?.catch(end);
-      });
-
-      const response = (await engine.handle({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'wallet_invokeKeyring',
-        params: {
-          snapId: MOCK_SNAP_ID,
-          request: { method: 'foo' },
-        },
-      })) as JsonRpcFailure;
-
-      expect(response.error).toStrictEqual({
-        ...rpcErrors
-          .invalidRequest({
-            message:
-              'The origin "metamask.io" is not allowed to invoke the method "foo".',
-          })
-          .serialize(),
-        stack: expect.any(String),
-      });
-    });
-
-    it("fails if the request doesn't have a method name", async () => {
-      const { implementation } = invokeKeyringHandler;
-
-      const hooks = getMockHooks();
-
-      hooks.hasPermission.mockImplementation(() => true);
-      hooks.getSnap.mockImplementation(() => getSnapObject());
-      hooks.handleSnapRpcRequest.mockImplementation(() => {
-        throw rpcErrors.invalidRequest({
-          message: 'Failed to start snap.',
-        });
-      });
-      hooks.getAllowedKeyringMethods.mockImplementation(() => ['foo']);
-
-      const engine = new JsonRpcEngine();
-      engine.push(createOriginMiddleware('metamask.io'));
-      engine.push((req, res, next, end) => {
-        const result = implementation(
-          req as JsonRpcRequest<InvokeKeyringParams>,
-          res,
-          next,
-          end,
-          hooks,
-        );
-
-        result?.catch(end);
-      });
-
-      const response = (await engine.handle({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'wallet_invokeKeyring',
-        params: {
-          snapId: MOCK_SNAP_ID,
-          request: { something: 'foo' },
-        },
-      })) as JsonRpcFailure;
-
-      expect(response.error).toStrictEqual({
-        ...rpcErrors
-          .invalidRequest({ message: 'The request must have a method.' })
-          .serialize(),
-        stack: expect.any(String),
-      });
-    });
-
-    it("fails if the origin doesn't have the permission to invoke the snap", async () => {
-      const { implementation } = invokeKeyringHandler;
-
-      const hooks = getMockHooks();
-
-      hooks.hasPermission.mockImplementation(() => false);
-
-      const engine = new JsonRpcEngine();
-      engine.push(createOriginMiddleware('metamask.io'));
-      engine.push((req, res, next, end) => {
-        const result = implementation(
-          req as JsonRpcRequest<InvokeKeyringParams>,
-          res,
-          next,
-          end,
-          hooks,
-        );
-
-        result?.catch(end);
-      });
-
-      const response = (await engine.handle({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'wallet_invokeKeyring',
-        params: {
-          snapId: MOCK_SNAP_ID,
-          request: { method: 'foo' },
-        },
-      })) as JsonRpcFailure;
-
-      expect(response.error).toStrictEqual({
-        ...rpcErrors
-          .invalidRequest({
-            message: `The snap "${MOCK_SNAP_ID}" is not connected to "metamask.io". Please connect before invoking the snap.`,
-          })
-          .serialize(),
-        stack: expect.any(String),
-      });
-    });
-
-    it('fails if the snap is not installed', async () => {
-      const { implementation } = invokeKeyringHandler;
-
-      const hooks = getMockHooks();
-
-      hooks.hasPermission.mockImplementation(() => true);
-      hooks.getSnap.mockImplementation(() => undefined);
-
-      const engine = new JsonRpcEngine();
-      engine.push(createOriginMiddleware('metamask.io'));
-      engine.push((req, res, next, end) => {
-        const result = implementation(
-          req as JsonRpcRequest<InvokeKeyringParams>,
-          res,
-          next,
-          end,
-          hooks,
-        );
-
-        result?.catch(end);
-      });
-
-      const response = (await engine.handle({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'wallet_invokeKeyring',
-        params: {
-          snapId: MOCK_SNAP_ID,
-          request: { method: 'foo' },
-        },
-      })) as JsonRpcFailure;
-
-      expect(response.error).toStrictEqual({
-        ...rpcErrors
-          .invalidRequest({
-            message: `The snap "${MOCK_SNAP_ID}" is not installed. Please install it first, before invoking the snap.`,
-          })
-          .serialize(),
-        stack: expect.any(String),
-      });
-    });
-
-    it('fails if params are invalid', async () => {
+    it('throws if the params is not an object', async () => {
       const { implementation } = invokeKeyringHandler;
 
       const hooks = getMockHooks();
@@ -332,19 +90,12 @@ describe('wallet_invokeKeyring', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'wallet_invokeKeyring',
-        params: {
-          request: [],
-        },
+        params: [],
       })) as JsonRpcFailure;
 
-      expect(response.error).toStrictEqual({
-        ...rpcErrors
-          .invalidParams({
-            message: 'Must specify a valid snap ID.',
-          })
-          .serialize(),
-        stack: expect.any(String),
-      });
+      expect(response.error.message).toBe(
+        'Expected params to be a single object.',
+      );
     });
   });
 });

--- a/packages/snaps-rpc-methods/src/permitted/invokeKeyring.ts
+++ b/packages/snaps-rpc-methods/src/permitted/invokeKeyring.ts
@@ -1,24 +1,20 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
 import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
-import type {
-  InvokeKeyringParams,
-  InvokeKeyringResult,
-  InvokeSnapParams,
+import {
+  AccountsSnapHandlerType,
+  type InvokeAccountsSnapParams,
+  type InvokeKeyringParams,
+  type InvokeKeyringResult,
+  type InvokeSnapParams,
 } from '@metamask/snaps-sdk';
-import type { Snap, SnapRpcHookArgs } from '@metamask/snaps-utils';
-import { HandlerType, WALLET_SNAP_PERMISSION_KEY } from '@metamask/snaps-utils';
 import type { PendingJsonRpcResponse, JsonRpcRequest } from '@metamask/utils';
-import { hasProperty, type Json } from '@metamask/utils';
+import { isObject, type Json } from '@metamask/utils';
 
 import type { MethodHooksObject } from '../utils';
-import { getValidatedParams } from './invokeSnapSugar';
 
 const hookNames: MethodHooksObject<InvokeKeyringHooks> = {
-  hasPermission: true,
-  handleSnapRpcRequest: true,
-  getSnap: true,
-  getAllowedKeyringMethods: true,
+  invokeAccountSnap: true,
 };
 
 /**
@@ -35,17 +31,7 @@ export const invokeKeyringHandler: PermittedHandlerExport<
 };
 
 export type InvokeKeyringHooks = {
-  hasPermission: (permissionName: string) => boolean;
-
-  handleSnapRpcRequest: ({
-    snapId,
-    handler,
-    request,
-  }: Omit<SnapRpcHookArgs, 'origin'> & { snapId: string }) => Promise<unknown>;
-
-  getSnap: (snapId: string) => Snap | undefined;
-
-  getAllowedKeyringMethods: () => string[];
+  invokeAccountSnap: (params: InvokeAccountsSnapParams) => Promise<unknown>;
 };
 
 /**
@@ -58,11 +44,8 @@ export type InvokeKeyringHooks = {
  * function.
  * @param end - The `json-rpc-engine` "end" callback.
  * @param hooks - The RPC method hooks.
- * @param hooks.handleSnapRpcRequest - Invokes a snap with a given RPC request.
- * @param hooks.hasPermission - Checks whether a given origin has a given permission.
- * @param hooks.getSnap - Gets information about a given snap.
- * @param hooks.getAllowedKeyringMethods - Get the list of allowed Keyring
- * methods for a given origin.
+ * @param hooks.invokeAccountSnap - A function to invoke an account Snap designated by its parameters,
+ * bound to the requesting origin.
  * @returns Nothing.
  */
 async function invokeKeyringImplementation(
@@ -70,62 +53,21 @@ async function invokeKeyringImplementation(
   res: PendingJsonRpcResponse<InvokeKeyringResult>,
   _next: unknown,
   end: JsonRpcEngineEndCallback,
-  {
-    handleSnapRpcRequest,
-    hasPermission,
-    getSnap,
-    getAllowedKeyringMethods,
-  }: InvokeKeyringHooks,
+  { invokeAccountSnap }: InvokeKeyringHooks,
 ): Promise<void> {
-  let params: InvokeSnapParams;
   try {
-    params = getValidatedParams(req.params);
-  } catch (error) {
-    return end(error);
-  }
+    const { params } = req;
 
-  // We expect the MM middleware stack to always add the origin to requests
-  const { origin } = req as JsonRpcRequest & { origin: string };
-  const { snapId, request } = params;
+    if (!isObject(params)) {
+      throw rpcErrors.invalidParams({
+        message: 'Expected params to be a single object.',
+      });
+    }
 
-  if (!origin || !hasPermission(WALLET_SNAP_PERMISSION_KEY)) {
-    return end(
-      rpcErrors.invalidRequest({
-        message: `The snap "${snapId}" is not connected to "${origin}". Please connect before invoking the snap.`,
-      }),
-    );
-  }
-
-  if (!getSnap(snapId)) {
-    return end(
-      rpcErrors.invalidRequest({
-        message: `The snap "${snapId}" is not installed. Please install it first, before invoking the snap.`,
-      }),
-    );
-  }
-
-  if (!hasProperty(request, 'method') || typeof request.method !== 'string') {
-    return end(
-      rpcErrors.invalidRequest({
-        message: 'The request must have a method.',
-      }),
-    );
-  }
-
-  const allowedMethods = getAllowedKeyringMethods();
-  if (!allowedMethods.includes(request.method)) {
-    return end(
-      rpcErrors.invalidRequest({
-        message: `The origin "${origin}" is not allowed to invoke the method "${request.method}".`,
-      }),
-    );
-  }
-
-  try {
-    res.result = (await handleSnapRpcRequest({
-      snapId,
-      request,
-      handler: HandlerType.OnKeyringRequest,
+    res.result = (await invokeAccountSnap({
+      snapId: params.snapId,
+      request: params.request,
+      type: AccountsSnapHandlerType.Keyring,
     })) as Json;
   } catch (error) {
     return end(error);

--- a/packages/snaps-sdk/src/types/handlers/accounts-chain.ts
+++ b/packages/snaps-sdk/src/types/handlers/accounts-chain.ts
@@ -1,0 +1,23 @@
+import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
+
+/**
+ * The `onAccountsChainRequest` handler, which is called when a Snap receives a
+ * accounts chain request.
+ *
+ * Note that using this handler requires the `endowment:accounts-chain` permission.
+ *
+ * @param args - The request arguments.
+ * @param args.origin - The origin of the request. This can be the ID of another
+ * Snap, or the URL of a website.
+ * @param args.request - The keyring request sent to the Snap. This includes
+ * the method name and parameters.
+ * @returns The response to the keyring request. This must be a
+ * JSON-serializable value. In order to return an error, throw a `SnapError`
+ * instead.
+ */
+export type OnAccountsChainRequestHandler<
+  Params extends JsonRpcParams = JsonRpcParams,
+> = (args: {
+  origin: string;
+  request: JsonRpcRequest<Params>;
+}) => Promise<Json>;

--- a/packages/snaps-sdk/src/types/methods/index.ts
+++ b/packages/snaps-sdk/src/types/methods/index.ts
@@ -9,6 +9,7 @@ export * from './get-file';
 export * from './get-interface-state';
 export * from './get-locale';
 export * from './get-snaps';
+export * from './invoke-accounts-snap';
 export * from './invoke-keyring';
 export * from './invoke-snap';
 export * from './manage-accounts';

--- a/packages/snaps-sdk/src/types/methods/invoke-accounts-snap.test.ts
+++ b/packages/snaps-sdk/src/types/methods/invoke-accounts-snap.test.ts
@@ -1,0 +1,9 @@
+import { AccountsSnapHandlerType } from './invoke-accounts-snap';
+
+describe('AccountsSnapHandlerType', () => {
+  it('has the correct values', () => {
+    expect(Object.values(AccountsSnapHandlerType)).toHaveLength(2);
+    expect(AccountsSnapHandlerType.Keyring).toBe('keyring');
+    expect(AccountsSnapHandlerType.Chain).toBe('chain');
+  });
+});

--- a/packages/snaps-sdk/src/types/methods/invoke-accounts-snap.ts
+++ b/packages/snaps-sdk/src/types/methods/invoke-accounts-snap.ts
@@ -1,0 +1,25 @@
+import type { Json } from '@metamask/utils';
+
+import type { InvokeSnapParams } from './invoke-snap';
+
+export enum AccountsSnapHandlerType {
+  Keyring = 'keyring',
+  Chain = 'chain',
+}
+
+/**
+ * The request parameters for the `wallet_invokeAccountsSnap` method.
+ *
+ * @property snapId - The ID of the snap to invoke.
+ * @property request - The JSON-RPC request to send to the snap.
+ * @property type - The type of handler to invoke.
+ */
+export type InvokeAccountsSnapParams = InvokeSnapParams & {
+  type: AccountsSnapHandlerType;
+};
+
+/**
+ * The result returned by the `wallet_invokeAccountsSnap` method, which is the result
+ * returned by the Snap.
+ */
+export type InvokeAccountsSnapResult = Json;

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 96.7,
-  "functions": 98.72,
+  "functions": 98.73,
   "lines": 98.81,
-  "statements": 94.79
+  "statements": 94.8
 }

--- a/packages/snaps-utils/src/handler-types.ts
+++ b/packages/snaps-utils/src/handler-types.ts
@@ -7,6 +7,7 @@ export enum HandlerType {
   OnUpdate = 'onUpdate',
   OnNameLookup = 'onNameLookup',
   OnKeyringRequest = 'onKeyringRequest',
+  OnAccountsChainRequest = 'onAccountsChainRequest',
   OnHomePage = 'onHomePage',
   OnUserInput = 'onUserInput',
 }

--- a/packages/snaps-utils/src/handlers.ts
+++ b/packages/snaps-utils/src/handlers.ts
@@ -82,6 +82,13 @@ export const SNAP_EXPORTS = {
       return typeof snapExport === 'function';
     },
   },
+  [HandlerType.OnAccountsChainRequest]: {
+    type: HandlerType.OnAccountsChainRequest,
+    required: true,
+    validator: (snapExport: unknown): snapExport is OnUserInputHandler => {
+      return typeof snapExport === 'function';
+    },
+  },
   [HandlerType.OnHomePage]: {
     type: HandlerType.OnHomePage,
     required: true,

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -199,6 +199,12 @@ export const PermissionsStruct: Describe<InitialPermissions> = type({
   'endowment:keyring': optional(
     assign(HandlerCaveatsStruct, KeyringOriginsStruct),
   ),
+  'endowment:accounts-chain': optional(
+    assign(
+      HandlerCaveatsStruct,
+      assign(KeyringOriginsStruct, object({ chains: ChainIdsStruct })),
+    ),
+  ),
   'endowment:lifecycle-hooks': optional(HandlerCaveatsStruct),
   'endowment:name-lookup': optional(
     assign(


### PR DESCRIPTION
Adds a new endowment: `endowment:accounts-chain`, which can be used to expose `onAccountsChainRequest`, and is in many ways identical to `endowment:keyring`.

```
  "initialPermissions": {
    "endowment:accounts-chain": {
      "chains": [
        "bip122:000000000019d6689c085ae165831e93"
      ],
      "allowedOrigins": [
        "http://localhost:8080"
      ]
    }
  },
```

Also adds a new RPC method `wallet_invokeAccountsSnap` which allows routing requests to either `onKeyringRequest` or `onAccountsChainRequest` using a `type` parameter. Otherwise the RPC method is identical to `wallet_invokeKeyring`.

`wallet_invokeKeyring` is now effectively an alias of `wallet_invokeAccountsSnap`, in a similar fashion to `wallet_invokeSnap`.

WIP

Progresses https://github.com/MetaMask/snaps/issues/2355