### PR TITLE
BREAKING: Defer creation of offscreen document in `OffscreenExecutionService`

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 91.68,
+  "branches": 91.66,
   "functions": 96.77,
   "lines": 97.89,
   "statements": 97.57

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.test.ts
@@ -1,6 +1,5 @@
 import {
   DEFAULT_SNAP_BUNDLE,
-  MOCK_LOCAL_SNAP_ID,
   MOCK_SNAP_ID,
 } from '@metamask/snaps-utils/test-utils';
 import type { Json, JsonRpcRequest } from '@metamask/utils';
@@ -9,8 +8,6 @@ import { isJsonRpcRequest, isPlainObject } from '@metamask/utils';
 import { createService } from '../../test-utils';
 import { getMockedFunction } from '../../test-utils/mock';
 import { OffscreenExecutionService } from './OffscreenExecutionService';
-
-const DOCUMENT_URL = new URL('https://foo');
 
 /**
  * Create a response message for the given request. This function assumes that
@@ -96,71 +93,19 @@ describe('OffscreenExecutionService', () => {
             removeListener: jest.fn(),
           },
         },
-
-        offscreen: {
-          hasDocument: jest.fn(),
-          createDocument: jest.fn(),
-        },
       },
     });
   });
 
   it('can boot', async () => {
-    const { service } = createService(OffscreenExecutionService, {
-      documentUrl: DOCUMENT_URL,
-    });
+    const { service } = createService(OffscreenExecutionService);
 
     expect(service).toBeDefined();
     await service.terminateAllSnaps();
   });
 
-  it('creates a document if it does not exist', async () => {
-    const { service } = createService(OffscreenExecutionService, {
-      documentUrl: DOCUMENT_URL,
-    });
-
-    const hasDocument = chrome.offscreen.hasDocument as jest.MockedFunction<
-      () => Promise<boolean>
-    >;
-    const createDocument = getMockedFunction(chrome.offscreen.createDocument);
-
-    hasDocument.mockResolvedValueOnce(false).mockResolvedValue(true);
-
-    expect(hasDocument).not.toHaveBeenCalled();
-    expect(createDocument).not.toHaveBeenCalled();
-
-    // Run two snaps to ensure that the document is created only once.
-    expect(
-      await service.executeSnap({
-        snapId: MOCK_SNAP_ID,
-        sourceCode: DEFAULT_SNAP_BUNDLE,
-        endowments: [],
-      }),
-    ).toBe('OK');
-
-    expect(
-      await service.executeSnap({
-        snapId: MOCK_LOCAL_SNAP_ID,
-        sourceCode: DEFAULT_SNAP_BUNDLE,
-        endowments: [],
-      }),
-    ).toBe('OK');
-
-    expect(hasDocument).toHaveBeenCalledTimes(2);
-    expect(createDocument).toHaveBeenCalledTimes(1);
-    expect(createDocument).toHaveBeenCalledWith({
-      justification: 'MetaMask Snaps Execution Environment',
-      reasons: ['IFRAME_SCRIPTING'],
-      url: DOCUMENT_URL.toString(),
-    });
-
-    await service.terminateAllSnaps();
-  });
-
   it('writes a termination command to the stream', async () => {
-    const { service } = createService(OffscreenExecutionService, {
-      documentUrl: DOCUMENT_URL,
-    });
+    const { service } = createService(OffscreenExecutionService);
 
     expect(
       await service.executeSnap({

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
@@ -8,22 +8,16 @@ type OffscreenExecutionEnvironmentServiceArgs = {
 } & ExecutionServiceArgs;
 
 export class OffscreenExecutionService extends ProxyExecutionService {
-  public readonly documentUrl: URL;
-
   /**
    * Create a new offscreen execution service.
    *
    * @param args - The constructor arguments.
-   * @param args.documentUrl - The URL of the offscreen document to use as the
-   * execution environment. This must be a URL relative to the location where
-   * this is called. This cannot be a public (http(s)) URL.
    * @param args.messenger - The messenger to use for communication with the
    * `SnapController`.
    * @param args.setupSnapProvider - The function to use to set up the snap
    * provider.
    */
   constructor({
-    documentUrl,
     messenger,
     setupSnapProvider,
   }: OffscreenExecutionEnvironmentServiceArgs) {
@@ -34,39 +28,6 @@ export class OffscreenExecutionService extends ProxyExecutionService {
         name: 'parent',
         target: 'child',
       }),
-    });
-
-    this.documentUrl = documentUrl;
-  }
-
-  /**
-   * Create a new stream for the specified job. This wraps the runtime stream
-   * in a stream specific to the job.
-   *
-   * @param jobId - The job ID.
-   */
-  protected async initEnvStream(jobId: string) {
-    // Lazily create the offscreen document.
-    await this.#createDocument();
-
-    return super.initEnvStream(jobId);
-  }
-
-  /**
-   * Creates the offscreen document to be used as the execution environment.
-   *
-   * If the document already exists, this does nothing.
-   */
-  async #createDocument() {
-    // Extensions can only have a single offscreen document.
-    if (await chrome.offscreen.hasDocument()) {
-      return;
-    }
-
-    await chrome.offscreen.createDocument({
-      justification: 'MetaMask Snaps Execution Environment',
-      reasons: ['IFRAME_SCRIPTING' as chrome.offscreen.Reason],
-      url: this.documentUrl.toString(),
     });
   }
 }

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
@@ -4,10 +4,12 @@ import type { ExecutionServiceArgs } from '../AbstractExecutionService';
 import { ProxyExecutionService } from '../proxy/ProxyExecutionService';
 
 type OffscreenExecutionEnvironmentServiceArgs = {
-  documentUrl: URL;
+  offscreenPromise: Promise<unknown>;
 } & ExecutionServiceArgs;
 
 export class OffscreenExecutionService extends ProxyExecutionService {
+  readonly #offscreenPromise: Promise<unknown>;
+
   /**
    * Create a new offscreen execution service.
    *
@@ -16,10 +18,13 @@ export class OffscreenExecutionService extends ProxyExecutionService {
    * `SnapController`.
    * @param args.setupSnapProvider - The function to use to set up the snap
    * provider.
+   * @param args.offscreenPromise - A promise that resolves when the offscreen
+   * environment is ready.
    */
   constructor({
     messenger,
     setupSnapProvider,
+    offscreenPromise,
   }: OffscreenExecutionEnvironmentServiceArgs) {
     super({
       messenger,
@@ -29,5 +34,20 @@ export class OffscreenExecutionService extends ProxyExecutionService {
         target: 'child',
       }),
     });
+
+    this.#offscreenPromise = offscreenPromise;
+  }
+
+  /**
+   * Create a new stream for the given job ID. This will wait for the offscreen
+   * environment to be ready before creating the stream.
+   *
+   * @param jobId - The job ID to create a stream for.
+   * @returns The stream for the given job ID.
+   */
+  protected async initEnvStream(jobId: string) {
+    await this.#offscreenPromise;
+
+    return await super.initEnvStream(jobId);
   }
 }


### PR DESCRIPTION
Previously, the offscreen document needed to be created from the `OffscreenExecutionService` because the extension did not do any offscreen set up. Nowadays though, the offscreen document is used by the extension for functionality other than Snaps, and the set up is handled from the extension.

Instead, we the offscreen service now accepts a `Promise` which should resolve when the offscreen document is ready. The service will wait for the promise to resolve before continuing.