### PR TITLE
Add `Custom` button to the dialog example snap in `test-snaps`

### DIFF
--- a/packages/test-snaps/src/features/snaps/dialogs/Dialogs.tsx
+++ b/packages/test-snaps/src/features/snaps/dialogs/Dialogs.tsx
@@ -36,6 +36,13 @@ export const Dialogs: FunctionComponent = () => {
     }).catch(logError);
   };
 
+  const handleSubmitCustom = () => {
+    invokeSnap({
+      snapId,
+      method: 'showCustom',
+    }).catch(logError);
+  };
+
   return (
     <Snap
       name="Dialogs Snap"
@@ -65,6 +72,13 @@ export const Dialogs: FunctionComponent = () => {
           disabled={isLoading}
         >
           Prompt
+        </Button>
+        <Button
+          id="sendCustomButton"
+          onClick={handleSubmitCustom}
+          disabled={isLoading}
+        >
+          Custom
         </Button>
       </ButtonGroup>
 


### PR DESCRIPTION
This adds a button to trigger the `showCustom` method of the dialog example snap in `test-snaps`.