### PR TITLE
Support conditional children in most JSX components

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "31c28sD4FsnT5AULXF2f5eN7iFqOrrCtdE0Ci3XhdYA=",
+    "shasum": "okOtnPSp63QzvGqnfiFeIj9upF+l2GUcuX0hld/8zS4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Myfiv00eKUdOQh/6VURJt/NLEHvF7t8p+arvI8ZEy2E=",
+    "shasum": "Paw1MvcKp4fAIaHD7wOjms0TM6v0+9UrSindsKiIT2U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Paw1MvcKp4fAIaHD7wOjms0TM6v0+9UrSindsKiIT2U=",
+    "shasum": "31c28sD4FsnT5AULXF2f5eN7iFqOrrCtdE0Ci3XhdYA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "okOtnPSp63QzvGqnfiFeIj9upF+l2GUcuX0hld/8zS4=",
+    "shasum": "WfupwVnHUswiO0x/o2coJ0oj85v1x0j7wx1c5lYxP+o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7AJkQic0kErNfOuBozGOUaJ5U5Z24yOV28zHL+WEPz0=",
+    "shasum": "Myfiv00eKUdOQh/6VURJt/NLEHvF7t8p+arvI8ZEy2E=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9Wtu1MGgCNlXREDrOX5nYcUe+E8jESmmCEveUBR8n/c=",
+    "shasum": "+WhZ7cQ8dqA46bL5kzblh/1+GRShg87VtAS5N8N8+bU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TdU+l8244ylKZfMGvU4zVxcsjNneDaOcGlsksIzbVxI=",
+    "shasum": "F8umX6ibuhH1ASBxnoN8GaGo1LE8zE9ahQmnhfB/w+4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "F8umX6ibuhH1ASBxnoN8GaGo1LE8zE9ahQmnhfB/w+4=",
+    "shasum": "9Wtu1MGgCNlXREDrOX5nYcUe+E8jESmmCEveUBR8n/c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "kEd5v0Da+ONo/Pemo/W/+Rj+DCBcMlq8UoDkR3j+7hg=",
+    "shasum": "TdU+l8244ylKZfMGvU4zVxcsjNneDaOcGlsksIzbVxI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "R/jtwKJg/6gTCuMrphuKHZkTtUlggfwnNgKiOXx11GU=",
+    "shasum": "kEd5v0Da+ONo/Pemo/W/+Rj+DCBcMlq8UoDkR3j+7hg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "E3C1cZqVCd3yMoPWu1CZ0EFCccoMU1qwFeYgfdsVRNE=",
+    "shasum": "U3DkPSJLzf4OO7/Ybma4bBYP0fp+QpwrQXjHHyyVrW4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "WyGF29tepKkbA72BLSay+O0HmuBKeX6xVls18XGUPJ0=",
+    "shasum": "E3C1cZqVCd3yMoPWu1CZ0EFCccoMU1qwFeYgfdsVRNE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "U3DkPSJLzf4OO7/Ybma4bBYP0fp+QpwrQXjHHyyVrW4=",
+    "shasum": "cvVZ8a8g9/b3tXhh9d1zf1GU11WvqcwVnR90ilpGSGw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AtCtWmMVDhVL7nTsaqqCnm+M9tNQpPsp+i/w3G+dvK0=",
+    "shasum": "WyGF29tepKkbA72BLSay+O0HmuBKeX6xVls18XGUPJ0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "u7x/swxx6XHT7G0BDY8mJkwcY/mP/i4YmdYaRQ/QKZY=",
+    "shasum": "AtCtWmMVDhVL7nTsaqqCnm+M9tNQpPsp+i/w3G+dvK0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vMjY250Ko3ULV8mMenZFFKbTfHYY8HLQizQJkOK/Ee0=",
+    "shasum": "jhy7YR2US99yHnczuyLNq7wfXffFsXN+McgE7i+HtQw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "O0+BkKmGK6BN1eYbct7KQEnvW3CRks/YrNUPzG79qlE=",
+    "shasum": "fuKiL65m1QakTuad3sCbK8YzRLNgVb9o/gSg80FK4RE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5XCJq4Wk9xZREQ+fhCPe36Y/XoE5zQWtgwo7s9CVkLo=",
+    "shasum": "O0+BkKmGK6BN1eYbct7KQEnvW3CRks/YrNUPzG79qlE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "jhy7YR2US99yHnczuyLNq7wfXffFsXN+McgE7i+HtQw=",
+    "shasum": "5XCJq4Wk9xZREQ+fhCPe36Y/XoE5zQWtgwo7s9CVkLo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "105XsceecyaQZ+reC6ZNusiOJVUMBoNSYK4PHvREPQw=",
+    "shasum": "vMjY250Ko3ULV8mMenZFFKbTfHYY8HLQizQJkOK/Ee0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9Ttl+TbR7gufQzhQx4o/keKeINCjio65rjLWOlP36NM=",
+    "shasum": "uo2UGVZKuD4tO104OeC7Y2oBkpLPrvJWWyGPJTWPVD4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "f9mN2RXTGTpOgMCJJEw4gKMxD5pnwX9iEzN7uwD0hyM=",
+    "shasum": "f8zeIa09pXt1W8vKHjDjznEdSjC2OBn3QVIijtHUwPg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "uo2UGVZKuD4tO104OeC7Y2oBkpLPrvJWWyGPJTWPVD4=",
+    "shasum": "h5z+EGOVyd8FjthPUfK+8KndCsHVd/dJWQbEV5HV7Pk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "f8zeIa09pXt1W8vKHjDjznEdSjC2OBn3QVIijtHUwPg=",
+    "shasum": "I8VkGGWoxhalUw5IIncvCY/InJ15yst1MTnICJ6jUZ4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "h5z+EGOVyd8FjthPUfK+8KndCsHVd/dJWQbEV5HV7Pk=",
+    "shasum": "f9mN2RXTGTpOgMCJJEw4gKMxD5pnwX9iEzN7uwD0hyM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0NNqpKgq/+zNokLs67+6vrA+kZxvDnDe9PWrX6X8Goc=",
+    "shasum": "NuMOVeN5RPc/tuAINdZLD7Q0wccvhS9w0YLCq7JXs8M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZPu4DoRwnCQNfpTF005B0AvJ5NPCPyV1GGtKRUpm5x8=",
+    "shasum": "ogz/CDOrL/5h5eZAIhDHc+lPhM00154OECWokO0DdwI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "v4TY+hN5aUAIdvb31+YEvWCR/Dhc5eSoqv4QZAjgE6w=",
+    "shasum": "bt0ymBAUIDJC0ksow6/BO2+TCm8l5f4I7myCg/tXJfc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "NuMOVeN5RPc/tuAINdZLD7Q0wccvhS9w0YLCq7JXs8M=",
+    "shasum": "ZPu4DoRwnCQNfpTF005B0AvJ5NPCPyV1GGtKRUpm5x8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ogz/CDOrL/5h5eZAIhDHc+lPhM00154OECWokO0DdwI=",
+    "shasum": "v4TY+hN5aUAIdvb31+YEvWCR/Dhc5eSoqv4QZAjgE6w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "lAN8Csyf0HsFkfxsi01msDAdLusKLuPnGmtbcZGH+L0=",
+    "shasum": "OSa/uP5sUDFb9cgnyJF43CHugmssYIbVYFJGXutEOJ8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ea8+eIv5lXEiUUr/jhYv4O5zTAEHHkFgP1dvE0FjqyY=",
+    "shasum": "lAN8Csyf0HsFkfxsi01msDAdLusKLuPnGmtbcZGH+L0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OSa/uP5sUDFb9cgnyJF43CHugmssYIbVYFJGXutEOJ8=",
+    "shasum": "P87ZOtKfVhN78E9zEw5fTGWhgKG0assHA1MZQNAZ0Xk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "tDbsxyvQUz2VoKmIzIXbLr3mtJfNewiHzoEjW7X6c8k=",
+    "shasum": "7Zm7WDQ4Dvg8YnbqTacXu0oC3C25O1oMJkPnLW+r5co=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7Zm7WDQ4Dvg8YnbqTacXu0oC3C25O1oMJkPnLW+r5co=",
+    "shasum": "ea8+eIv5lXEiUUr/jhYv4O5zTAEHHkFgP1dvE0FjqyY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "k0CibdCt3wsBIq47PPqzR193o2VjuddFrcOribmHHmc=",
+    "shasum": "LC5iXkcfN/MGtp2xYrlVceu1Bk/t8+Q9A4hmcn1n4DI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LC5iXkcfN/MGtp2xYrlVceu1Bk/t8+Q9A4hmcn1n4DI=",
+    "shasum": "o+VevN11IEZxklZjSyfhVSB5slBKWW0K6hKFck7LgH4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "UIm8NaJ2HQ+b0/gwzMrUolBPH94WaX0krT2j2vqS8Sw=",
+    "shasum": "sNKcZWHKrpSkWmsHD9nw4SNjuYehxTTXI+PhF0PAyP4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "o+VevN11IEZxklZjSyfhVSB5slBKWW0K6hKFck7LgH4=",
+    "shasum": "UIm8NaJ2HQ+b0/gwzMrUolBPH94WaX0krT2j2vqS8Sw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8/P91GreWpqGOWLGAntmd3Kyu6A3WMelRIWUuxKcsGI=",
+    "shasum": "k0CibdCt3wsBIq47PPqzR193o2VjuddFrcOribmHHmc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "qjKEBv3E1LSeoe6b8ea45bvyC38xxA9O+m19++WQHAc=",
+    "shasum": "vYA+3gTFQtkm/gMBuqF8IKATR5zYEBslQn4E9ZjeQZo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1bLwZCxQusG/VCAswAJ5ohHF6fBgiQtTLhQG1Mby4HI=",
+    "shasum": "pFmqP6z84qAB39wGZcxFQifiNlDOKT7QBPMeKDKNRwg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "pFmqP6z84qAB39wGZcxFQifiNlDOKT7QBPMeKDKNRwg=",
+    "shasum": "qjKEBv3E1LSeoe6b8ea45bvyC38xxA9O+m19++WQHAc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2hc5tU0+vTc55vOTJm8pDwaZJBGCCrzwrkSY/ob/C/w=",
+    "shasum": "y9N2+eSpLMWFxoH+gmVT9u7oR95EP8QaYnlFNowAdZE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vYA+3gTFQtkm/gMBuqF8IKATR5zYEBslQn4E9ZjeQZo=",
+    "shasum": "2hc5tU0+vTc55vOTJm8pDwaZJBGCCrzwrkSY/ob/C/w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9m0//6LmoFrxb/Mpkjlr7eNRe9HK92iKJgtqtijlkFw=",
+    "shasum": "OK/QqfPZc/L7VitrdRypHggyR4/4PnAG/j9erpJfJww=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "IVgoNs8h1fS3imREb3FdCLB5Zf9qmyVwFcILUK9Xt7E=",
+    "shasum": "Y8FjAWQERPZnXFiHwMDpR5yF0loWMbOdJjdvO+uYf5A=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Y8FjAWQERPZnXFiHwMDpR5yF0loWMbOdJjdvO+uYf5A=",
+    "shasum": "+uPTb3bOlEydaXXUp1YaaCuR77bs/KYlnnsDrc983DY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OK/QqfPZc/L7VitrdRypHggyR4/4PnAG/j9erpJfJww=",
+    "shasum": "IVgoNs8h1fS3imREb3FdCLB5Zf9qmyVwFcILUK9Xt7E=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+uPTb3bOlEydaXXUp1YaaCuR77bs/KYlnnsDrc983DY=",
+    "shasum": "axxTRcxOlRzfmwdfTGo0MGMGxIXqxWW3ZMcvgZgU0RU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vTdjnqfw1FFAu/GdTETN6naPNZLvBKQveKb5SfgarRM=",
+    "shasum": "LoFFGA3qj24Pe9Vr/Hpv0KAxUwI80Qdb3ihWR7M7Eag=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "sKg86tSHApZz49OdruONj63Yhts7zDlyLF2lpf6sguw=",
+    "shasum": "lFmdEJF/RldpN7/U6roJJm9BqSI5Bb/Whzh6dockQAw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LoFFGA3qj24Pe9Vr/Hpv0KAxUwI80Qdb3ihWR7M7Eag=",
+    "shasum": "9dG5S/QzV8DC7DQ10d4pp65QYKhGdsSYpUVQXM5qBN0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9dG5S/QzV8DC7DQ10d4pp65QYKhGdsSYpUVQXM5qBN0=",
+    "shasum": "+Dq7vWhymZkiKZPixpzPOac9GYNFd3NXZmThe+RP5Rk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "lFmdEJF/RldpN7/U6roJJm9BqSI5Bb/Whzh6dockQAw=",
+    "shasum": "vTdjnqfw1FFAu/GdTETN6naPNZLvBKQveKb5SfgarRM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "E5ZJ6XhrkUVcH19inuDA64yZQg92JuW8xO2HD0NaWY0=",
+    "shasum": "bLUkDZXvhV/kAyeqPFVp3Bd0SPk42AVkVtfWTWKoBd4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FzazaYSj1m1eJbWO3x4CVkrZj95VfbnzbO7P8mfJnNI=",
+    "shasum": "E5ZJ6XhrkUVcH19inuDA64yZQg92JuW8xO2HD0NaWY0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0vuiA3xbMMPYDMcE7ytDmXM0B4wwc+b90Ncy114JU24=",
+    "shasum": "oX0FZa9+kdiEHrtU1sMbUCJMoXpiM9ur2W7WG8s/OW8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "bLUkDZXvhV/kAyeqPFVp3Bd0SPk42AVkVtfWTWKoBd4=",
+    "shasum": "YONnSNnY1QXI799OnXcq7pOJ9mB2mf0TKA+hwrXei0M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "oX0FZa9+kdiEHrtU1sMbUCJMoXpiM9ur2W7WG8s/OW8=",
+    "shasum": "FzazaYSj1m1eJbWO3x4CVkrZj95VfbnzbO7P8mfJnNI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6Q2MkQCJd9UneQoCp3vxQGGQ8Ajrsf86BTiPBR4CIlk=",
+    "shasum": "A9oCcxfQ/Ze21a+qSjmFEMjpyJDZTXBEUF/eEtzr00g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "I2MgHF7MuMKoGGKMSJTB2TAdRNt3ThuAs7N5QLqsFwc=",
+    "shasum": "YV8OblLCDm1crxxmNDvWA3W8FL5Im3754++56NBSbUY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "YV8OblLCDm1crxxmNDvWA3W8FL5Im3754++56NBSbUY=",
+    "shasum": "8AKxcoo/a6Xxfj6TUhcEs2aEXMwxibJLcWPRiXI9mig=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LQXgfkmMDLHqG23UE+vq7V2NTV2G+okrbWGtitICkBY=",
+    "shasum": "6Q2MkQCJd9UneQoCp3vxQGGQ8Ajrsf86BTiPBR4CIlk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8AKxcoo/a6Xxfj6TUhcEs2aEXMwxibJLcWPRiXI9mig=",
+    "shasum": "LQXgfkmMDLHqG23UE+vq7V2NTV2G+okrbWGtitICkBY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "b6z/vd9UzvmbWax8XEqdu1Da6c0U8nx2fW8O3e3OVhU=",
+    "shasum": "QpOZlqHNXUWxJEkcks0CEg15OO3HSximP79r+3hronM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wquuFPu3DiUvPAXvUsSwnYN6l8SltYivBAlMdfHXLS4=",
+    "shasum": "HiZjEop93vH1rfFXz4k7SPgxiaUeGzXPvpjeMAcb0NU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "HiZjEop93vH1rfFXz4k7SPgxiaUeGzXPvpjeMAcb0NU=",
+    "shasum": "JFhngXwNXV1gfnin9435etNBL/Y4vEYrWImgZZCILD0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "JFhngXwNXV1gfnin9435etNBL/Y4vEYrWImgZZCILD0=",
+    "shasum": "b6z/vd9UzvmbWax8XEqdu1Da6c0U8nx2fW8O3e3OVhU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "F+ZTNm0I7LeuhiRfFLz34sEn1nQrHEmZ4vbl4V1buiU=",
+    "shasum": "wquuFPu3DiUvPAXvUsSwnYN6l8SltYivBAlMdfHXLS4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LSk+GmGMP8byzHX013+Fnj8hPWxFD1ctKE7FwmXwUZ4=",
+    "shasum": "AYkzHZhTfVEuyZbMIOrbwX+fTYIm97M2rs/iwXEG954=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AYkzHZhTfVEuyZbMIOrbwX+fTYIm97M2rs/iwXEG954=",
+    "shasum": "sZTDQUyjc2KheUbOG0H/CIVYRLiCHAj9LRwaE8GIooM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "sZTDQUyjc2KheUbOG0H/CIVYRLiCHAj9LRwaE8GIooM=",
+    "shasum": "Pi3qH8IlyNlERthaWzFGRxJGZb+XDJ89QdkY4XDxTqo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Pi3qH8IlyNlERthaWzFGRxJGZb+XDJ89QdkY4XDxTqo=",
+    "shasum": "V/YxuQSq7yqlK2h/zypPPaEWeloh0J9tVMjPGYm0Mgo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "V/YxuQSq7yqlK2h/zypPPaEWeloh0J9tVMjPGYm0Mgo=",
+    "shasum": "hFzGG0OogA6v6B3SOokVHVqTRuuTyLdA9iULpuifFAo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7mRu1KFdFY6XxJCVdUBj+vHOgiuEtdbuQ7pNXrwVZdw=",
+    "shasum": "xwnHVWihUs6GD1HCciN89gkTzKcMqISeBROgEUN4wgk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "gRoujvXbGzclQmIEgWQQvuKxeeTXt4jt8Kv+SggT5I8=",
+    "shasum": "7mRu1KFdFY6XxJCVdUBj+vHOgiuEtdbuQ7pNXrwVZdw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xwnHVWihUs6GD1HCciN89gkTzKcMqISeBROgEUN4wgk=",
+    "shasum": "K/YoIRPCc1i39hakRMVA/Eqnqc7MY+36G8I6/Ca1gqc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "K/YoIRPCc1i39hakRMVA/Eqnqc7MY+36G8I6/Ca1gqc=",
+    "shasum": "5+rhF05TzrBN+IAV/3tL2OElXjDV3JTMpRA6ZicthAs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5+rhF05TzrBN+IAV/3tL2OElXjDV3JTMpRA6ZicthAs=",
+    "shasum": "cRsMxa73YE9a7rrLfAvqWkL7LtqDCt1KQifgF4bA/YA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "DFc9t3YIo2l+iK0uST4anZvk3OVnR9roGokhha5SNaw=",
+    "shasum": "z7xE1BJuNCfznRO3/1C3Et1FT/oKATYB3nrchlIIjTk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "DMgBdNXhzY5eanbB+zfrshV+NfhYhwcf3N7+OpXOfVg=",
+    "shasum": "K+/ZeTU0gQlrcwy0oCKaxjpxpv8f8GLYbkAv6ZLZhls=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "K+/ZeTU0gQlrcwy0oCKaxjpxpv8f8GLYbkAv6ZLZhls=",
+    "shasum": "DFc9t3YIo2l+iK0uST4anZvk3OVnR9roGokhha5SNaw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "z7xE1BJuNCfznRO3/1C3Et1FT/oKATYB3nrchlIIjTk=",
+    "shasum": "o4UgAxX2mrxEIUbi2og85R/dECjjg+q51X0t1x8KXb4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "pgKvkVBqtJ4sPb6shDMNXiDc1C8apmV4+WfN6ciavKg=",
+    "shasum": "DMgBdNXhzY5eanbB+zfrshV+NfhYhwcf3N7+OpXOfVg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "y06YrfQGNwFwo/kH3HfwJaWNYQu5C6UAKuZlafLWYHk=",
+    "shasum": "IN1A0Mn2HzGMv+1DskqAOdGq7Z/VswhldNMetQFn7WY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "IN1A0Mn2HzGMv+1DskqAOdGq7Z/VswhldNMetQFn7WY=",
+    "shasum": "gneP1YqODXq++KJZjTtuGjr1RB8izfkURNyyWxu9Uac=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "gneP1YqODXq++KJZjTtuGjr1RB8izfkURNyyWxu9Uac=",
+    "shasum": "P6W+9HEzJ6H0XuZX6lERuskbzYdOATjxbW+NjcjUmPA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "P6W+9HEzJ6H0XuZX6lERuskbzYdOATjxbW+NjcjUmPA=",
+    "shasum": "3F5KdhaTzO0rYEAOJ9Y7Q0COWJqXOqcyTkG0FqdZ05s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "MDjrpUYVTAW1NxWp544Gn4DcF0t6GoDBQIR3F+zeqtI=",
+    "shasum": "y06YrfQGNwFwo/kH3HfwJaWNYQu5C6UAKuZlafLWYHk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2bTgXzMoOamgCLZor3obQ5SPdFMY+jIQpuHWHtFzEbs=",
+    "shasum": "whLo5E6I9SsxqOEhqSoZCmSSAi9y00t5IIoB95zj56g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "G9fNyPGqUsjlqzMskFKEkdy04ny6eZDBBlXSajmQcN8=",
+    "shasum": "6qUXiZopZ2r/V/Hd6v8v4OjP2IKpBwMu5WAZjO4Ikgs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6qUXiZopZ2r/V/Hd6v8v4OjP2IKpBwMu5WAZjO4Ikgs=",
+    "shasum": "2bTgXzMoOamgCLZor3obQ5SPdFMY+jIQpuHWHtFzEbs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "whLo5E6I9SsxqOEhqSoZCmSSAi9y00t5IIoB95zj56g=",
+    "shasum": "g1h6l5PmU3C2tXZyfdsXRmcxGWR7rmfsVLw45t3eEtg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "g1h6l5PmU3C2tXZyfdsXRmcxGWR7rmfsVLw45t3eEtg=",
+    "shasum": "NUAroyflmKAfjOcXwHF9PWN9Ioa9AbakdYBBduNtlEI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "XKLkCOhCgU+yQ2Z+qnX7mSrlduxJeqMqBd5nqKKdz6Q=",
+    "shasum": "QPc5ZS6VlcPrDtb3GPyk7vOq/g/hItqSqkq9H6Al3Wg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4FnjVvoeQC7msz0OdpwMatXvXlXyPPXxEwlhRUOt6Io=",
+    "shasum": "o89z7gAMsuZ88FMA2m+7LjmH0ZXStQ4VV5joHlza15A=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1Vo2b7dgicVZYWx6DMTlnkDnK6UBbk4fmilSsLKwSDg=",
+    "shasum": "XKLkCOhCgU+yQ2Z+qnX7mSrlduxJeqMqBd5nqKKdz6Q=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "o89z7gAMsuZ88FMA2m+7LjmH0ZXStQ4VV5joHlza15A=",
+    "shasum": "Hpmj/t7F9hsI52wGOdI+ak3W8yYLsQAKDrwT5tVhnYg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "QPc5ZS6VlcPrDtb3GPyk7vOq/g/hItqSqkq9H6Al3Wg=",
+    "shasum": "4FnjVvoeQC7msz0OdpwMatXvXlXyPPXxEwlhRUOt6Io=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "czQq93Uay+jE8HZvwSViZfMdDQTPn0ClMJaH34VN0dc=",
+    "shasum": "ZFIL9SrOEbTWaUDGIJZXZJPJFGraq3sPiWM8bC2tLy4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "bb9yl3sUFSzfelkwY7LgGK9OOQlQI7lpPMwdOBsFTK4=",
+    "shasum": "O0whqPrZ7Iqr4RGBdWIi7nMcXPa/X08whUVOLT9V/ws=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZFIL9SrOEbTWaUDGIJZXZJPJFGraq3sPiWM8bC2tLy4=",
+    "shasum": "3u0roIrlyn6qhMMtTc/U36RkuhiB4oF8DFu9H1h5bbc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3u0roIrlyn6qhMMtTc/U36RkuhiB4oF8DFu9H1h5bbc=",
+    "shasum": "bb9yl3sUFSzfelkwY7LgGK9OOQlQI7lpPMwdOBsFTK4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "O0whqPrZ7Iqr4RGBdWIi7nMcXPa/X08whUVOLT9V/ws=",
+    "shasum": "wtOoGYeD+m/9PFLtyVgAEOLeJaZbmScyb5ovC1S4AWA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "lvCLamKc9tutH9zT6ECKjMoVgKxaueZxEm2Soy+GIX0=",
+    "shasum": "0iSgKQXeEePTFOenbfI1FS/N5mB403Z9Et7mn+qwxzo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Vr0QhrtHYgg7DFczqQc4KEkAkKrOCOAc3ZnNesEVZ+w=",
+    "shasum": "lvCLamKc9tutH9zT6ECKjMoVgKxaueZxEm2Soy+GIX0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0iSgKQXeEePTFOenbfI1FS/N5mB403Z9Et7mn+qwxzo=",
+    "shasum": "DPp7KHenp69URctJORMZuDaibhxInE43yiwPLEXPwJw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "DPp7KHenp69URctJORMZuDaibhxInE43yiwPLEXPwJw=",
+    "shasum": "UxIvaI4TmlafrguqYUWmJ/L8iz57LSgLBBkYmqzOhaI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "UxIvaI4TmlafrguqYUWmJ/L8iz57LSgLBBkYmqzOhaI=",
+    "shasum": "3CUmmQR8Rm9YPrR2vYdg97SGUzUndQf3OgYrUzlvLI4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "GhbegDCUE81gFKKZLRBBf/D2hfEOU9NfAczaTR0sOYc=",
+    "shasum": "9qUDCBIHh+FgaJSYylelB3JB1VcPmgNBESZZGNKK3/4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "osTfC/2Y6+aDcYtRj6N7YxVRLfVgNEHAmL7Km8nkwI4=",
+    "shasum": "XHg6R5zNIYiH4dHBwqO2Om0TMvK8koQu6WOe6CcvRio=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6btrG6bcFAWosjSF/ldUuTd3sXNlYxVsRm0gcTJRE2M=",
+    "shasum": "osTfC/2Y6+aDcYtRj6N7YxVRLfVgNEHAmL7Km8nkwI4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9qUDCBIHh+FgaJSYylelB3JB1VcPmgNBESZZGNKK3/4=",
+    "shasum": "VDkYGW0UgbTFLVuhnjjbYCJvHlMaFRfklmdUK3wyl4w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "XHg6R5zNIYiH4dHBwqO2Om0TMvK8koQu6WOe6CcvRio=",
+    "shasum": "GhbegDCUE81gFKKZLRBBf/D2hfEOU9NfAczaTR0sOYc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZEUzTVWOhCkH9K+WmtspfXEu16imY9ee4HdK7wH8hew=",
+    "shasum": "AaxZSpg3ajf3EphiCRvndaiJshfP8PLZh90I8lMGTPg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xM6Q/SRD4ivSYzwqD2NhmlVQ5v2RHLnEN8ohxWtWcBU=",
+    "shasum": "ZEUzTVWOhCkH9K+WmtspfXEu16imY9ee4HdK7wH8hew=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "khCrwAziXNhRJrV8cHp3hfRyudXVBYVB3Cew7YpWDG0=",
+    "shasum": "xM6Q/SRD4ivSYzwqD2NhmlVQ5v2RHLnEN8ohxWtWcBU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vfs20ja+DvBv5vZukhW2Y38sJY1CL3zEA14JS7725Ao=",
+    "shasum": "6os9tFCmhv3HTapJ6Mzr5eG04r28c+hjgD/cLSDraEY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AaxZSpg3ajf3EphiCRvndaiJshfP8PLZh90I8lMGTPg=",
+    "shasum": "vfs20ja+DvBv5vZukhW2Y38sJY1CL3zEA14JS7725Ao=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7wOe/70O/A4BoUF5+CabV0Rjivnnv2D/xcQ1AlAZdw0=",
+    "shasum": "9DHCPiYk3FZZqg0rdsH0YIJFL3x8BfUH3jcZAD2gqA4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Gmn3gYzZm188ctTJgWVvvXsBCMnqKgy5MvmwHQEYowM=",
+    "shasum": "rG0w/CpDp7pUUEYz6z6LB/t2UtOnLPq3tXNC0ZuI5p4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2u8Ff+LVeGGDTlSIqX1tyfRECv4nf13rwm11sKZ4/Qg=",
+    "shasum": "z3FmXq08vm9sXiJI4wfkPbZ7sBB8gdsPOrcVuEVa0xM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "z3FmXq08vm9sXiJI4wfkPbZ7sBB8gdsPOrcVuEVa0xM=",
+    "shasum": "Gmn3gYzZm188ctTJgWVvvXsBCMnqKgy5MvmwHQEYowM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9DHCPiYk3FZZqg0rdsH0YIJFL3x8BfUH3jcZAD2gqA4=",
+    "shasum": "2u8Ff+LVeGGDTlSIqX1tyfRECv4nf13rwm11sKZ4/Qg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Xpb9v3Lycj3WJ15xvBbTmHuYZR4vb9iyhnkgATh18po=",
+    "shasum": "PfW4LfNyQP9K9MD/ZPF/oumq7RJf/SyJU2jeoUSJ2aM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "SBw2f5d1MMrve92+z+rGmPpJ5hJmyuMi1N6Pza/9nXU=",
+    "shasum": "Xpb9v3Lycj3WJ15xvBbTmHuYZR4vb9iyhnkgATh18po=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5dDSK6C4XDIT1ukZh1nEimci2a+z0hnqUNEqi7qBNAk=",
+    "shasum": "SBw2f5d1MMrve92+z+rGmPpJ5hJmyuMi1N6Pza/9nXU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Qj1+BivQzIMmikoDbUznJQJoEW/8BTaQaseCOcON+Zw=",
+    "shasum": "3sWzEjRApKpX8lrHwPjB4f0kuvwx7o1ZiuPxqTrEl3s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "PfW4LfNyQP9K9MD/ZPF/oumq7RJf/SyJU2jeoUSJ2aM=",
+    "shasum": "Qj1+BivQzIMmikoDbUznJQJoEW/8BTaQaseCOcON+Zw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9kalAse/bhDXFV4vXXNSlNZt/jxm1KkGkC1DF2nDcW8=",
+    "shasum": "h6yDf1EBo4mpSb1qqHGQiutSvuExPmtthseHyuXhsvQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3r3+aNEdyR7CWPvBmmSCuZY+FTA+eFdkulS+0a2+KYU=",
+    "shasum": "9kalAse/bhDXFV4vXXNSlNZt/jxm1KkGkC1DF2nDcW8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "unSCLB8GJ5KyYT3YfHSMDFcD5ClGtWcWbJZ7eIpjlk4=",
+    "shasum": "3r3+aNEdyR7CWPvBmmSCuZY+FTA+eFdkulS+0a2+KYU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FBzAQuGVTVij6SLPkzro0OmcEPNXKT1NLHjiY3rUcxQ=",
+    "shasum": "unSCLB8GJ5KyYT3YfHSMDFcD5ClGtWcWbJZ7eIpjlk4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8kKJRiaM18IxSr89svPvmzGIjRszgJvmfLkJxJLyFA4=",
+    "shasum": "FBzAQuGVTVij6SLPkzro0OmcEPNXKT1NLHjiY3rUcxQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "yUK4OmLGC/zSUUc/Nqlj2rPQ/Oy0/Rx7+su/pEL83uU=",
+    "shasum": "PLD8S8Lsjnkabuv6I1DxuMvdkjvbDF9o1Sc3X5zfAr4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "PLD8S8Lsjnkabuv6I1DxuMvdkjvbDF9o1Sc3X5zfAr4=",
+    "shasum": "fNPOi4FAZa4IXTEj/gZyBBx93NmiFlv2wGABRXK+3TY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "DGgaRZmS8KSVnUzCq/V7f9TauAelSCFe9sg3myXrWks=",
+    "shasum": "xEkfElvZ0ndhl1PcdkqDL6gicxdKxae/aKDl011Tgs4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xEkfElvZ0ndhl1PcdkqDL6gicxdKxae/aKDl011Tgs4=",
+    "shasum": "yUK4OmLGC/zSUUc/Nqlj2rPQ/Oy0/Rx7+su/pEL83uU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "fNPOi4FAZa4IXTEj/gZyBBx93NmiFlv2wGABRXK+3TY=",
+    "shasum": "VWTxqVgjWnanv5fmejkDm5Gz+yiKveFROceWqIg6vi0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "A5g5mxLzrae+3ShTHi1QDLdeHRDuUt4dGjwC2Mq/1NE=",
+    "shasum": "0PQHPzqWuahbPrh5XviC7NnEnRhA185kaAIdCZcOfqs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OtUyvj24INOaosESd2O9fN5hnxBSW//UctFgaY+Ha3A=",
+    "shasum": "e79yLA9JvLIWDuBMPXLYFNKT+6Tpun4yAkAUJEx/vrA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+x5V9w2ybgWUj2j/DvhKFRI3yo0ng8zhQ/BFN55F7yw=",
+    "shasum": "OtUyvj24INOaosESd2O9fN5hnxBSW//UctFgaY+Ha3A=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "U4Zhw9ZpNVXJHoYfuYJ4a6j/ynAaFXxZYUYo0DSESVs=",
+    "shasum": "+x5V9w2ybgWUj2j/DvhKFRI3yo0ng8zhQ/BFN55F7yw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "e79yLA9JvLIWDuBMPXLYFNKT+6Tpun4yAkAUJEx/vrA=",
+    "shasum": "A5g5mxLzrae+3ShTHi1QDLdeHRDuUt4dGjwC2Mq/1NE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-jest/src/matchers.ts
+++ b/packages/snaps-jest/src/matchers.ts
@@ -11,7 +11,11 @@ import type {
   ComponentOrElement,
   Component,
 } from '@metamask/snaps-sdk';
