### PR TITLE
fix: Add typed union validation

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Pyw9v/S7ZnVllFIocfOeELkfTPERcS6a4kox9grMiK8=",
+    "shasum": "cG78m4B2d8yHgKq1rKrZsbGZApWbJyd3MNoBPGcjKUQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "RuWpXFKAcKwsw2uHEMyh1O5w6KjngWSs/9u1b3OO6Vc=",
+    "shasum": "Pyw9v/S7ZnVllFIocfOeELkfTPERcS6a4kox9grMiK8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5PMrWZx7E0qhvfU3I39nCJnEDcoa84ZgZCjOmwitLU0=",
+    "shasum": "YvyYRUgAVoeYPTzZRjxKRYNAjJe5usTDyqQkKbGTFTo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9O5Ttwb8OsYZhjOdQvef5cvbzlaX7ofgH6C6a9rOXmo=",
+    "shasum": "5PMrWZx7E0qhvfU3I39nCJnEDcoa84ZgZCjOmwitLU0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "v821sxB2ekoolCcPzAu0pkiEWgsHAyyoMw51IWxl5pk=",
+    "shasum": "of/KRemyjywqFKi+kmEOWh2lqWFt9dg641GOFLjVSTc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "of/KRemyjywqFKi+kmEOWh2lqWFt9dg641GOFLjVSTc=",
+    "shasum": "FQwKp8UTAOjE30njzUvGS2OElCud9Hyj2+xkfRGeqIk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "T1qpvOOU4GE2bi0ajyHSS/unHIcKTTVrFD7Pon62ddw=",
+    "shasum": "VglMoBJGhWpq4P+2P0DXMHVL3oF5+W2D4tlJtH8kdvw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "uCU3Ng6rztza9Gdqdv1lARTj7Jd26/bkTek9yBvFv1o=",
+    "shasum": "T1qpvOOU4GE2bi0ajyHSS/unHIcKTTVrFD7Pon62ddw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "owFhLEXDWkncrq2vtoJ8vL+wGyGdYokhhJHk82YrVvc=",
+    "shasum": "sLUWFIdGWE37IKnXMroCiikwZcGZwf2mtGtDvjk3BCA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "sLUWFIdGWE37IKnXMroCiikwZcGZwf2mtGtDvjk3BCA=",
+    "shasum": "FHyz1K8TqeKyGniGR77kZFwRcm7IkjBuQ1zBifDPHvo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "zpZkwMb/yIHk0p4QB02njlNLZbngJjK09/gAtQ6uoKo=",
+    "shasum": "QUq06Xlg+PBuocJCi0MwWUEK9CKUN97crhgkA/00Qgg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "QUq06Xlg+PBuocJCi0MwWUEK9CKUN97crhgkA/00Qgg=",
+    "shasum": "9bT28snShrLQ7/OHDWJT6qDXdlc/asYH7x8o6zqfuUo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "yb9Qyz/WzW5Q0hsQxcb+2f3w7EpniwcT0UzN75Sb1qU=",
+    "shasum": "6wbvDwwlI95lbH9O4sCRl2vF9+pA46eEh8940ErWyhg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6wbvDwwlI95lbH9O4sCRl2vF9+pA46eEh8940ErWyhg=",
+    "shasum": "bozHl8e7Md1GuWvLOXtPbKGejiE2gBOGV0cIg6M7zFc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "dshXsDhCXIjHKWm8YbSlP8t2/bDUvUKA7/p4mGlMauE=",
+    "shasum": "bxkIfLtUJIjpxk2VXyvKJrgqSOO6p5xTr5EvlHATZlc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "bxkIfLtUJIjpxk2VXyvKJrgqSOO6p5xTr5EvlHATZlc=",
+    "shasum": "AKvlBnNv0PrE8VfPCdxMmbTMq451QKo9ggsERIMPEZc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+OSD7HUZ7RgMfgV9hqVqy1iGC3aQhpylGDYpAjNu7RM=",
+    "shasum": "60LZXNvbDxyYnWy5qP43Tj8UZTfnmUsjItCOpnLTju0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cwKYUQP6FNdcc49qw4vQd4xy1KsPmIfQTSbMOwxmgK8=",
+    "shasum": "+OSD7HUZ7RgMfgV9hqVqy1iGC3aQhpylGDYpAjNu7RM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "U53WH5GtWdsqEpVnQnNEHBTvG0ecPrOKw1cUTfZPOfs=",
+    "shasum": "JEqPXJBPLzIyOx0gFjHKrY7aMuznvwPvNlYaW9bFMkE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "JEqPXJBPLzIyOx0gFjHKrY7aMuznvwPvNlYaW9bFMkE=",
+    "shasum": "E6A+dO1EcNp9XYm9M0yEUafFXRM0W72ylmOhbA9FFio=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "HLpt3DP4OEdEDNnTE6YcYLn3GNSW8nVVsoaK2f/3b2s=",
+    "shasum": "GFAjUWW8q9iX+2J/wKFlVRjq1oJ377NW5qSVTbkYtIQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "iMdZJabdJey8pON8c83C1/wSn5toUOMZVb1my1/Iq/8=",
+    "shasum": "HLpt3DP4OEdEDNnTE6YcYLn3GNSW8nVVsoaK2f/3b2s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "EaZILnnNYSZ4R0y+l7/PL0jUSsdpHodUKa4slYJLkMQ=",
+    "shasum": "37wMtBqKrmWF3CUdyQHZ3Ey86NpGnffqIq6GnqTf+Ro=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "CAT7l9BD2Pl72sKYvzVShJAK38l0p5/QmDcISlh7A9A=",
+    "shasum": "EaZILnnNYSZ4R0y+l7/PL0jUSsdpHodUKa4slYJLkMQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wcGav9POD8Y28L5HGRGSYkb+x8LmnRWl/QEoc2FEAHQ=",
+    "shasum": "4orLCaQXEnhuUUe9a+SUExj5TyYQ1nlcGyaip+z2BiM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4orLCaQXEnhuUUe9a+SUExj5TyYQ1nlcGyaip+z2BiM=",
+    "shasum": "9eJQJL4e2McSiHzayvby/1zLdHvf7Uc9ppUUw7v+rHQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "066gxukk8RbnEx16dAfYR5ewVkiqTCxWJMxitCrt9VU=",
+    "shasum": "JLBEYLlsDDBvRyumvQyFX2dIuck2liWkGsqWeW+HkfE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "JLBEYLlsDDBvRyumvQyFX2dIuck2liWkGsqWeW+HkfE=",
+    "shasum": "oyaKZ7cbZisTYS6p9+ol9+tbjfq2Yly3G5UDvIwDLOQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "X2WPAcUuon2f5/z+7j6R5w6qylUNgO9p7ssL4s8+5N8=",
+    "shasum": "LfydCMo1VRRXKdciizK7HPLso/tVufqM0JGpWSts/os=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "71fsjwKD7Ylpb4vCoL0OImpY2913qUPHZn6uLr5tdJ4=",
+    "shasum": "X2WPAcUuon2f5/z+7j6R5w6qylUNgO9p7ssL4s8+5N8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "tr8SlYGomxBi7ntbd9HZMLbMRR7I9fKp9uxp6915Dqk=",
+    "shasum": "8MoLqit0ldP9dXby0k6nOsNPcfTVhHFwD+NDkGTLWpE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "l0DffJ4FRaT7CYesLlKnn6/TABqoGwDbaP8xX9MZFSE=",
+    "shasum": "tr8SlYGomxBi7ntbd9HZMLbMRR7I9fKp9uxp6915Dqk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9156YmSnoZ2HL1BW1BagQVZs1aqZVZA/WgVUl9L+zuE=",
+    "shasum": "dd2RRHpmyhOtK2A1mWqgzYz+AI/UG2gyFWUsuCjW/QY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "B/tH17jw0/0icAW8XhfqvHn48tWejZAiOt8jXVlY8P4=",
+    "shasum": "9156YmSnoZ2HL1BW1BagQVZs1aqZVZA/WgVUl9L+zuE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "11m+yh3Qrt0eezPtngR3U8z0ufSGR0swK8eTGwSv7kQ=",
+    "shasum": "bO6BCe6o4G/BEyJ2plru0KIMcy2c8Js9q+J7+Dk2qy4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "bO6BCe6o4G/BEyJ2plru0KIMcy2c8Js9q+J7+Dk2qy4=",
+    "shasum": "wXoG3PQ8lhJu5MCXOoFXPd/eEzrkMzdCYNL5YKCzOXg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "IE72+89hdXH8uliyK2K/baG1QCZDksWHdxT7B3u10wE=",
+    "shasum": "8CWhVcRMrN0tSMtxV0UXNvvS6kwVVJ+xJxADZ1AMkxY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "QxhpO+N8HIfgzLZcAjRayscoP3BMlMiYKVSTnE/wg6I=",
+    "shasum": "IE72+89hdXH8uliyK2K/baG1QCZDksWHdxT7B3u10wE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "HGRg7Tgn9GRfHW+k03OWg+x9E/edQYYLp7yORvBtV6w=",
+    "shasum": "+bfsURFNxni7MV/98u6zHjp9QgzWIAXI2wud9ClfejM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "tlDICby29Io5VkQt9B3f6l7vjxGW7TH96JkFxLz5RBk=",
+    "shasum": "HGRg7Tgn9GRfHW+k03OWg+x9E/edQYYLp7yORvBtV6w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "i/1Z0hDFM8c5aXyI8zKOF9g7Q0fhCE4LYxsch8uEJI8=",
+    "shasum": "0tyRbcf9PCK7q/S3CHWd93PqFF0osxDxXC4DP0X2t64=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0tyRbcf9PCK7q/S3CHWd93PqFF0osxDxXC4DP0X2t64=",
+    "shasum": "U5POJ0kzznk+u1A4xxgFQX3LIU8QoVUqYYUylOUmUhs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "h/PHeqbq8vhWAjclfWJWOnIxIWWG12z/PjH9gzMqLnQ=",
+    "shasum": "tTkr02J7P98XBiVpFHm7QcnYD2rml3V5RELoyvT5Xw4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "tTkr02J7P98XBiVpFHm7QcnYD2rml3V5RELoyvT5Xw4=",
+    "shasum": "nP0QOJ+vurTLPgKtiYq2zWMxoBBfgZ4VkcQ8svyU1Sk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TyQpkQMzpJOUq6fSDh3x2hyxz7suSlHgBm2LI8baC6w=",
+    "shasum": "VSXdhOsUAKupm4JXWCZcQ4HFKNrmxD3LySAmJlRQkGQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0QylDwZOSxudUvfl0oBK6XU1rol3KZw3aJ302ffRtrs=",
+    "shasum": "TyQpkQMzpJOUq6fSDh3x2hyxz7suSlHgBm2LI8baC6w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Jp5Mz+1V/Pcy46a346OfMPYDy6bBg/1OrwapTc7jUlA=",
+    "shasum": "F+XHboDs91A70AhsVQf522aZZ4FKzGRsh0dtV7Hr01w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "F+XHboDs91A70AhsVQf522aZZ4FKzGRsh0dtV7Hr01w=",
+    "shasum": "AP1xFEuyMDWaiey+kkUzjlMl1tt4ey26cntnHHNix/s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "rxJVDugZ4KVmBIMQpMT0JfPUs6Byd7DrRFGZjOAilQY=",
+    "shasum": "R6xONAf4IA5HXDU2oyL732pa5T+Nhc6idkEr9Zo/fDo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "/00IgIA9lzQ37AT9YXLai2PI7I0g7egNnxfQPBfXSUI=",
+    "shasum": "rxJVDugZ4KVmBIMQpMT0JfPUs6Byd7DrRFGZjOAilQY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "SEEx+2z6HRQ3AWXrW/SxgYE+WRi1EjRxBcJuFsfWmT4=",
+    "shasum": "nOHygj95R/T+NtgyXLdS5YNxom7bflJoLGaSqAiLZNU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7rtXzRXXniBYGoIU2M4IF5fjWByHGMxxrkFhH8Tj6cA=",
+    "shasum": "SEEx+2z6HRQ3AWXrW/SxgYE+WRi1EjRxBcJuFsfWmT4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "rUToXzoOsq2NG80Fo7Ldo6FeIwnUSe6nkAeGyYJ8gyQ=",
+    "shasum": "mQOGM9a8ovQXemN3Pt/HOKD3f9+zfUHQ65jzWs4YkRo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "mQOGM9a8ovQXemN3Pt/HOKD3f9+zfUHQ65jzWs4YkRo=",
+    "shasum": "z18RzBaiNCS+tdOltE3CD6s/S+nTZTVHjLotmaVgKN8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "EVusAjusqBDipLeelxbkJYzfN7CeMovX5ty+2wbR5IM=",
+    "shasum": "u9gdUhWQ33B74sMCdZ7bCFfLwon2QmFnx1xZEU+OYko=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "u9gdUhWQ33B74sMCdZ7bCFfLwon2QmFnx1xZEU+OYko=",
+    "shasum": "ZQJV6BNeSLTrnxxnbT+P+I1O9/novFlZcKVJuTxnRRM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "l/j53uUy6hUdbiKpTbc2PWHwGeZ556zaF8dpDv1Wl2Q=",
+    "shasum": "CwintJFAqwsEE69sm5PCWKaWqI5wV1XbtKd0pelwMG0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "CwintJFAqwsEE69sm5PCWKaWqI5wV1XbtKd0pelwMG0=",
+    "shasum": "nXyQsrdxb0igyATQImUC4UyAw598ldkJCRuu/OZTvss=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-rpc-methods/src/permitted/createInterface.test.tsx
+++ b/packages/snaps-rpc-methods/src/permitted/createInterface.test.tsx
@@ -132,7 +132,7 @@ describe('snap_createInterface', () => {
       error: {
         code: -32602,
         message:
-          'Invalid params: At path: ui -- Expected the value to satisfy a union of `union | union`, but received: "foo".',
+          'Invalid params: At path: ui -- Expected the value to satisfy a union of `typedUnion | union`, but received: "foo".',
         stack: expect.any(String),
       },
       id: 1,

--- a/packages/snaps-rpc-methods/src/permitted/createInterface.test.tsx
+++ b/packages/snaps-rpc-methods/src/permitted/createInterface.test.tsx
@@ -132,7 +132,7 @@ describe('snap_createInterface', () => {
       error: {
         code: -32602,
         message:
-          'Invalid params: At path: ui -- Expected the value to satisfy a union of `typedUnion | union`, but received: "foo".',
+          'Invalid params: At path: ui -- Expected the value to satisfy a union of `union | union`, but received: "foo".',
         stack: expect.any(String),
       },
       id: 1,

--- a/packages/snaps-sdk/src/internals/structs.test.ts
+++ b/packages/snaps-sdk/src/internals/structs.test.ts
@@ -44,7 +44,8 @@ describe('literal', () => {
 describe('typedUnion', () => {
   const unionStruct = typedUnion([BoxStruct, TextStruct, FieldStruct]);
   it('validates strictly the part of the union that matches the type', () => {
-    const result = validate(Text({} as any), unionStruct);
+    // @ts-expect-error Invalid props.
+    const result = validate(Text({}), unionStruct);
 
     expect(result[0]?.message).toBe(
       'At path: props.children -- Expected the value to satisfy a union of `union | array`, but received: undefined',

--- a/packages/snaps-sdk/src/internals/structs.test.ts
+++ b/packages/snaps-sdk/src/internals/structs.test.ts
@@ -1,6 +1,8 @@
 import { is, validate } from 'superstruct';
 
-import { enumValue, literal, union } from './structs';
+import { Text } from '../jsx';
+import { BoxStruct, FieldStruct, TextStruct } from '../jsx/validation';
+import { enumValue, literal, typedUnion, union } from './structs';
 
 describe('enumValue', () => {
   it('validates an enum value', () => {
@@ -35,6 +37,33 @@ describe('literal', () => {
     );
     expect(unionError?.message).toBe(
       'Expected the value to satisfy a union of `"bar" | "baz"`, but received: "foo"',
+    );
+  });
+});
+
+describe('typedUnion', () => {
+  const unionStruct = typedUnion([BoxStruct, TextStruct, FieldStruct]);
+  it('validates strictly the part of the union that matches the type', () => {
+    const result = validate(Text({} as any), unionStruct);
+
+    expect(result[0]?.message).toBe(
+      'At path: props.children -- Expected the value to satisfy a union of `union | array`, but received: undefined',
+    );
+  });
+
+  it('returns an error if the value has no type', () => {
+    const result = validate({}, unionStruct);
+
+    expect(result[0]?.message).toBe(
+      'Expected type to be one of: "Box", "Text", "Field", but received: undefined',
+    );
+  });
+
+  it('returns an error if the type doesnt exist in the union', () => {
+    const result = validate({ type: 'foo' }, unionStruct);
+
+    expect(result[0]?.message).toBe(
+      'Expected type to be one of: "Box", "Text", "Field", but received: "foo"',
     );
   });
 });

--- a/packages/snaps-sdk/src/internals/structs.ts
+++ b/packages/snaps-sdk/src/internals/structs.ts
@@ -1,7 +1,9 @@
+import { assert, hasProperty, isPlainObject } from '@metamask/utils';
 import type { Infer } from 'superstruct';
 import {
   Struct,
   define,
+  is,
   literal as superstructLiteral,
   union as superstructUnion,
 } from 'superstruct';
@@ -75,4 +77,60 @@ export function enumValue<Type extends string>(
   constant: Type,
 ): Struct<EnumToUnion<Type>, null> {
   return literal(constant as EnumToUnion<Type>);
+}
+
+/**
+ * Create a custom union struct that validates exclusively based on a `type` field.
+ *
+ * This should improve error messaging for unions with many structs in them.
+ *
+ * @param structs - The structs to union.
+ * @returns The `superstruct` struct, which validates that the value satisfies
+ * one of the structs.
+ */
+export function typedUnion<Head extends AnyStruct, Tail extends AnyStruct[]>(
+  structs: [head: Head, ...tail: Tail],
+): Struct<Infer<Head> | InferStructTuple<Tail>[number], null> {
+  return new Struct({
+    type: 'typedUnion',
+    schema: null,
+    *entries(value, context) {
+      if (isPlainObject(value) && hasProperty(value, 'type')) {
+        const { type } = value;
+        const struct = structs.find(({ schema }) => is(type, schema.type));
+
+        assert(struct, 'Expected at least one struct to match');
+
+        for (const entry of struct.entries(value, context)) {
+          yield entry;
+        }
+      }
+    },
+    validator(value, context) {
+      const types = structs.map(({ schema }) => schema.type.type);
+
+      if (
+        !isPlainObject(value) ||
+        !hasProperty(value, 'type') ||
+        typeof value.type !== 'string'
+      ) {
+        return `Expected type to be one of: ${types.join(
+          ', ',
+        )}, but received: undefined`;
+      }
+
+      const { type } = value;
+
+      const struct = structs.find(({ schema }) => is(type, schema.type));
+
+      if (struct) {
+        // This only validates the root of the struct, entries does the rest of the work.
+        return struct.validator(value, context);
+      }
+
+      return `Expected type to be one of: ${types.join(
+        ', ',
+      )}, but received: "${type}"`;
+    },
+  }) as unknown as Struct<Infer<Head> | InferStructTuple<Tail>[number], null>;
 }

--- a/packages/snaps-sdk/src/internals/structs.ts
+++ b/packages/snaps-sdk/src/internals/structs.ts
@@ -92,7 +92,7 @@ export function typedUnion<Head extends AnyStruct, Tail extends AnyStruct[]>(
   structs: [head: Head, ...tail: Tail],
 ): Struct<Infer<Head> | InferStructTuple<Tail>[number], null> {
   return new Struct({
-    type: 'typedUnion',
+    type: 'union',
     schema: null,
     *entries(value, context) {
       if (!isPlainObject(value) || !hasProperty(value, 'type')) {

--- a/packages/snaps-sdk/src/internals/structs.ts
+++ b/packages/snaps-sdk/src/internals/structs.ts
@@ -1,4 +1,4 @@
-import { assert, hasProperty, isPlainObject } from '@metamask/utils';
+import { hasProperty, isPlainObject } from '@metamask/utils';
 import type { Infer } from 'superstruct';
 import {
   Struct,
@@ -95,15 +95,19 @@ export function typedUnion<Head extends AnyStruct, Tail extends AnyStruct[]>(
     type: 'typedUnion',
     schema: null,
     *entries(value, context) {
-      if (isPlainObject(value) && hasProperty(value, 'type')) {
-        const { type } = value;
-        const struct = structs.find(({ schema }) => is(type, schema.type));
+      if (!isPlainObject(value) || !hasProperty(value, 'type')) {
+        return;
+      }
 
-        assert(struct, 'Expected at least one struct to match');
+      const { type } = value;
+      const struct = structs.find(({ schema }) => is(type, schema.type));
 
-        for (const entry of struct.entries(value, context)) {
-          yield entry;
-        }
+      if (!struct) {
+        return;
+      }
+
+      for (const entry of struct.entries(value, context)) {
+        yield entry;
       }
     },
     validator(value, context) {

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -25,7 +25,7 @@ import type {
 } from 'superstruct/dist/utils';
 
 import type { Describe } from '../internals';
-import { literal, nullUnion, svg } from '../internals';
+import { literal, nullUnion, svg, typedUnion } from '../internals';
 import type { EmptyObject } from '../types';
 import type {
   GenericSnapElement,
@@ -480,7 +480,7 @@ export const SpinnerStruct: Describe<SpinnerElement> = element('Spinner');
  * This set includes all components, except components that need to be nested in
  * another component (e.g., Field must be contained in a Form).
  */
-export const BoxChildStruct = nullUnion([
+export const BoxChildStruct = typedUnion([
   AddressStruct,
   BoldStruct,
   BoxStruct,
@@ -515,7 +515,7 @@ export const RootJSXElementStruct = nullUnion([
 /**
  * A struct for the {@link JSXElement} type.
  */
-export const JSXElementStruct: Describe<JSXElement> = nullUnion([
+export const JSXElementStruct: Describe<JSXElement> = typedUnion([
   ButtonStruct,
   InputStruct,
   FileInputStruct,

--- a/packages/snaps-sdk/src/ui/components/panel.ts
+++ b/packages/snaps-sdk/src/ui/components/panel.ts
@@ -1,6 +1,7 @@
 import type { Infer, Struct } from 'superstruct';
-import { array, assign, lazy, literal, object, union } from 'superstruct';
+import { array, assign, lazy, literal, object } from 'superstruct';
 
+import { typedUnion } from '../../internals';
 import { createBuilder } from '../builder';
 import { NodeStruct, NodeType } from '../nodes';
 import { AddressStruct } from './address';
@@ -86,7 +87,7 @@ export type Panel = {
 export const panel = createBuilder(NodeType.Panel, PanelStruct, ['children']);
 
 // This is defined separately from `Component` to avoid circular dependencies.
-export const ComponentStruct = union([
+export const ComponentStruct = typedUnion([
   CopyableStruct,
   DividerStruct,
   HeadingStruct,


### PR DESCRIPTION
Adds a `typedUnion` utility which strictly validates members of the union based on a `type` field. This should reduce the noise when trying to parse through Superstruct validation failures resulting in validating large unions such as the JSX unions.

This doesn't solve the Superstruct union problem generally as we still have many unions of unions, but it might make the problem easier to solve.