### PR TITLE
fix: Fix fetch binding under LavaMoat

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -790,7 +790,7 @@ export class SnapController extends BaseController<
     idleTimeCheckInterval = inMilliseconds(5, Duration.Second),
     maxIdleTime = inMilliseconds(30, Duration.Second),
     maxRequestTime = inMilliseconds(60, Duration.Second),
-    fetchFunction = globalThis.fetch.bind(globalThis),
+    fetchFunction = globalThis.fetch.bind(undefined),
     featureFlags = {},
     detectSnapLocation: detectSnapLocationFunction = detectSnapLocation,
     preinstalledSnaps = null,

--- a/packages/snaps-controllers/src/snaps/location/http.ts
+++ b/packages/snaps-controllers/src/snaps/location/http.ts
@@ -41,7 +41,7 @@ export class HttpLocation implements SnapLocation {
 
   constructor(url: URL, opts: HttpOptions = {}) {
     assertStruct(url.toString(), HttpSnapIdStruct, 'Invalid Snap Id: ');
-    this.fetchFn = opts.fetch ?? globalThis.fetch.bind(globalThis);
+    this.fetchFn = opts.fetch ?? globalThis.fetch.bind(undefined);
     this.fetchOptions = opts.fetchOptions;
     this.url = url;
   }

--- a/packages/snaps-controllers/src/snaps/location/npm.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.ts
@@ -60,7 +60,7 @@ export abstract class BaseNpmLocation implements SnapLocation {
 
   constructor(url: URL, opts: DetectSnapLocationOptions = {}) {
     const allowCustomRegistries = opts.allowCustomRegistries ?? false;
-    const fetchFunction = opts.fetch ?? globalThis.fetch.bind(globalThis);
+    const fetchFunction = opts.fetch ?? globalThis.fetch.bind(undefined);
     const requestedRange = opts.versionRange ?? DEFAULT_REQUESTED_SNAP_VERSION;
     const defaultResolve = async (range: SemVerRange) => range;
     const resolveVersion = opts.resolveVersion ?? defaultResolve;

--- a/packages/snaps-controllers/src/snaps/registry/json.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.ts
@@ -120,7 +120,7 @@ export class JsonSnapsRegistry extends BaseController<
       signature: SNAP_REGISTRY_SIGNATURE_URL,
     },
     publicKey = DEFAULT_PUBLIC_KEY,
-    fetchFunction = globalThis.fetch.bind(globalThis),
+    fetchFunction = globalThis.fetch.bind(undefined),
     recentFetchThreshold = inMilliseconds(5, Duration.Minute),
     refetchOnAllowlistMiss = true,
   }: JsonSnapsRegistryArgs) {


### PR DESCRIPTION
Fixes `fetch` binding under LavaMoat by using `undefined` as the parameter instead of `globalThis`, as suggested here: https://github.com/MetaMask/metamask-extension/pull/26431#issuecomment-2293923392