-import type { JSXElement, SnapNode } from '@metamask/snaps-sdk/jsx';
+import type {
+  GenericSnapElement,
+  JSXElement,
+  SnapNode,
+} from '@metamask/snaps-sdk/jsx';
 import { isJSXElementUnsafe } from '@metamask/snaps-sdk/jsx';
 import { getJsxElementFromComponent } from '@metamask/snaps-utils';
 import type { Json } from '@metamask/utils';
@@ -234,7 +238,7 @@ export function serialiseJsx(node: SnapNode, indentation = 0): string {
     return '';
   }
 
-  const { type, props } = node;
+  const { type, props } = node as GenericSnapElement;
   const trailingNewline = indentation > 0 ? '\n' : '';
 
   if (hasProperty(props, 'children')) {

--- a/packages/snaps-sdk/CONTRIBUTING.md
+++ b/packages/snaps-sdk/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing
+
+## Adding new JSX components
+
+The MetaMask Snaps SDK uses JSX components for building user interfaces in
+Snaps. To add a new component, follow these steps:
+
+1. Create a new file in the `src/jsx/components` directory, optionally in a
+   subdirectory if the component is part of a group of related components.
+2. It is recommended to copy an existing component file and modify it to create
+   the new component.
+3. Create a test for the new component, following the existing test files for
+   the other components.
+4. Add the new component to the `src/jsx/components/index.ts` file, exporting it
+   from the file.
+   - This file also contains a `JSXElement` union type that should
+     be updated to include the new component.
+5. Add validation for the component to `src/jsx/validation.ts`, making sure to
+   use the `Describe` helper type to ensure that the component is correctly
+   validated.
+   - Make sure to add tests for the validation in `src/jsx/validation.test.ts`
+     as well.
+6. If the component is stateful, make sure to add it to the
+   `SnapInterfaceController` too.
+   - You can use [this PR](https://github.com/MetaMask/snaps/pull/2501) as a
+     reference.
+
+### Component props
+
+When adding a new component, make sure to document the props that the component
+accepts. This can be done by adding a JSDoc comment to the component function
+declaration, like so:
+
+```typescript
+/**
+ * The props of the {@link Dropdown} component.
+ *
+ * @property name - The name of the dropdown. This is used to identify the
+ * state in the form data.
+ * @property value - The selected value of the dropdown.
+ * @property children - The children of the dropdown.
+ */
+export type DropdownProps = {
+  name: string;
+  value?: string | undefined;
+  children: MaybeArray<OptionElement | boolean>;
+};
+```
+
+The props type should be exported from the component file and used in the
+component function declaration, like so:
+
+```typescript
+// ...
+export const Dropdown = createSnapComponent<DropdownProps, typeof TYPE>(TYPE);
+```
+
+To ensure consistency, make sure to follow the existing patterns in the codebase
+when documenting component props.
+
+#### Optional props
+
+Optional props should be both marked with a `?` in the type definition, and
+also include `undefined` in the type definition. This is to ensure that the
+component can be used with or without TypeScript's exact optional props feature.
+
+```typescript
+export type ComponentProps = {
+  value?: string | undefined;
+};
+```
+
+#### Children
+
+In most cases, the children prop should be defined as `MaybeArray` to allow for
+both a single child element or an array of child elements. There are some
+exceptions to this rule, such as when the component only accepts a single child
+element (e.g., `Field`).
+
+Children should also accept `boolean` and `null` values to allow for conditional
+rendering of child elements.
+
+```typescript
+export type ComponentProps = {
+  children: MaybeArray<string | boolean | null>;
+};
+```
+
+If the children are optional, make sure to include `undefined` in the type and
+add the `?` to the prop definition.
+
+```typescript
+export type ComponentProps = {
+  children?: MaybeArray<string | boolean | null> | undefined;
+};
+```

--- a/packages/snaps-sdk/CONTRIBUTING.md
+++ b/packages/snaps-sdk/CONTRIBUTING.md
@@ -43,7 +43,7 @@ declaration, like so:
 export type DropdownProps = {
   name: string;
   value?: string | undefined;
-  children: MaybeArray<OptionElement | boolean>;
+  children: SnapsChildren<OptionElement>;
 };
 ```
 
@@ -78,7 +78,8 @@ exceptions to this rule, such as when the component only accepts a single child
 element (e.g., `Field`).
 
 Children should also accept `boolean` and `null` values to allow for conditional
-rendering of child elements.
+rendering of child elements. This is handled automatically by the
+`SnapsChildren` type.
 
 ```typescript
 export type ComponentProps = {

--- a/packages/snaps-sdk/CONTRIBUTING.md
+++ b/packages/snaps-sdk/CONTRIBUTING.md
@@ -72,8 +72,8 @@ export type ComponentProps = {
 
 #### Children
 
-In most cases, the children prop should be defined as `MaybeArray` to allow for
-both a single child element or an array of child elements. There are some
+In most cases, the children prop should be defined as `SnapsChildren` to allow
+for both a single child element or an array of child elements. There are some
 exceptions to this rule, such as when the component only accepts a single child
 element (e.g., `Field`).
 
@@ -82,7 +82,7 @@ rendering of child elements.
 
 ```typescript
 export type ComponentProps = {
-  children: MaybeArray<string | boolean | null>;
+  children: SnapsChildren<string>; // Nestable<string | boolean | null>;
 };
 ```
 
@@ -91,6 +91,6 @@ add the `?` to the prop definition.
 
 ```typescript
 export type ComponentProps = {
-  children?: MaybeArray<string | boolean | null> | undefined;
+  children?: SnapsChildren<string> | undefined;
 };
 ```

--- a/packages/snaps-sdk/jest.config.js
+++ b/packages/snaps-sdk/jest.config.js
@@ -4,7 +4,11 @@ const { resolve } = require('path');
 const baseConfig = require('../../jest.config.base');
 
 module.exports = deepmerge(baseConfig, {
-  collectCoverageFrom: ['!./src/**/index.ts'],
+  collectCoverageFrom: [
+    '!./src/**/index.ts',
+    '!./src/types/global.ts',
+    '!./src/types/images.ts',
+  ],
 
   coverageThreshold: {
     global: {

--- a/packages/snaps-sdk/src/internals/jsx.ts
+++ b/packages/snaps-sdk/src/internals/jsx.ts
@@ -90,7 +90,7 @@ export type Describe<Type> = Struct<Type, StructSchema<Type>>;
  */
 export function nullUnion<Head extends AnyStruct, Tail extends AnyStruct[]>(
   structs: [head: Head, ...tail: Tail],
-) {
+): Struct<Infer<Head> | InferStructTuple<Tail>[number], null> {
   return union(structs) as unknown as Struct<
     Infer<Head> | InferStructTuple<Tail>[number],
     null

--- a/packages/snaps-sdk/src/jsx/component.ts
+++ b/packages/snaps-sdk/src/jsx/component.ts
@@ -64,12 +64,13 @@ export type MaybeArray<Type> = Nestable<Type>;
 /**
  * A JSX node, which can be an element, a string, null, or an array of nodes.
  */
-export type SnapNode = MaybeArray<GenericSnapElement | string | null>;
+export type SnapNode = MaybeArray<GenericSnapElement | string | boolean | null>;
 
 /**
- * A JSX string element, which can be a string or an array of strings.
+ * A JSX string element, which can be a string or an array of strings, or
+ * booleans (for conditional rendering).
  */
-export type StringElement = MaybeArray<string>;
+export type StringElement = MaybeArray<string | boolean>;
 
 /**
  * A JSX component.

--- a/packages/snaps-sdk/src/jsx/component.ts
+++ b/packages/snaps-sdk/src/jsx/component.ts
@@ -51,26 +51,22 @@ export type SnapElement<
 export type Nestable<Type> = Type | Nestable<Type>[];
 
 /**
- * A type that can be a single value or an array of values.
+ * A type that can be a single value or an array of values, a boolean, or null.
  *
  * @template Type - The type that can be an array.
- * @example
- * type MaybeArrayString = MaybeArray<string>;
- * const maybeArrayString: MaybeArrayString = 'hello';
- * const maybeArrayStringArray: MaybeArrayString = ['hello', 'world'];
  */
-export type MaybeArray<Type> = Nestable<Type>;
+export type SnapsChildren<Type> = Nestable<Type | boolean | null>;
 
 /**
  * A JSX node, which can be an element, a string, null, or an array of nodes.
  */
-export type SnapNode = MaybeArray<GenericSnapElement | string | boolean | null>;
+export type SnapNode = SnapsChildren<GenericSnapElement | string>;
 
 /**
  * A JSX string element, which can be a string or an array of strings, or
  * booleans (for conditional rendering).
  */
-export type StringElement = MaybeArray<string | boolean>;
+export type StringElement = SnapsChildren<string>;
 
 /**
  * A JSX component.

--- a/packages/snaps-sdk/src/jsx/components/Box.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/Box.test.tsx
@@ -89,4 +89,22 @@ describe('Box', () => {
       },
     });
   });
+
+  it('renders a box with a conditional', () => {
+    const result = (
+      <Box direction="horizontal" alignment="space-between">
+        {false && <Text>Hello</Text>}
+      </Box>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Box',
+      key: null,
+      props: {
+        direction: 'horizontal',
+        alignment: 'space-between',
+        children: false,
+      },
+    });
+  });
 });

--- a/packages/snaps-sdk/src/jsx/components/Box.ts
+++ b/packages/snaps-sdk/src/jsx/components/Box.ts
@@ -10,7 +10,7 @@ import { createSnapComponent } from '../component';
  */
 export type BoxProps = {
   // We can't use `JSXElement` because it causes a circular reference.
-  children: MaybeArray<GenericSnapElement | null>;
+  children: MaybeArray<GenericSnapElement | boolean | null>;
   direction?: 'vertical' | 'horizontal' | undefined;
   alignment?:
     | 'start'

--- a/packages/snaps-sdk/src/jsx/components/Box.ts
+++ b/packages/snaps-sdk/src/jsx/components/Box.ts
@@ -1,4 +1,4 @@
-import type { GenericSnapElement, MaybeArray } from '../component';
+import type { GenericSnapElement, SnapsChildren } from '../component';
 import { createSnapComponent } from '../component';
 
 /**
@@ -10,7 +10,7 @@ import { createSnapComponent } from '../component';
  */
 export type BoxProps = {
   // We can't use `JSXElement` because it causes a circular reference.
-  children: MaybeArray<GenericSnapElement | boolean | null>;
+  children: SnapsChildren<GenericSnapElement>;
   direction?: 'vertical' | 'horizontal' | undefined;
   alignment?:
     | 'start'

--- a/packages/snaps-sdk/src/jsx/components/Heading.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/Heading.test.tsx
@@ -24,4 +24,21 @@ describe('Heading', () => {
       },
     });
   });
+
+  it('renders a heading with a conditional value', () => {
+    const result = (
+      <Heading>
+        Hello
+        {false && 'world'}
+      </Heading>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Heading',
+      key: null,
+      props: {
+        children: ['Hello', false],
+      },
+    });
+  });
 });

--- a/packages/snaps-sdk/src/jsx/components/Link.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/Link.test.tsx
@@ -26,4 +26,22 @@ describe('Link', () => {
       },
     });
   });
+
+  it('renders a link with a conditional value', () => {
+    const result = (
+      <Link href="https://example.com">
+        Hello
+        {false && 'world'}
+      </Link>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Link',
+      key: null,
+      props: {
+        href: 'https://example.com',
+        children: ['Hello', false],
+      },
+    });
+  });
 });

