### PR TITLE
fix: Revert requiring at least one child

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7qpyFL9Pu+rrKy2ydPQLhVlJ+HylgeOJe+WANMnoAEI=",
+    "shasum": "F9C8poQGsqx2OqL+ywTBmQAvgb2ag6j2oHRzQNZzWH4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ufpj3zzf5KQRZSuvRCQ+gj/NyqsjT6V7QaJHIl3zJgA=",
+    "shasum": "gjSBWJnkvtf31+ik5BfkIjZnYP7oh1JnobZZ5BkLfbc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "l+jV5D1/4zM+fnkdFjSs/jwezcmKvBhVaF0STLy4xqQ=",
+    "shasum": "sN/Zydu1fWcdEli53pLyt816NWRkuFE3qzDDoDmX3MU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "WEiHEpnwzvfE1Re2eE4UTnm2Sv4+tfHIFyM+ioQxULA=",
+    "shasum": "bbmWpDqA5oK2hnINll8LuAztMQ0vLPPHyGGIQyuDIRc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "GHSoEGc2ojlVhlUueon3CFYbRb4T3AMsajJu1cFaDOA=",
+    "shasum": "d7et4jssA6aB1LDqTPbOZ1IkVUkxGJtRWiy8xpQ19cg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "b30zRB0blws2hZ204ViXqjj5ZPISRggK1wkiR2/EhjU=",
+    "shasum": "n9MuztZrrleOa9lJvJPaFghz0bka5TeHiTe2fMWGGIk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "fXJwayEWZusQWUbnjfhCpE0zaLdbVDWHMLTHuqrrM3U=",
+    "shasum": "0GH4QHuvCp6S20Q/pudibSuVrvu0Qro41eNSrB6p6Fw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "76da52qjX67ZIiAFwFwIASI4xg5L12Wxmo0bSxHscEY=",
+    "shasum": "vS4MjHCFOP+3kbETw1+niz86z6NTRMCPFVMsnyil12E=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZlJJJ7phHTQa4aEjDfHbZjc1cDzpllI5p2pLtlanIXc=",
+    "shasum": "6ro5G2OUcUgMp2tpBN0xzT4RsMbqp8QCkeqxad/WjBA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "18uL0w0wt2tnDNiGObnXnVraxaMuMpy6hy3upoCefCQ=",
+    "shasum": "PO2J2jXCoRqQFnXAsYGopLD414i1sGS8X1kt30njMPk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "CLT4Peg4c2WYiWQcK9JMDLLGD770kxivEcoBjy87CyM=",
+    "shasum": "cC2ejufAsJycw7jwk0+Qacv1EQT47SgNVVUc9hrnUqc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "kaZ/yngTuxpt+0CW+NQSivy/kr0UpZxGgfGpQ3xXzXk=",
+    "shasum": "6e9kjMqt8l37yriNvlnvY5v2X/jHSoq+PLYQJ53RPpA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "i746sYB/ifg6CgJsL87X1yDLvBg1Nei9LvgKPMZI1hk=",
+    "shasum": "b29xwWlOvxoJFPJKxmhgXq91w12guPNUwiBBb5yAlKE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "F7vjxIRenH4Sw49q29U78/LzuR1r6qwdQiIotbyRxMg=",
+    "shasum": "/EXKHEO4JKy1rzlvt+0PlHHBTEoma2i7ADxWsoQz158=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0JUGV3rxJeyutr9yjZSsjDVfWvdYDF4esvSJV5UpLgI=",
+    "shasum": "zxBvR8FbPcMyPBfmbRCwo7xLK2V8QbKHDGCwKwYYxns=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "rphachQ7mFPTgq44DdqSago5O/iYvyCX0HHJFn5if0k=",
+    "shasum": "Ob5yPFYtfqzdTx0LEshRnx3wSu08TN17do9jNW9B9UM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8KZ4QJZV4k9+jIVqJwcVz5zonyKe0sxF31grqbTKy24=",
+    "shasum": "7PJOV2G0pMYE8Vvv0g1oPseH8V5Nr1kXwe4o7Zql/I4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "PzQKXBUmFKDPxiiKzfknbjGVEVqU9KkAzgFRGQS4uno=",
+    "shasum": "XLUWgAWSNsyX3KDDgRNb//XQ/ir9ojf46Ay7o4/6EgU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OfG6J/E9bqigSCsVbUOY/sHQXJNN9Uw1Y6iOm286Q9M=",
+    "shasum": "OL0jaEOZDjvUn259L3vIOIP0EW3y7iUfuaW0qq+tUy4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "arY+omYS2xzHR46Kq+PRzsR0XEj5S4jDu3SbCRmTGaI=",
+    "shasum": "t4gJ9TT5yTfDMbFDdg2NkT3u0RxIh0shm1TJol78FCM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "pcX8+WLM212BES8ZEeFytIPmtQCktBtT1QnEZn7NwT8=",
+    "shasum": "hXMwZufxlkw7iTui9Ro6z/WKEQolQUPFk6HS8ps3KKA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "PAXkzc6iXekIASWw5D0PXQjEilIFIn2Xc66FGrUIppw=",
+    "shasum": "GzN3oeEj4yc1X7r03LMbe7Z3wQTt3ZcdYM0vvCEyyjc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xA6kAggAdLz4tAtsbveV66kR77X2D9GAJ/s98M8ryq0=",
+    "shasum": "dZ99KKfubKl5u1S90Yfbn6WyQEGAcVLGCj9FBuIb9p0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "NmiynH1hsIe4Ew6CYoLIyygqeiK9MtGkunDJQFrDMTI=",
+    "shasum": "jnQsivil7rusQP7K+WumbjVH19WbJN/ZYrpeSM7RPEU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "zFh8zlpbIYYsTOE0GaVJCij37Hh5hwKdM6P01fdPVL4=",
+    "shasum": "mGg958TU8sDwfHS6vesKjgD6sdYmU7z8Mu3eyRgNi/s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vEdkA6x+kcOJKVhf48x6x6Naqmd+SBRlabIqLIsT390=",
+    "shasum": "WlcLFeS8ZB2MTS0qAU2XKdjKP+5OzbxYx+Ce8+doKMw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "yvpO6VAiXRgLdG7GJmGL77pLP9z57OISIH7CcF9FaiE=",
+    "shasum": "UcNZQBVKNac+Mhw0yOB924NloS9tnc3JMULGKvsC+o4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "kszyLkEFFJV6k8dln9E1oUemgyw9cHHQm4cAGvvyie8=",
+    "shasum": "2Ucnmkx0Qre71OID0EvHOHXBHbjcGrU738iAjcmuamM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -63,7 +63,7 @@ function constructComponentSpecificDefaultState(
 ) {
   if (element.type === 'Dropdown') {
     const children = getJsxChildren(element) as OptionElement[];
-    return children[0].props.value;
+    return children[0]?.props.value;
   }
 
   return null;

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -428,9 +428,6 @@ describe('BoxStruct', () => {
     undefined,
     {},
     [],
-    // @ts-expect-error - Invalid props.
-    <Box />,
-    <Box children={[]} />,
     <Text>foo</Text>,
     <Row label="label">
       <Image src="<svg />" alt="alt" />
@@ -762,9 +759,6 @@ describe('DropdownStruct', () => {
     undefined,
     {},
     [],
-    // @ts-expect-error - Invalid props.
-    <Dropdown name="foo" />,
-    <Dropdown name="foo" children={[]} />,
     // @ts-expect-error - Invalid props.
     <Spinner>foo</Spinner>,
     <Text>foo</Text>,

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -6,7 +6,6 @@ import {
 } from '@metamask/utils';
 import type { Struct } from 'superstruct';
 import {
-  nonempty,
   is,
   boolean,
   optional,
@@ -78,18 +77,6 @@ export const ElementStruct: Describe<GenericSnapElement> = object({
 });
 
 /**
- * A struct for the {@link NonEmptyArray} type.
- *
- * @param struct - The struct for the non-empty array type.
- * @returns The struct for the non-empty array type.
- */
-function nonEmptyArray<Type, Schema>(
-  struct: Struct<Type, Schema>,
-): Struct<Type[], Struct<Type, Schema>> {
-  return nonempty(array(struct));
-}
-
-/**
  * A helper function for creating a struct for a {@link MaybeArray} type.
  *
  * @param struct - The struct for the maybe array type.
@@ -98,7 +85,7 @@ function nonEmptyArray<Type, Schema>(
 function maybeArray<Type, Schema>(
   struct: Struct<Type, Schema>,
 ): Struct<MaybeArray<Type>, any> {
-  return nullUnion([struct, nonEmptyArray(struct)]);
+  return nullUnion([struct, array(struct)]);
 }
 
 /**


### PR DESCRIPTION
Reverts a change to require at least one child in JSX components that use `MaybeArray`. This requirement turned out to be too strict and added too much complexity. We will have to deal with the edge-cases it causes instead.