### PR TITLE
chore: Correct docs for Input and Dropdown

### DIFF
--- a/packages/snaps-sdk/src/jsx/components/form/Dropdown.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Dropdown.ts
@@ -19,8 +19,7 @@ type DropdownProps = {
 const TYPE = 'Dropdown';
 
 /**
- * A dropdown component, which is used to create a dropdown. This component
- * can only be used as a child of the {@link Field} component.
+ * A dropdown component, which is used to create a dropdown.
  *
  * @param props - The props of the component.
  * @param props.name - The name of the dropdown field. This is used to identify the

--- a/packages/snaps-sdk/src/jsx/components/form/Input.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Input.ts
@@ -21,8 +21,7 @@ type InputProps = {
 const TYPE = 'Input';
 
 /**
- * An input component, which is used to create an input field. This component
- * can only be used as a child of the {@link Field} component.
+ * An input component, which is used to create an input field.
  *
  * @param props - The props of the component.
  * @param props.name - The name of the input field. This is used to identify the


### PR DESCRIPTION
Removes a line in the documentation about `Dropdown` and `Input` only being children of `Field`. This is not accurate as they can also be used outside of forms.