### PR TITLE
fix: correct JSX runtime path in tsconfig

### DIFF
--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -11,8 +11,8 @@
     "paths": {
       "@metamask/*/test-utils": ["../*/src/test-utils"],
       "@metamask/*/node": ["../*/src/node"],
-      "@metamask/*/jsx-dev-runtime": ["../*/src/jsx"],
-      "@metamask/*/jsx-runtime": ["../*/src/jsx"],
+      "@metamask/*/jsx-dev-runtime": ["../*/src/jsx/jsx-dev-runtime.ts"],
+      "@metamask/*/jsx-runtime": ["../*/src/jsx/jsx-runtime.ts"],
       "@metamask/*/jsx": ["../*/src/jsx"],
       "@metamask/*": ["../*/src"]
     },


### PR DESCRIPTION
Modifies TS paths to point more directly to the JSX runtime. This prevents problems where TS would incorrectly use an import of `/jsx-runtime`.

```
    children: import("@metamask/snaps-sdk/jsx-runtime").MaybeArray<import("@metamask/snaps-sdk/jsx-runtime").SnapElement<{
        value: string;
        children: string;
    }, "Option">>;
```