--- a/packages/snaps-sdk/src/jsx/components/Link.ts
+++ b/packages/snaps-sdk/src/jsx/components/Link.ts
@@ -6,7 +6,7 @@ import type { StandardFormattingElement } from './formatting';
  * The children of the {@link Link} component.
  */
 export type LinkChildren = MaybeArray<
-  string | StandardFormattingElement | null
+  string | StandardFormattingElement | boolean | null
 >;
 
 /**

--- a/packages/snaps-sdk/src/jsx/components/Link.ts
+++ b/packages/snaps-sdk/src/jsx/components/Link.ts
@@ -1,13 +1,11 @@
-import type { MaybeArray } from '../component';
+import type { SnapsChildren } from '../component';
 import { createSnapComponent } from '../component';
 import type { StandardFormattingElement } from './formatting';
 
 /**
  * The children of the {@link Link} component.
  */
-export type LinkChildren = MaybeArray<
-  string | StandardFormattingElement | boolean | null
->;
+export type LinkChildren = SnapsChildren<string | StandardFormattingElement>;
 
 /**
  * The props of the {@link Link} component.

--- a/packages/snaps-sdk/src/jsx/components/Text.ts
+++ b/packages/snaps-sdk/src/jsx/components/Text.ts
@@ -7,7 +7,7 @@ import type { LinkElement } from './Link';
  * The children of the {@link Text} component.
  */
 export type TextChildren = MaybeArray<
