### PR TITLE
fix: Enforce stricter size limits for source code and auxiliary files

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -135,7 +135,13 @@ const OTHER_ENCRYPTION_KEY =
 describe('SnapController', () => {
   beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/require-await
-    fetchMock.mockImplementation(async () => {
+    fetchMock.mockImplementation(async (request) => {
+      if (
+        typeof request === 'string' &&
+        request.startsWith('data:application/octet-stream;base64,')
+      ) {
+        return globalThis.fetch(request);
+      }
       throw new AssertionError({ message: 'Unmocked access to internet.' });
     });
   });
@@ -6069,6 +6075,34 @@ describe('SnapController', () => {
     });
   });
 
+  it('throws if the Snap source code is too large', async () => {
+    const messenger = getSnapControllerMessenger();
+    const { manifest, sourceCode, svgIcon, localizationFiles } =
+      await getMockSnapFilesWithUpdatedChecksum({
+        sourceCode: 'a'.repeat(64_000_001),
+      });
+
+    const snapController = getSnapController(
+      getSnapControllerOptions({
+        messenger,
+        detectSnapLocation: loopbackDetect({
+          manifest,
+          files: [sourceCode, svgIcon as VirtualFile, ...localizationFiles],
+        }),
+      }),
+    );
+
+    await expect(
+      snapController.installSnaps(MOCK_ORIGIN, {
+        [MOCK_SNAP_ID]: {},
+      }),
+    ).rejects.toThrow(
+      'Failed to fetch snap "npm:@metamask/example-snap": Snap source code must be smaller than 64 MB..',
+    );
+
+    snapController.destroy();
+  });
+
   describe('updateSnap', () => {
     it('throws an error for non installed snap', async () => {
       const detectSnapLocation = loopbackDetect();
@@ -8984,6 +9018,59 @@ describe('SnapController', () => {
 
       snapController.destroy();
     });
+
+    it('throws if encoding is too large', async () => {
+      const auxiliaryFile = new VirtualFile({
+        path: 'src/foo.json',
+        value: new Uint8Array(33_000_000),
+      });
+      const { manifest, sourceCode, svgIcon, auxiliaryFiles } =
+        await getMockSnapFilesWithUpdatedChecksum({
+          manifest: getSnapManifest({ files: ['./src/foo.json'] }),
+          auxiliaryFiles: [auxiliaryFile],
+        });
+
+      const messenger = getSnapControllerMessenger();
+
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          detectSnapLocation: loopbackDetect({
+            manifest,
+            files: [sourceCode, svgIcon as VirtualFile, ...auxiliaryFiles],
+          }),
+        }),
+      );
+
+      // Because jest-fetch-mock replaces native fetch, we mock it here
+      Object.defineProperty(globalThis, 'fetch', {
+        value: async (dataUrl: string) => {
+          const base64 = dataUrl.replace(
+            'data:application/octet-stream;base64,',
+            '',
+          );
+          const u8 = base64ToBytes(base64);
+          return new File([u8], '');
+        },
+      });
+
+      await snapController.installSnaps(MOCK_ORIGIN, {
+        [MOCK_SNAP_ID]: {},
+      });
+
+      await expect(
+        messenger.call(
+          'SnapController:getFile',
+          MOCK_SNAP_ID,
+          './src/foo.json',
+          AuxiliaryFileEncoding.Hex,
+        ),
+      ).rejects.toThrow(
+        'Failed to encode static file to "hex": Static files must be less than 64 MB when encoded.',
+      );
+
+      snapController.destroy();
+    }, 20_000);
   });
 
   describe('SnapController:snapInstalled', () => {

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -82,6 +82,7 @@ import {
   OnNameLookupResponseStruct,
   getLocalizedSnapManifest,
   parseJson,
+  MAX_FILE_SIZE,
 } from '@metamask/snaps-utils';
 import type { Json, NonEmptyArray, SemVerRange } from '@metamask/utils';
 import {
@@ -1818,7 +1819,14 @@ export class SnapController extends BaseController<
       return null;
     }
 
-    return encodeAuxiliaryFile(value, encoding);
+    const encoded = await encodeAuxiliaryFile(value, encoding);
+
+    assert(
+      encoded.length < MAX_FILE_SIZE,
+      `Failed to encode static file to "${encoding}": Static files must be less than 64 MB when encoded.`,
+    );
+
+    return encoded;
   }
 
   /**

--- a/packages/snaps-controllers/src/utils.ts
+++ b/packages/snaps-controllers/src/utils.ts
@@ -1,9 +1,11 @@
 import type { PermissionConstraint } from '@metamask/permission-controller';
 import type { SnapId } from '@metamask/snaps-sdk';
-import { getErrorMessage } from '@metamask/snaps-sdk';
+import { assert, getErrorMessage } from '@metamask/snaps-sdk';
 import {
+  MAX_FILE_SIZE,
   encodeBase64,
   getValidatedLocalizationFiles,
+  validateAuxiliaryFiles,
   validateFetchedSnap,
 } from '@metamask/snaps-utils';
 import type { Json } from '@metamask/utils';
@@ -275,9 +277,16 @@ export async function getSnapFiles(
 export async function fetchSnap(snapId: SnapId, location: SnapLocation) {
   try {
     const manifest = await location.manifest();
+
     const sourceCode = await location.fetch(
       manifest.result.source.location.npm.filePath,
     );
+
+    assert(
+      sourceCode.size < MAX_FILE_SIZE,
+      'Snap source code must be smaller than 64 MB.',
+    );
+
     const { iconPath } = manifest.result.source.location.npm;
     const svgIcon = iconPath ? await location.fetch(iconPath) : undefined;
 
@@ -285,6 +294,8 @@ export async function fetchSnap(snapId: SnapId, location: SnapLocation) {
       location,
       manifest.result.source.files,
     );
+
+    validateAuxiliaryFiles(auxiliaryFiles);
 
     await Promise.all(
       auxiliaryFiles.map(async (file) => {

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 96.84,
-  "functions": 98.8,
-  "lines": 98.87,
-  "statements": 95.19
+  "branches": 96.85,
+  "functions": 98.81,
+  "lines": 98.88,
+  "statements": 95.21
 }

--- a/packages/snaps-utils/src/auxiliary-files.test.ts
+++ b/packages/snaps-utils/src/auxiliary-files.test.ts
@@ -2,7 +2,8 @@ import { AuxiliaryFileEncoding } from '@metamask/snaps-sdk';
 import { bytesToHex, stringToBytes } from '@metamask/utils';
 import { base64 } from '@scure/base';
 
-import { encodeAuxiliaryFile } from './auxiliary-files';
+import { encodeAuxiliaryFile, validateAuxiliaryFiles } from './auxiliary-files';
+import { VirtualFile } from './virtual-file';
 
 describe('encodeAuxiliaryFile', () => {
   it('returns value without modifying it for base64', async () => {
@@ -25,6 +26,22 @@ describe('encodeAuxiliaryFile', () => {
     const value = base64.encode(bytes);
     expect(await encodeAuxiliaryFile(value, AuxiliaryFileEncoding.Utf8)).toBe(
       'foo',
+    );
+  });
+});
+
+describe('validateAuxiliaryFiles', () => {
+  it('throws if files are too large', async () => {
+    expect(() =>
+      validateAuxiliaryFiles([new VirtualFile(new Uint8Array(100_000_000))]),
+    ).toThrow('Static files required by the Snap must be smaller than 64 MB.');
+  });
+
+  it('passes when files are within size limits', async () => {
+    expect(() =>
+      validateAuxiliaryFiles([new VirtualFile(new Uint8Array(63_000_000))]),
+    ).not.toThrow(
+      'Static files required by the Snap must be smaller than 64 MB.',
     );
   });
 });

--- a/packages/snaps-utils/src/auxiliary-files.ts
+++ b/packages/snaps-utils/src/auxiliary-files.ts
@@ -1,7 +1,9 @@
 import { AuxiliaryFileEncoding } from '@metamask/snaps-sdk';
-import { bytesToHex, bytesToString } from '@metamask/utils';
+import { assert, bytesToHex, bytesToString } from '@metamask/utils';
 
 import { decodeBase64 } from './base64';
+import { MAX_FILE_SIZE } from './constants';
+import type { VirtualFile } from './virtual-file';
 
 /**
  * Re-encodes an auxiliary file if needed depending on the requested file encoding.
@@ -26,4 +28,18 @@ export async function encodeAuxiliaryFile(
   }
 
   return bytesToHex(decoded);
+}
+
+/**
+ * Validate that auxiliary files used by the Snap are within size limits.
+ *
+ * @param files - A list of auxiliary files.
+ */
+export function validateAuxiliaryFiles(files: VirtualFile[]) {
+  for (const file of files) {
+    assert(
+      file.size < MAX_FILE_SIZE,
+      'Static files required by the Snap must be smaller than 64 MB.',
+    );
+  }
 }

--- a/packages/snaps-utils/src/constants.ts
+++ b/packages/snaps-utils/src/constants.ts
@@ -1,0 +1,4 @@
+// The max file size for Snap source code and auxiliary files.
+// 64 MB - we chose this number because it is the size limit for postMessage
+// between the extension and the offscreen document enforced by Chrome.
+export const MAX_FILE_SIZE = 64_000_000;

--- a/packages/snaps-utils/src/index.ts
+++ b/packages/snaps-utils/src/index.ts
@@ -4,6 +4,7 @@ export * from './base64';
 export * from './bytes';
 export * from './caveats';
 export * from './checksum';
+export * from './constants';
 export * from './cronjob';
 export * from './deep-clone';
 export * from './default-endowments';

--- a/packages/snaps-utils/src/virtual-file/VirtualFile.test.ts
+++ b/packages/snaps-utils/src/virtual-file/VirtualFile.test.ts
@@ -26,6 +26,19 @@ describe('VirtualFile', () => {
     expect(file1.value).toStrictEqual(VALUE);
   });
 
+  describe('size', () => {
+    it('returns string length for strings', () => {
+      const file = new VirtualFile({ value: 'foo' });
+      expect(file.size).toBe(3);
+    });
+
+    it('returns byte length for Uint8Array', () => {
+      const value = stringToBytes('foo bar');
+      const file = new VirtualFile({ value });
+      expect(file.size).toBe(7);
+    });
+  });
+
   describe('toString()', () => {
     it('supports encodings', () => {
       // TextEncoder doesn't support utf-16 anymore

--- a/packages/snaps-utils/src/virtual-file/VirtualFile.ts
+++ b/packages/snaps-utils/src/virtual-file/VirtualFile.ts
@@ -72,6 +72,12 @@ export class VirtualFile<Result = unknown> {
 
   path: string;
 
+  get size() {
+    return typeof this.value === 'string'
+      ? this.value.length
+      : this.value.byteLength;
+  }
+
   toString(encoding?: string) {
     if (typeof this.value === 'string') {
       assert(encoding === undefined, 'Tried to encode string.');


### PR DESCRIPTION
Following the change in the MetaMask extension to use MV3, the Snaps execution environment is now using extension message passing as part of the JSON-RPC stack. This in turn means that messages sent between MetaMask and the Snap must be smaller than 64 MB per message. Because of this, we need to enforce sizing limits for the source code of the Snap as well as any static auxiliary files that can be loaded at runtime.

This PR adds that validation on install, but also validates that any returned value by `snap_getFile` is within these bounds, preventing communication failure with the execution environment.

TODO: Add a warning or error in the CLI for these sizing limits?