### PR TITLE
Add support for custom dialogs in `snaps-jest`

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Ard/F/8RqOYcKlxb3xx6OB5XLtmv7t/Asrn8bhkCooQ=",
+    "shasum": "te1oZPWHfniZ/ST6D/blxr8w6yhoR4qaJeeNoOP7O6A=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/src/index.test.ts
+++ b/packages/examples/packages/bip32/src/index.test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@jest/globals';
-import { installSnap } from '@metamask/snaps-jest';
+import { assertIsConfirmationDialog, installSnap } from '@metamask/snaps-jest';
 import { copyable, heading, panel, text } from '@metamask/snaps-sdk';
-import { assert } from '@metamask/utils';
 
 describe('onRpcRequest', () => {
   it('throws an error if the requested method does not exist', async () => {
@@ -109,6 +108,7 @@ describe('onRpcRequest', () => {
       });
 
       const ui = await response.getInterface();
+      assertIsConfirmationDialog(ui);
       expect(ui).toRender(
         panel([
           heading('Signature request'),
@@ -141,6 +141,7 @@ describe('onRpcRequest', () => {
       });
 
       const ui = await response.getInterface();
+      assertIsConfirmationDialog(ui);
       expect(ui).toRender(
         panel([
           heading('Signature request'),
@@ -173,6 +174,7 @@ describe('onRpcRequest', () => {
       });
 
       const ui = await response.getInterface();
+      assertIsConfirmationDialog(ui);
       expect(ui).toRender(
         panel([
           heading('Signature request'),
@@ -205,7 +207,7 @@ describe('onRpcRequest', () => {
       });
 
       const ui = await response.getInterface();
-      assert(ui.type === 'confirmation');
+      assertIsConfirmationDialog(ui);
       await ui.cancel();
 
       expect(await response).toRespondWithError({

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "jJuoqF4p++cEfWb3YdEfuwlOEw7bByfpEMh6adH8sOI=",
+    "shasum": "yzw5UM4aWmD8vLglR9gazcNC0yKntyPp5A5sPSmouL4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/src/index.test.ts
+++ b/packages/examples/packages/bip44/src/index.test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@jest/globals';
-import { installSnap } from '@metamask/snaps-jest';
+import { assertIsConfirmationDialog, installSnap } from '@metamask/snaps-jest';
 import { copyable, heading, panel, text } from '@metamask/snaps-sdk';
-import { assert } from '@metamask/utils';
 
 describe('onRpcRequest', () => {
   it('throws an error if the requested method does not exist', async () => {
@@ -84,6 +83,8 @@ describe('onRpcRequest', () => {
       });
 
       const ui = await response.getInterface();
+      assertIsConfirmationDialog(ui);
+
       expect(ui).toRender(
         panel([
           heading('Signature request'),
@@ -114,6 +115,8 @@ describe('onRpcRequest', () => {
       });
 
       const ui = await response.getInterface();
+      assertIsConfirmationDialog(ui);
+
       expect(ui).toRender(
         panel([
           heading('Signature request'),
@@ -144,7 +147,8 @@ describe('onRpcRequest', () => {
       });
 
       const ui = await response.getInterface();
-      assert(ui.type === 'confirmation');
+      assertIsConfirmationDialog(ui);
+
       await ui.cancel();
 
       expect(await response).toRespondWithError({

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "nBoIUO4s8aakybthHavEuRjxCoNVzevKVv1mr1u2uNM=",
+    "shasum": "a+jOIwfxC3ITF6MbF5ltQvM0ZvCJ5/NQJlbEsqWTQrk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Kq4I9q6BdkSUrUsjysqqsfjlQ1gu6vM4sXSo7pgNruI=",
+    "shasum": "HPCtZ7reZrbut7cl09SnaoAHkzrvlvjc60leUfkcsVI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "RNHnGSZaZRAEkH7h4eqFfmic8Ixq30CXj4JWnhWkQbI=",
+    "shasum": "7BLeIk79FlkIK9fNKHcCdX8UChmjU7kOkGVLxOc29Kw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0YLZlM7w5GpjDWYmmJFxiYB2kJnNG55ru3/8ywKVT9I=",
+    "shasum": "DMmgoUR+Q1/eYJTjZQ96jI406CpgObFs454UR1nKGM4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/package.json
+++ b/packages/examples/packages/dialogs/package.json
@@ -42,7 +42,6 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@metamask/utils": "^8.3.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",

--- a/packages/examples/packages/dialogs/snap.config.ts
+++ b/packages/examples/packages/dialogs/snap.config.ts
@@ -2,7 +2,7 @@ import type { SnapConfig } from '@metamask/snaps-cli';
 import { resolve } from 'path';
 
 const config: SnapConfig = {
-  input: resolve(__dirname, 'src/index.ts'),
+  input: resolve(__dirname, 'src/index.tsx'),
   server: {
     port: 8005,
   },

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5cc1fSlz4S5sDjlkjWhBUNjOQu6VdCqS5ln/DJjssSk=",
+    "shasum": "F5K30FZGcmERlgvw8D8v4Vuqh2FP2fxSeq0KVOT4LYg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/src/components/custom.tsx
+++ b/packages/examples/packages/dialogs/src/components/custom.tsx
@@ -9,6 +9,11 @@ import {
   type SnapComponent,
 } from '@metamask/snaps-sdk/jsx';
 
+/**
+ * A custom dialog component.
+ *
+ * @returns The custom dialog component.
+ */
 export const CustomDialog: SnapComponent = () => (
   <Container>
     <Box>

--- a/packages/examples/packages/dialogs/src/components/custom.tsx
+++ b/packages/examples/packages/dialogs/src/components/custom.tsx
@@ -1,0 +1,27 @@
+import {
+  Box,
+  Button,
+  Container,
+  Footer,
+  Heading,
+  Input,
+  Text,
+  type SnapComponent,
+} from '@metamask/snaps-sdk/jsx';
+
+export const CustomDialog: SnapComponent = () => (
+  <Container>
+    <Box>
+      <Heading>Custom Dialog</Heading>
+      <Text>
+        This is a custom dialog. It has a custom Footer and can be resolved to
+        any value.
+      </Text>
+      <Input name="custom-input" placeholder="Enter something..." />
+    </Box>
+    <Footer>
+      <Button name="cancel">Cancel</Button>
+      <Button name="confirm">Confirm</Button>
+    </Footer>
+  </Container>
+);

--- a/packages/examples/packages/dialogs/src/components/index.ts
+++ b/packages/examples/packages/dialogs/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from './custom';

--- a/packages/examples/packages/dialogs/src/index.test.tsx
+++ b/packages/examples/packages/dialogs/src/index.test.tsx
@@ -1,7 +1,14 @@
 import { expect } from '@jest/globals';
-import { installSnap } from '@metamask/snaps-jest';
+import {
+  assertIsAlertDialog,
+  assertIsConfirmationDialog,
+  assertIsCustomDialog,
+  assertIsPromptDialog,
+  installSnap,
+} from '@metamask/snaps-jest';
 import { heading, panel, text } from '@metamask/snaps-sdk';
-import { assert } from '@metamask/utils';
+
+import { CustomDialog } from './components';
 
 describe('onRpcRequest', () => {
   it('throws an error if the requested method does not exist', async () => {
@@ -31,7 +38,7 @@ describe('onRpcRequest', () => {
       });
 
       const ui = await response.getInterface();
-      assert(ui.type === 'alert');
+      assertIsAlertDialog(ui);
 
       expect(ui).toRender(
         panel([
@@ -55,7 +62,7 @@ describe('onRpcRequest', () => {
       });
 
       const ui = await response.getInterface();
-      assert(ui.type === 'confirmation');
+      assertIsConfirmationDialog(ui);
 
       expect(ui).toRender(
         panel([
@@ -79,7 +86,7 @@ describe('onRpcRequest', () => {
       });
 
       const ui = await response.getInterface();
-      assert(ui.type === 'confirmation');
+      assertIsConfirmationDialog(ui);
       await ui.cancel();
 
       expect(await response).toRespondWith(false);
@@ -95,7 +102,7 @@ describe('onRpcRequest', () => {
       });
 
       const ui = await response.getInterface();
-      assert(ui.type === 'prompt');
+      assertIsPromptDialog(ui);
 
       expect(ui).toRender(
         panel([
@@ -119,10 +126,34 @@ describe('onRpcRequest', () => {
       });
 
       const ui = await response.getInterface();
-      assert(ui.type === 'prompt');
+      assertIsPromptDialog(ui);
+
       await ui.cancel();
 
       expect(await response).toRespondWith(null);
+    });
+  });
+
+  describe('showCustom', () => {
+    it('shows a custom dialog and can return the input value', async () => {
+      const value = 'Hello, world!';
+
+      const { request } = await installSnap();
+
+      const response = request({
+        method: 'showCustom',
+      });
+
+      const ui = await response.getInterface();
+      assertIsCustomDialog(ui);
+
+      expect(ui).toRender(<CustomDialog />);
+
+      await ui.typeInField('custom-input', value);
+
+      await ui.clickElement('confirm');
+
+      expect(await response).toRespondWith(value);
     });
   });
 });

--- a/packages/examples/packages/dialogs/src/index.tsx
+++ b/packages/examples/packages/dialogs/src/index.tsx
@@ -21,6 +21,7 @@ import { CustomDialog } from './components';
  * - `showAlert`: Show an alert dialog.
  * - `showConfirmation`: Show a confirmation dialog.
  * - `showPrompt`: Show a prompt dialog.
+ * - `showCustom`: Show a custom dialog with the resolution handled by the snap.
  *
  * The dialogs are shown using the [`snap_dialog`](https://docs.metamask.io/snaps/reference/rpc-api/#snap_dialog)
  * method.

--- a/packages/examples/packages/dialogs/src/index.tsx
+++ b/packages/examples/packages/dialogs/src/index.tsx
@@ -94,6 +94,14 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   }
 };
 
+/**
+ * Handle incoming user events coming from the MetaMask clients open interfaces.
+ *
+ * @param params - The event parameters.
+ * @param params.id - The Snap interface ID where the event was fired.
+ * @param params.event - The event object containing the event type, name and value.
+ * @see https://docs.metamask.io/snaps/reference/exports/#onuserinput
+ */
 export const onUserInput: OnUserInputHandler = async ({ id, event }) => {
   if (event.type === UserInputEventType.ButtonClickEvent) {
     switch (event.name) {

--- a/packages/examples/packages/dialogs/tsconfig.json
+++ b/packages/examples/packages/dialogs/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./",
+    "jsx": "react-jsxdev",
     "paths": {
+      "@metamask/*/jsx": ["../../../*/src/jsx"],
+      "@metamask/*/jsx-dev-runtime": ["../../../*/src/jsx"],
       "@metamask/*": ["../../../*/src"]
     }
   },

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8L6HiuUzKAQVeog5uIIYiqBOuEb2Qm3+9HH+fXs5PlM=",
+    "shasum": "iHt9Se2I/fFZeIQW6p5qyNGt+wD7S2NKlNPLYjSTZMc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/package.json
+++ b/packages/examples/packages/ethers-js/package.json
@@ -43,7 +43,6 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/snaps-cli": "workspace:^",
     "@metamask/snaps-jest": "workspace:^",
-    "@metamask/utils": "^8.3.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.42.1",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5fi+IIMm/FubpDnpYP+YGW/dCUgTT4bVIxxDmcuybr8=",
+    "shasum": "K1gDsaTcrhG5vRH5Tb1uswHg6QnxYIqKjynyvzLlbfM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/src/index.test.ts
+++ b/packages/examples/packages/ethers-js/src/index.test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@jest/globals';
-import { installSnap } from '@metamask/snaps-jest';
+import { assertIsConfirmationDialog, installSnap } from '@metamask/snaps-jest';
 import { copyable, heading, panel, text } from '@metamask/snaps-sdk';
-import { assert } from '@metamask/utils';
 
 describe('onRpcRequest', () => {
   it('throws an error if the requested method does not exist', async () => {
@@ -48,6 +47,8 @@ describe('onRpcRequest', () => {
       });
 
       const ui = await response.getInterface();
+      assertIsConfirmationDialog(ui);
+
       expect(ui).toRender(
         panel([
           heading('Signature request'),
@@ -74,7 +75,7 @@ describe('onRpcRequest', () => {
       });
 
       const ui = await response.getInterface();
-      assert(ui.type === 'confirmation');
+      assertIsConfirmationDialog(ui);
       await ui.cancel();
 
       expect(await response).toRespondWithError({

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+yioSnJPHDQRsStHxbK9pm9bUTAgvCFrpWjwvWZNWqE=",
+    "shasum": "XWQyeVfzXAXLSNiE9je6OjMU8dqlDw0Mw4q6QApCgFo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "nlhNiocqRC/yaz73W2wMGxIXswHm6YCCigdd6X/maeU=",
+    "shasum": "WXUTcCOLbtQnTMVKVz2X2IeQG8ICXkmDozXlil/Z3rI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "opNYkgiLjqm7OBH2Wi4eAewEntFg0trEfw8yk8sQJGk=",
+    "shasum": "dhEHU8KvnRAcZlEq4cnrhaVaEeRux9b0HA8LrA5GPnI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "undUBL7PBSvSR81E5AfodCp7nY0658OuaCe6eY2Xjaw=",
+    "shasum": "YYz045/kftDaFs5MVv7EJzcMOtu7KBZa9RgceCoD9Gc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "yOiOfKpriNZCSbXVfddcEw8EOkKd+bjPlvtl/yowGNo=",
+    "shasum": "17xibkzbvbonxdKRhYc1/hcy07SMuF1kUnWTww01Wh8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "qonHJAYzv7XPR96X+J3qOs5wxnWkfmWkUqK3ooYdkGI=",
+    "shasum": "RjotFvCYvRLQkQh0/MfN+KnVdoYaX/iG5xJ72hgea+8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/src/index.test.tsx
+++ b/packages/examples/packages/interactive-ui/src/index.test.tsx
@@ -1,6 +1,5 @@
 import { expect } from '@jest/globals';
-import { installSnap } from '@metamask/snaps-jest';
-import { assert } from '@metamask/utils';
+import { assertIsConfirmationDialog, installSnap } from '@metamask/snaps-jest';
 
 import {
   Insight,
@@ -37,7 +36,6 @@ describe('onRpcRequest', () => {
       });
 
       const formScreen = await response.getInterface();
-      assert(formScreen.type === 'confirmation');
 
       expect(formScreen).toRender(<InteractiveForm />);
 
@@ -50,6 +48,7 @@ describe('onRpcRequest', () => {
       await formScreen.clickElement('submit');
 
       const resultScreen = await response.getInterface();
+      assertIsConfirmationDialog(resultScreen);
 
       expect(resultScreen).toRender(
         <Result
@@ -73,13 +72,13 @@ describe('onRpcRequest', () => {
       });
 
       const formScreen = await response.getInterface();
-      assert(formScreen.type === 'confirmation');
 
       expect(formScreen).toRender(<InteractiveForm />);
 
       await formScreen.clickElement('submit');
 
       const resultScreen = await response.getInterface();
+      assertIsConfirmationDialog(resultScreen);
 
       expect(resultScreen).toRender(
         <Result

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OHys23ojjMrAsFyeQwDQqaa1EFHn3etlJHegD4UeS8I=",
+    "shasum": "x2DFl/pD2oP4tX1xA+nGRlMKygBxECdsoUEuv+SIDCg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "HJh4l8PwtDUgt1RENdhuHAFexpl7waVkztKP4AjvrNY=",
+    "shasum": "/Jd80mRS0sRtJkysLijC+nFivuYFcpJN88c+0uPEAmE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TWiDk1fuzRMAhmlkKuiSUSDvKCz9xcI5WSWW3iy34Mc=",
+    "shasum": "k38ku5e19Ma18bw8Fj7X7EdplcNcNUYGe1YSvMXSFFc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4gXdMd04QGteEKq+8ybmEUZMZ7rp8VhznbIsLbwJt2M=",
+    "shasum": "sG6nzWp3egu6KVdzrrx/xDnZxoHoropwbpw16VWRq1I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1KncbhFxNyySOUIYyT6hjm2cAYJjVfz2nqO+F27UKHk=",
+    "shasum": "5GnkRgxSJ31ZrC88L5YT4085IXAtEW/ssOzb3vKdhGk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "y/xbICamUYIgA9PTdRJZFqrrsEvfwU6QnyLPRkar8yY=",
+    "shasum": "gEbnqa/dhseAw+m5voKOPmZU3RtrsAMzVv71TGgyrSI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "t2caVEw3o6ogsMMTYazugSPYT7LUwnEVm5h1c0C6PJU=",
+    "shasum": "QYVpepzwJ55thY051dZjkO+FK/WTsIYoG/pH46PHz34=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VOl9PL2wEitwk002uFI31Dtqam+n31V3hjsJZyH0c7g=",
+    "shasum": "pIiNNUSwbqXQsniqxkj40MNPi4Clf6mlfq1VIZAzfIM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TSKQNGgt1ihK1sMYWCyeSRbnq4LhHfWPI1OcemzK5jw=",
+    "shasum": "IoRhxK1wXSXko6nMqmkAUePNyMgVpWowoAWzjiPw5HE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "bwd1Enr1AhLtstNX7BZ6ZYkZEhY0I6wKUSYufb1eu1M=",
+    "shasum": "YkohC4woUwiIwSOsXUvhrL9g5xMQ4f094tVwtTmQQ0Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "oscX5enhoOZdKEwZr/6XNwMiNe0bnIqUDkpYwmmgBeo=",
+    "shasum": "pP2JIcm3hGBQ2qpQHZUZckKEM/k6IJU2MEy0hm02HQg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "CReSrcACFurEbxlGTm3aw4MQOo+CFs/XvgZ4mY+Cn/I=",
+    "shasum": "mHNCDPJXx/vNcx6bHIuU4yqGl6MI8MkGO2WDGTWORJI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "M5dLjvmrk86SNv9ZFRUOz5hcPW24aAfS7rGm/UHO0k0=",
+    "shasum": "up4UE5+k0FrYVyONu3Nf11+ngzt9DqW/0TxrUd45380=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "BeAg29ZE55KRGNJiaZpT3y/tdo4D6alWxCzsw8z4k64=",
+    "shasum": "zN8Dkb34se77/TXqLyMRINMxX4YfhcjhBHtGLo1kGPU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-jest/README.md
+++ b/packages/snaps-jest/README.md
@@ -362,7 +362,7 @@ functions that can be used to interact with the user interface.
 ##### Example
 
 ```js
-import { installSnap } from '@metamask/snaps-jest';
+import { installSnap, assertIsAlertDialog } from '@metamask/snaps-jest';
 import { text } from '@metamask/snaps-sdk';
 import { assert } from '@metamask/utils';
 
@@ -379,7 +379,7 @@ describe('MySnap', () => {
 
     // This is useful if you're using TypeScript, since it will infer the type
     // of the user interface.
-    assert(ui.type === 'alert');
+    assertIsAlertDialog(ui);
     expect(ui).toRender(text('Hello, world!'));
 
     // "Click" the OK button.

--- a/packages/snaps-jest/src/helpers.test.tsx
+++ b/packages/snaps-jest/src/helpers.test.tsx
@@ -2,9 +2,13 @@ import { NodeProcessExecutionService } from '@metamask/snaps-controllers/node';
 import { DialogType } from '@metamask/snaps-sdk';
 import { Text } from '@metamask/snaps-sdk/jsx';
 import { getSnapManifest } from '@metamask/snaps-utils/test-utils';
-import { assert } from '@metamask/utils';
 
-import { installSnap } from './helpers';
+import {
+  assertIsAlertDialog,
+  assertIsConfirmationDialog,
+  assertIsPromptDialog,
+  installSnap,
+} from './helpers';
 import type { InstallSnapOptions } from './internals';
 import { handleInstallSnap } from './internals';
 import { getMockServer } from './test-utils';
@@ -397,7 +401,7 @@ describe('installSnap', () => {
       });
 
       const ui = await response.getInterface();
-      assert(ui.type === DialogType.Prompt);
+      assertIsPromptDialog(ui);
       expect(ui).toStrictEqual({
         type: DialogType.Prompt,
         content: <Text>Hello, world!</Text>,
@@ -457,7 +461,7 @@ describe('installSnap', () => {
       });
 
       const ui = await response.getInterface();
-      assert(ui.type === DialogType.Confirmation);
+      assertIsConfirmationDialog(ui);
       expect(ui).toStrictEqual({
         type: DialogType.Confirmation,
         content: <Text>Hello, world!</Text>,
@@ -517,6 +521,7 @@ describe('installSnap', () => {
       });
 
       const ui = await response.getInterface();
+      assertIsAlertDialog(ui);
       expect(ui).toStrictEqual({
         type: DialogType.Alert,
         content: <Text>Hello, world!</Text>,

--- a/packages/snaps-jest/src/helpers.ts
+++ b/packages/snaps-jest/src/helpers.ts
@@ -1,7 +1,13 @@
 import type { AbstractExecutionService } from '@metamask/snaps-controllers';
-import type { SnapId } from '@metamask/snaps-sdk';
-import { HandlerType, logInfo } from '@metamask/snaps-utils';
-import { assertStruct, createModuleLogger } from '@metamask/utils';
+import { DialogType, type SnapId } from '@metamask/snaps-sdk';
+import type { FooterElement } from '@metamask/snaps-sdk/jsx';
+import { HandlerType, getJsxChildren, logInfo } from '@metamask/snaps-utils';
+import {
+  assertStruct,
+  createModuleLogger,
+  hasProperty,
+  assert,
+} from '@metamask/utils';
 import { create } from 'superstruct';
 
 import {
@@ -12,6 +18,7 @@ import {
   JsonRpcMockOptionsStruct,
   SignatureOptionsStruct,
   SnapResponseWithInterfaceStruct,
+  getElementByType,
 } from './internals';
 import type { InstallSnapOptions } from './internals';
 import {
@@ -25,6 +32,15 @@ import type {
   Snap,
   SnapResponse,
   TransactionOptions,
+  SnapInterface,
+  SnapAlertInterface,
+  SnapInterfaceActions,
+  SnapConfirmationInterface,
+  SnapPromptInterface,
+  SnapDefaultInterface,
+  SnapDefaultInterfaceWithFooter,
+  SnapDefaultInterfaceWithPartialFooter,
+  SnapDefaultInterfaceWithoutFooter,
 } from './types';
 
 const log = createModuleLogger(rootLogger, 'helpers');
@@ -60,6 +76,89 @@ function assertIsResponseWithInterface(
   response: SnapResponse,
 ): asserts response is SnapResponseWithInterface {
   assertStruct(response, SnapResponseWithInterfaceStruct);
+}
+
+/**
+ * Ensure that the actual interface is an alert dialog.
+ *
+ * @param ui - The interface to verify.
+ */
+export function assertIsAlertDialog(
+  ui: SnapInterface,
+): asserts ui is SnapAlertInterface & SnapInterfaceActions {
+  assert(hasProperty(ui, 'type') && ui.type === DialogType.Alert);
+}
+
+/**
+ * Ensure that the actual interface is a confirmation dialog.
+ *
+ * @param ui - The interface to verify.
+ */
+export function assertIsConfirmationDialog(
+  ui: SnapInterface,
+): asserts ui is SnapConfirmationInterface & SnapInterfaceActions {
+  assert(hasProperty(ui, 'type') && ui.type === DialogType.Confirmation);
+}
+
+/**
+ * Ensure that the actual interface is a Prompt dialog.
+ *
+ * @param ui - The interface to verify.
+ */
+export function assertIsPromptDialog(
+  ui: SnapInterface,
+): asserts ui is SnapPromptInterface & SnapInterfaceActions {
+  assert(hasProperty(ui, 'type') && ui.type === DialogType.Prompt);
+}
+
+/**
+ * Ensure that the actual interface is a custom dialog.
+ *
+ * @param ui - The interface to verify.
+ */
+export function assertIsCustomDialog(
+  ui: SnapInterface,
+): asserts ui is SnapDefaultInterface & SnapInterfaceActions {
+  assert(!hasProperty(ui, 'type'));
+}
+
+/**
+ * Ensure that the actual interface is a custom dialog with a complete footer.
+ *
+ * @param ui - The interface to verify.
+ */
+export function assertCustomDialogHasFooter(
+  ui: SnapDefaultInterface & SnapInterfaceActions,
+): asserts ui is SnapDefaultInterfaceWithFooter & SnapInterfaceActions {
+  const footer = getElementByType<FooterElement>(ui.content, 'Footer');
+
+  assert(footer && getJsxChildren(footer).length === 2);
+}
+
+/**
+ * Ensure that the actual interface is a custom dialog with a partial footer.
+ *
+ * @param ui - The interface to verify.
+ */
+export function assertCustomDialogHasPartialFooter(
+  ui: SnapDefaultInterface & SnapInterfaceActions,
+): asserts ui is SnapDefaultInterfaceWithPartialFooter & SnapInterfaceActions {
+  const footer = getElementByType<FooterElement>(ui.content, 'Footer');
+
+  assert(footer && getJsxChildren(footer).length === 1);
+}
+
+/**
+ * Ensure that the actual interface is a custom dialog without a footer.
+ *
+ * @param ui - The interface to verify.
+ */
+export function assertCustomDialogHasNoFooter(
+  ui: SnapDefaultInterface & SnapInterfaceActions,
+): asserts ui is SnapDefaultInterfaceWithoutFooter & SnapInterfaceActions {
+  const footer = getElementByType<FooterElement>(ui.content, 'Footer');
+
+  assert(!footer);
 }
 
 /**

--- a/packages/snaps-jest/src/helpers.ts
+++ b/packages/snaps-jest/src/helpers.ts
@@ -37,10 +37,10 @@ import type {
   SnapInterfaceActions,
   SnapConfirmationInterface,
   SnapPromptInterface,
-  SnapDefaultInterface,
-  SnapDefaultInterfaceWithFooter,
-  SnapDefaultInterfaceWithPartialFooter,
-  SnapDefaultInterfaceWithoutFooter,
+  DefaultSnapInterface,
+  DefaultSnapInterfaceWithFooter,
+  DefaultSnapInterfaceWithPartialFooter,
+  DefaultSnapInterfaceWithoutFooter,
 } from './types';
 
 const log = createModuleLogger(rootLogger, 'helpers');
@@ -118,7 +118,7 @@ export function assertIsPromptDialog(
  */
 export function assertIsCustomDialog(
   ui: SnapInterface,
-): asserts ui is SnapDefaultInterface & SnapInterfaceActions {
+): asserts ui is DefaultSnapInterface & SnapInterfaceActions {
   assert(!hasProperty(ui, 'type'));
 }
 
@@ -128,8 +128,8 @@ export function assertIsCustomDialog(
  * @param ui - The interface to verify.
  */
 export function assertCustomDialogHasFooter(
-  ui: SnapDefaultInterface & SnapInterfaceActions,
-): asserts ui is SnapDefaultInterfaceWithFooter & SnapInterfaceActions {
+  ui: DefaultSnapInterface & SnapInterfaceActions,
+): asserts ui is DefaultSnapInterfaceWithFooter & SnapInterfaceActions {
   const footer = getElementByType<FooterElement>(ui.content, 'Footer');
 
   assert(footer && getJsxChildren(footer).length === 2);
@@ -141,8 +141,8 @@ export function assertCustomDialogHasFooter(
  * @param ui - The interface to verify.
  */
 export function assertCustomDialogHasPartialFooter(
-  ui: SnapDefaultInterface & SnapInterfaceActions,
-): asserts ui is SnapDefaultInterfaceWithPartialFooter & SnapInterfaceActions {
+  ui: DefaultSnapInterface & SnapInterfaceActions,
+): asserts ui is DefaultSnapInterfaceWithPartialFooter & SnapInterfaceActions {
   const footer = getElementByType<FooterElement>(ui.content, 'Footer');
 
   assert(footer && getJsxChildren(footer).length === 1);
@@ -154,8 +154,8 @@ export function assertCustomDialogHasPartialFooter(
  * @param ui - The interface to verify.
  */
 export function assertCustomDialogHasNoFooter(
-  ui: SnapDefaultInterface & SnapInterfaceActions,
-): asserts ui is SnapDefaultInterfaceWithoutFooter & SnapInterfaceActions {
+  ui: DefaultSnapInterface & SnapInterfaceActions,
+): asserts ui is DefaultSnapInterfaceWithoutFooter & SnapInterfaceActions {
   const footer = getElementByType<FooterElement>(ui.content, 'Footer');
 
   assert(!footer);

--- a/packages/snaps-jest/src/internals/simulation/controllers.test.ts
+++ b/packages/snaps-jest/src/internals/simulation/controllers.test.ts
@@ -9,11 +9,13 @@ import { getControllers } from './controllers';
 import type { MiddlewareHooks } from './simulation';
 
 const MOCK_HOOKS: MiddlewareHooks = {
+  getIsLocked: jest.fn(),
   getMnemonic: jest.fn(),
   getSnapFile: jest.fn(),
   createInterface: jest.fn(),
   updateInterface: jest.fn(),
   getInterfaceState: jest.fn(),
+  resolveInterface: jest.fn(),
 };
 
 describe('getControllers', () => {

--- a/packages/snaps-jest/src/internals/simulation/controllers.ts
+++ b/packages/snaps-jest/src/internals/simulation/controllers.ts
@@ -82,6 +82,8 @@ export function getControllers(options: GetControllersOptions): Controllers {
       allowedActions: [
         'PhishingController:maybeUpdateState',
         'PhishingController:testOrigin',
+        'ApprovalController:hasRequest',
+        'ApprovalController:acceptRequest',
       ],
       allowedEvents: [],
     }),

--- a/packages/snaps-jest/src/internals/simulation/store/ui.ts
+++ b/packages/snaps-jest/src/internals/simulation/store/ui.ts
@@ -6,7 +6,7 @@ import { createAction, createSelector, createSlice } from '@reduxjs/toolkit';
 import type { ApplicationState } from './store';
 
 export type Interface = {
-  type: DialogApprovalTypes[DialogType];
+  type: DialogApprovalTypes[DialogType | 'default'];
   id: string;
 };
 

--- a/packages/snaps-jest/src/test-utils/controller.ts
+++ b/packages/snaps-jest/src/test-utils/controller.ts
@@ -32,7 +32,7 @@ export const getRootControllerMessenger = (mocked = true) => {
 
     messenger.registerActionHandler(
       'ApprovalController:acceptRequest',
-      async (_id: string, value: unknown) => Promise.resolve({ value }),
+      async (_id: string, value: unknown) => ({ value }),
     );
   }
 

--- a/packages/snaps-jest/src/test-utils/controller.ts
+++ b/packages/snaps-jest/src/test-utils/controller.ts
@@ -24,6 +24,16 @@ export const getRootControllerMessenger = (mocked = true) => {
       'ExecutionService:handleRpcRequest',
       jest.fn(),
     );
+
+    messenger.registerActionHandler(
+      'ApprovalController:hasRequest',
+      () => true,
+    );
+
+    messenger.registerActionHandler(
+      'ApprovalController:acceptRequest',
+      async (_id: string, value: unknown) => Promise.resolve({ value }),
+    );
   }
 
   return messenger;
@@ -43,6 +53,8 @@ export const getRestrictedSnapInterfaceControllerMessenger = (
     allowedActions: [
       'PhishingController:testOrigin',
       'PhishingController:maybeUpdateState',
+      'ApprovalController:hasRequest',
+      'ApprovalController:acceptRequest',
     ],
     allowedEvents: [],
   });

--- a/packages/snaps-jest/src/types.ts
+++ b/packages/snaps-jest/src/types.ts
@@ -220,7 +220,7 @@ export type SnapPromptInterface = {
  * A `snap_dialog` default interface that has a Footer with two buttons defined.
  * The approval of this confirmation is handled by the snap.
  */
-type DefaultSnapInterfaceWithFooter = {
+export type DefaultSnapInterfaceWithFooter = {
   /**
    * The content to show in the interface.
    */
@@ -231,18 +231,19 @@ type DefaultSnapInterfaceWithFooter = {
  * A `snap_dialog` default interface that has a Footer with one button defined.
  * A cancel button is automatically applied to the interface in this case.
  */
-type DefaultSnapInterfaceWithPartialFooter = DefaultSnapInterfaceWithFooter & {
-  /**
-   * Cancel the dialog.
-   */
-  cancel(): Promise<void>;
-};
+export type DefaultSnapInterfaceWithPartialFooter =
+  DefaultSnapInterfaceWithFooter & {
+    /**
+     * Cancel the dialog.
+     */
+    cancel(): Promise<void>;
+  };
 
 /**
  * A `snap_dialog` default interface that has no Footer defined.
  * A cancel and ok button is automatically applied to the interface in this case.
  */
-type DefaultSnapInterfaceWithoutFooter =
+export type DefaultSnapInterfaceWithoutFooter =
   DefaultSnapInterfaceWithPartialFooter & {
     /**
      * Close the dialog.

--- a/packages/snaps-jest/src/types.ts
+++ b/packages/snaps-jest/src/types.ts
@@ -233,7 +233,7 @@ type DefaultSnapInterfaceWithFooter = {
  */
 type DefaultSnapInterfaceWithPartialFooter = DefaultSnapInterfaceWithFooter & {
   /**
-   * Cancel the prompt.
+   * Cancel the dialog.
    */
   cancel(): Promise<void>;
 };
@@ -245,7 +245,7 @@ type DefaultSnapInterfaceWithPartialFooter = DefaultSnapInterfaceWithFooter & {
 type DefaultSnapInterfaceWithoutFooter =
   DefaultSnapInterfaceWithPartialFooter & {
     /**
-     * Close the prompt.
+     * Close the dialog.
      *
      */
     ok(): Promise<void>;

--- a/packages/snaps-jest/src/types.ts
+++ b/packages/snaps-jest/src/types.ts
@@ -216,10 +216,54 @@ export type SnapPromptInterface = {
   cancel(): Promise<void>;
 };
 
+export type SnapDefaultInterfaceWithFooter = {
+  /**
+   * The content to show in the interface.
+   */
+  content: JSXElement;
+};
+
+export type SnapDefaultInterfaceWithPartialFooter = {
+  /**
+   * The content to show in the interface.
+   */
+  content: JSXElement;
+
+  /**
+   * Cancel the prompt.
+   */
+  cancel(): Promise<void>;
+};
+
+export type SnapDefaultInterfaceWithoutFooter = {
+  /**
+   * The content to show in the interface.
+   */
+  content: JSXElement;
+
+  /**
+   * Close the prompt.
+   *
+   * @param value - The value to close the prompt with.
+   */
+  ok(): Promise<void>;
+
+  /**
+   * Cancel the prompt.
+   */
+  cancel(): Promise<void>;
+};
+
+export type SnapDefaultInterface =
+  | SnapDefaultInterfaceWithFooter
+  | SnapDefaultInterfaceWithPartialFooter
+  | SnapDefaultInterfaceWithoutFooter;
+
 export type SnapInterface = (
   | SnapAlertInterface
   | SnapConfirmationInterface
   | SnapPromptInterface
+  | SnapDefaultInterface
 ) &
   SnapInterfaceActions;
 

--- a/packages/snaps-jest/src/types.ts
+++ b/packages/snaps-jest/src/types.ts
@@ -216,54 +216,51 @@ export type SnapPromptInterface = {
   cancel(): Promise<void>;
 };
 
-export type SnapDefaultInterfaceWithFooter = {
+/**
+ * A `snap_dialog` default interface that has a Footer with two buttons defined.
+ * The approval of this confirmation is handled by the snap.
+ */
+type DefaultSnapInterfaceWithFooter = {
   /**
    * The content to show in the interface.
    */
   content: JSXElement;
 };
 
-export type SnapDefaultInterfaceWithPartialFooter = {
-  /**
-   * The content to show in the interface.
-   */
-  content: JSXElement;
-
+/**
+ * A `snap_dialog` default interface that has a Footer with one button defined.
+ * A cancel button is automatically applied to the interface in this case.
+ */
+type DefaultSnapInterfaceWithPartialFooter = DefaultSnapInterfaceWithFooter & {
   /**
    * Cancel the prompt.
    */
   cancel(): Promise<void>;
 };
 
-export type SnapDefaultInterfaceWithoutFooter = {
-  /**
-   * The content to show in the interface.
-   */
-  content: JSXElement;
+/**
+ * A `snap_dialog` default interface that has no Footer defined.
+ * A cancel and ok button is automatically applied to the interface in this case.
+ */
+type DefaultSnapInterfaceWithoutFooter =
+  DefaultSnapInterfaceWithPartialFooter & {
+    /**
+     * Close the prompt.
+     *
+     */
+    ok(): Promise<void>;
+  };
 
-  /**
-   * Close the prompt.
-   *
-   * @param value - The value to close the prompt with.
-   */
-  ok(): Promise<void>;
-
-  /**
-   * Cancel the prompt.
-   */
-  cancel(): Promise<void>;
-};
-
-export type SnapDefaultInterface =
-  | SnapDefaultInterfaceWithFooter
-  | SnapDefaultInterfaceWithPartialFooter
-  | SnapDefaultInterfaceWithoutFooter;
+export type DefaultSnapInterface =
+  | DefaultSnapInterfaceWithFooter
+  | DefaultSnapInterfaceWithPartialFooter
+  | DefaultSnapInterfaceWithoutFooter;
 
 export type SnapInterface = (
   | SnapAlertInterface
   | SnapConfirmationInterface
   | SnapPromptInterface
-  | SnapDefaultInterface
+  | DefaultSnapInterface
 ) &
   SnapInterfaceActions;
 

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -494,7 +494,10 @@ export const BoxChildStruct = nullUnion([
  * For now, the allowed JSX elements at the root are the same as the allowed
  * children of the Box component.
  */
-export const RootJSXElementStruct = BoxChildStruct;
+export const RootJSXElementStruct = nullUnion([
+  BoxChildStruct,
+  ContainerStruct,
+]);
 
 /**
  * A struct for the {@link JSXElement} type.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4291,7 +4291,6 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
-    "@metamask/utils": ^8.3.0
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -4526,7 +4525,6 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
-    "@metamask/utils": ^8.3.0
     "@swc/core": 1.3.78
     "@swc/jest": ^0.2.26
     "@typescript-eslint/eslint-plugin": ^5.42.1


### PR DESCRIPTION
This PR adds the support for the new `default` type dialog.

- Add a new dialog to the dialog test snap.
- Add logic to handle custom dialogs.
- Add assertion utils