### PR TITLE
feat: allow wildcards in `allowedOrigins`

### DIFF
--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 96.71,
-  "functions": 98.74,
-  "lines": 98.82,
-  "statements": 94.83
+  "branches": 96.73,
+  "functions": 98.75,
+  "lines": 98.83,
+  "statements": 94.85
 }

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 96.72,
-  "functions": 98.75,
+  "branches": 96.71,
+  "functions": 98.74,
   "lines": 98.82,
-  "statements": 94.84
+  "statements": 94.83
 }

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 96.7,
-  "functions": 98.73,
+  "branches": 96.72,
+  "functions": 98.75,
   "lines": 98.82,
-  "statements": 94.81
+  "statements": 94.84
 }

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 96.7,
-  "functions": 98.72,
-  "lines": 98.81,
-  "statements": 94.79
+  "functions": 98.73,
+  "lines": 98.82,
+  "statements": 94.81
 }

--- a/packages/snaps-utils/src/json-rpc.test.ts
+++ b/packages/snaps-utils/src/json-rpc.test.ts
@@ -152,6 +152,81 @@ describe('isOriginAllowed', () => {
     expect(isOriginAllowed(origins, SubjectType.Snap, 'foo')).toBe(false);
     expect(isOriginAllowed(origins, SubjectType.Website, 'bar')).toBe(false);
   });
+
+  it('supports wildcards', () => {
+    const origins: RpcOrigins = {
+      allowedOrigins: ['*'],
+    };
+
+    expect(isOriginAllowed(origins, SubjectType.Snap, 'foo')).toBe(true);
+    expect(isOriginAllowed(origins, SubjectType.Website, 'bar')).toBe(true);
+  });
+
+  it('supports prefixes with wildcards', () => {
+    const origins: RpcOrigins = {
+      allowedOrigins: ['https://*', 'npm:*'],
+    };
+
+    expect(
+      isOriginAllowed(
+        origins,
+        SubjectType.Website,
+        'https://snaps.metamask.io',
+      ),
+    ).toBe(true);
+    expect(isOriginAllowed(origins, SubjectType.Snap, 'npm:filsnap')).toBe(
+      true,
+    );
+    expect(
+      isOriginAllowed(origins, SubjectType.Website, 'http://snaps.metamask.io'),
+    ).toBe(false);
+    expect(
+      isOriginAllowed(origins, SubjectType.Snap, 'local:http://localhost:8080'),
+    ).toBe(false);
+  });
+
+  it('supports partial strings with wildcards', () => {
+    const origins: RpcOrigins = {
+      allowedOrigins: ['*.metamask.io'],
+    };
+
+    expect(
+      isOriginAllowed(
+        origins,
+        SubjectType.Website,
+        'https://snaps.metamask.io',
+      ),
+    ).toBe(true);
+    expect(
+      isOriginAllowed(origins, SubjectType.Website, 'https://foo.metamask.io'),
+    ).toBe(true);
+  });
+
+  it('supports multiple wildcards', () => {
+    const origins: RpcOrigins = {
+      allowedOrigins: ['*.metamask.*'],
+    };
+
+    expect(
+      isOriginAllowed(
+        origins,
+        SubjectType.Website,
+        'https://snaps.metamask.io',
+      ),
+    ).toBe(true);
+    expect(
+      isOriginAllowed(origins, SubjectType.Website, 'https://foo.metamask.io'),
+    ).toBe(true);
+    expect(
+      isOriginAllowed(origins, SubjectType.Website, 'https://foo.metamask.dk'),
+    ).toBe(true);
+    expect(
+      isOriginAllowed(origins, SubjectType.Website, 'https://foo.metamask2.io'),
+    ).toBe(false);
+    expect(
+      isOriginAllowed(origins, SubjectType.Website, 'https://ametamask2.io'),
+    ).toBe(false);
+  });
 });
 
 describe('assertIsJsonRpcSuccess', () => {

--- a/packages/snaps-utils/src/json-rpc.test.ts
+++ b/packages/snaps-utils/src/json-rpc.test.ts
@@ -65,6 +65,14 @@ describe('assertIsRpcOrigins', () => {
       'Invalid JSON-RPC origins: Must specify at least one JSON-RPC origin.',
     );
   });
+
+  it('throws if allowedOrigins contains too many wildcards', () => {
+    expect(() =>
+      assertIsRpcOrigins({ allowedOrigins: ['*.*.metamask.***'] }),
+    ).toThrow(
+      'Invalid JSON-RPC origins: At path: allowedOrigins.0 -- No more than two wildcards (*) are allowed in "allowedOrigins"',
+    );
+  });
 });
 
 describe('assertIsKeyringOrigin', () => {

--- a/packages/snaps-utils/src/json-rpc.test.ts
+++ b/packages/snaps-utils/src/json-rpc.test.ts
@@ -70,7 +70,7 @@ describe('assertIsRpcOrigins', () => {
     expect(() =>
       assertIsRpcOrigins({ allowedOrigins: ['*.*.metamask.***'] }),
     ).toThrow(
-      'Invalid JSON-RPC origins: At path: allowedOrigins.0 -- No more than two wildcards (*) are allowed in "allowedOrigins"',
+      'Invalid JSON-RPC origins: At path: allowedOrigins.0 -- No more than two wildcards ("*") are allowed in an origin specifier.',
     );
   });
 });

