### PR TITLE
Add `Tooltip` component

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "BB1+9pvHl5G2iudcAUaVWy8kprwT1nfp3DxPk4Ijct8=",
+    "shasum": "EmIaWoL8nod1rTuXeLuMVRItSn4yygM0QwF0575u4pI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8D4ebYpXIanxifZIoDx/4RRIiUpV0kNXXEAnV8dIyBY=",
+    "shasum": "3MsLr8jtTbv2bEGnK4qfD6OhE16rtXctYYW8LDjbL1U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "NFKbyUcvtcg4cjFsScuZ9K5U7wcQ2vWFVkWBC/vdeus=",
+    "shasum": "93dNm72NPNodS7UnTsxbAbxEgr81msGHGlBnxasd4hA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wJxHirjCewTn0AEH80KiNl5DGm+I0S0TU0KhNb0QGW0=",
+    "shasum": "rSs7zVVuekYGpvFT7xMmVHUwuJVmrYtJ1TpZiLln4+M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VkDbVKN11iYQXds2IaJ8gM+bUVh9w+R3I/3LftXPHAk=",
+    "shasum": "Lw+o0xSBK3RLoxMPA3VV9pcJts7slKwlw/FLH2os7Rs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "rttj1fYEAaln9fq0X+4fUnpQpgzPBCVlA/gX72aWhNU=",
+    "shasum": "suKnTPMwveOjTGAh5LZhnEflYUfoEclrm7MEQMekFSc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Tiu7E0Za1n0Erj/hY90kN2WBTDBQLqe0ZB5g8PX9Uo0=",
+    "shasum": "sVbh3wlE3T2kxAgUvCwBk7aBxmJGwyMYojvVamglYyc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9cPZYGIWcu53Dhxf14K4kTSpuqhNl+GHDVH9HU35yAI=",
+    "shasum": "iha5MN97D891xWP1typXrc0OHZAyRZQRQgpbrYtrub0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "z3LErF1RXhS01ErXrJSIWXqvjP44vm+TfHVjGoexxuY=",
+    "shasum": "D7hWiwyKT0CVTINjQZvUDKk3kj8mhngADM1bSKpp/js=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "SbuJLsNB4S4tzkrq2SMX1JwexcdrAIZ0vfBhq/5mn18=",
+    "shasum": "LtCe3Khdid7ufThHQQEJb1OOrO72iD5uyK7B2DQRi4c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6P5WA3V2Sw/lc2VGNaXsHNThlglFhWW2eKm+v42F+ak=",
+    "shasum": "zuc2MclbVUnpaFuvx3H1HwYsJymvVsfJsBq1wrSEElQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "x3U2v0ix/dIo1fgxbFC0JEjA749mW9eS5hA1Z/uPn3s=",
+    "shasum": "eiyB374KOWchfjaUeqCmN5wpKhBNb1yNiTobgJMJG6I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0y8qGup1KW+sFpC3wYNBZ90YJYnrBRL0fldN7ZKHJE8=",
+    "shasum": "RZyBT/FIDK7GtFwshSGOYXczOrVteUn4H5DS+ZbgsbU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "k0XiC0mJ6Zw9sudmKH8j7fjnPc0TlsNndtf58KBdPgA=",
+    "shasum": "xcXlfc8BGEa4XLJ9uGTWNveYej9QikFZn4nQ9NdxlsM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZrmkKMXWu90H7Ea3O1aDTlAsv10mt2W3qK6U/Bu6Ef4=",
+    "shasum": "Q5Uq4v0Mmevehh0PIJvusWEHFH+ITLysyyY+17JUsK0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "zd9v3UmiESa6JD1Pc9uenZ2bH+pfqqN3LgryYf4PkPk=",
+    "shasum": "Xr795QUI4U++cOYMm9FVpXVarO1mjIDSjKF+QQF2UZI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LKU/dRxxeMKb9yUzzDwhP1sVTcqqHSmE3DDspw4i4vw=",
+    "shasum": "1E0eIMXYC+twPeiAqcuRRPu5fxf5FD4f1dV08VUGwK0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Q4i6cNhFqTmQq+LZqkpdtA0bzP//XwU3CN+9SEi5HV4=",
+    "shasum": "yJziKY8cECUlDoxP8VFfsH2oEhPFn0ZWKFbYPkjujpM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "qTxO+zikJeylsmKgvGuKtrPOgXOOARr9+agGHy6jRLw=",
+    "shasum": "hMfqZ8Nrz8lpBhxOdId3kaND5WZrwxQd5Sx+KxjY0K8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TwzD1ldZMXP1G5Xh0imRnANPmfWcWWxwMWfnD89fTmU=",
+    "shasum": "oLzmeZcE9qxgf+jQpA9OiqFpuf2dfBT3Y9nED5z6nWs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "DOffnM76/Axe+pctk0eR8KYfAe8H8Mz5FvWk/Gdd9c4=",
+    "shasum": "Se1CTGg3ExDVv9SNZ6oaAE4ADWDYiET+Y4OW7N+P8xE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "bynm+cOfGCGK+IqcbE3WjuHMXaK94Wngz46ZiRCTA9o=",
+    "shasum": "wwwWEa/1xj0n+1uUmkCs7tUYvDcbfoDYQKOXfJfPJuY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "joVkDlMRDqCfZ+3Mx7ZnKeLWPYHmEiTic47gDYsVDo0=",
+    "shasum": "6cLHi5YriTK9gqn9cOx6CJavruqrkhRLaX/Ckgy6s4s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "52mermVIKcN8PYT0buRjmsHBTxCMsLd2YoT+sxm1qsI=",
+    "shasum": "UPKvEsDiuFKi9GAm42/PaCXR9iy4yf7sHVF4dl4Sc84=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1R21n92RzfVfQxjScRON3cOxSk+Ez5u3O/i9fKuPs/o=",
+    "shasum": "Vx4Qu2N6v706JMplTl9yZjjY+E1SzH3E4kRvPS6aO9c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "plbQA+egc3NMftFNlJ7ONX09tY5vTL3sUm/VcxqgFfM=",
+    "shasum": "tRru7Bgry6u3eoboCgkXy5pAYrEDVhVVZg0CcTI8K88=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wJz5xT13dghX5Z/tN0C2i43fdloxZg0yy2EQVwt0DbA=",
+    "shasum": "+sNj2KKAA6mES8j1X544gahfD1EVxN7NUruGHug7PAw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hLt7f+ezZ+X7hhYNQsVaKaRxSBTL2sCoCfj0fnMwefk=",
+    "shasum": "wrvKQQKLWFp3fD4gVxAUd/g89JCMk3dYCTh/jTvmrl0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "UPthnrafIh2vEr2kkDXb5l3HBcgke2dQg5RoKygbGEs=",
+    "shasum": "g2mArhUUuqRTQKapIisLg0ZcjmrOuDa+9K+LHyUBdJ8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-sdk/src/jsx/components/Tooltip.ts
+++ b/packages/snaps-sdk/src/jsx/components/Tooltip.ts
@@ -1,0 +1,44 @@
+import { createSnapComponent } from '../component';
+import type { StandardFormattingElement } from './formatting';
+import type { ImageElement } from './Image';
+import type { LinkElement } from './Link';
+import type { TextElement } from './Text';
+
+export type TooltipChildren =
+  | TextElement
+  | StandardFormattingElement
+  | LinkElement
+  | ImageElement
+  | null;
+
+/**
+ * The props of the {@link Tooltip} component.
+ *
+ * @property children - The children of the box.
+ */
+export type TooltipProps = {
+  children: TooltipChildren;
+  value: TextElement | StandardFormattingElement | LinkElement | string;
+};
+
+const TYPE = 'Tooltip';
+
+/**
+ * A tooltip component, which is used to display text in a tooltip.
+ *
+ * @param props - The props of the component.
+ * @param props.children - The children of the tooltip.
+ * @returns A tooltip element.
+ * @example
+ * <Tooltip value={<Text>foo</Text>}>
+ *   <Text>Hello world!</Text>
+ * </Tooltip>
+ */
+export const Tooltip = createSnapComponent<TooltipProps, typeof TYPE>(TYPE);
+
+/**
+ * A box element.
+ *
+ * @see Tooltip
+ */
+export type TooltipElement = ReturnType<typeof Tooltip>;

