### PR TITLE
Add `Container` and `Footer` components

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "WfupwVnHUswiO0x/o2coJ0oj85v1x0j7wx1c5lYxP+o=",
+    "shasum": "8/Mr0b0oeGWE/q/c92K65WzbkycM7YeeAEMLD8Y0fXc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+WhZ7cQ8dqA46bL5kzblh/1+GRShg87VtAS5N8N8+bU=",
+    "shasum": "MJMTC9FluALYjR+OWG88PkRuy6UoV4ljzzZFKDKGubo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cvVZ8a8g9/b3tXhh9d1zf1GU11WvqcwVnR90ilpGSGw=",
+    "shasum": "wRAgYZS5C5B3jdmpT/X0t7bI1m3n+h9D7qnK+7Buvbw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "fuKiL65m1QakTuad3sCbK8YzRLNgVb9o/gSg80FK4RE=",
+    "shasum": "V3KG+PJgJFByudNBjZalk5Lbi8wpn45U9KgCJ5zai8k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "I8VkGGWoxhalUw5IIncvCY/InJ15yst1MTnICJ6jUZ4=",
+    "shasum": "vWH5q4YbhnASxrQ4FTQPewJdbmlLYVmBPy7wZGnucyE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "bt0ymBAUIDJC0ksow6/BO2+TCm8l5f4I7myCg/tXJfc=",
+    "shasum": "yFi92dzJviUDgewXEm7iaIQi7tC+tt7a0v++OGGpaM8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "P87ZOtKfVhN78E9zEw5fTGWhgKG0assHA1MZQNAZ0Xk=",
+    "shasum": "3+FfXpbdaUJQGXpuS9HM8Bki3gtsHpFvlvCKEZ04yhM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "sNKcZWHKrpSkWmsHD9nw4SNjuYehxTTXI+PhF0PAyP4=",
+    "shasum": "d0iHV/ctlmJkNxMaMTh/OSkZkXy8D9p2JTJiIBwNOOw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "y9N2+eSpLMWFxoH+gmVT9u7oR95EP8QaYnlFNowAdZE=",
+    "shasum": "bQNNPR43ccMh4wEjKP1+gaFwzskeBq1e2XVynViFPio=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "GeSSonGmFmVw2NPGOhmX2JQWzexQ/sLlCpXZzoNACIM=",
+    "shasum": "xK+V+VsfDfpBQuevEy4Ieg2GtxJIjKPiygc/oJ+k2Io=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+Dq7vWhymZkiKZPixpzPOac9GYNFd3NXZmThe+RP5Rk=",
+    "shasum": "RqDUsJkpWtSZti+7RMHmxbLlbwuiG+cUl7JnaxaBfU8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "YONnSNnY1QXI799OnXcq7pOJ9mB2mf0TKA+hwrXei0M=",
+    "shasum": "2WkC3ANERYHIuBSIaWgwLZx0eTJ81YGPWBT3M8yHTTk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "A9oCcxfQ/Ze21a+qSjmFEMjpyJDZTXBEUF/eEtzr00g=",
+    "shasum": "6QS5l+DDRAtafIC0IfcZC7PLoN+ETZ/Rbhrf8BC3kOU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "QpOZlqHNXUWxJEkcks0CEg15OO3HSximP79r+3hronM=",
+    "shasum": "fcZQ4CedTNafKCOzdJP8smIAWY7C/mH5QkbxHRY1dw8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Ko9xBAU/AMTQmdJHIKVaXEvIMRKil4LMaFj+3gS3eZo=",
+    "shasum": "9YRObcT8OuIChZltwbRLLqpAeHasRJaswiHEyEshYxs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cRsMxa73YE9a7rrLfAvqWkL7LtqDCt1KQifgF4bA/YA=",
+    "shasum": "ARQRqFAc5Jmz222ZHFRccXXJBMQd0otOaG8UEGlXgBA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "o4UgAxX2mrxEIUbi2og85R/dECjjg+q51X0t1x8KXb4=",
+    "shasum": "YdeGvHvXGfqmcQo/vkTxO+Prwt32IjYLgbgAEiKKpz0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3F5KdhaTzO0rYEAOJ9Y7Q0COWJqXOqcyTkG0FqdZ05s=",
+    "shasum": "slCc1hSMDWjFzf+nDLJWS90mz34tBwjjDxssLpuTuxs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "RKQvu6SSgoRBULQF/tZU7VbTCDgsy6ud6uFPTEeCs7w=",
+    "shasum": "8tKZ/zV6edYSnpZmxL8dIsuAmOJP1ch36xXGZ17hnnY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Hpmj/t7F9hsI52wGOdI+ak3W8yYLsQAKDrwT5tVhnYg=",
+    "shasum": "u2PeRFBSwSTk0EdMTKTYYIXgQ9Qh1pSscn8C0TUyXYk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wtOoGYeD+m/9PFLtyVgAEOLeJaZbmScyb5ovC1S4AWA=",
+    "shasum": "tpyE+jYZvd7O0DkG8h4R6oQUbhysXPpt9laegc1FoO4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3CUmmQR8Rm9YPrR2vYdg97SGUzUndQf3OgYrUzlvLI4=",
+    "shasum": "w6AHudZxoQLwT1yl3nFBKXm9C4OZ5LRi8tNuHw7z+Fo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VDkYGW0UgbTFLVuhnjjbYCJvHlMaFRfklmdUK3wyl4w=",
+    "shasum": "i4Wd65tgQ36ByBhHq/Y5i4Z6WrASHTSYzMDC71Th/Is=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6os9tFCmhv3HTapJ6Mzr5eG04r28c+hjgD/cLSDraEY=",
+    "shasum": "U2vQXBXGs2JSVkMQxK4pxu3Odqv/jKGyVObdqvusEds=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "rG0w/CpDp7pUUEYz6z6LB/t2UtOnLPq3tXNC0ZuI5p4=",
+    "shasum": "f2ZTVxtTT5vprGyggIdEh1A7X/+g9UpK/DSE0tVGR1Q=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3sWzEjRApKpX8lrHwPjB4f0kuvwx7o1ZiuPxqTrEl3s=",
+    "shasum": "2h8tHQqi+od6yWpZX+PcxOkcPLhoTPhpTEnhO0tw+aI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "h6yDf1EBo4mpSb1qqHGQiutSvuExPmtthseHyuXhsvQ=",
+    "shasum": "YinZeCF81cpyqZDRhFruxDA7Nn8iMs71BOw6mdcZosU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VWTxqVgjWnanv5fmejkDm5Gz+yiKveFROceWqIg6vi0=",
+    "shasum": "BmBGt2AIjSy+cD1WQGDWzCNJKx2CEUBl751AQzRNHzU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0PQHPzqWuahbPrh5XviC7NnEnRhA185kaAIdCZcOfqs=",
+    "shasum": "cGDtdl4nhFTL3GZefTnfHg0pX74wQbvfoHkOlG8QG6U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-sdk/src/jsx/components/Container.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/Container.test.tsx
@@ -1,0 +1,86 @@
+import { Box } from './Box';
+import { Container } from './Container';
+import { Footer } from './Footer';
+import { Button } from './form';
+import { Text } from './Text';
+
+describe('Container', () => {
+  it('renders a container element with a box', () => {
+    const result = (
+      <Container>
+        <Box>
+          <Text>Hello world!</Text>
+        </Box>
+      </Container>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Container',
+      key: null,
+      props: {
+        children: {
+          type: 'Box',
+          key: null,
+          props: {
+            children: {
+              type: 'Text',
+              key: null,
+              props: {
+                children: 'Hello world!',
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('renders a container element with a box and a footer', () => {
+    const result = (
+      <Container>
+        <Box>
+          <Text>Hello world!</Text>
+        </Box>
+        <Footer>
+          <Button name="confirm">Confirm</Button>
+        </Footer>
+      </Container>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Container',
+      key: null,
+      props: {
+        children: [
+          {
+            type: 'Box',
+            key: null,
+            props: {
+              children: {
+                type: 'Text',
+                key: null,
+                props: {
+                  children: 'Hello world!',
+                },
+              },
+            },
+          },
+          {
+            type: 'Footer',
+            key: null,
+            props: {
+              children: {
+                type: 'Button',
+                key: null,
+                props: {
+                  name: 'confirm',
+                  children: 'Confirm',
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/snaps-sdk/src/jsx/components/Container.ts
+++ b/packages/snaps-sdk/src/jsx/components/Container.ts
@@ -1,0 +1,40 @@
+import { createSnapComponent } from '../component';
+import type { BoxElement } from './Box';
+import type { FooterElement } from './Footer';
+
+/**
+ * The props of the {@link Container} component.
+ *
+ * @property children - The Box and the Footer or the Box element.
+ */
+export type ContainerProps = {
+  children: [BoxElement, FooterElement] | BoxElement;
+};
+
+const TYPE = 'Container';
+
+/**
+ * A container component, which is used to create a container with a box and a footer.
+ *
+ * @param props - The props of the component.
+ * @param props.children - The Box and the Footer or the Box element.
+ * @returns A container element.
+ * @example
+ * <Container>
+ *   <Box>
+ *     <Text>Hello world!</Text>
+ *   </Box>
+ *   <Footer>
+ *     <Button name="cancel">Cancel</Button>
+ *     <Button name="confirm">Confirm</Button>
+ *   </Footer>
+ * </Container>
+ */
+export const Container = createSnapComponent<ContainerProps, typeof TYPE>(TYPE);
+
+/**
+ * A container element.
+ *
+ * @see Container
+ */
+export type ContainerElement = ReturnType<typeof Container>;

--- a/packages/snaps-sdk/src/jsx/components/Footer.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/Footer.test.tsx
@@ -1,0 +1,61 @@
+import { Footer } from './Footer';
+import { Button } from './form';
+
+describe('Footer', () => {
+  it('renders a footer element with a button', () => {
+    const result = (
+      <Footer>
+        <Button name="confirm">Confirm</Button>
+      </Footer>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Footer',
+      key: null,
+      props: {
+        children: {
+          type: 'Button',
+          key: null,
+          props: {
+            name: 'confirm',
+            children: 'Confirm',
+          },
+        },
+      },
+    });
+  });
+
+  it('renders a footer element with multiple buttons', () => {
+    const result = (
+      <Footer>
+        <Button name="cancel">Cancel</Button>
+        <Button name="confirm">Confirm</Button>
+      </Footer>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Footer',
+      key: null,
+      props: {
+        children: [
+          {
+            type: 'Button',
+            key: null,
+            props: {
+              name: 'cancel',
+              children: 'Cancel',
+            },
+          },
+          {
+            type: 'Button',
+            key: null,
+            props: {
+              name: 'confirm',
+              children: 'Confirm',
+            },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/snaps-sdk/src/jsx/components/Footer.ts
+++ b/packages/snaps-sdk/src/jsx/components/Footer.ts
@@ -1,0 +1,34 @@
+import { createSnapComponent } from '../component';
+import type { ButtonElement } from './form';
+
+/**
+ * The props of the {@link Footer} component.
+ *
+ * @property children - The single or multiple buttons in the footer.
+ */
+export type FooterProps = {
+  children: ButtonElement | [ButtonElement, ButtonElement];
+};
+
+const TYPE = 'Footer';
+
+/**
+ * A footer component, which is used to create a footer with buttons.
+ *
+ * @param props - The props of the component.
+ * @param props.children - The single or multiple buttons in the footer.
+ * @returns A footer element.
+ * @example
+ * <Footer>
+ *   <Button name="cancel">Cancel</Button>
+ *   <Button name="confirm">Confirm</Button>
+ * </Footer>
+ */
+export const Footer = createSnapComponent<FooterProps, typeof TYPE>(TYPE);
+
+/**
+ * A footer element.
+ *
+ * @see Footer
+ */
+export type FooterElement = ReturnType<typeof Footer>;

--- a/packages/snaps-sdk/src/jsx/components/index.ts
+++ b/packages/snaps-sdk/src/jsx/components/index.ts
@@ -1,7 +1,9 @@
 import type { AddressElement } from './Address';
 import type { BoxElement } from './Box';
+import type { ContainerElement } from './Container';
 import type { CopyableElement } from './Copyable';
 import type { DividerElement } from './Divider';
+import type { FooterElement } from './Footer';
 import type { StandardFormElement } from './form';
 import type { StandardFormattingElement } from './formatting';
 import type { HeadingElement } from './Heading';
@@ -27,6 +29,8 @@ export * from './Row';
 export * from './Spinner';
 export * from './Text';
 export * from './Tooltip';
+export * from './Footer';
+export * from './Container';
 
 /**
  * A built-in JSX element, which can be used in a Snap user interface.
@@ -36,8 +40,10 @@ export type JSXElement =
   | StandardFormattingElement
   | AddressElement
   | BoxElement
+  | ContainerElement
   | CopyableElement
   | DividerElement
+  | FooterElement
   | ValueElement
   | HeadingElement
   | ImageElement

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -23,6 +23,8 @@ import {
   Value,
   FileInput,
   Checkbox,
+  Footer,
+  Container,
 } from './components';
 import {
   AddressStruct,
@@ -31,12 +33,14 @@ import {
   BoxStruct,
   ButtonStruct,
   CheckboxStruct,
+  ContainerStruct,
   CopyableStruct,
   DividerStruct,
   DropdownStruct,
   ElementStruct,
   FieldStruct,
   FileInputStruct,
+  FooterStruct,
   FormStruct,
   HeadingStruct,
   ImageStruct,
@@ -468,6 +472,91 @@ describe('BoxStruct', () => {
     </Box>,
   ])('does not validate "%p"', (value) => {
     expect(is(value, BoxStruct)).toBe(false);
+  });
+});
+
+describe('FooterStruct', () => {
+  it.each([
+    <Footer>
+      <Button name="confirm">Confirm</Button>
+    </Footer>,
+    <Footer>
+      <Button name="cancel">Cancel</Button>
+      <Button name="confirm">Confirm</Button>
+    </Footer>,
+  ])('validates a footer element', (value) => {
+    expect(is(value, FooterStruct)).toBe(true);
+  });
+
+  it.each([
+    'foo',
+    42,
+    null,
+    undefined,
+    {},
+    [],
+    // @ts-expect-error - Invalid props.
+    <Footer />,
+    <Footer>
+      <Text>foo</Text>
+    </Footer>,
+    <Text>foo</Text>,
+    <Box>
+      <Text>foo</Text>
+    </Box>,
+    <Row label="label">
+      <Image src="<svg />" alt="alt" />
+    </Row>,
+  ])('does not validate "%p"', (value) => {
+    expect(is(value, FooterStruct)).toBe(false);
+  });
+});
+
+describe('ContainerStruct', () => {
+  it.each([
+    <Container>
+      <Box>
+        <Text>Hello world!</Text>
+      </Box>
+    </Container>,
+    <Container>
+      <Box>
+        <Text>Hello world!</Text>
+      </Box>
+      <Footer>
+        <Button name="confirm">Confirm</Button>
+      </Footer>
+    </Container>,
+  ])('validates a container element', (value) => {
+    expect(is(value, ContainerStruct)).toBe(true);
+  });
+
+  it.each([
+    'foo',
+    42,
+    null,
+    undefined,
+    {},
+    [],
+    // @ts-expect-error - Invalid props.
+    <Container />,
+    <Container>
+      <Box>
+        <Text>Hello world!</Text>
+      </Box>
+      <Footer>
+        <Text>foo</Text>
+      </Footer>
+    </Container>,
+    <Text>foo</Text>,
+    <Box>
+      <Text>foo</Text>
+    </Box>,
+    <Row label="label">
+      <Image src="<svg />" alt="alt" />
+    </Row>,
+  ])('does not validate "%p"', (value) => {
+    expect(is(value, ContainerStruct)).toBe(false);
   });
 });
 

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -61,6 +61,8 @@ import type {
   TooltipElement,
   ValueElement,
   FileInputElement,
+  ContainerElement,
+  FooterElement,
 } from './components';
 
 /**
@@ -282,6 +284,41 @@ export const BoxStruct: Describe<BoxElement> = element('Box', {
 });
 
 /**
+ * A subset of JSX elements that are allowed as children of the Footer component.
+ * This set should include a single button or a tuple of two buttons.
+ */
+export const FooterChildStruct = nullUnion([
+  tuple([ButtonStruct, ButtonStruct]),
+  ButtonStruct,
+]);
+
+/**
+ * A struct for the {@link FooterElement} type.
+ */
+export const FooterStruct: Describe<FooterElement> = element('Footer', {
+  children: FooterChildStruct,
+});
+
+/**
+ * A subset of JSX elements that are allowed as children of the Container component.
+ * This set should include a single Box or a tuple of a Box and a Footer component.
+ */
+export const ContainerChildStruct = nullUnion([
+  tuple([BoxStruct, FooterStruct]),
+  BoxStruct,
+]);
+
+/**
+ * A struct for the {@link ContainerElement} type.
+ */
+export const ContainerStruct: Describe<ContainerElement> = element(
+  'Container',
+  {
+    children: ContainerChildStruct,
+  },
+);
+
+/**
  * A struct for the {@link CopyableElement} type.
  */
 export const CopyableStruct: Describe<CopyableElement> = element('Copyable', {
@@ -444,6 +481,8 @@ export const JSXElementStruct: Describe<JSXElement> = nullUnion([
   ValueStruct,
   TooltipStruct,
   CheckboxStruct,
+  FooterStruct,
+  ContainerStruct,
 ]);
 
 /**


### PR DESCRIPTION
This PR adds the `Footer` and `Container` JSX Components.

- `Footer` accepts a single `Button` or a tuple of two `Button`
- `Container` accepts a single `Box` or a tuple of a `Box` and a `Footer`