### PR TITLE
fix: Properly terminate origin regex with $

### DIFF
--- a/packages/snaps-utils/src/json-rpc.test.ts
+++ b/packages/snaps-utils/src/json-rpc.test.ts
@@ -208,6 +208,13 @@ describe('isOriginAllowed', () => {
     expect(
       isOriginAllowed(origins, SubjectType.Website, 'https://foo.metamask.io'),
     ).toBe(true);
+    expect(
+      isOriginAllowed(
+        origins,
+        SubjectType.Website,
+        'https://foo.metamask.io.bad.com',
+      ),
+    ).toBe(false);
   });
 
   it('supports multiple wildcards', () => {

--- a/packages/snaps-utils/src/json-rpc.ts
+++ b/packages/snaps-utils/src/json-rpc.ts
@@ -107,8 +107,8 @@ function createOriginRegExp(matcher: string) {
   // Escape potential Regex characters
   const escaped = matcher.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
   // Support wildcards
-  const regex = escaped.replace(/\*/gu, '.*');
-  return RegExp(regex, 'u');
+  const regex = escaped.replace(/\\\*/gu, '.*');
+  return RegExp(`${regex}$`, 'u');
 }
 
 /**


### PR DESCRIPTION
Fixes an oversight in the regex generation for `allowedOrigins` that allows a bypass of the functionality due to the regex not being properly terminated.

Also fixes a mistake in the regex generation that wouldn't properly add `.*` to the regex but instead use somewhat escaped characters.