### PR TITLE
fix: Filter out some Struct errors based on key

### DIFF
--- a/packages/snaps-rpc-methods/src/restricted/dialog.test.tsx
+++ b/packages/snaps-rpc-methods/src/restricted/dialog.test.tsx
@@ -469,7 +469,6 @@ describe('implementation', () => {
     );
 
     it.each([
-      { type: DialogType.Alert },
       { type: DialogType.Alert, content: null },
       { type: DialogType.Alert, content: false },
       { type: DialogType.Alert, content: '' },
@@ -487,7 +486,22 @@ describe('implementation', () => {
           params: value as any,
         }),
       ).rejects.toThrow(
-        /Invalid params: At path: .* — Expected a value of type .*, but received: .*\./u,
+        /Invalid params: At path: .* — Expected the value to be one of: object, object, but received: .*\./u,
+      );
+    });
+
+    it('rejects invalid fields', async () => {
+      const hooks = getMockDialogHooks();
+      const implementation = getDialogImplementation(hooks);
+
+      await expect(
+        implementation({
+          context: { origin: 'foo' },
+          method: 'snap_dialog',
+          params: { type: DialogType.Alert } as any,
+        }),
+      ).rejects.toThrow(
+        'Invalid params: At path: id — Expected a value of type string, but received: undefined.',
       );
     });
 

--- a/packages/snaps-utils/src/structs.test.ts
+++ b/packages/snaps-utils/src/structs.test.ts
@@ -12,6 +12,7 @@ import superstruct, {
   union as superstructUnion,
   array,
   is,
+  boolean,
 } from 'superstruct';
 
 import { RpcOriginsStruct } from './json-rpc';
@@ -345,6 +346,47 @@ describe('validateUnion', () => {
       validateUnion({ type: 'a', value: 42 }, Union, 'type'),
     ).toThrow(
       `At path: value — Expected a value of type string, but received: 42.`,
+    );
+  });
+
+  it('throws a readable error even if input is missing keys', () => {
+    const FooStruct = object({
+      type: literal('a'),
+      value: string(),
+    });
+
+    const BarStruct = object({
+      type: literal('b'),
+      value: number(),
+    });
+
+    const Union = union([FooStruct, BarStruct]);
+    expect(() => validateUnion({ type: 'a' }, Union, 'type')).toThrow(
+      `At path: value — Expected a value of type string, but received: undefined.`,
+    );
+  });
+
+  it('selects the error with the least failures', () => {
+    const FooStruct = object({
+      type: literal('a'),
+      value: union([boolean(), string()]),
+    });
+
+    const OtherFooStruct = object({
+      type: literal('a'),
+      value: boolean(),
+    });
+
+    const BarStruct = object({
+      type: literal('b'),
+      value: number(),
+    });
+
+    const Union = union([FooStruct, OtherFooStruct, BarStruct]);
+    expect(() =>
+      validateUnion({ type: 'a', value: 42 }, Union, 'type'),
+    ).toThrow(
+      `At path: value — Expected a value of type boolean, but received: 42.`,
     );
   });
 


### PR DESCRIPTION
Filters out some Struct errors in `validateUnion` by looking at the `key`. If the `key` isn't specified in the object we are trying to validate we will assume that that branch of validation errors isn't interesting to the user.

This improves error messages for `snap_dialog` somewhat as the error message will correctly mention that `content` is invalid: `Invalid params: At path: content — Expected the value to be one of: object, object, but received: ...`.

This PR does not fix the fact that the error message still doesn't explain what was expected of the union.