-  string | StandardFormattingElement | LinkElement | null
+  string | boolean | StandardFormattingElement | LinkElement | null
 >;
 
 /**

--- a/packages/snaps-sdk/src/jsx/components/Text.ts
+++ b/packages/snaps-sdk/src/jsx/components/Text.ts
@@ -1,4 +1,4 @@
-import type { MaybeArray } from '../component';
+import type { SnapsChildren } from '../component';
 import { createSnapComponent } from '../component';
 import type { StandardFormattingElement } from './formatting';
 import type { LinkElement } from './Link';
@@ -6,8 +6,8 @@ import type { LinkElement } from './Link';
 /**
  * The children of the {@link Text} component.
  */
-export type TextChildren = MaybeArray<
-  string | boolean | StandardFormattingElement | LinkElement | null
+export type TextChildren = SnapsChildren<
+  string | StandardFormattingElement | LinkElement
 >;
 
 /**

--- a/packages/snaps-sdk/src/jsx/components/Tooltip.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/Tooltip.test.tsx
@@ -1,0 +1,102 @@
+import { Link } from './Link';
+import { Text } from './Text';
+import { Tooltip } from './Tooltip';
+
+describe('Tooltip', () => {
+  it('renders a tooltip', () => {
+    const result = (
+      <Tooltip content={<Text>Hello</Text>}>
+        <Text>World</Text>
+      </Tooltip>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Tooltip',
+      props: {
+        children: {
+          type: 'Text',
+          props: {
+            children: 'World',
+          },
+          key: null,
+        },
+        content: {
+          type: 'Text',
+          props: {
+            children: 'Hello',
+          },
+          key: null,
+        },
+      },
+      key: null,
+    });
+  });
+
+  it('renders a tooltip with a string content', () => {
+    const result = (
+      <Tooltip content="Hello">
+        <Text>World</Text>
+      </Tooltip>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Tooltip',
+      props: {
+        children: {
+          type: 'Text',
+          props: {
+            children: 'World',
+          },
+          key: null,
+        },
+        content: 'Hello',
+      },
+      key: null,
+    });
+  });
+
+  it('renders a tooltip with a link content', () => {
+    const result = (
+      <Tooltip content={<Link href="https://example.com">Link</Link>}>
+        <Text>World</Text>
+      </Tooltip>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Tooltip',
+      props: {
+        children: {
+          type: 'Text',
+          props: {
+            children: 'World',
+          },
+          key: null,
+        },
+        content: {
+          type: 'Link',
+          props: {
+            children: 'Link',
+            href: 'https://example.com',
+          },
+          key: null,
+        },
+      },
+      key: null,
+    });
+  });
+
+  it('renders a tooltip with a conditional value', () => {
+    const result = (
+      <Tooltip content="Hello">{false && <Text>World</Text>}</Tooltip>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Tooltip',
+      props: {
+        children: false,
+        content: 'Hello',
+      },
+      key: null,
+    });
+  });
+});

--- a/packages/snaps-sdk/src/jsx/components/Tooltip.ts
+++ b/packages/snaps-sdk/src/jsx/components/Tooltip.ts
@@ -9,6 +9,7 @@ export type TooltipChildren =
   | StandardFormattingElement
   | LinkElement
   | ImageElement
+  | boolean
   | null;
 
 /**

--- a/packages/snaps-sdk/src/jsx/components/form/Dropdown.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/Dropdown.test.tsx
@@ -1,0 +1,69 @@
+import { Dropdown } from './Dropdown';
+import { Option } from './Option';
+
+describe('Dropdown', () => {
+  it('renders a dropdown with options', () => {
+    const result = (
+      <Dropdown name="dropdown" value="foo">
+        <Option value="foo">Foo</Option>
+        <Option value="bar">Bar</Option>
+      </Dropdown>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Dropdown',
+      props: {
+        name: 'dropdown',
+        value: 'foo',
+        children: [
+          {
+            type: 'Option',
+            props: {
+              value: 'foo',
+              children: 'Foo',
+            },
+            key: null,
+          },
+          {
+            type: 'Option',
+            props: {
+              value: 'bar',
+              children: 'Bar',
+            },
+            key: null,
+          },
+        ],
+      },
+      key: null,
+    });
+  });
+
+  it('renders a dropdown with a conditional option', () => {
+    const result = (
+      <Dropdown name="dropdown" value="foo">
+        <Option value="foo">Foo</Option>
+        {false && <Option value="bar">Bar</Option>}
+      </Dropdown>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Dropdown',
+      props: {
+        name: 'dropdown',
+        value: 'foo',
+        children: [
+          {
+            type: 'Option',
+            props: {
+              value: 'foo',
+              children: 'Foo',
+            },
+            key: null,
+          },
+          false,
+        ],
+      },
+      key: null,
+    });
+  });
+});

--- a/packages/snaps-sdk/src/jsx/components/form/Dropdown.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Dropdown.ts
@@ -10,10 +10,10 @@ import type { OptionElement } from './Option';
  * @property value - The selected value of the dropdown.
  * @property children - The children of the dropdown.
  */
