### PR TITLE
Add files for `react-native` export compatibility

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -196,6 +196,7 @@ gen_enforced_field(WorkspaceCwd, 'files', ['dist']) :-
   WorkspaceCwd \= '.',
   WorkspaceCwd \= 'packages/snaps-jest',
   WorkspaceCwd \= 'packages/snaps-cli',
+  WorkspaceCwd \= 'packages/snaps-controllers',
   WorkspaceCwd \= 'packages/snaps-sdk'.
 gen_enforced_field(WorkspaceCwd, 'files', ['dist', 'jest-preset.js']) :-
   WorkspaceCwd = 'packages/snaps-jest'.

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -29,7 +29,9 @@
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "react-native.d.ts",
+    "react-native.js"
   ],
   "scripts": {
     "test:prepare": "yarn mkdirp test/fixtures && ./scripts/generate-fixtures.sh",

--- a/packages/snaps-controllers/react-native.d.ts
+++ b/packages/snaps-controllers/react-native.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types/react-native';

--- a/packages/snaps-controllers/react-native.js
+++ b/packages/snaps-controllers/react-native.js
@@ -1,0 +1,5 @@
+/* eslint-disable */
+
+// Re-exported for compatibility with build tools that don't support the
+// `exports` field in package.json
+module.exports = require('./dist/react-native');

--- a/packages/snaps-controllers/tsconfig.json
+++ b/packages/snaps-controllers/tsconfig.json
@@ -3,7 +3,13 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "include": ["./src", "scripts", "package.json", "tsup.config.ts"],
+  "include": [
+    "./src",
+    "scripts",
+    "package.json",
+    "tsup.config.ts",
+    "react-native.d.ts"
+  ],
   "references": [
     { "path": "../snaps-execution-environments" },
     { "path": "../snaps-rpc-methods" },


### PR DESCRIPTION
`@metamask/snaps-controllers` has a `/react-native` export, but React Native seemingly doesn't support exports (or at least the version we use in the mobile repository)? This adds a `react-native.js` and `react-native.d.ts` file to support tools that don't support exports.