### PR TITLE
Persist `severity` property in `SnapInsightsController`

### DIFF
--- a/packages/snaps-controllers/src/insights/SnapInsightsController.test.ts
+++ b/packages/snaps-controllers/src/insights/SnapInsightsController.test.ts
@@ -73,12 +73,14 @@ describe('SnapInsightsController', () => {
         interfaceId: expect.any(String),
         loading: false,
         error: undefined,
+        severity: undefined,
       },
       [MOCK_LOCAL_SNAP_ID]: {
         snapId: MOCK_LOCAL_SNAP_ID,
         interfaceId: undefined,
         loading: false,
         error: 'Internal JSON-RPC error.',
+        severity: undefined,
       },
     });
 
@@ -196,12 +198,14 @@ describe('SnapInsightsController', () => {
         interfaceId: expect.any(String),
         loading: false,
         error: undefined,
+        severity: undefined,
       },
       [MOCK_LOCAL_SNAP_ID]: {
         snapId: MOCK_LOCAL_SNAP_ID,
         interfaceId: undefined,
         loading: false,
         error: 'Internal JSON-RPC error.',
+        severity: undefined,
       },
     });
 
@@ -319,12 +323,14 @@ describe('SnapInsightsController', () => {
         interfaceId: expect.any(String),
         loading: false,
         error: undefined,
+        severity: undefined,
       },
       [MOCK_LOCAL_SNAP_ID]: {
         snapId: MOCK_LOCAL_SNAP_ID,
         interfaceId: expect.any(String),
         loading: false,
         error: undefined,
+        severity: undefined,
       },
     });
 
@@ -431,12 +437,14 @@ describe('SnapInsightsController', () => {
         interfaceId: expect.any(String),
         loading: false,
         error: undefined,
+        severity: undefined,
       },
       [MOCK_LOCAL_SNAP_ID]: {
         snapId: MOCK_LOCAL_SNAP_ID,
         interfaceId: expect.any(String),
         loading: false,
         error: undefined,
+        severity: undefined,
       },
     });
 

--- a/packages/snaps-controllers/src/insights/SnapInsightsController.ts
+++ b/packages/snaps-controllers/src/insights/SnapInsightsController.ts
@@ -54,6 +54,7 @@ export type SnapInsight = {
   interfaceId?: string | null;
   error?: string;
   loading: boolean;
+  severity?: string;
 };
 
 export type SnapInsightsControllerState = {
@@ -375,6 +376,7 @@ export class SnapInsightsController extends BaseController<
     this.update((state) => {
       state.insights[id][snapId].loading = false;
       state.insights[id][snapId].interfaceId = response?.id as string;
+      state.insights[id][snapId].severity = response?.severity as string;
       state.insights[id][snapId].error = error?.message;
     });
   }


### PR DESCRIPTION
Additionally persisting the `severity` property as insight snaps can also return this property indicating some escalation of their insights being shown in the extension.