### PR TITLE
fix: Add structs to `typedUnion` schema

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "WNhzkvYVd0xOpOg6MmYvBmsJ0w4KCIAREcPBEZNrg+c=",
+    "shasum": "Mkd9oASmCmGg0DyVRRWh2VbFCMST9Na7qwXl1KQ8FnM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+UQXDxKLVSrolt66+DeyR78774UQY6umQLoS7mnt8KI=",
+    "shasum": "jVA+qyhcyF8fX5sC0YJd5fGL+ikpyiz4c6D5/wqnumg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wb6AsKr6qrNvT8pusf0Pd1ipSuqXGtGahoWuCH6zm8g=",
+    "shasum": "31fK1is4iCMYBeTXqFSw0vu/fdd0YnXpOyv2rwyg+I0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "pcSuQBX7alunJRZc0LeMZA6bBfEFliQCLSUI9AP4K1Y=",
+    "shasum": "KaZ3y2exIBrqFwqrYuAK+nuY1ZTu/5y+B6Zng5wFa2w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2bGMwuIxHS3LyOZVBBIHiIUrs81iXlZlSdMH1Bxa3Wo=",
+    "shasum": "9hopHYuT+ClCiqLSSxtULgGLt2c5brY95bAjHy1L7h0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "l81/4yCc8cF+YDkvX16CtkOHYPkzuTPTT0MLvxWXx8o=",
+    "shasum": "0ddTHdHMOoNjKO9m2Ek1EvxepLAoqZ2OC3KsjMTgCgI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Os7gpMBdr9ZYsLGc5xNCSgjVZ4lAkm0qXy7Nsfytvxs=",
+    "shasum": "33mwURdHYfK3IiBqV6r/pi5SjMFquEJ95wo+TbxipcI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "j+X/IG9GaPmq2plxOVfNL9HnTlUCygrHdBotVzvXsQU=",
+    "shasum": "zLYiM3hZxvbSmXsvp2rA8G5wYvR8EjWBkUxiICBQRsE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1KkHDC1Omu73rW7lZMGjSUVE90bIhOn/crjvAjzs+4c=",
+    "shasum": "1g56e/Bv5SRRArOncf2dkeAKhOPUqDZ5yYm7KZ6V0VI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "e+17MgQS5Y26/3bQMvlOMIboQtB7HurFoKn47+lXeBQ=",
+    "shasum": "kJjgl6Ppuw0WLM8Emha215mPis7v5RDz1KID0a9QK2w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "BoxfS/Rq9Qnuz1PwTKLJ6kZUG9gOtoBvZuT60P2mTZM=",
+    "shasum": "WZzKtnfIzCCYaExaKORwWIy1QFalXuybjTYOmWB835o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hGr6jbj2wqgXSVlBEkh6YaNM20qibJS0pmSNnnzbrPo=",
+    "shasum": "SeGqZlbvJqdpWMvABSQQtGhpw1vYfedj6O2bEd7pvD8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "J4MZSgobYT2voAIOWmh26oE9Jfhmw/EhJ5wUF0x4dMs=",
+    "shasum": "SjemTVQOC28rBV3VHo6Nf2G+6849OUCyaT8Lwkk3RPA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "NEE7Uljm8LscKgqSpgl8+ORBUKv+Of7ddQOLAMwdLgc=",
+    "shasum": "57kVYKdS9lYNS64Tu0MY9YvoQgFFbGsnIVUG3GXC8ks=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "gAlUmrpqDhqJ7Suu3Fpr7Do1y7MFEi7qR22uyjhRDb8=",
+    "shasum": "EAfmavIfji6Az9He80EwPoraU68DzguwTsVtdUdpjpI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Sh4evK9MVBJU76d6c871vwwIMy4pZLZfyunpIgRY16M=",
+    "shasum": "11N/unTgtaW46Rkmlv0hnFpAq7oN57ry0/VuDM5lGrM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "R6vnCPwtky2dww8FD4bWg+3xcW5Z1Aq3jR7SV26lp20=",
+    "shasum": "amZ1s8SrGtZvSK1BRT0feFGB0E7G4hwGSJCGb1YGLow=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "GtTCmgH0M9TMGt26X776icOrGv3McF4p4MzKSgftmQA=",
+    "shasum": "zLqJi9tpzkgN3G1bKmQj/PZXybfi1pxVEwnY2phs8/o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5vrTBeoOseOkZaw/UnE5u/lGg8kLMBhZTwDZ7m8rNt0=",
+    "shasum": "X292WXBEhHeUTChyu78QDduGMG4TFyYTDAJtKqia6kk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Pa9/lWvpvS29g/ffuKALB+1QpnoZG+k6qfHjajhVN6s=",
+    "shasum": "i57hKRY4Dt+orqcAi9DaDe2aJTGfYYGERxrQ3pRZJAY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "WJbdDTE22t4Q2sfPZE4w1UGrw9GqIwb9IbIA2nZNKic=",
+    "shasum": "C+hYxmQ9mAe8UtZIR7S7gMM2O8nePxJUSLWkrvrPRms=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "tS3LCn96CrR8/u9r4ZQ+/BX/DsfQyUL6QmyRKwbDHOc=",
+    "shasum": "62FP2xgY9LqzlQglPDDarjy+eCcSGLPNeKESDMshjfc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Y4AV6VIEb/7W8S1c4BKUkLx0P5RnNcCVelNf0xLng/c=",
+    "shasum": "a5ug45IG2uvrt+hWVahbdqMyi8fY08p8TaHxp1C3V2Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "74Jdif2X6SP5hUFo/Aze4aMveg1KXBNHIzbnv9+8oug=",
+    "shasum": "qDNg/gFcc1i8XroDFwL9hsUs2028awN1+cRbDJC4Id0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "PQjFlmBc5ZMtDw+UgTV8zlWIbIMCytWBWGE2ha7QjbI=",
+    "shasum": "biI1bOv4Dia05bKxG7eN1NeDnj1Z3zUyMLOzFl05DBk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LQImo2GsBpVxgz5HgkoQuHKDbecwITvmsKhDtUPT9JA=",
+    "shasum": "KBubigJyzD1vmm0iurmINuIHbzrUxWKVM3h/DHxaTC0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Na88LjAm9R1hQE/ogO3W9t0fpn572XoOA8zN8oK6leo=",
+    "shasum": "5GNGafRvDWnLec2DtqSOWpOLABirTYvsiOtJN2xschA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "sRktKOiqiVeKvzsdOerxaRlinUd7l1fRWDdgATsn0Kk=",
+    "shasum": "a8FyWUezGIMqL6Ke0/5oFYBrUoBCloWAmJveRagi13Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "gAFGtmKKoA8q0wD4mV/I/wl/Pk4DW+zFXaCmNnhMZMQ=",
+    "shasum": "vWaXhJBkvRBULl4afd029NxaTipt7ipk5/F/vYh4pUM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-sdk/src/internals/structs.test.ts
+++ b/packages/snaps-sdk/src/internals/structs.test.ts
@@ -67,4 +67,12 @@ describe('typedUnion', () => {
       'Expected type to be one of: "Box", "Text", "Field", but received: "foo"',
     );
   });
+
+  it('contains structs as part of the schema', () => {
+    expect(unionStruct.schema).toStrictEqual([
+      BoxStruct,
+      TextStruct,
+      FieldStruct,
+    ]);
+  });
 });

--- a/packages/snaps-sdk/src/internals/structs.ts
+++ b/packages/snaps-sdk/src/internals/structs.ts
@@ -92,7 +92,7 @@ export function typedUnion<Head extends AnyStruct, Tail extends AnyStruct[]>(
 ): Struct<Infer<Head> | InferStructTuple<Tail>[number], null> {
   return new Struct({
     type: 'union',
-    schema: null,
+    schema: structs,
     *entries(value, context) {
       if (!isPlainObject(value) || !hasProperty(value, 'type')) {
         return;


### PR DESCRIPTION
Add structs that are part of the union to the `typedUnion` schema. This mirrors our implementation of `union`, which we were using before: https://github.com/MetaMask/snaps/blob/083493cc7d89a2202fe8bc0381fab546af295ec1/packages/snaps-sdk/src/internals/structs.ts#L64

This makes it easier to understand what structs are contained in a union at runtime.