### PR TITLE
Require at least 1 child in JSX components

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cFY+EKFr9Kca+FLDLLEx+b7UwSXDdRAASw+Afr0KGSA=",
+    "shasum": "UgvqSwtLZpPAlyxInu2snm6xM4hfp2Tp3XMeMAQLUcw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VytbTBFlZ+M81Z4l5pROqmcSWdCKpM4tzxmWblpde6g=",
+    "shasum": "ToXUzLWGx1LI0QX57qdQ0mM1ieI8g8hu41YsyWLaOOY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "rkXbqoYaR8U/UTEXxLgEOaesrse7Z+hRnlSRDa8AB8M=",
+    "shasum": "L+pHEDfgu4+dMO5g54EKjIxMRCYFq4+R638prOkKZ6k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0UnJAEXH1sFqi0q7L5tfkmlzs88XQXMZCHcFfQ/+gBA=",
+    "shasum": "EPx8LcR5Rtn2T5o+cBz3QCvNDCZdISPKD6zetX0IuNc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0uuXsh7pXsfl2cA4RQWLFz4yuqDwGccpoty6IVRMiU0=",
+    "shasum": "RfsjWGBwFwkeafTBpN+Yooz7k/7XDADQT52w4nLiNuk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "DMAEulSYYWINAu3OX+wKp2x3Y70AoMljQTQI12aYFuQ=",
+    "shasum": "irrkSxCeemT63ukzUnbP4KU/YkQv9Vba4OhEAh+zQGo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "UM/EVAQVHaVOEFPFGaLVVlauLNsMCeNsKZRGvO7VAtE=",
+    "shasum": "hcVi0nQ9q+5rkm31S3gV/ZGYzTHlf4FEyk7WV1urJjc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9HbumrSfL0hXeWthM4qoO2MUBeExC4cYUJ2SwWG2+Oo=",
+    "shasum": "Kqmwnz5fO7DKp/oyefTlcii7ixY3+o6TED89PousGcg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2ma2OI4wRfGns24irY+LbzBHztiMWFbXKZ6tzVPuEPQ=",
+    "shasum": "akS15Rwaw6t07AkYcEeksXW3OM3aDDciwHv7g2L4bqM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9cSUqxBQhzsJ12+JhdWlQ2tgeIGevNzQOaLw2Eu7ybc=",
+    "shasum": "NwL63w242Ae8YpzVIMklj6fY3xJdJWifofqHrNDi++k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "e961jfpGVUCq1Sx38/EPnV1wt/Ew9bmaCcgIWVt4O+I=",
+    "shasum": "Uye+gHiPLoxG/k3MPhS9XzEZrwk1dYMk8PaPWpOLTOU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "gyhHeBnqa27Mls2BAaF6tyBTFCJcntdBTzYlUOnIa/U=",
+    "shasum": "MUMSUUGuRRNjdYRbeudOLGSBBkM7/LIOAV6x5kZDtGo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "EkloXy+Hnk8vQWhieMXxzKVKB1ktxVoEjx9pK6mhUNA=",
+    "shasum": "ecdfz7QgKNBQ5P5Acysn+U75TEnxvms/iQPxLM1F5Ig=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Bzph8qHiipWZxvfPRRIF8uTNn/B6vsru5Y/iM4oncuo=",
+    "shasum": "peVmdN7MVnmeMquVOc4KZJQm1Karzqz4n/xiAIqgj8w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9JkfxrXYsx06JYmUW2Qp3rl3DOIEIjvABpvsiFSia5Q=",
+    "shasum": "A0jHEuEQBpjc3Pcz5oFeCAWyPpPSrsnE8opoZ7s1dPQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FJYxumLs73HbbfEIlfh9ZvR4AP4Kgq7UgKA7TESveXs=",
+    "shasum": "W0Auz+ZZEgOjHINo/Y09pbruAaiZ9FNpCK+Izv6Gif8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7v5lrOSV14ZDMIPlzj+VASXn9VKpBRN7SNbsSyJ1CSQ=",
+    "shasum": "PMY3+gJTWoCYdAuABMOnfHtUbIcrEhq/By5/U8EhY6c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "zaM8WKt5Zem762uFTzwAR19J4amlUBiAUM6YkEYZ6no=",
+    "shasum": "Pu/gS1jEqTQRYmHzCAXgaByusAYvZfVpLSYcXBTS2+0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6pJvgAEIldKvO/oLxEY55eTxb815KqTnxsyx3BtSFmk=",
+    "shasum": "hnBmFA0koHKlv5nrZ5skBhSf3U89o2D0N2ceCA2ML9I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "HBeA5kBirLozGhipgVpxnpT4EnezAbUCMamHTCJOq4s=",
+    "shasum": "JFk1jcbamm/ZeGaMB983hIG8KJ0DSgLFZG/Nkln45Y8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "eKWUByCvXWGXMK5FWBRkyT3JUGqfYygBSgS+Uh1W0aI=",
+    "shasum": "ge2E2UZC0XxpfSuJLROj8yzVtRYHy1pQfdFa6ZhmYQI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "mGcqbPqmdrCK/Lqx9oir6m/WAutiIEdfDHy3rN40pcc=",
+    "shasum": "3TRfPDcUn5JIEtNFpzbS5C60zyZTfIzNEDKdsbP2tm0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3v0RwJoJr+8shFIVoOxsXvsR/O8HoEtzHZj22VdyPJc=",
+    "shasum": "86uPtE8llpFVHt84gwUwmTSZNWgRVTPjE5RziQGR8oA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Fx0P/7/JMnREmerzzLaWuO+xpUW/ivndDPoojN7y5uI=",
+    "shasum": "/dxX4K1Ve6aCBoGSHFg7UW+9pV9VduWWnmp+zfcf2Ps=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TeOUZI6CUfjYwHPNIdwbHYCMwriGob8N4Ji5dz5aWdc=",
+    "shasum": "JK6pIbYHYDBm9f4t/bz1sCPlxc0BaW3OYjD7eq1h6wo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3HsgUcdh64rsJlsgNtM5dSSJ/MkSOlwp0Oc/f0wnnxM=",
+    "shasum": "sQKkg56a9hnrqHHEnQOeyM8Hz3hxbXKj9MIFKTj/o7E=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "A4p1KBznkAVyZmOBrYsii0+fEHN0tZ+QGYmzyoCBFis=",
+    "shasum": "uMJPnl1uK0s4hKUu9EoLZe8KpLjhgoQjjcvIBVoDhe0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "pOBkAJYhgr5AzfLCdU46tMqMnVysucpVW5rBJb+/+gs=",
+    "shasum": "zdnnUcBrVCQRpfoDxedcXDBZVja6gGSWMzc4xAhcv2I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-sdk/src/jsx/component.ts
+++ b/packages/snaps-sdk/src/jsx/component.ts
@@ -1,4 +1,4 @@
-import type { Json } from '@metamask/utils';
+import type { Json, NonEmptyArray } from '@metamask/utils';
 
 /**
  * A key, which can be a string or a number.
@@ -48,7 +48,7 @@ export type SnapElement<
  * const maybeArrayString: MaybeArrayString = 'hello';
  * const maybeArrayStringArray: MaybeArrayString = ['hello', 'world'];
  */
