### PR TITLE
chore(devDep): Bump `typescript` from `~4.8.4` to `~5.0.4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "simple-git-hooks": "^2.7.0",
     "ts-node": "^10.9.1",
     "tsup": "^8.0.1",
-    "typescript": "~4.8.4",
+    "typescript": "~5.0.4",
     "vite": "^4.3.9"
   },
   "engines": {

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -84,7 +84,7 @@
     "ts-node": "^10.9.1",
     "tsc-watch": "^4.5.0",
     "tsup": "^8.0.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -47,7 +47,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/bip32/package.json
+++ b/packages/examples/packages/bip32/package.json
@@ -64,7 +64,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/bip44/package.json
+++ b/packages/examples/packages/bip44/package.json
@@ -64,7 +64,7 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^4.1.2",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/browserify-plugin/package.json
+++ b/packages/examples/packages/browserify-plugin/package.json
@@ -61,7 +61,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/browserify/package.json
+++ b/packages/examples/packages/browserify/package.json
@@ -61,7 +61,7 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^4.1.2",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/client-status/package.json
+++ b/packages/examples/packages/client-status/package.json
@@ -61,7 +61,7 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^4.1.2",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/cronjobs/package.json
+++ b/packages/examples/packages/cronjobs/package.json
@@ -61,7 +61,7 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^4.1.2",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/dialogs/package.json
+++ b/packages/examples/packages/dialogs/package.json
@@ -60,7 +60,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/errors/package.json
+++ b/packages/examples/packages/errors/package.json
@@ -60,7 +60,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/ethereum-provider/package.json
+++ b/packages/examples/packages/ethereum-provider/package.json
@@ -61,7 +61,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/ethers-js/package.json
+++ b/packages/examples/packages/ethers-js/package.json
@@ -61,7 +61,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4",
+    "typescript": "~5.0.4",
     "webpack": "^5.88.0"
   },
   "engines": {

--- a/packages/examples/packages/file-upload/package.json
+++ b/packages/examples/packages/file-upload/package.json
@@ -62,7 +62,7 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^4.1.2",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/get-entropy/package.json
+++ b/packages/examples/packages/get-entropy/package.json
@@ -62,7 +62,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/get-file/package.json
+++ b/packages/examples/packages/get-file/package.json
@@ -61,7 +61,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/home-page/package.json
+++ b/packages/examples/packages/home-page/package.json
@@ -60,7 +60,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/images/package.json
+++ b/packages/examples/packages/images/package.json
@@ -61,7 +61,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/interactive-ui/package.json
+++ b/packages/examples/packages/interactive-ui/package.json
@@ -62,7 +62,7 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^4.1.2",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/invoke-snap/package.json
+++ b/packages/examples/packages/invoke-snap/package.json
@@ -45,7 +45,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
@@ -63,7 +63,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/invoke-snap/packages/core-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/package.json
@@ -65,7 +65,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/json-rpc/package.json
+++ b/packages/examples/packages/json-rpc/package.json
@@ -60,7 +60,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/jsx/package.json
+++ b/packages/examples/packages/jsx/package.json
@@ -62,7 +62,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/lifecycle-hooks/package.json
+++ b/packages/examples/packages/lifecycle-hooks/package.json
@@ -60,7 +60,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/localization/package.json
+++ b/packages/examples/packages/localization/package.json
@@ -61,7 +61,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/manage-state/package.json
+++ b/packages/examples/packages/manage-state/package.json
@@ -60,7 +60,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/name-lookup/package.json
+++ b/packages/examples/packages/name-lookup/package.json
@@ -60,7 +60,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/network-access/package.json
+++ b/packages/examples/packages/network-access/package.json
@@ -62,7 +62,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/notifications/package.json
+++ b/packages/examples/packages/notifications/package.json
@@ -60,7 +60,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/rollup-plugin/package.json
+++ b/packages/examples/packages/rollup-plugin/package.json
@@ -68,7 +68,7 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "rollup": "^2.73.0",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/signature-insights/package.json
+++ b/packages/examples/packages/signature-insights/package.json
@@ -60,7 +60,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/transaction-insights/package.json
+++ b/packages/examples/packages/transaction-insights/package.json
@@ -61,7 +61,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/wasm/package.json
+++ b/packages/examples/packages/wasm/package.json
@@ -62,7 +62,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/examples/packages/webpack-plugin/package.json
+++ b/packages/examples/packages/webpack-plugin/package.json
@@ -63,7 +63,7 @@
     "swc-loader": "^0.2.3",
     "terser-webpack-plugin": "^5.3.9",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4",
+    "typescript": "~5.0.4",
     "webpack": "^5.88.0",
     "webpack-cli": "^5.1.4"
   },

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -78,7 +78,7 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^4.1.2",
     "tsup": "^8.0.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -136,7 +136,7 @@
     "ts-node": "^10.9.1",
     "tsc-watch": "^4.5.0",
     "tsup": "^8.0.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -130,7 +130,7 @@
     "rimraf": "^4.1.2",
     "ts-node": "^10.9.1",
     "tsup": "^8.0.1",
-    "typescript": "~4.8.4",
+    "typescript": "~5.0.4",
     "vite": "^4.3.9",
     "vite-tsconfig-paths": "^4.0.5",
     "wdio-chromedriver-service": "^8.1.1",

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -121,7 +121,7 @@
     "terser": "^5.17.7",
     "ts-node": "^10.9.1",
     "tsup": "^8.0.1",
-    "typescript": "~4.8.4",
+    "typescript": "~5.0.4",
     "vite": "^4.3.9",
     "vite-tsconfig-paths": "^4.0.5",
     "wdio-chromedriver-service": "^8.1.1",

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -93,7 +93,7 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^4.1.2",
     "tsup": "^8.0.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -75,7 +75,7 @@
     "rimraf": "^4.1.2",
     "rollup": "^2.73.0",
     "tsup": "^8.0.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/snaps-rpc-methods/package.json
+++ b/packages/snaps-rpc-methods/package.json
@@ -77,7 +77,7 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^4.1.2",
     "tsup": "^8.0.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -95,7 +95,7 @@
     "rimraf": "^4.1.2",
     "ts-jest": "^29.1.1",
     "tsup": "^8.0.1",
-    "typescript": "~4.8.4"
+    "typescript": "~5.0.4"
   },
   "engines": {
     "node": "^18.16 || >=20"

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -126,7 +126,7 @@
     "ts-node": "^10.9.1",
     "tsconfig-paths-webpack-plugin": "^4.0.1",
     "tsup": "^8.0.1",
-    "typescript": "~4.8.4",
+    "typescript": "~5.0.4",
     "webpack": "^5.88.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^4.15.1",

--- a/packages/snaps-simulator/src/features/builder/components/BaseNode.tsx
+++ b/packages/snaps-simulator/src/features/builder/components/BaseNode.tsx
@@ -39,7 +39,7 @@ export const BaseNode: FunctionComponent<BaseNodeProps> = ({
       borderColor="border.default"
       display={isDragging ? 'none' : 'flex'}
       marginX="4"
-      cursor={node.id > 1 ? 'move' : 'default'}
+      cursor={Number(node.id) > 1 ? 'move' : 'default'}
     >
       <Icon icon={node.data.type.toLowerCase() as IconName} width="16px" />
       <Text
@@ -53,7 +53,7 @@ export const BaseNode: FunctionComponent<BaseNodeProps> = ({
         {node.data.type}
       </Text>
       {children}
-      {node.id >= 2 && (
+      {Number(node.id) >= 2 && (
         <Icon
           icon="cross"
           width="11px"

--- a/packages/snaps-simulator/src/features/builder/components/NodeTree.tsx
+++ b/packages/snaps-simulator/src/features/builder/components/NodeTree.tsx
@@ -99,7 +99,7 @@ export const NodeTree: FunctionComponent<NodeTreeProps> = ({
 
   const handleCanDrag = (node?: NodeModel<JSXElement>) => {
     if (node) {
-      return node.id >= 2;
+      return Number(node.id) >= 2;
     }
 
     return false;
@@ -113,7 +113,7 @@ export const NodeTree: FunctionComponent<NodeTreeProps> = ({
       return (
         canDropElement(dropTarget?.data, dragSource?.data) &&
         dropTarget?.droppable &&
-        dropTargetId > 0
+        Number(dropTargetId) > 0
       );
     }
 

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -122,7 +122,7 @@
     "rimraf": "^4.1.2",
     "ts-node": "^10.9.1",
     "tsup": "^8.0.1",
-    "typescript": "~4.8.4",
+    "typescript": "~5.0.4",
     "vite": "^4.3.9",
     "vite-tsconfig-paths": "^4.0.5",
     "wdio-chromedriver-service": "^8.1.1",

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -77,7 +77,7 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^4.1.2",
     "tsup": "^8.0.1",
-    "typescript": "~4.8.4",
+    "typescript": "~5.0.4",
     "webpack": "^5.88.0"
   },
   "engines": {

--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -105,7 +105,7 @@
     "terser-webpack-plugin": "^5.3.9",
     "ts-node": "^10.9.1",
     "tsconfig-paths-webpack-plugin": "^4.0.1",
-    "typescript": "~4.8.4",
+    "typescript": "~5.0.4",
     "webpack": "^5.88.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^4.15.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3910,7 +3910,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -3950,7 +3950,7 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^4.1.2
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -3996,7 +3996,7 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^4.1.2
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4034,7 +4034,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4071,7 +4071,7 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^4.1.2
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4110,7 +4110,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4168,7 +4168,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4233,7 +4233,7 @@ __metadata:
     ts-node: ^10.9.1
     tsc-watch: ^4.5.0
     tsup: ^8.0.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
     yargs: ^17.7.1
   bin:
     create-snap: ./dist/main.js
@@ -4273,7 +4273,7 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^4.1.2
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4309,7 +4309,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4345,7 +4345,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4511,7 +4511,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4548,7 +4548,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
     webpack: ^5.88.0
   languageName: unknown
   linkType: soft
@@ -4589,7 +4589,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4627,7 +4627,7 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^4.1.2
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4665,7 +4665,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4701,7 +4701,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4737,7 +4737,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4773,7 +4773,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
     uqr: ^0.1.2
   languageName: unknown
   linkType: soft
@@ -4811,7 +4811,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4849,7 +4849,7 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^4.1.2
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4877,7 +4877,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4924,7 +4924,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -4974,7 +4974,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -5023,7 +5023,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -5059,7 +5059,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -5095,7 +5095,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -5131,7 +5131,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -5169,7 +5169,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -5205,7 +5205,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -5333,7 +5333,7 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.11
     rollup: ^2.73.0
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -5396,7 +5396,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -5446,7 +5446,7 @@ __metadata:
     readable-stream: ^3.6.2
     rimraf: ^4.1.2
     tsup: ^8.0.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -5533,7 +5533,7 @@ __metadata:
     tsc-watch: ^4.5.0
     tsup: ^8.0.1
     tty-browserify: ^0.0.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
     url: ^0.11.1
     util: ^0.12.5
     vm-browserify: ^1.1.2
@@ -5624,7 +5624,7 @@ __metadata:
     tar-stream: ^3.1.7
     ts-node: ^10.9.1
     tsup: ^8.0.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
     vite: ^4.3.9
     vite-tsconfig-paths: ^4.0.5
     wdio-chromedriver-service: ^8.1.1
@@ -5710,7 +5710,7 @@ __metadata:
     terser: ^5.17.7
     ts-node: ^10.9.1
     tsup: ^8.0.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
     vite: ^4.3.9
     vite-tsconfig-paths: ^4.0.5
     wdio-chromedriver-service: ^8.1.1
@@ -5778,7 +5778,7 @@ __metadata:
     redux-saga: ^1.2.3
     rimraf: ^4.1.2
     tsup: ^8.0.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -5829,7 +5829,7 @@ __metadata:
     rimraf: ^4.1.2
     rollup: ^2.73.0
     tsup: ^8.0.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -5873,7 +5873,7 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^4.1.2
     tsup: ^8.0.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -5915,7 +5915,7 @@ __metadata:
     rimraf: ^4.1.2
     ts-jest: ^29.1.1
     tsup: ^8.0.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -6022,7 +6022,7 @@ __metadata:
     ts-node: ^10.9.1
     tsconfig-paths-webpack-plugin: ^4.0.1
     tsup: ^8.0.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
     webpack: ^5.88.0
     webpack-cli: ^5.1.4
     webpack-dev-server: ^4.15.1
@@ -6103,7 +6103,7 @@ __metadata:
     ses: ^1.1.0
     ts-node: ^10.9.1
     tsup: ^8.0.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
     validate-npm-package-name: ^5.0.0
     vite: ^4.3.9
     vite-tsconfig-paths: ^4.0.5
@@ -6149,7 +6149,7 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^4.1.2
     tsup: ^8.0.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
     webpack: ^5.88.0
     webpack-sources: ^3.2.3
   languageName: unknown
@@ -6248,7 +6248,7 @@ __metadata:
     terser-webpack-plugin: ^5.3.9
     ts-node: ^10.9.1
     tsconfig-paths-webpack-plugin: ^4.0.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
     webpack: ^5.88.0
     webpack-cli: ^5.1.4
     webpack-dev-server: ^4.15.1
@@ -6322,7 +6322,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   languageName: unknown
   linkType: soft
 
@@ -6361,7 +6361,7 @@ __metadata:
     swc-loader: ^0.2.3
     terser-webpack-plugin: ^5.3.9
     ts-node: ^10.9.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
     webpack: ^5.88.0
     webpack-cli: ^5.1.4
   languageName: unknown
@@ -20329,7 +20329,7 @@ __metadata:
     simple-git-hooks: ^2.7.0
     ts-node: ^10.9.1
     tsup: ^8.0.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
     vite: ^4.3.9
   languageName: unknown
   linkType: soft
@@ -22250,23 +22250,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.8.4":
-  version: 4.8.4
-  resolution: "typescript@npm:4.8.4"
+"typescript@npm:~5.0.4":
+  version: 5.0.4
+  resolution: "typescript@npm:5.0.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 3e4f061658e0c8f36c820802fa809e0fd812b85687a9a2f5430bc3d0368e37d1c9605c3ce9b39df9a05af2ece67b1d844f9f6ea8ff42819f13bcb80f85629af0
+  checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~4.8.4#~builtin<compat/typescript>":
-  version: 4.8.4
-  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=1a91c8"
+"typescript@patch:typescript@~5.0.4#~builtin<compat/typescript>":
+  version: 5.0.4
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=1f5320"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: c981e82b77a5acdcc4e69af9c56cdecf5b934a87a08e7b52120596701e389a878b8e3f860e73ffb287bf649cc47a8c741262ce058148f71de4cdd88bb9c75153
+  checksum: 6a1fe9a77bb9c5176ead919cc4a1499ee63e46b4e05bf667079f11bf3a8f7887f135aa72460a4c3b016e6e6bb65a822cb8689a6d86cbfe92d22cc9f501f09213
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Motivation

As part of its OKRs (Q2 2024 O3KR4, Q3 2024 O2KR4) the Wallet Framework Team has upgraded all core packages to use TypeScript v5.0, and is enabling other packages throughout our codebase to upgrade as well. Unblocking the snaps monorepo is a high priority, as it has close interdependencies with core monorepo.

This commit upgrades the TypeScript version used in the snaps monorepo by two major versions: v4.9 and v5.0.

- https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/
- https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/

## Features

### `v4.9`
- [`satisfies` operator](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#the-satisfies-operator)
  - See https://github.com/MetaMask/core/issues/1972
- [Unlisted property narrowing with `in` operator](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#in-narrowing)

### `v5.0`
- [`const` Type Parameters](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#const-type-parameters):
  - Causes `as const` inference by default.
  - 77 `as const` instances in the snaps monorepo.
```ts
type HasNames = { names: readonly string[] };
function getNamesExactly<const T extends HasNames>(arg: T): T["names"] {
//                       ^^^^^
    return arg.names;
}
// Inferred type without `const`: string[]
// Inferred type with `const`: readonly ["Alice", "Bob", "Eve"]
// Note: Didn't need to write 'as const' here
const names = getNamesExactly({ names: ["Alice", "Bob", "Eve"] });
```
- `enum` improvements:
  - [All `enum`s are union `enum`s](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#all-enums-are-union-enums)
  - [`enum` overhaul](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#enum-overhaul)
  - 30 `enum` instances in the snaps monorepo.
- Decorators

## Breaking Changes

### `v5.0`
- Full list of breaking changes and deprecations: https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#breaking-changes-and-deprecations
- Regressions in Snaps repo
  - [Forbidden Implicit Coercions in Relational Operators](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#forbidden-implicit-coercions-in-relational-operators)
    - Fixed here: https://github.com/MetaMask/snaps/pull/2594/commits/fffe4b2f18d3869042ff7b7abdccbbb007bad511