-type DropdownProps = {
+export type DropdownProps = {
   name: string;
   value?: string | undefined;
-  children: MaybeArray<OptionElement>;
+  children: MaybeArray<OptionElement | boolean>;
 };
 
 const TYPE = 'Dropdown';

--- a/packages/snaps-sdk/src/jsx/components/form/Dropdown.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Dropdown.ts
@@ -1,4 +1,4 @@
-import type { MaybeArray } from '../../component';
+import type { SnapsChildren } from '../../component';
 import { createSnapComponent } from '../../component';
 import type { OptionElement } from './Option';
 
@@ -13,7 +13,7 @@ import type { OptionElement } from './Option';
 export type DropdownProps = {
   name: string;
   value?: string | undefined;
-  children: MaybeArray<OptionElement | boolean>;
+  children: SnapsChildren<OptionElement>;
 };
 
 const TYPE = 'Dropdown';

--- a/packages/snaps-sdk/src/jsx/components/form/Field.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Field.ts
@@ -20,8 +20,7 @@ export type FieldProps = {
     | DropdownElement
     | FileInputElement
     | InputElement
-    | CheckboxElement
-    | boolean;
+    | CheckboxElement;
 };
 
 const TYPE = 'Field';

--- a/packages/snaps-sdk/src/jsx/components/form/Field.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Field.ts
@@ -20,7 +20,8 @@ export type FieldProps = {
     | DropdownElement
     | FileInputElement
     | InputElement
-    | CheckboxElement;
+    | CheckboxElement
+    | boolean;
 };
 
 const TYPE = 'Field';

--- a/packages/snaps-sdk/src/jsx/components/form/Form.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Form.ts
@@ -11,7 +11,7 @@ import { createSnapComponent } from '../../component';
  * the event handler.
  */
 export type FormProps = {
-  children: MaybeArray<GenericSnapElement | null>;
+  children: MaybeArray<GenericSnapElement | boolean | null>;
   name: string;
 };
 

--- a/packages/snaps-sdk/src/jsx/components/form/Form.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Form.ts
@@ -1,4 +1,4 @@
-import type { GenericSnapElement, MaybeArray } from '../../component';
+import type { GenericSnapElement, SnapsChildren } from '../../component';
 import { createSnapComponent } from '../../component';
 
 // TODO: Add `onSubmit` prop to the `FormProps` type.
@@ -11,7 +11,7 @@ import { createSnapComponent } from '../../component';
  * the event handler.
  */
 export type FormProps = {
-  children: MaybeArray<GenericSnapElement | boolean | null>;
+  children: SnapsChildren<GenericSnapElement>;
   name: string;
 };
 

--- a/packages/snaps-sdk/src/jsx/components/form/Option.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/Option.test.tsx
@@ -1,0 +1,34 @@
+import { Option } from './Option';
+
+describe('Option', () => {
+  it('renders a dropdown option', () => {
+    const result = <Option value="foo">Foo</Option>;
+
+    expect(result).toStrictEqual({
+      type: 'Option',
+      props: {
+        value: 'foo',
+        children: 'Foo',
+      },
+      key: null,
+    });
+  });
+
+  it('renders a dropdown option with a conditional value', () => {
+    const result = (
+      <Option value="foo">
+        Foo
+        {false && <span>Bar</span>}
+      </Option>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Option',
+      props: {
+        value: 'foo',
+        children: ['Foo', false],
+      },
+      key: null,
+    });
+  });
+});

