### PR TITLE
feat: add hidden flag for preinstalled Snaps

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -4789,6 +4789,45 @@ describe('SnapController', () => {
       snapController.destroy();
     });
 
+    it('supports preinstalled Snaps specifying the hidden flag', async () => {
+      const rootMessenger = getControllerMessenger();
+      jest.spyOn(rootMessenger, 'call');
+
+      // The snap should not have permission initially
+      rootMessenger.registerActionHandler(
+        'PermissionController:getPermissions',
+        () => ({}),
+      );
+
+      const preinstalledSnaps = [
+        {
+          snapId: MOCK_SNAP_ID,
+          manifest: getSnapManifest(),
+          hidden: true,
+          files: [
+            {
+              path: DEFAULT_SOURCE_PATH,
+              value: stringToBytes(DEFAULT_SNAP_BUNDLE),
+            },
+            {
+              path: DEFAULT_ICON_PATH,
+              value: stringToBytes(DEFAULT_SNAP_ICON),
+            },
+          ],
+        },
+      ];
+
+      const snapControllerOptions = getSnapControllerWithEESOptions({
+        preinstalledSnaps,
+        rootMessenger,
+      });
+      const [snapController] = getSnapControllerWithEES(snapControllerOptions);
+
+      expect(snapController.get(MOCK_SNAP_ID)?.hidden).toBe(true);
+
+      snapController.destroy();
+    });
+
     it('authorizes permissions needed for snaps', async () => {
       const manifest = getSnapManifest();
       const rootMessenger = getControllerMessenger();

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -174,6 +174,7 @@ export interface PreinstalledSnap {
   manifest: SnapManifest;
   files: PreinstalledSnapFile[];
   removable?: boolean;
+  hidden?: boolean;
 }
 
 type SnapRpcHandler = (
@@ -687,6 +688,7 @@ type SetSnapArgs = Omit<AddSnapArgs, 'location' | 'versionRange'> & {
   isUpdate?: boolean;
   removable?: boolean;
   preinstalled?: boolean;
+  hidden?: boolean;
 };
 
 const defaultState: SnapControllerState = {
@@ -1083,7 +1085,13 @@ export class SnapController extends BaseController<
   }
 
   #handlePreinstalledSnaps(preinstalledSnaps: PreinstalledSnap[]) {
-    for (const { snapId, manifest, files, removable } of preinstalledSnaps) {
+    for (const {
+      snapId,
+      manifest,
+      files,
+      removable,
+      hidden,
+    } of preinstalledSnaps) {
       const existingSnap = this.get(snapId);
       const isAlreadyInstalled = existingSnap !== undefined;
       const isUpdate =
@@ -1152,6 +1160,7 @@ export class SnapController extends BaseController<
         origin: 'metamask',
         files: filesObject,
         removable,
+        hidden,
         preinstalled: true,
       });
 
@@ -2769,6 +2778,7 @@ export class SnapController extends BaseController<
       isUpdate = false,
       removable,
       preinstalled,
+      hidden,
     } = args;
 
     const {
@@ -2824,6 +2834,7 @@ export class SnapController extends BaseController<
 
       removable,
       preinstalled,
+      hidden,
 
       id: snapId,
       initialConnections: manifest.result.initialConnections,

--- a/packages/snaps-utils/src/snaps.ts
+++ b/packages/snaps-utils/src/snaps.ts
@@ -148,6 +148,11 @@ export type Snap = TruncatedSnap & {
    * A lack of specifying this option will be deemed as removable.
    */
   removable?: boolean;
+
+  /**
+   * Flag to signal whether this snap should be hidden from the user or not.
+   */
+  hidden?: boolean;
 };
 
 export type TruncatedSnapFields =


### PR DESCRIPTION
Adds a `hidden` flag that preinstalled Snaps can use to signal whether they should be displayed to the user or not.