--- a/packages/snaps-sdk/src/jsx/components/Tooltip.ts
+++ b/packages/snaps-sdk/src/jsx/components/Tooltip.ts
@@ -32,14 +32,18 @@ const TYPE = 'Tooltip';
  * @param props.content - The text to display in the tooltip.
  * @returns A tooltip element.
  * @example
- * <Tooltip content={<Text>foo</Text>}>
+ * <Tooltip content="Tooltip text">
+ *   <Text>Hello world!</Text>
+ * </Tooltip>
+ * @example
+ * <Tooltip content={<Text>Text with <Bold>formatting</Bold></Text>}>
  *   <Text>Hello world!</Text>
  * </Tooltip>
  */
 export const Tooltip = createSnapComponent<TooltipProps, typeof TYPE>(TYPE);
 
 /**
- * A box element.
+ * A tooltip element.
  *
  * @see Tooltip
  */

--- a/packages/snaps-sdk/src/jsx/components/Tooltip.ts
+++ b/packages/snaps-sdk/src/jsx/components/Tooltip.ts
@@ -15,10 +15,11 @@ export type TooltipChildren =
  * The props of the {@link Tooltip} component.
  *
  * @property children - The children of the box.
+ * @property content - The text to display in the tooltip.
  */
 export type TooltipProps = {
   children: TooltipChildren;
-  value: TextElement | StandardFormattingElement | LinkElement | string;
+  content: TextElement | StandardFormattingElement | LinkElement | string;
 };
 
 const TYPE = 'Tooltip';
