### PR TITLE
feat: provide origin to lifecycle hooks

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -8865,7 +8865,7 @@ describe('SnapController', () => {
         MOCK_SNAP_ID,
         {
           handler: HandlerType.OnInstall,
-          origin: '',
+          origin: MOCK_ORIGIN,
           request: {
             jsonrpc: '2.0',
             id: expect.any(String),
@@ -9008,7 +9008,7 @@ describe('SnapController', () => {
         MOCK_SNAP_ID,
         {
           handler: HandlerType.OnUpdate,
-          origin: '',
+          origin: MOCK_ORIGIN,
           request: {
             jsonrpc: '2.0',
             id: expect.any(String),

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 80,
   "functions": 90.06,
-  "lines": 90.76,
-  "statements": 90.13
+  "lines": 90.77,
+  "statements": 90.15
 }

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1615,7 +1615,7 @@ describe('BaseSnapExecutor', () => {
       // eslint-disable-next-line no-loop-func
       it(`supports \`${handler}\` export`, async () => {
         const CODE = `
-          module.exports.${handler} = ({ request }) => request.params[0];
+          module.exports.${handler} = ({ origin }) => origin;
         `;
 
         const executor = new TestSnapExecutor();
@@ -1635,14 +1635,14 @@ describe('BaseSnapExecutor', () => {
             MOCK_SNAP_ID,
             handler,
             MOCK_ORIGIN,
-            { jsonrpc: '2.0', method: 'foo', params: ['bar'] },
+            { jsonrpc: '2.0', method: handler },
           ],
         });
 
         expect(await executor.readCommand()).toStrictEqual({
           id: 2,
           jsonrpc: '2.0',
-          result: 'bar',
+          result: MOCK_ORIGIN,
         });
       });
 

--- a/packages/snaps-execution-environments/src/common/commands.ts
+++ b/packages/snaps-execution-environments/src/common/commands.ts
@@ -79,9 +79,11 @@ export function getHandlerArguments(
       return { origin, request };
 
     case HandlerType.OnCronjob:
+      return { request };
+
     case HandlerType.OnInstall:
     case HandlerType.OnUpdate:
-      return { request };
+      return { origin };
 
     case HandlerType.OnHomePage:
       return {};

--- a/packages/snaps-sdk/src/types/handlers/lifecycle.ts
+++ b/packages/snaps-sdk/src/types/handlers/lifecycle.ts
@@ -1,5 +1,3 @@
-import type { JsonRpcRequest } from '@metamask/utils';
-
 /**
  * A lifecycle event handler. This is called whenever a lifecycle event occurs,
  * such as the Snap being installed or updated.
@@ -8,11 +6,10 @@ import type { JsonRpcRequest } from '@metamask/utils';
  * permission.
  *
  * @param args - The request arguments.
- * @param args.request - The JSON-RPC request sent to the Snap. This does not
- * contain any parameters.
+ * @param args.origin - The origin that triggered the lifecycle event hook.
  */
 export type LifecycleEventHandler = (args: {
-  request: JsonRpcRequest;
+  origin: string;
 }) => Promise<unknown>;
 
 /**
@@ -24,8 +21,7 @@ export type LifecycleEventHandler = (args: {
  * This type is an alias for {@link LifecycleEventHandler}.
  *
  * @param args - The request arguments.
- * @param args.request - The JSON-RPC request sent to the Snap. This does not
- * contain any parameters.
+ * @param args.origin - The origin that triggered the lifecycle event hook.
  */
 export type OnInstallHandler = LifecycleEventHandler;
 
@@ -38,7 +34,6 @@ export type OnInstallHandler = LifecycleEventHandler;
  * This type is an alias for {@link LifecycleEventHandler}.
  *
  * @param args - The request arguments.
- * @param args.request - The JSON-RPC request sent to the Snap. This does not
- * contain any parameters.
+ * @param args.origin - The origin that triggered the lifecycle event hook.
  */
 export type OnUpdateHandler = LifecycleEventHandler;


### PR DESCRIPTION
Provide the `origin` parameter to lifecycle hooks, the origin will be the origin that originally triggered the install or update process.

This PR also removes `request` from the handler since this is unused and [undocumented](https://docs.metamask.io/snaps/features/lifecycle-hooks/#2-run-an-action-on-installation).