### PR TITLE
Move bold tags in JSX Example Snap

### DIFF
--- a/packages/examples/packages/jsx/package.json
+++ b/packages/examples/packages/jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/jsx-example-snap",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "description": "MetaMask example snap demonstrating the use of JSX for UI components.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/jsx/package.json
+++ b/packages/examples/packages/jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/jsx-example-snap",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "MetaMask example snap demonstrating the use of JSX for UI components.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "MetaMask example snap demonstrating the use of JSX for UI components.",
   "proposedName": "JSX Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "KS52KW9YZ2Gx4IOzKXKC0E3JhvBpPIDlmOxq1Cm21l4=",
+    "shasum": "21SHurFxkqSSML7EDePnsByVZitSpvYweBaNv4IrpjQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.1",
+  "version": "1.1.0",
   "description": "MetaMask example snap demonstrating the use of JSX for UI components.",
   "proposedName": "JSX Example Snap",
   "repository": {

--- a/packages/examples/packages/jsx/src/components/Counter.tsx
+++ b/packages/examples/packages/jsx/src/components/Counter.tsx
@@ -35,7 +35,7 @@ export const Counter: SnapComponent<CounterProps> = ({ count }) => {
     <Box>
       <Tooltip content={<TooltipContent />}>
         <Text>
-          <Bold>Count:</Bold> {String(count)}
+          Count: <Bold>{String(count)}</Bold>
         </Text>
       </Tooltip>
       <Button name="increment">Increment</Button>


### PR DESCRIPTION
This moves the bold tags in the example snap to the number, allowing for easier E2E testing.