-export type MaybeArray<Type> = Type | Type[];
+export type MaybeArray<Type> = Type | NonEmptyArray<Type>;
 
 /**
  * A JSX node, which can be an element, a string, null, or an array of nodes.

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -430,6 +430,8 @@ describe('BoxStruct', () => {
     [],
     // @ts-expect-error - Invalid props.
     <Box />,
+    // @ts-expect-error - Invalid props.
+    <Box children={[]} />,
     <Text>foo</Text>,
     <Row label="label">
       <Image src="src" alt="alt" />

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -746,7 +746,7 @@ describe('SpinnerStruct', () => {
   });
 });
 
-describe('Dropdown', () => {
+describe('DropdownStruct', () => {
   it.each([
     <Dropdown name="foo">
       <Option value="option1">Option 1</Option>
@@ -763,6 +763,10 @@ describe('Dropdown', () => {
     undefined,
     {},
     [],
+    // @ts-expect-error - Invalid props.
+    <Dropdown name="foo" />,
+    // @ts-expect-error - Invalid props.
+    <Dropdown name="foo" children={[]} />,
     // @ts-expect-error - Invalid props.
     <Spinner>foo</Spinner>,
     <Text>foo</Text>,

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -1,3 +1,4 @@
+import type { NonEmptyArray } from '@metamask/utils';
 import {
   hasProperty,
   HexChecksumAddressStruct,
@@ -6,6 +7,7 @@ import {
 } from '@metamask/utils';
 import type { Struct } from 'superstruct';
 import {
+  refine,
   is,
   boolean,
   optional,
@@ -77,6 +79,22 @@ export const ElementStruct: Describe<GenericSnapElement> = object({
 });
 
 /**
+ * A struct for the {@link NonEmptyArray} type.
+ *
+ * @param struct - The struct for the non-empty array type.
+ * @returns The struct for the non-empty array type.
+ */
+function nonEmptyArray<Type, Schema>(
+  struct: Struct<Type, Schema>,
+): Struct<NonEmptyArray<Type>, any> {
+  return refine(
+    array(struct),
+    'NonEmptyArray',
+    (value) => value.length > 0,
+  ) as unknown as Struct<NonEmptyArray<Type>, Schema>;
+}
+
+/**
  * A helper function for creating a struct for a {@link MaybeArray} type.
  *
  * @param struct - The struct for the maybe array type.
@@ -85,7 +103,7 @@ export const ElementStruct: Describe<GenericSnapElement> = object({
 function maybeArray<Type, Schema>(
   struct: Struct<Type, Schema>,
 ): Struct<MaybeArray<Type>, any> {
-  return nullUnion([struct, array(struct)]);
+  return nullUnion([struct, nonEmptyArray(struct)]);
 }
 
 /**

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -7,7 +7,7 @@ import {
 } from '@metamask/utils';
 import type { Struct } from 'superstruct';
 import {
-  refine,
+  nonempty,
   is,
   boolean,
   optional,
@@ -87,11 +87,10 @@ export const ElementStruct: Describe<GenericSnapElement> = object({
 function nonEmptyArray<Type, Schema>(
   struct: Struct<Type, Schema>,
 ): Struct<NonEmptyArray<Type>, any> {
-  return refine(
-    array(struct),
-    'NonEmptyArray',
-    (value) => value.length > 0,
-  ) as unknown as Struct<NonEmptyArray<Type>, Schema>;
+  return nonempty(array(struct)) as unknown as Struct<
+    NonEmptyArray<Type>,
+    Schema
+  >;
 }
 
 /**

--- a/packages/snaps-utils/src/ui.tsx
+++ b/packages/snaps-utils/src/ui.tsx
@@ -163,7 +163,8 @@ export function getTextChildren(
   value: string,
 ): NonEmptyArray<string | StandardFormattingElement | LinkElement> {
   const rootTokens = lexer(value, { gfm: false });
-  const children: TextChildren = [null];
+  const children: (string | StandardFormattingElement | LinkElement | null)[] =
+    [];
 
   walkTokens(rootTokens, (token) => {
     if (token.type === 'paragraph') {

--- a/packages/snaps-utils/src/ui.tsx
+++ b/packages/snaps-utils/src/ui.tsx
@@ -29,6 +29,7 @@ import {
   Button,
   Address,
 } from '@metamask/snaps-sdk/jsx';
+import type { NonEmptyArray } from '@metamask/utils';
 import {
   assert,
   assertExhaustive,
@@ -66,7 +67,7 @@ function getButtonVariant(variant?: 'primary' | 'secondary' | undefined) {
  * @param elements - The JSX elements.
  * @returns The child or children.
  */
