### PR TITLE
fix: properly decrypt legacy state blobs

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 91.64,
+  "branches": 91.68,
   "functions": 96.77,
   "lines": 97.89,
   "statements": 97.57

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -78,7 +78,6 @@ import {
   getSnapControllerOptions,
   getSnapControllerWithEES,
   getSnapControllerWithEESOptions,
-  LEGACY_ENCRYPTION_KEY_DERIVATION_OPTIONS,
   loopbackDetect,
   LoopbackLocation,
   MOCK_BLOCK_NUMBER,
@@ -96,6 +95,7 @@ import {
   sleep,
 } from '../test-utils';
 import { delay } from '../utils';
+import { LEGACY_ENCRYPTION_KEY_DERIVATION_OPTIONS } from './constants';
 import { SnapsRegistryStatus } from './registry';
 import type { SnapControllerState } from './SnapController';
 import {

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1676,7 +1676,14 @@ export class SnapController extends BaseController<
         snapId,
         salt,
         useCache,
-        keyMetadata,
+        // When decrypting state we expect key metadata to be present.
+        // If it isn't present, we assume that the Snap state we are decrypting is old enough to use the legacy encryption params.
+        keyMetadata: keyMetadata ?? {
+          algorithm: 'PBKDF2',
+          params: {
+            iterations: 10_000,
+          },
+        },
       });
       const decryptedState = await this.#encryptor.decryptWithKey(key, parsed);
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -128,7 +128,10 @@ import {
   setDiff,
   withTimeout,
 } from '../utils';
-import { ALLOWED_PERMISSIONS } from './constants';
+import {
+  ALLOWED_PERMISSIONS,
+  LEGACY_ENCRYPTION_KEY_DERIVATION_OPTIONS,
+} from './constants';
 import type { SnapLocation } from './location';
 import { detectSnapLocation } from './location';
 import type {
@@ -1678,12 +1681,7 @@ export class SnapController extends BaseController<
         useCache,
         // When decrypting state we expect key metadata to be present.
         // If it isn't present, we assume that the Snap state we are decrypting is old enough to use the legacy encryption params.
-        keyMetadata: keyMetadata ?? {
-          algorithm: 'PBKDF2',
-          params: {
-            iterations: 10_000,
-          },
-        },
+        keyMetadata: keyMetadata ?? LEGACY_ENCRYPTION_KEY_DERIVATION_OPTIONS,
       });
       const decryptedState = await this.#encryptor.decryptWithKey(key, parsed);
 

--- a/packages/snaps-controllers/src/snaps/constants.ts
+++ b/packages/snaps-controllers/src/snaps/constants.ts
@@ -13,3 +13,10 @@ export const ALLOWED_PERMISSIONS = Object.freeze([
   SnapEndowments.TransactionInsight,
   SnapEndowments.SignatureInsight,
 ]);
+
+export const LEGACY_ENCRYPTION_KEY_DERIVATION_OPTIONS = {
+  algorithm: 'PBKDF2' as const,
+  params: {
+    iterations: 10_000,
+  },
+};

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -454,6 +454,13 @@ export const DEFAULT_ENCRYPTION_KEY_DERIVATION_OPTIONS = {
   },
 };
 
+export const LEGACY_ENCRYPTION_KEY_DERIVATION_OPTIONS = {
+  algorithm: 'PBKDF2' as const,
+  params: {
+    iterations: 10_000,
+  },
+};
+
 const getSnapControllerEncryptor = () => {
   return {
     encryptWithKey,

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -454,13 +454,6 @@ export const DEFAULT_ENCRYPTION_KEY_DERIVATION_OPTIONS = {
   },
 };
 
-export const LEGACY_ENCRYPTION_KEY_DERIVATION_OPTIONS = {
-  algorithm: 'PBKDF2' as const,
-  params: {
-    iterations: 10_000,
-  },
-};
-
 const getSnapControllerEncryptor = () => {
   return {
     encryptWithKey,


### PR DESCRIPTION
Fixes a problem where encrypted state blobs produced before `keyMetadata` was added would fail to decrypt. 

The encryptor would attempt to use the latest key derivation parameters when no `keyMetadata` was passed in, causing a failure to decrypt: https://github.com/MetaMask/metamask-extension/blob/ed5ec2d28f7e118803c6fdc74abe90db4e00f480/app/scripts/lib/encryptor-factory.ts#L78-L82

This PR simply falls back to the legacy key derivation parameters whenever `keyMetadata` isn't present strictly for decryption purposes. The default key derivation parameters are still in use for all encryption.