### PR TITLE
Handle initial connections for preinstalled Snaps

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 92.46,
+  "branches": 92.5,
   "functions": 96.91,
   "lines": 98.01,
   "statements": 97.7

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1180,6 +1180,14 @@ export class SnapController extends BaseController<
 
       this.#updatePermissions({ snapId, newPermissions, unusedPermissions });
 
+      if (manifest.initialConnections) {
+        this.#handleInitialConnections(
+          snapId,
+          existingSnap?.initialConnections ?? null,
+          manifest.initialConnections,
+        );
+      }
+
       // Set status
       this.update((state) => {
         state.snaps[snapId].status = SnapStatus.Stopped;


### PR DESCRIPTION
`#handlePreinstalledSnaps` previously did not account for initial connections in preinstalled Snaps. I've added a call to `#handleInitialConnections` if the preinstalled Snap has initial connections.

Closes #2588.