--- a/packages/snaps-utils/src/json-rpc.ts
+++ b/packages/snaps-utils/src/json-rpc.ts
@@ -85,6 +85,20 @@ export function assertIsKeyringOrigins(
 }
 
 /**
+ * Create regular expression for matching against an origin while allowing wildcards.
+ *
+ * @param matcher - The string to create the regular expression with.
+ * @returns The regular expression.
+ */
+function createOriginRegExp(matcher: string) {
+  // Escape potential Regex characters
+  const escaped = matcher.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+  // Support wildcards
+  const regex = escaped.replace(/\*/gu, '.*');
+  return RegExp(regex, 'u');
+}
+
+/**
  * Check if the given origin is allowed by the given JSON-RPC origins object.
  *
  * @param origins - The JSON-RPC origins object.
@@ -103,7 +117,11 @@ export function isOriginAllowed(
   }
 
   // If the origin is in the `allowedOrigins` list, it is allowed.
-  if (origins.allowedOrigins?.includes(origin)) {
+  if (
+    origins.allowedOrigins
+      ?.map(createOriginRegExp)
+      .some((regex) => regex.test(origin))
+  ) {
     return true;
   }
 

--- a/packages/snaps-utils/src/json-rpc.ts
+++ b/packages/snaps-utils/src/json-rpc.ts
@@ -16,7 +16,7 @@ const AllowedOriginsStruct = array(
   refine(string(), 'Allowed origin', (value) => {
     const wildcards = value.split('*').length - 1;
     if (wildcards > 2) {
-      return 'No more than two wildcards (*) are allowed in "allowedOrigins".';
+      return 'No more than two wildcards ("*") are allowed in an origin specifier.';
     }
 
     return true;

--- a/packages/snaps-utils/src/json-rpc.ts
+++ b/packages/snaps-utils/src/json-rpc.ts
@@ -14,13 +14,7 @@ import { array, boolean, object, optional, refine, string } from 'superstruct';
 
 const AllowedOriginsStruct = array(
   refine(string(), 'Allowed origin', (value) => {
-    const wildcards = value.split('').reduce((accumulator, character) => {
-      if (character === '*') {
-        return accumulator + 1;
-      }
-      return accumulator;
-    }, 0);
-
+    const wildcards = value.split('*').length - 1;
     if (wildcards > 2) {
       return 'No more than two wildcards (*) are allowed in "allowedOrigins".';
     }

--- a/packages/snaps-utils/src/json-rpc.ts
+++ b/packages/snaps-utils/src/json-rpc.ts
@@ -12,11 +12,28 @@ import {
 import type { Infer } from 'superstruct';
 import { array, boolean, object, optional, refine, string } from 'superstruct';
 
+const AllowedOriginsStruct = array(
+  refine(string(), 'Allowed origin', (value) => {
+    const wildcards = value.split('').reduce((accumulator, character) => {
+      if (character === '*') {
+        return accumulator + 1;
+      }
+      return accumulator;
+    }, 0);
+
+    if (wildcards > 2) {
+      return 'No more than two wildcards (*) are allowed in "allowedOrigins".';
+    }
+
+    return true;
+  }),
+);
+
 export const RpcOriginsStruct = refine(
   object({
     dapps: optional(boolean()),
     snaps: optional(boolean()),
-    allowedOrigins: optional(array(string())),
+    allowedOrigins: optional(AllowedOriginsStruct),
   }),
   'RPC origins',
   (value) => {
@@ -58,7 +75,7 @@ export function assertIsRpcOrigins(
 }
 
 export const KeyringOriginsStruct = object({
-  allowedOrigins: optional(array(string())),
+  allowedOrigins: optional(AllowedOriginsStruct),
 });
 
 export type KeyringOrigins = Infer<typeof KeyringOriginsStruct>;


### PR DESCRIPTION
Allow wildcards in `allowedOrigins` by generating a RegExp based on each allowed origin and testing the origin against it.


Closes #2457 