-function getChildren<Type>(elements: Type[]) {
+function getChildren<Type>(elements: NonEmptyArray<Type>) {
   if (elements.length === 1) {
     return elements[0];
   }
@@ -82,7 +83,11 @@ function getChildren<Type>(elements: Type[]) {
  */
 function getLinkText(token: Tokens.Link | Tokens.Generic) {
   if (token.tokens && token.tokens.length > 0) {
-    return getChildren(token.tokens.flatMap(getTextChildFromToken));
+    return getChildren(
+      token.tokens.flatMap(
+        getTextChildFromToken,
+      ) as NonEmptyArray<TextChildren>,
+    );
   }
 
   return token.href;
@@ -95,7 +100,9 @@ function getLinkText(token: Tokens.Link | Tokens.Generic) {
  * @returns The text child.
  */
 function getTextChildFromTokens(tokens: Token[]) {
-  return getChildren(tokens.flatMap(getTextChildFromToken));
+  return getChildren(
+    tokens.flatMap(getTextChildFromToken) as NonEmptyArray<TextChildren>,
+  );
 }
 
 /**
@@ -154,9 +161,9 @@ function getTextChildFromToken(token: Token): TextChildren {
  */
 export function getTextChildren(
   value: string,
-): (string | StandardFormattingElement | LinkElement)[] {
+): NonEmptyArray<string | StandardFormattingElement | LinkElement> {
   const rootTokens = lexer(value, { gfm: false });
-  const children: TextChildren = [];
+  const children: TextChildren = [null];
 
   walkTokens(rootTokens, (token) => {
     if (token.type === 'paragraph') {
@@ -169,11 +176,9 @@ export function getTextChildren(
     }
   });
 
-  return children.filter((child) => child !== null) as (
-    | string
-    | StandardFormattingElement
-    | LinkElement
-  )[];
+  return children.filter((child) => child !== null) as NonEmptyArray<
+    string | StandardFormattingElement | LinkElement
+  >;
 }
 
 /**
@@ -243,7 +248,9 @@ export function getJsxElementFromComponent(
       case NodeType.Form:
         return (
           <Form name={component.name}>
-            {getChildren(component.children.map(getElement)) as FieldElement[]}
+            {getChildren(
+              component.children.map(getElement) as NonEmptyArray<FieldElement>,
+            )}
           </Form>
         );
 
@@ -269,7 +276,11 @@ export function getJsxElementFromComponent(
       case NodeType.Panel:
         // `Panel` is renamed to `Box` in JSX.
         return (
-          <Box children={getChildren(component.children.map(getElement))} />
+          <Box
+            children={getChildren(
+              component.children.map(getElement) as NonEmptyArray<JSXElement>,
+            )}
+          />
         );
 
       case NodeType.Row:


### PR DESCRIPTION
This changes the types and validation for JSX components to require at least one child. Previously it was possible to do something like `<Box children={[]} />`, but this will now result in an error.