@@ -28,9 +29,10 @@ const TYPE = 'Tooltip';
  *
  * @param props - The props of the component.
  * @param props.children - The children of the tooltip.
+ * @param props.content - The text to display in the tooltip.
  * @returns A tooltip element.
  * @example
- * <Tooltip value={<Text>foo</Text>}>
+ * <Tooltip content={<Text>foo</Text>}>
  *   <Text>Hello world!</Text>
  * </Tooltip>
  */

--- a/packages/snaps-sdk/src/jsx/components/index.ts
+++ b/packages/snaps-sdk/src/jsx/components/index.ts
@@ -10,6 +10,7 @@ import type { LinkElement } from './Link';
 import type { RowElement } from './Row';
 import type { SpinnerElement } from './Spinner';
 import type { TextElement } from './Text';
+import type { TooltipElement } from './Tooltip';
 import type { ValueElement } from './Value';
 
 export * from './form';
@@ -25,6 +26,7 @@ export * from './Link';
 export * from './Row';
 export * from './Spinner';
 export * from './Text';
+export * from './Tooltip';
 
 /**
  * A built-in JSX element, which can be used in a Snap user interface.
@@ -42,4 +44,5 @@ export type JSXElement =
   | LinkElement
   | RowElement
   | SpinnerElement
-  | TextElement;
+  | TextElement
+  | TooltipElement;

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -19,6 +19,7 @@ import {
   Row,
   Spinner,
   Text,
+  Tooltip,
   Value,
   FileInput,
 } from './components';
@@ -47,6 +48,7 @@ import {
   SpinnerStruct,
   StringElementStruct,
   TextStruct,
+  TooltipStruct,
   ValueStruct,
 } from './validation';
 
@@ -718,6 +720,45 @@ describe('TextStruct', () => {
     </Row>,
   ])('does not validate "%p"', (value) => {
     expect(is(value, TextStruct)).toBe(false);
+  });
+});
+
+describe('TooltipStruct', () => {
+  it.each([
+    <Tooltip value="foo">
+      <Text>bar</Text>
+    </Tooltip>,
+    <Tooltip value={<Text>foo</Text>}>
+      <Bold>bar</Bold>
+    </Tooltip>,
+  ])(`validates a tooltip element`, (value) => {
+    expect(is(value, TooltipStruct)).toBe(true);
+  });
+
+  it.each([
+    'foo',
+    42,
+    null,
+    undefined,
+    {},
+    [],
+    // @ts-expect-error - Invalid props.
+    <Tooltip />,
+    // @ts-expect-error - Invalid props.
+    <Tooltip foo="bar">foo</Tooltip>,
+    <Tooltip value={<Copyable value="bar" />}>
+      <Text>foo</Text>
+    </Tooltip>,
+    <Box>
+      <Tooltip value={'foo'}>
+        <Text>foo</Text>
+      </Tooltip>
+    </Box>,
+    <Row label="label">
+      <Image src="<svg />" alt="alt" />
+    </Row>,
+  ])('does not validate "%p"', (value) => {
+    expect(is(value, TooltipStruct)).toBe(false);
   });
 });
 

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -725,10 +725,10 @@ describe('TextStruct', () => {
 
 describe('TooltipStruct', () => {
   it.each([
-    <Tooltip value="foo">
+    <Tooltip content="foo">
       <Text>bar</Text>
     </Tooltip>,
-    <Tooltip value={<Text>foo</Text>}>
+    <Tooltip content={<Text>foo</Text>}>
       <Bold>bar</Bold>
     </Tooltip>,
   ])(`validates a tooltip element`, (value) => {
@@ -746,11 +746,11 @@ describe('TooltipStruct', () => {
     <Tooltip />,
     // @ts-expect-error - Invalid props.
     <Tooltip foo="bar">foo</Tooltip>,
-    <Tooltip value={<Copyable value="bar" />}>
+    <Tooltip content={<Copyable value="bar" />}>
       <Text>foo</Text>
     </Tooltip>,
     <Box>
-      <Tooltip value={'foo'}>
+      <Tooltip content={'foo'}>
         <Text>foo</Text>
       </Tooltip>
     </Box>,

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -333,10 +333,10 @@ export const TooltipChildStruct = nullUnion([
 ]);
 
 /**
- * A subset of JSX elements that are allowed as value of the Tooltip component.
+ * A subset of JSX elements that are allowed as content of the Tooltip component.
  * This set should include all text components.
  */