--- a/packages/snaps-sdk/src/jsx/components/form/Option.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/Option.test.tsx
@@ -13,22 +13,4 @@ describe('Option', () => {
       key: null,
     });
   });
-
-  it('renders a dropdown option with a conditional value', () => {
-    const result = (
-      <Option value="foo">
-        Foo
-        {false && <span>Bar</span>}
-      </Option>
-    );
-
-    expect(result).toStrictEqual({
-      type: 'Option',
-      props: {
-        value: 'foo',
-        children: ['Foo', false],
-      },
-      key: null,
-    });
-  });
 });

--- a/packages/snaps-sdk/src/jsx/components/form/Option.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Option.ts
@@ -1,3 +1,4 @@
+import type { StringElement } from '../../component';
 import { createSnapComponent } from '../../component';
 
 /**
@@ -9,7 +10,7 @@ import { createSnapComponent } from '../../component';
  */
 type OptionProps = {
   value: string;
-  children: string;
+  children: StringElement;
 };
 
 const TYPE = 'Option';

--- a/packages/snaps-sdk/src/jsx/components/form/Option.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Option.ts
@@ -1,4 +1,3 @@
-import type { StringElement } from '../../component';
 import { createSnapComponent } from '../../component';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Dropdown } from './Dropdown';
@@ -12,7 +11,7 @@ import { Dropdown } from './Dropdown';
  */
 type OptionProps = {
   value: string;
-  children: StringElement;
+  children: string;
 };
 
 const TYPE = 'Option';

