### PR TITLE
fix: Account for revoked origins in `initialConnections`

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 92.08,
-  "functions": 96.75,
-  "lines": 97.97,
-  "statements": 97.65
+  "functions": 96.77,
+  "lines": 97.98,
+  "statements": 97.66
 }

--- a/packages/snaps-controllers/src/utils.test.ts
+++ b/packages/snaps-controllers/src/utils.test.ts
@@ -14,12 +14,7 @@ import {
   MOCK_RPC_ORIGINS_PERMISSION,
   MOCK_SNAP_DIALOG_PERMISSION,
 } from './test-utils';
-import {
-  calculateConnectionsChange,
-  getSnapFiles,
-  permissionsDiff,
-  setDiff,
-} from './utils';
+import { getSnapFiles, permissionsDiff, setDiff } from './utils';
 
 describe('setDiff', () => {
   it('does nothing on empty type {}-B', () => {
@@ -183,34 +178,5 @@ describe('getSnapFiles', () => {
         value: 'bar',
       }),
     ]);
-  });
-});
-
-describe('calculateConnectionsChange', () => {
-  it('should properly calculate connection change based on the input data', () => {
-    const oldConnections = {
-      'npm:filsnap': {},
-      'https://snaps.metamask.io': {},
-      'https://metamask.github.io': {},
-    };
-    const newConnections = {
-      'https://snaps.metamask.io': {},
-      'https://portfolio.metamask.io': {},
-    };
-
-    expect(
-      calculateConnectionsChange(oldConnections, newConnections),
-    ).toStrictEqual({
-      newConnections: {
-        'https://portfolio.metamask.io': {},
-      },
-      unusedConnections: {
-        'npm:filsnap': {},
-        'https://metamask.github.io': {},
-      },
-      approvedConnections: {
-        'https://snaps.metamask.io': {},
-      },
-    });
   });
 });

--- a/packages/snaps-controllers/src/utils.ts
+++ b/packages/snaps-controllers/src/utils.ts
@@ -8,7 +8,6 @@ import {
   validateAuxiliaryFiles,
   validateFetchedSnap,
 } from '@metamask/snaps-utils';
-import type { Json } from '@metamask/utils';
 import deepEqual from 'fast-deep-equal';
 
 import type { SnapLocation } from './snaps';
@@ -329,30 +328,4 @@ export async function fetchSnap(snapId: SnapId, location: SnapLocation) {
       `Failed to fetch snap "${snapId}": ${getErrorMessage(error)}.`,
     );
   }
-}
-
-/**
- * Calculate change of initialConnections.
- *
- * @param oldConnectionsSet - Previously approved connections.
- * @param desiredConnectionsSet - New connections.
- * @returns Object containing newConnections, unusedConnections and approvedConnections.
- */
-export function calculateConnectionsChange(
-  oldConnectionsSet: Record<string, Json>,
-  desiredConnectionsSet: Record<string, Json>,
-): {
-  newConnections: Record<string, Json>;
-  unusedConnections: Record<string, Json>;
-  approvedConnections: Record<string, Json>;
-} {
-  const newConnections = setDiff(desiredConnectionsSet, oldConnectionsSet);
-
-  const unusedConnections = setDiff(oldConnectionsSet, desiredConnectionsSet);
-
-  // It's a Set Intersection of oldConnections and desiredConnectionsSet
-  // oldConnections ∖ (oldConnections ∖ desiredConnectionsSet) ⟺ oldConnections ∩ desiredConnectionsSet
-  const approvedConnections = setDiff(oldConnectionsSet, unusedConnections);
-
-  return { newConnections, unusedConnections, approvedConnections };
 }


### PR DESCRIPTION
This PR adds logic to account for revoked origins when calculating the difference in `initialConnections`. Essentially, we don't need to revoke permissions that are already revoked and we want to show revoked connections as being re-added in the UI.

Fixes #2532 