-export const TooltipValueStruct = nullUnion([
+export const TooltipContentStruct = nullUnion([
   TextStruct,
   BoldStruct,
   ItalicStruct,
@@ -349,7 +349,7 @@ export const TooltipValueStruct = nullUnion([
  */
 export const TooltipStruct: Describe<TooltipElement> = element('Tooltip', {
   children: nullable(TooltipChildStruct),
-  value: TooltipValueStruct,
+  content: TooltipContentStruct,
 });
 
 /**

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -53,6 +53,7 @@ import type {
   SpinnerElement,
   StandardFormattingElement,
   TextElement,
+  TooltipElement,
   ValueElement,
   FileInputElement,
 } from './components';
@@ -320,6 +321,38 @@ export const TextStruct: Describe<TextElement> = element('Text', {
 });
 
 /**
+ * A subset of JSX elements that are allowed as children of the Tooltip component.
+ * This set should include all text components and the Image.
+ */
+export const TooltipChildStruct = nullUnion([
+  TextStruct,
+  BoldStruct,
+  ItalicStruct,
+  LinkStruct,
+  ImageStruct,
+]);
+
+/**
+ * A subset of JSX elements that are allowed as value of the Tooltip component.
+ * This set should include all text components.
+ */
+export const TooltipValueStruct = nullUnion([
+  TextStruct,
+  BoldStruct,
+  ItalicStruct,
+  LinkStruct,
+  string(),
+]);
+
+/**
+ * A struct for the {@link TooltipElement} type.
+ */
+export const TooltipStruct: Describe<TooltipElement> = element('Tooltip', {
+  children: nullable(TooltipChildStruct),
+  value: TooltipValueStruct,
+});
+
+/**
  * A struct for the {@link RowElement} type.
  */
 export const RowStruct: Describe<RowElement> = element('Row', {
@@ -359,6 +392,7 @@ export const BoxChildStruct = nullUnion([
   RowStruct,
   SpinnerStruct,
   TextStruct,
+  TooltipStruct,
 ]);
 
 /**
@@ -391,6 +425,7 @@ export const JSXElementStruct: Describe<JSXElement> = nullUnion([
   DropdownStruct,
   OptionStruct,
   ValueStruct,
+  TooltipStruct,
 ]);
 
 /**


### PR DESCRIPTION
This adds a new component `Tooltip` which can be used to display a tooltip on a text element or an image.

```tsx
<Tooltip content="foo">
  <Text>bar</Text>
</Tooltip>
```

This component can wrap any text element (`Text`, `Italic`, `Bold`, `Link`) and `Image` and accepts a string or a text element (`Text`, `Italic`, `Bold`, `Link`) to be displayed inside it via its `value` prop.