--- a/packages/snaps-sdk/src/jsx/components/form/Option.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Option.ts
@@ -1,5 +1,7 @@
 import type { StringElement } from '../../component';
 import { createSnapComponent } from '../../component';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { Dropdown } from './Dropdown';
 
 /**
  * The props of the {@link Option} component.

--- a/packages/snaps-sdk/src/jsx/components/formatting/Bold.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/formatting/Bold.test.tsx
@@ -24,4 +24,21 @@ describe('Bold', () => {
       key: null,
     });
   });
+
+  it('returns a bold element with a conditional value', () => {
+    const result = (
+      <Bold>
+        Hello
+        {false && 'world'}
+      </Bold>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Bold',
+      props: {
+        children: ['Hello', false],
+      },
+      key: null,
+    });
+  });
 });

--- a/packages/snaps-sdk/src/jsx/components/formatting/Bold.ts
+++ b/packages/snaps-sdk/src/jsx/components/formatting/Bold.ts
@@ -10,6 +10,7 @@ export type BoldChildren = MaybeArray<
   | string
   // We have to specify the type here to avoid a circular reference.
   | SnapElement<JsonObject, 'Italic'>
+  | boolean
   | null
 >;
 

--- a/packages/snaps-sdk/src/jsx/components/formatting/Bold.ts
+++ b/packages/snaps-sdk/src/jsx/components/formatting/Bold.ts
@@ -1,17 +1,15 @@
-import type { JsonObject, MaybeArray, SnapElement } from '../../component';
+import type { JsonObject, SnapElement, SnapsChildren } from '../../component';
 import { createSnapComponent } from '../../component';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import type { Text } from '../Text';
+import { Text } from '../Text';
 
 /**
  * The children of the {@link Bold} component.
  */
-export type BoldChildren = MaybeArray<
+export type BoldChildren = SnapsChildren<
   | string
   // We have to specify the type here to avoid a circular reference.
   | SnapElement<JsonObject, 'Italic'>
-  | boolean
-  | null
 >;
 
 /**

--- a/packages/snaps-sdk/src/jsx/components/formatting/Italic.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/formatting/Italic.test.tsx
@@ -24,4 +24,21 @@ describe('Italic', () => {
       key: null,
     });
   });
+
+  it('returns an italic element with a conditional value', () => {
+    const result = (
+      <Italic>
+        Hello
+        {false && 'world'}
+      </Italic>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Italic',
+      props: {
+        children: ['Hello', false],
+      },
+      key: null,
+    });
+  });
 });

--- a/packages/snaps-sdk/src/jsx/components/formatting/Italic.ts
+++ b/packages/snaps-sdk/src/jsx/components/formatting/Italic.ts
@@ -8,6 +8,7 @@ export type ItalicChildren = MaybeArray<
   | string
   // We have to specify the type here to avoid a circular reference.
   | SnapElement<JsonObject, 'Bold'>
+  | boolean
   | null
 >;
 

--- a/packages/snaps-sdk/src/jsx/components/formatting/Italic.ts
+++ b/packages/snaps-sdk/src/jsx/components/formatting/Italic.ts
@@ -1,15 +1,13 @@
-import type { JsonObject, MaybeArray, SnapElement } from '../../component';
+import type { JsonObject, SnapElement, SnapsChildren } from '../../component';
 import { createSnapComponent } from '../../component';
 
 /**
  * The children of the {@link Italic} component.
  */
-export type ItalicChildren = MaybeArray<
+export type ItalicChildren = SnapsChildren<
   | string
   // We have to specify the type here to avoid a circular reference.
   | SnapElement<JsonObject, 'Bold'>
