### PR TITLE
Update `onNameLookup` response

### DIFF
--- a/packages/examples/packages/name-lookup/snap.manifest.json
+++ b/packages/examples/packages/name-lookup/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "WN15beK70xlxFC71Zv+AFJn0laKEPJxgF63Rpwbboc8=",
+    "shasum": "ZfMOIycB14/VYXiwzlQy1e06ukUQbdq0zUGw8cmHUws=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/name-lookup/src/index.test.ts
+++ b/packages/examples/packages/name-lookup/src/index.test.ts
@@ -19,6 +19,7 @@ describe('onNameLookup', () => {
         {
           resolvedAddress: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
           protocol: 'test protocol',
+          domainName: DOMAIN_MOCK,
         },
       ],
     });

--- a/packages/examples/packages/name-lookup/src/index.ts
+++ b/packages/examples/packages/name-lookup/src/index.ts
@@ -23,7 +23,9 @@ export const onNameLookup: OnNameLookupHandler = async (request) => {
   if (domain) {
     const resolvedAddress = '0xc0ffee254729296a45a3885639AC7E10F9d54979';
     return {
-      resolvedAddresses: [{ resolvedAddress, protocol: 'test protocol' }],
+      resolvedAddresses: [
+        { resolvedAddress, protocol: 'test protocol', domainName: domain },
+      ],
     };
   }
 

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -3465,6 +3465,7 @@ describe('SnapController', () => {
         {
           protocol: 'lens',
           resolvedAddress: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+          domainName: 'foobar',
         },
       ],
     };

--- a/packages/snaps-sdk/src/types/handlers/name-lookup.ts
+++ b/packages/snaps-sdk/src/types/handlers/name-lookup.ts
@@ -35,6 +35,7 @@ export type AddressLookupArgs = BaseOnNameLookupArgs & {
 export type AddressResolution = {
   protocol: string;
   resolvedAddress: string;
+  domainName: string;
 };
 
 /**

--- a/packages/snaps-utils/src/handlers.ts
+++ b/packages/snaps-utils/src/handlers.ts
@@ -153,6 +153,7 @@ export const AddressResolutionStruct = object({
 export const DomainResolutionStruct = object({
   protocol: string(),
   resolvedAddress: string(),
+  domainName: string(),
 });
 
 export const AddressResolutionResponseStruct = object({


### PR DESCRIPTION
Updating the name lookup response object to include a `domainName` property to let a snap indicate which domain the returned address was resolved against. This essentially allows for fuzzy matching results to be properly displayed in the extension.