### PR TITLE
Fix documentation inconsistency

### DIFF
--- a/packages/snaps-utils/src/json-rpc.ts
+++ b/packages/snaps-utils/src/json-rpc.ts
@@ -123,7 +123,7 @@ function createOriginRegExp(matcher: string) {
  *
  * The matcher string may be a specific origin to match or include wildcards.
  * The "*" symbol is treated as a wildcard and will match 0 or more characters.
- * Note: this means that https://*metamask.io matches both https://metamask.io
+ * Note: this means that https://*.metamask.io matches both https://metamask.io
  * and https://snaps.metamask.io.
  *
  * @param matcher - The matcher string.


### PR DESCRIPTION
*metamask.io is an incorrect matcher since it'll match ametamask.io and other incorrect domains instead of *.metamask.io

Noticed this while reviewing the source file so figured I'd make a pr for it.