### PR TITLE
feat: Support checkboxes in `snaps-jest`

### DIFF
--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "g3mpbdCR/iVYrsNGxMJD82H3nosh9lytNI2XAkZJmqk=",
+    "shasum": "79flM7DJLGVf3VAkc5TCu9JkfbjfB0xoQIAKCUpL12Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hFzGG0OogA6v6B3SOokVHVqTRuuTyLdA9iULpuifFAo=",
+    "shasum": "g3mpbdCR/iVYrsNGxMJD82H3nosh9lytNI2XAkZJmqk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/src/components/InteractiveForm.tsx
+++ b/packages/examples/packages/interactive-ui/src/components/InteractiveForm.tsx
@@ -8,6 +8,7 @@ import {
   Input,
   Dropdown,
   Option,
+  Checkbox,
 } from '@metamask/snaps-sdk/jsx';
 
 /**
@@ -23,6 +24,11 @@ export type InteractiveFormState = {
    * The value of the example dropdown.
    */
   'example-dropdown': string;
+
+  /**
+   * The value of the example checkbox.
+   */
+  'example-checkbox': boolean;
 };
 
 export const InteractiveForm: SnapComponent = () => {
@@ -39,6 +45,9 @@ export const InteractiveForm: SnapComponent = () => {
             <Option value="option2">Option 2</Option>
             <Option value="option3">Option 3</Option>
           </Dropdown>
+        </Field>
+        <Field label="Example Checkbox">
+          <Checkbox name="example-checkbox" label="Checkbox" />
         </Field>
         <Button type="submit" name="submit">
           Submit

--- a/packages/examples/packages/interactive-ui/src/components/Result.tsx
+++ b/packages/examples/packages/interactive-ui/src/components/Result.tsx
@@ -14,7 +14,7 @@ export const Result: SnapComponent<ResultProps> = ({ values }) => {
       <Text>You submitted the following values:</Text>
       <Box>
         {Object.values(values).map((value) => (
-          <Copyable value={value ?? ''} />
+          <Copyable value={value?.toString() ?? ''} />
         ))}
       </Box>
       <Button name="back">Back</Button>

--- a/packages/examples/packages/interactive-ui/src/index.test.tsx
+++ b/packages/examples/packages/interactive-ui/src/index.test.tsx
@@ -45,13 +45,19 @@ describe('onRpcRequest', () => {
 
       await formScreen.selectInDropdown('example-dropdown', 'option3');
 
+      await formScreen.clickElement('example-checkbox');
+
       await formScreen.clickElement('submit');
 
       const resultScreen = await response.getInterface();
 
       expect(resultScreen).toRender(
         <Result
-          values={{ 'example-input': 'foobar', 'example-dropdown': 'option3' }}
+          values={{
+            'example-input': 'foobar',
+            'example-dropdown': 'option3',
+            'example-checkbox': true,
+          }}
         />,
       );
       await resultScreen.ok();
@@ -77,7 +83,11 @@ describe('onRpcRequest', () => {
 
       expect(resultScreen).toRender(
         <Result
-          values={{ 'example-input': '', 'example-dropdown': 'option1' }}
+          values={{
+            'example-input': '',
+            'example-dropdown': 'option1',
+            'example-checkbox': false,
+          }}
         />,
       );
       await resultScreen.ok();
@@ -107,7 +117,11 @@ describe('onHomePage', () => {
 
     expect(resultScreen).toRender(
       <Result
-        values={{ 'example-input': 'foobar', 'example-dropdown': 'option3' }}
+        values={{
+          'example-input': 'foobar',
+          'example-dropdown': 'option3',
+          'example-checkbox': false,
+        }}
       />,
     );
   });

--- a/packages/snaps-jest/src/internals/simulation/interface.test.tsx
+++ b/packages/snaps-jest/src/internals/simulation/interface.test.tsx
@@ -17,6 +17,8 @@ import {
   Box,
   Input,
   FileInput,
+  Checkbox,
+  Form,
 } from '@metamask/snaps-sdk/jsx';
 import {
   getJsxElementFromComponent,
@@ -379,6 +381,76 @@ describe('clickElement', () => {
     });
   });
 
+  it('supports checkboxes', async () => {
+    const content = (
+      <Form name="form">
+        <Checkbox name="checkbox" />
+        <Button name="button" type="submit">
+          Submit
+        </Button>
+      </Form>
+    );
+
+    const interfaceId = await interfaceController.createInterface(
+      MOCK_SNAP_ID,
+      content,
+    );
+
+    await clickElement(
+      rootControllerMessenger,
+      interfaceId,
+      content,
+      MOCK_SNAP_ID,
+      'checkbox',
+    );
+
+    await clickElement(
+      rootControllerMessenger,
+      interfaceId,
+      content,
+      MOCK_SNAP_ID,
+      'button',
+    );
+
+    expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
+      origin: '',
+      handler: HandlerType.OnUserInput,
+      request: {
+        jsonrpc: '2.0',
+        method: ' ',
+        params: {
+          event: {
+            type: UserInputEventType.InputChangeEvent,
+            name: 'checkbox',
+            value: true,
+          },
+          id: interfaceId,
+          context: null,
+        },
+      },
+    });
+
+    expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
+      origin: '',
+      handler: HandlerType.OnUserInput,
+      request: {
+        jsonrpc: '2.0',
+        method: ' ',
+        params: {
+          event: {
+            type: UserInputEventType.FormSubmitEvent,
+            name: 'form',
+            value: {
+              checkbox: true,
+            },
+          },
+          id: interfaceId,
+          context: null,
+        },
+      },
+    });
+  });
+
   it('throws if there is no button with the given name in the interface', async () => {
     const content = button({ value: 'foo', name: 'foo' });
 
@@ -419,7 +491,7 @@ describe('clickElement', () => {
         'foo',
       ),
     ).rejects.toThrow(
-      'Expected an element of type "Button", but found "Input".',
+      'Expected an element of type "Button" or "Checkbox", but found "Input".',
     );
 
     expect(handleRpcRequestMock).not.toHaveBeenCalled();


### PR DESCRIPTION
Add support for checkboxes in `snaps-jest` by allowing `clickElement` to also simulate clicks on checkboxes.

Also expands the interactive UI example to include a checkbox.