-  | boolean
-  | null
 >;
 
 /**

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -73,7 +73,7 @@ describe('StringElementStruct', () => {
     expect(is(['foo', 'bar'], StringElementStruct)).toBe(true);
   });
 
-  it.each([null, undefined, {}])('does not validate "%p"', (value) => {
+  it.each([undefined, {}])('does not validate "%p"', (value) => {
     expect(is(value, StringElementStruct)).toBe(false);
   });
 });

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -229,7 +229,6 @@ export const FormStruct: Describe<FormElement> = element('Form', {
 export const BoldStruct: Describe<BoldElement> = element('Bold', {
   children: children([
     string(),
-    boolean(),
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     lazy(() => ItalicStruct) as unknown as Struct<
       SnapElement<JsonObject, 'Italic'>
@@ -243,7 +242,6 @@ export const BoldStruct: Describe<BoldElement> = element('Bold', {
 export const ItalicStruct: Describe<ItalicElement> = element('Italic', {
   children: children([
     string(),
-    boolean(),
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     lazy(() => BoldStruct) as unknown as Struct<
       SnapElement<JsonObject, 'Bold'>
@@ -324,20 +322,14 @@ export const ImageStruct: Describe<ImageElement> = element('Image', {
  */
 export const LinkStruct: Describe<LinkElement> = element('Link', {
   href: string(),
-  children: children([FormattingStruct, string(), boolean()]),
+  children: children([FormattingStruct, string()]),
 });
 
 /**
  * A struct for the {@link TextElement} type.
  */
 export const TextStruct: Describe<TextElement> = element('Text', {
-  children: children([
-    string(),
-    boolean(),
-    BoldStruct,
-    ItalicStruct,
-    LinkStruct,
-  ]),
+  children: children([string(), BoldStruct, ItalicStruct, LinkStruct]),
   alignment: optional(
     nullUnion([literal('start'), literal('center'), literal('end')]),
   ),

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -172,7 +172,7 @@ export const InputStruct: Describe<InputElement> = element('Input', {
  */
 export const OptionStruct: Describe<OptionElement> = element('Option', {
   value: string(),
-  children: StringElementStruct,
+  children: string(),
 });
 
 /**

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -33,6 +33,7 @@ import type {
   Key,
   Nestable,
   SnapElement,
+  SnapsChildren,
   StringElement,
 } from './component';
 import type {
@@ -217,8 +218,8 @@ export const FieldStruct: Describe<FieldElement> = element('Field', {
 export const FormStruct: Describe<FormElement> = element('Form', {
   children: children(
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    [FieldStruct, lazy(() => BoxChildStruct), boolean()],
-  ) as unknown as Struct<Nestable<GenericSnapElement | boolean | null>, null>,
+    [FieldStruct, lazy(() => BoxChildStruct)],
+  ) as unknown as Struct<SnapsChildren<GenericSnapElement>, null>,
   name: string(),
 });
 
@@ -268,8 +269,8 @@ export const AddressStruct: Describe<AddressElement> = element('Address', {
 export const BoxStruct: Describe<BoxElement> = element('Box', {
   children: children(
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    [lazy(() => BoxChildStruct), boolean()],
-  ) as unknown as Struct<Nestable<GenericSnapElement | boolean | null>, null>,
+    [lazy(() => BoxChildStruct)],
+  ) as unknown as Struct<SnapsChildren<GenericSnapElement>, null>,
   direction: optional(nullUnion([literal('horizontal'), literal('vertical')])),
   alignment: optional(
     nullUnion([

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -68,7 +68,7 @@ export const KeyStruct: Describe<Key> = nullUnion([string(), number()]);
  * A struct for the {@link StringElement} type.
  */
 export const StringElementStruct: Describe<StringElement> = maybeArray(
-  string(),
+  nullUnion([string(), boolean()]),
 );
 
 /**
@@ -163,7 +163,7 @@ export const InputStruct: Describe<InputElement> = element('Input', {
  */
 export const OptionStruct: Describe<OptionElement> = element('Option', {
   value: string(),
-  children: string(),
+  children: StringElementStruct,
 });
 
 /**
@@ -172,7 +172,7 @@ export const OptionStruct: Describe<OptionElement> = element('Option', {
 export const DropdownStruct: Describe<DropdownElement> = element('Dropdown', {
   name: string(),
   value: optional(string()),
-  children: maybeArray(OptionStruct),
+  children: maybeArray(nullUnion([OptionStruct, boolean()])),
 });
 
 /**
@@ -199,6 +199,7 @@ export const FieldStruct: Describe<FieldElement> = element('Field', {
     FileInputStruct,
     InputStruct,
     CheckboxStruct,
+    boolean(),
   ]),
 });
 
@@ -208,8 +209,8 @@ export const FieldStruct: Describe<FieldElement> = element('Field', {
 export const FormStruct: Describe<FormElement> = element('Form', {
   children: maybeArray(
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    nullable(nullUnion([FieldStruct, lazy(() => BoxChildStruct)])),
-  ) as unknown as Struct<MaybeArray<GenericSnapElement | null>, null>,
+    nullable(nullUnion([FieldStruct, lazy(() => BoxChildStruct), boolean()])),
+  ) as unknown as Struct<MaybeArray<GenericSnapElement | boolean | null>, null>,
   name: string(),
 });
 
@@ -221,6 +222,7 @@ export const BoldStruct: Describe<BoldElement> = element('Bold', {
     nullable(
       nullUnion([
         string(),
+        boolean(),
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         lazy(() => ItalicStruct) as unknown as Struct<
           SnapElement<JsonObject, 'Italic'>
@@ -238,6 +240,7 @@ export const ItalicStruct: Describe<ItalicElement> = element('Italic', {
     nullable(
       nullUnion([
         string(),
+        boolean(),
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         lazy(() => BoldStruct) as unknown as Struct<
           SnapElement<JsonObject, 'Bold'>
@@ -265,8 +268,8 @@ export const AddressStruct: Describe<AddressElement> = element('Address', {
 export const BoxStruct: Describe<BoxElement> = element('Box', {
   children: maybeArray(
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    nullable(lazy(() => BoxChildStruct)),
-  ) as unknown as Struct<MaybeArray<GenericSnapElement | null>, null>,
+    nullable(nullUnion([lazy(() => BoxChildStruct), boolean()])),
+  ) as unknown as Struct<MaybeArray<GenericSnapElement | boolean | null>, null>,
   direction: optional(nullUnion([literal('horizontal'), literal('vertical')])),
   alignment: optional(
     nullUnion([
@@ -320,7 +323,9 @@ export const ImageStruct: Describe<ImageElement> = element('Image', {
  */
 export const LinkStruct: Describe<LinkElement> = element('Link', {
   href: string(),
-  children: maybeArray(nullable(nullUnion([FormattingStruct, string()]))),
+  children: maybeArray(
+    nullable(nullUnion([FormattingStruct, string(), boolean()])),
+  ),
 });
 
 /**
@@ -328,7 +333,9 @@ export const LinkStruct: Describe<LinkElement> = element('Link', {
  */
 export const TextStruct: Describe<TextElement> = element('Text', {
   children: maybeArray(
-    nullable(nullUnion([string(), BoldStruct, ItalicStruct, LinkStruct])),
+    nullable(
+      nullUnion([string(), boolean(), BoldStruct, ItalicStruct, LinkStruct]),
+    ),
   ),
   alignment: optional(
     nullUnion([literal('start'), literal('center'), literal('end')]),
@@ -345,6 +352,7 @@ export const TooltipChildStruct = nullUnion([
   ItalicStruct,
   LinkStruct,
   ImageStruct,
+  boolean(),
 ]);
 
 /**

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -208,7 +208,6 @@ export const FieldStruct: Describe<FieldElement> = element('Field', {
     FileInputStruct,
     InputStruct,
     CheckboxStruct,
-    boolean(),
   ]),
 });
 

--- a/packages/snaps-sdk/tsconfig.json
+++ b/packages/snaps-sdk/tsconfig.json
@@ -12,5 +12,6 @@
     "jsx.d.ts",
     "jsx-runtime.d.ts",
     "jsx-dev-runtime.d.ts"
-  ]
+  ],
+  "exclude": ["./dist"]
 }

--- a/packages/snaps-sdk/tsconfig.json
+++ b/packages/snaps-sdk/tsconfig.json
@@ -12,6 +12,5 @@
     "jsx.d.ts",
     "jsx-runtime.d.ts",
     "jsx-dev-runtime.d.ts"
-  ],
-  "exclude": ["./dist"]
+  ]
 }

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 96.75,
+  "branches": 96.77,
   "functions": 98.76,
-  "lines": 98.84,
+  "lines": 98.85,
   "statements": 94.92
 }

--- a/packages/snaps-utils/src/ui.test.tsx
+++ b/packages/snaps-utils/src/ui.test.tsx
@@ -785,6 +785,45 @@ describe('getJsxChildren', () => {
     ]);
   });
 
+  it('removes falsy children from the array', () => {
+    const element = (
+      <Box>
+        <Text>Hello</Text>
+        {false && <Text>Foo</Text>}
+        <Text>World</Text>
+      </Box>
+    );
+
+    expect(getJsxChildren(element)).toStrictEqual([
+      <Text>Hello</Text>,
+      <Text>World</Text>,
+    ]);
+  });
+
+  it('removes falsy children from a text element', () => {
+    const element = (
+      <Text>
+        Hello
+        {false && 'Foo'}
+        World
+      </Text>
+    );
+
+    expect(getJsxChildren(element)).toStrictEqual(['Hello', 'World']);
+  });
+
+  it('removes `true` children from the array', () => {
+    const element = (
+      <Text>
+        Hello
+        {true}
+        World
+      </Text>
+    );
+
+    expect(getJsxChildren(element)).toStrictEqual(['Hello', 'World']);
+  });
+
   it('flattens the children array', () => {
     const element = (
       <Box>

--- a/packages/snaps-utils/src/ui.tsx
+++ b/packages/snaps-utils/src/ui.tsx
@@ -439,6 +439,18 @@ export function hasChildren<Element extends JSXElement>(
 }
 
 /**
+ * Filter a JSX child to remove `null`, `undefined`, plain booleans, and empty
+ * strings.
+ *
+ * @param child - The JSX child to filter.
+ * @returns `true` if the child is not `null`, `undefined`, a plain boolean, or
+ * an empty string, `false` otherwise.
+ */
+function filterJsxChild(child: JSXElement | string | boolean | null): boolean {
+  return Boolean(child) && child !== true;
+}
+
+/**
  * Get the children of a JSX element as an array. If the element has only one
  * child, the child is returned as an array.
  *
@@ -450,7 +462,7 @@ export function getJsxChildren(element: JSXElement): (JSXElement | string)[] {
     if (Array.isArray(element.props.children)) {
       // @ts-expect-error - Each member of the union type has signatures, but
       // none of those signatures are compatible with each other.
-      return element.props.children.filter(Boolean).flat(Infinity);
+      return element.props.children.filter(filterJsxChild).flat(Infinity);
     }
 
     if (element.props.children) {

--- a/packages/snaps-utils/src/ui.tsx
+++ b/packages/snaps-utils/src/ui.tsx
@@ -5,7 +5,7 @@ import type {
   ItalicChildren,
   JSXElement,
   LinkElement,
-  MaybeArray,
+  Nestable,
   RowChildren,
   StandardFormattingElement,
   TextChildren,
@@ -433,7 +433,7 @@ export function getTotalTextLength(component: Component): number {
 export function hasChildren<Element extends JSXElement>(
   element: Element,
 ): element is Element & {
-  props: { children: MaybeArray<JSXElement | string> };
+  props: { children: Nestable<JSXElement | string> };
 } {
   return hasProperty(element.props, 'children');
 }


### PR DESCRIPTION
This adds support for conditional children in most JSX components. The exceptions are `Field`, `Row`, and other components which don't have children in the first place. For example, the following is now possible:

```tsx
<Box direction="horizontal" alignment="space-between">
  {condition && <Text>Hello</Text>}
</Box>
```

To support this, I've added `boolean` as valid prop for the JSX components. The `getJsxChildren` function filters out any falsy or literal `true` values.

I've also added a small contributing guide for conventions around JSX components, including the support for conditional children.

Closes #2505.