### PR TITLE
feat: Add selector component

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ik7uBPZA2o4lF5QljJZQSa2RdCng8nYtKsEulOWXZU4=",
+    "shasum": "meplfIhDKAdAYfRjk1slGTks3rI6+uPewth+sL7o/Go=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vpc0ie9a1H8KWv8UMpOBaPZyGJTjESuvjv1ERUMttaM=",
+    "shasum": "hM4uyKv1VEidiHratstws0S/LdBzPWjOQncUkHBNDP0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "HRGY/ewBpqh8U7fsF/3QgRrpKqn0uDNTdpi83ZCqPQ0=",
+    "shasum": "uFeB4RsFZsV7ZYjLPEp8R+R96iuN9gpHjYB1MKUy0bw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "x1+/hSsNK4ymlrifMWvkwpibVxNSUekwvYdIwmw7T2k=",
+    "shasum": "9RcL8rtVPwRiXki5Vs+pEA6lO1CthaofVv2UQF1COlY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "YaCBzI0O1i5L5l5gFfzmNhfwuvnnxbkfmsNjLkwFhfY=",
+    "shasum": "BmrBVhdD2ZmEdDjNVdEiVSzd3uS8PiGgmZcvYmHnHxw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "dxp0O4Nhq7QOU1k6S5FJvaxvuc5wGnLsInCZ184N6gM=",
+    "shasum": "oZbPamYypPK6BHoVJ/Mx0l7pLIBjQRBtbZNZWyDMPGs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AP2i5PiuYC9Dr9chFNMP1FMDJmPwpsFBr34+OKEfo/4=",
+    "shasum": "prxccwZ+383T+7jjMrSabwO74aBRyoKEnnP1o7r1Aac=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6NIpWbenThi4e3LAiAAB0MP2PQcAcdadhcKAccM66yo=",
+    "shasum": "GSpRcUSfCYEWViNqYyG3NdTa4/nO8EGukSHvGBVXtT8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4Nt428/mGU2ozcXM+X28gZjmKbyI1BQxuDntChDFl0M=",
+    "shasum": "bG6octHXbG5c1Keftfj2kCbHcATOJMnVe5oy4ENLGYM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "YNic7/VXJF32HBUr5npNpXopQB7wwY50d9ejLpVclKI=",
+    "shasum": "dRJ64XJAM36aNfsZBN7FC8fGmh/4b3nd0V0wJZQfmzk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0vquB1L/2Ftqhkth3a2hhU9P8Ij6QAh0VFDhvFi60sw=",
+    "shasum": "z/xO4vaYBErIumDuzkS1JuWD0w3M/JQzrkl7QdH+Rsw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FZAIkcXgzle5cFsso165dzSTwerIFAzASA8rptjezmc=",
+    "shasum": "RY6WMOfBdTEWYMUX7zIzNy7ZmMjZdxEZUbsW4d7bAWc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "B2lQ3m9r4PRZ2vRrrFgenZvRSomQKIs8sJOSM5U9hDQ=",
+    "shasum": "7w5lE7ZVBqS66ghFwA5z3USgqOxh6vU2d71JBi5dx+s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "kA505849kj9G8hG1R92ZD0qGYEoUr4TXXk8PxGBG5nQ=",
+    "shasum": "xJUmec7F6/It7kfSljqHWM76MSJSmytZlPvlgyLxxXI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9RyN2IznzsqwJO/7mhIKxp4DVQd0ongnYbN9MeFowI0=",
+    "shasum": "rvE1wmZmbTWiskg2VPVLbn8KT2PFkFQ5v3tGFqybsRE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "IPgrx/srJ0pnYXbMpymuHMWWHMb9MZfyekCiiH8IDjQ=",
+    "shasum": "dsc+T0qqSAe1LoKYI/8HPVk3yBktRoaRSOvRMjlF5B8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "WFtsYTJglOJChmrR8AtwRRamhFXzrqmtyCizcg1zIK4=",
+    "shasum": "XZ4Pt2LJwOMXBm1wQXtJP3l/qZgC218Z/n3xYE8BGjM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "YDat1yOn2nLtxCIls+5lbNYnahRdV9EfASQI/b/9lhg=",
+    "shasum": "wokl2HTmrbZObmcc1MH9a7so9xrZkXNhRcCqtfepGA0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+Nb1THmpw/hGhx5AmYY8lJ8sdELuLKHv/n4ndO1WTCo=",
+    "shasum": "v2qKGCM4FTPM6wUB4lbKO556tDV00aYZDjd3RxvMcsI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Jrk/yg039/Qf51OfijNmqn+jA4+jS+DdbDTTXGK52t8=",
+    "shasum": "iyRAkal8Vql5iD1XJwIp/9KNi/kk3HjlfdfklQf3UW0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "iwYePZv3WxiRNwYWLJMYFVezr4FVNt9vKENR+l5cUv4=",
+    "shasum": "LofJCTQeoNFWE+F1S1OTGzcUyJPJiTskgK9aIRrt1NM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "yfuwl/IJSpXoW950VQsJYOt5wugF4zqrwEJmHpfXdH0=",
+    "shasum": "f6IlmDjDvF8G3hEaIF8mrBl5irEpYgg6WPqpdk7P+is=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "W6MFWW9qbN2L2Jrx49JjLzAvoiQA9uUcnWPTkNUFvE4=",
+    "shasum": "JtcrsUNAGdf3v4dr4uo1XQgom71wdtifM/rh54HgnEs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "MZSLIUmv+W4OVk8BdXpbCsrkpKZ2DcXbyWCbje1bZjA=",
+    "shasum": "Nm2UUq7WZAa+oFy8y08o0bDHwLrVKpP00WW+F/UVw4o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "CeDhOKcmnMXKwDdC2HozIABPQ+q/oVUFxrhiNNIclDc=",
+    "shasum": "DFfEzW8wLRohClvMLn+mN/pN+YmB39HgrDcQavUDISg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0eVnlZsCe7wuh964O9xM/hGczrpDZF7yekn9DZKgXNM=",
+    "shasum": "hsCvm1U9gV/4FzppkTRoVd8kjAmDHc1ar2KaV1SLUcM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "sq30Pjd883FkDKbg1hAvud3vc0XD3MOsHT6vqpNh5kE=",
+    "shasum": "Vizjf/UbRArRlUspGuMRFkCZXEMwK20c/8wTCJhNSc0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "726OomzJecbcMjZqZEFPBdM+Zn49gOljb6pFJNOmSW0=",
+    "shasum": "I5yXL+XH56rFZiJfGc6Pq4v4lcXwuUIhkk/vbMbS5O4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LuxkyGh4b6uksSaom6Yp4Uzezibjg9oskNh4L62vvMA=",
+    "shasum": "5hX1yMdOi/HxZesj7T4qXvR/Cu4GVpQHnfbavDPS45U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 92.54,
+  "branches": 92.59,
   "functions": 96.91,
   "lines": 98.01,
   "statements": 97.71

--- a/packages/snaps-controllers/src/interface/utils.test.tsx
+++ b/packages/snaps-controllers/src/interface/utils.test.tsx
@@ -12,6 +12,8 @@ import {
   Checkbox,
   RadioGroup,
   Radio,
+  Selector,
+  Card,
 } from '@metamask/snaps-sdk/jsx';
 
 import { assertNameIsUnique, constructState, getJsxInterface } from './utils';
@@ -453,6 +455,94 @@ describe('constructState', () => {
     const result = constructState({}, element);
     expect(result).toStrictEqual({
       form: { foo: true },
+    });
+  });
+
+  it('sets default value for root level Selector', () => {
+    const element = (
+      <Box>
+        <Selector name="foo" title="Choose an option">
+          <Selector.Option value="option1">
+            <Card title="Option 1" value="$1" />
+          </Selector.Option>
+          <Selector.Option value="option2">
+            <Card title="Option 1" value="$1" />
+          </Selector.Option>
+        </Selector>
+      </Box>
+    );
+
+    const result = constructState({}, element);
+    expect(result).toStrictEqual({
+      foo: 'option1',
+    });
+  });
+
+  it('supports root level Selector', () => {
+    const element = (
+      <Box>
+        <Selector name="foo" title="Choose an option" value="option2">
+          <Selector.Option value="option1">
+            <Card title="Option 1" value="$1" />
+          </Selector.Option>
+          <Selector.Option value="option2">
+            <Card title="Option 1" value="$1" />
+          </Selector.Option>
+        </Selector>
+      </Box>
+    );
+
+    const result = constructState({}, element);
+    expect(result).toStrictEqual({
+      foo: 'option2',
+    });
+  });
+
+  it('sets default value for Selector in form', () => {
+    const element = (
+      <Box>
+        <Form name="form">
+          <Field label="foo">
+            <Selector name="foo" title="Choose an option">
+              <Selector.Option value="option1">
+                <Card title="Option 1" value="$1" />
+              </Selector.Option>
+              <Selector.Option value="option2">
+                <Card title="Option 1" value="$1" />
+              </Selector.Option>
+            </Selector>
+          </Field>
+        </Form>
+      </Box>
+    );
+
+    const result = constructState({}, element);
+    expect(result).toStrictEqual({
+      form: { foo: 'option1' },
+    });
+  });
+
+  it('supports Selector in form', () => {
+    const element = (
+      <Box>
+        <Form name="form">
+          <Field label="foo">
+            <Selector name="foo" title="Choose an option" value="option2">
+              <Selector.Option value="option1">
+                <Card title="Option 1" value="$1" />
+              </Selector.Option>
+              <Selector.Option value="option2">
+                <Card title="Option 1" value="$1" />
+              </Selector.Option>
+            </Selector>
+          </Field>
+        </Form>
+      </Box>
+    );
+
+    const result = constructState({}, element);
+    expect(result).toStrictEqual({
+      form: { foo: 'option2' },
     });
   });
 

--- a/packages/snaps-controllers/src/interface/utils.test.tsx
+++ b/packages/snaps-controllers/src/interface/utils.test.tsx
@@ -14,6 +14,7 @@ import {
   Radio,
   Selector,
   Card,
+  SelectorOption,
 } from '@metamask/snaps-sdk/jsx';
 
 import { assertNameIsUnique, constructState, getJsxInterface } from './utils';
@@ -462,12 +463,12 @@ describe('constructState', () => {
     const element = (
       <Box>
         <Selector name="foo" title="Choose an option">
-          <Selector.Option value="option1">
+          <SelectorOption value="option1">
             <Card title="Option 1" value="$1" />
-          </Selector.Option>
-          <Selector.Option value="option2">
+          </SelectorOption>
+          <SelectorOption value="option2">
             <Card title="Option 1" value="$1" />
-          </Selector.Option>
+          </SelectorOption>
         </Selector>
       </Box>
     );
@@ -482,12 +483,12 @@ describe('constructState', () => {
     const element = (
       <Box>
         <Selector name="foo" title="Choose an option" value="option2">
-          <Selector.Option value="option1">
+          <SelectorOption value="option1">
             <Card title="Option 1" value="$1" />
-          </Selector.Option>
-          <Selector.Option value="option2">
+          </SelectorOption>
+          <SelectorOption value="option2">
             <Card title="Option 1" value="$1" />
-          </Selector.Option>
+          </SelectorOption>
         </Selector>
       </Box>
     );
@@ -504,12 +505,12 @@ describe('constructState', () => {
         <Form name="form">
           <Field label="foo">
             <Selector name="foo" title="Choose an option">
-              <Selector.Option value="option1">
+              <SelectorOption value="option1">
                 <Card title="Option 1" value="$1" />
-              </Selector.Option>
-              <Selector.Option value="option2">
+              </SelectorOption>
+              <SelectorOption value="option2">
                 <Card title="Option 1" value="$1" />
-              </Selector.Option>
+              </SelectorOption>
             </Selector>
           </Field>
         </Form>
@@ -528,12 +529,12 @@ describe('constructState', () => {
         <Form name="form">
           <Field label="foo">
             <Selector name="foo" title="Choose an option" value="option2">
-              <Selector.Option value="option1">
+              <SelectorOption value="option1">
                 <Card title="Option 1" value="$1" />
-              </Selector.Option>
-              <Selector.Option value="option2">
+              </SelectorOption>
+              <SelectorOption value="option2">
                 <Card title="Option 1" value="$1" />
-              </Selector.Option>
+              </SelectorOption>
             </Selector>
           </Field>
         </Form>

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -15,6 +15,7 @@ import type {
   CheckboxElement,
   RadioGroupElement,
   RadioElement,
+  SelectorElement,
 } from '@metamask/snaps-sdk/jsx';
 import { isJSXElementUnsafe } from '@metamask/snaps-sdk/jsx';
 import {
@@ -63,7 +64,12 @@ export function assertNameIsUnique(state: InterfaceState, name: string) {
  * @returns The default state for the specific component, if any.
  */
 function constructComponentSpecificDefaultState(
-  element: InputElement | DropdownElement | RadioGroupElement | CheckboxElement,
+  element:
+    | InputElement
+    | DropdownElement
+    | RadioGroupElement
+    | CheckboxElement
+    | SelectorElement,
 ) {
   switch (element.type) {
     case 'Dropdown': {
@@ -73,6 +79,11 @@ function constructComponentSpecificDefaultState(
 
     case 'RadioGroup': {
       const children = getJsxChildren(element) as RadioElement[];
+      return children[0]?.props.value;
+    }
+
+    case 'Selector': {
+      const children = getJsxChildren(element) as OptionElement[];
       return children[0]?.props.value;
     }
 
@@ -94,7 +105,12 @@ function constructComponentSpecificDefaultState(
  * @returns The state value for a given component.
  */
 function getComponentStateValue(
-  element: InputElement | DropdownElement | RadioGroupElement | CheckboxElement,
+  element:
+    | InputElement
+    | DropdownElement
+    | RadioGroupElement
+    | CheckboxElement
+    | SelectorElement,
 ) {
   switch (element.type) {
     case 'Checkbox':
@@ -120,7 +136,8 @@ function constructInputState(
     | DropdownElement
     | RadioGroupElement
     | FileInputElement
-    | CheckboxElement,
+    | CheckboxElement
+    | SelectorElement,
   form?: string,
 ) {
   const oldStateUnwrapped = form ? (oldState[form] as FormState) : oldState;
@@ -177,7 +194,8 @@ export function constructState(
         component.type === 'Dropdown' ||
         component.type === 'RadioGroup' ||
         component.type === 'FileInput' ||
-        component.type === 'Checkbox')
+        component.type === 'Checkbox' ||
+        component.type === 'Selector')
     ) {
       const formState = newState[currentForm.name] as FormState;
       assertNameIsUnique(formState, component.props.name);
@@ -195,7 +213,8 @@ export function constructState(
       component.type === 'Dropdown' ||
       component.type === 'RadioGroup' ||
       component.type === 'FileInput' ||
-      component.type === 'Checkbox'
+      component.type === 'Checkbox' ||
+      component.type === 'Selector'
     ) {
       assertNameIsUnique(newState, component.props.name);
       newState[component.props.name] = constructInputState(oldState, component);

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -16,6 +16,7 @@ import type {
   RadioGroupElement,
   RadioElement,
   SelectorElement,
+  SelectorOptionElement,
 } from '@metamask/snaps-sdk/jsx';
 import { isJSXElementUnsafe } from '@metamask/snaps-sdk/jsx';
 import {
@@ -83,7 +84,7 @@ function constructComponentSpecificDefaultState(
     }
 
     case 'Selector': {
-      const children = getJsxChildren(element) as OptionElement[];
+      const children = getJsxChildren(element) as SelectorOptionElement[];
       return children[0]?.props.value;
     }
 

--- a/packages/snaps-sdk/src/jsx/components/form/Field.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Field.ts
@@ -5,6 +5,7 @@ import type { DropdownElement } from './Dropdown';
 import type { FileInputElement } from './FileInput';
 import type { InputElement } from './Input';
 import type { RadioGroupElement } from './RadioGroup';
+import type { SelectorElement } from './Selector';
 
 /**
  * The props of the {@link Field} component.
@@ -22,7 +23,8 @@ export type FieldProps = {
     | RadioGroupElement
     | FileInputElement
     | InputElement
-    | CheckboxElement;
+    | CheckboxElement
+    | SelectorElement;
 };
 
 const TYPE = 'Field';

--- a/packages/snaps-sdk/src/jsx/components/form/Selector.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/Selector.test.tsx
@@ -1,0 +1,102 @@
+import { Card } from '../Card';
+import { Selector } from './Selector';
+
+describe('Selector', () => {
+  it('renders a selector with options', () => {
+    const result = (
+      <Selector name="selector" value="foo" title="Choose an option">
+        <Selector.Option value="foo">
+          <Card title="Foo" value="$1" />
+        </Selector.Option>
+        <Selector.Option value="bar">
+          <Card title="Bar" value="$1" />
+        </Selector.Option>
+      </Selector>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Selector',
+      props: {
+        name: 'selector',
+        value: 'foo',
+        title: 'Choose an option',
+        children: [
+          {
+            type: 'Option',
+            props: {
+              value: 'foo',
+              children: {
+                type: 'Card',
+                props: {
+                  title: 'Foo',
+                  value: '$1',
+                },
+                key: null,
+              },
+            },
+            key: null,
+          },
+          {
+            type: 'Option',
+            props: {
+              value: 'bar',
+              children: {
+                type: 'Card',
+                props: {
+                  title: 'Bar',
+                  value: '$1',
+                },
+                key: null,
+              },
+            },
+            key: null,
+          },
+        ],
+      },
+      key: null,
+    });
+  });
+
+  it('renders a selector with a conditional option', () => {
+    const result = (
+      <Selector name="selector" value="foo" title="Choose an option">
+        <Selector.Option value="foo">
+          <Card title="Foo" value="$1" />
+        </Selector.Option>
+        {false && (
+          <Selector.Option value="bar">
+            <Card title="Bar" value="$1" />
+          </Selector.Option>
+        )}
+      </Selector>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Selector',
+      props: {
+        name: 'selector',
+        value: 'foo',
+        title: 'Choose an option',
+        children: [
+          {
+            type: 'Option',
+            props: {
+              value: 'foo',
+              children: {
+                type: 'Card',
+                props: {
+                  title: 'Foo',
+                  value: '$1',
+                },
+                key: null,
+              },
+            },
+            key: null,
+          },
+          false,
+        ],
+      },
+      key: null,
+    });
+  });
+});

--- a/packages/snaps-sdk/src/jsx/components/form/Selector.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/Selector.test.tsx
@@ -22,7 +22,7 @@ describe('Selector', () => {
         title: 'Choose an option',
         children: [
           {
-            type: 'Option',
+            type: 'SelectorOption',
             props: {
               value: 'foo',
               children: {
@@ -37,7 +37,7 @@ describe('Selector', () => {
             key: null,
           },
           {
-            type: 'Option',
+            type: 'SelectorOption',
             props: {
               value: 'bar',
               children: {
@@ -79,7 +79,7 @@ describe('Selector', () => {
         title: 'Choose an option',
         children: [
           {
-            type: 'Option',
+            type: 'SelectorOption',
             props: {
               value: 'foo',
               children: {

--- a/packages/snaps-sdk/src/jsx/components/form/Selector.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/Selector.test.tsx
@@ -1,16 +1,17 @@
 import { Card } from '../Card';
 import { Selector } from './Selector';
+import { SelectorOption } from './SelectorOption';
 
 describe('Selector', () => {
   it('renders a selector with options', () => {
     const result = (
       <Selector name="selector" value="foo" title="Choose an option">
-        <Selector.Option value="foo">
+        <SelectorOption value="foo">
           <Card title="Foo" value="$1" />
-        </Selector.Option>
-        <Selector.Option value="bar">
+        </SelectorOption>
+        <SelectorOption value="bar">
           <Card title="Bar" value="$1" />
-        </Selector.Option>
+        </SelectorOption>
       </Selector>
     );
 
@@ -60,13 +61,13 @@ describe('Selector', () => {
   it('renders a selector with a conditional option', () => {
     const result = (
       <Selector name="selector" value="foo" title="Choose an option">
-        <Selector.Option value="foo">
+        <SelectorOption value="foo">
           <Card title="Foo" value="$1" />
-        </Selector.Option>
+        </SelectorOption>
         {false && (
-          <Selector.Option value="bar">
+          <SelectorOption value="bar">
             <Card title="Bar" value="$1" />
-          </Selector.Option>
+          </SelectorOption>
         )}
       </Selector>
     );

--- a/packages/snaps-sdk/src/jsx/components/form/Selector.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Selector.ts
@@ -14,7 +14,7 @@ export type SelectorOptionProps = {
   children: CardElement;
 };
 
-const OPTION_TYPE = 'Option';
+const OPTION_TYPE = 'SelectorOption';
 
 const SelectorOption = createSnapComponent<
   SelectorOptionProps,

--- a/packages/snaps-sdk/src/jsx/components/form/Selector.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Selector.ts
@@ -1,22 +1,45 @@
 import type { SnapsChildren } from '../../component';
 import { createSnapComponent } from '../../component';
-import type { OptionElement } from './Option';
+import type { CardElement } from '../Card';
+
+/**
+ * The props of the {@link Selector.Option} component.
+ *
+ * @property value - The value of the selector option. This is used to populate the
+ * state in the form data.
+ * @property children - The component to display.
+ */
+export type SelectorOptionProps = {
+  value: string;
+  children: CardElement;
+};
+
+const OPTION_TYPE = 'Option';
+
+const SelectorOption = createSnapComponent<
+  SelectorOptionProps,
+  typeof OPTION_TYPE
+>(OPTION_TYPE);
 
 /**
  * The props of the {@link Selector} component.
  *
- * @property name - The name of the dropdown. This is used to identify the
+ * @property name - The name of the selector. This is used to identify the
  * state in the form data.
- * @property value - The selected value of the dropdown.
- * @property children - The children of the dropdown.
+ * @property title - The title of the selector. This is displayed in the UI.
+ * @property value - The selected value of the selector.
+ * @property children - The children of the selector.
  */
 export type SelectorProps = {
   name: string;
+  title: string;
   value?: string | undefined;
-  children: SnapsChildren<OptionElement>;
+  children: SnapsChildren<SelectorOptionElement>;
 };
 
 const TYPE = 'Selector';
+
+const SelectorComponent = createSnapComponent<SelectorProps, typeof TYPE>(TYPE);
 
 /**
  * A selector component, which is used to create a selector.
@@ -24,21 +47,37 @@ const TYPE = 'Selector';
  * @param props - The props of the component.
  * @param props.name - The name of the selector field. This is used to identify the
  * state in the form data.
+ * @param props.title - The title of the selector field. This is displayed in the UI.
  * @param props.value - The selected value of the selector.
  * @param props.children - The children of the selector.
  * @returns A selector element.
  * @example
  * <Selector name="selector">
- *  <Option value="option1">Option 1</Option>
- *  <Option value="option2">Option 2</Option>
- *  <Option value="option3">Option 3</Option>
+ *  <Selector.Option value="option1"><Card title="Option 1" value="Foo" /></Selector.Option>
+ *  <Selector.Option value="option2"><Card title="Option 2" value="Bar" /></Selector.Option>
+ *  <Selector.Option value="option3"><Card title="Option 3" value="Baz" /></Selector.Option>
  * </Selector>
  */
-export const Selector = createSnapComponent<SelectorProps, typeof TYPE>(TYPE);
+export const Selector: typeof SelectorComponent & {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  Option: typeof SelectorOption;
+} = SelectorComponent as unknown as typeof SelectorComponent & {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  Option: typeof SelectorOption;
+};
+
+Selector.Option = SelectorOption;
 
 /**
  * A selector element.
  *
  * @see Selector
  */
-export type SelectorElement = ReturnType<typeof Selector>;
+export type SelectorElement = ReturnType<typeof SelectorComponent>;
+
+/**
+ * A selector option element.
+ *
+ * @see Selector.Option
+ */
+export type SelectorOptionElement = ReturnType<typeof SelectorOption>;

--- a/packages/snaps-sdk/src/jsx/components/form/Selector.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Selector.ts
@@ -1,0 +1,44 @@
+import type { SnapsChildren } from '../../component';
+import { createSnapComponent } from '../../component';
+import type { OptionElement } from './Option';
+
+/**
+ * The props of the {@link Selector} component.
+ *
+ * @property name - The name of the dropdown. This is used to identify the
+ * state in the form data.
+ * @property value - The selected value of the dropdown.
+ * @property children - The children of the dropdown.
+ */
+export type SelectorProps = {
+  name: string;
+  value?: string | undefined;
+  children: SnapsChildren<OptionElement>;
+};
+
+const TYPE = 'Selector';
+
+/**
+ * A selector component, which is used to create a selector.
+ *
+ * @param props - The props of the component.
+ * @param props.name - The name of the selector field. This is used to identify the
+ * state in the form data.
+ * @param props.value - The selected value of the selector.
+ * @param props.children - The children of the selector.
+ * @returns A selector element.
+ * @example
+ * <Selector name="selector">
+ *  <Option value="option1">Option 1</Option>
+ *  <Option value="option2">Option 2</Option>
+ *  <Option value="option3">Option 3</Option>
+ * </Selector>
+ */
+export const Selector = createSnapComponent<SelectorProps, typeof TYPE>(TYPE);
+
+/**
+ * A selector element.
+ *
+ * @see Selector
+ */
+export type SelectorElement = ReturnType<typeof Selector>;

--- a/packages/snaps-sdk/src/jsx/components/form/Selector.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Selector.ts
@@ -32,9 +32,9 @@ const TYPE = 'Selector';
  * @returns A selector element.
  * @example
  * <Selector name="selector">
- *  <Selector.Option value="option1"><Card title="Option 1" value="Foo" /></Selector.Option>
- *  <Selector.Option value="option2"><Card title="Option 2" value="Bar" /></Selector.Option>
- *  <Selector.Option value="option3"><Card title="Option 3" value="Baz" /></Selector.Option>
+ *  <SelectorOption value="option1"><Card title="Option 1" value="Foo" /></SelectorOption>
+ *  <SelectorOption value="option2"><Card title="Option 2" value="Bar" /></SelectorOption>
+ *  <SelectorOption value="option3"><Card title="Option 3" value="Baz" /></SelectorOption>
  * </Selector>
  */
 export const Selector = createSnapComponent<SelectorProps, typeof TYPE>(TYPE);

--- a/packages/snaps-sdk/src/jsx/components/form/Selector.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Selector.ts
@@ -1,25 +1,6 @@
 import type { SnapsChildren } from '../../component';
 import { createSnapComponent } from '../../component';
-import type { CardElement } from '../Card';
-
-/**
- * The props of the {@link Selector.Option} component.
- *
- * @property value - The value of the selector option. This is used to populate the
- * state in the form data.
- * @property children - The component to display.
- */
-export type SelectorOptionProps = {
-  value: string;
-  children: CardElement;
-};
-
-const OPTION_TYPE = 'SelectorOption';
-
-const SelectorOption = createSnapComponent<
-  SelectorOptionProps,
-  typeof OPTION_TYPE
->(OPTION_TYPE);
+import type { SelectorOptionElement } from './SelectorOption';
 
 /**
  * The props of the {@link Selector} component.
@@ -39,8 +20,6 @@ export type SelectorProps = {
 
 const TYPE = 'Selector';
 
-const SelectorComponent = createSnapComponent<SelectorProps, typeof TYPE>(TYPE);
-
 /**
  * A selector component, which is used to create a selector.
  *
@@ -58,26 +37,11 @@ const SelectorComponent = createSnapComponent<SelectorProps, typeof TYPE>(TYPE);
  *  <Selector.Option value="option3"><Card title="Option 3" value="Baz" /></Selector.Option>
  * </Selector>
  */
-export const Selector: typeof SelectorComponent & {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  Option: typeof SelectorOption;
-} = SelectorComponent as unknown as typeof SelectorComponent & {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  Option: typeof SelectorOption;
-};
-
-Selector.Option = SelectorOption;
+export const Selector = createSnapComponent<SelectorProps, typeof TYPE>(TYPE);
 
 /**
  * A selector element.
  *
  * @see Selector
  */
-export type SelectorElement = ReturnType<typeof SelectorComponent>;
-
-/**
- * A selector option element.
- *
- * @see Selector.Option
- */
-export type SelectorOptionElement = ReturnType<typeof SelectorOption>;
+export type SelectorElement = ReturnType<typeof Selector>;

--- a/packages/snaps-sdk/src/jsx/components/form/SelectorOption.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/SelectorOption.test.tsx
@@ -1,0 +1,16 @@
+import { Option } from './Option';
+
+describe('Option', () => {
+  it('renders a dropdown option', () => {
+    const result = <Option value="foo">Foo</Option>;
+
+    expect(result).toStrictEqual({
+      type: 'Option',
+      props: {
+        value: 'foo',
+        children: 'Foo',
+      },
+      key: null,
+    });
+  });
+});

--- a/packages/snaps-sdk/src/jsx/components/form/SelectorOption.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/SelectorOption.test.tsx
@@ -1,14 +1,26 @@
-import { Option } from './Option';
+import { Card } from '../Card';
+import { SelectorOption } from './SelectorOption';
 
 describe('Option', () => {
-  it('renders a dropdown option', () => {
-    const result = <Option value="foo">Foo</Option>;
+  it('renders a selector option', () => {
+    const result = (
+      <SelectorOption value="foo">
+        <Card title="Foo" value="Bar" />
+      </SelectorOption>
+    );
 
     expect(result).toStrictEqual({
-      type: 'Option',
+      type: 'SelectorOption',
       props: {
         value: 'foo',
-        children: 'Foo',
+        children: {
+          type: 'Card',
+          props: {
+            title: 'Foo',
+            value: 'Bar',
+          },
+          key: null,
+        },
       },
       key: null,
     });

--- a/packages/snaps-sdk/src/jsx/components/form/SelectorOption.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/SelectorOption.ts
@@ -1,0 +1,44 @@
+import { createSnapComponent } from '../../component';
+import type { CardElement } from '../Card';
+
+/**
+ * The props of the {@link SelectorOption} component.
+ *
+ * @property value - The value of the selector option. This is used to populate the
+ * state in the form data.
+ * @property children - The component to display.
+ */
+export type SelectorOptionProps = {
+  value: string;
+  children: CardElement;
+};
+
+const TYPE = 'SelectorOption';
+
+/**
+ * A selector option component, which is used to create a selector option. This component
+ * can only be used as a child of the {@link Selector} component.
+ *
+ * @param props - The props of the component.
+ * @param props.value - The value of the selector option. This is used to populate the
+ * state in the form data.
+ * @param props.children - The component to display.
+ * @returns A selector option element.
+ * @example
+ * <Selector name="selector">
+ *  <Selector.Option value="option1"><Card title="Option 1" value="Foo" /></Selector.Option>
+ *  <Selector.Option value="option2"><Card title="Option 2" value="Bar" /></Selector.Option>
+ *  <Selector.Option value="option3"><Card title="Option 3" value="Baz" /></Selector.Option>
+ * </Selector>
+ */
+export const SelectorOption = createSnapComponent<
+  SelectorOptionProps,
+  typeof TYPE
+>(TYPE);
+
+/**
+ * A selector option element.
+ *
+ * @see SelectorOption
+ */
+export type SelectorOptionElement = ReturnType<typeof SelectorOption>;

--- a/packages/snaps-sdk/src/jsx/components/form/SelectorOption.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/SelectorOption.ts
@@ -26,9 +26,9 @@ const TYPE = 'SelectorOption';
  * @returns A selector option element.
  * @example
  * <Selector name="selector">
- *  <Selector.Option value="option1"><Card title="Option 1" value="Foo" /></Selector.Option>
- *  <Selector.Option value="option2"><Card title="Option 2" value="Bar" /></Selector.Option>
- *  <Selector.Option value="option3"><Card title="Option 3" value="Baz" /></Selector.Option>
+ *  <SelectorOption value="option1"><Card title="Option 1" value="Foo" /></SelectorOption>
+ *  <SelectorOption value="option2"><Card title="Option 2" value="Bar" /></SelectorOption>
+ *  <SelectorOption value="option3"><Card title="Option 3" value="Baz" /></SelectorOption>
  * </Selector>
  */
 export const SelectorOption = createSnapComponent<

--- a/packages/snaps-sdk/src/jsx/components/form/index.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/index.ts
@@ -8,7 +8,7 @@ import type { InputElement } from './Input';
 import type { OptionElement } from './Option';
 import type { RadioElement } from './Radio';
 import type { RadioGroupElement } from './RadioGroup';
-import type { SelectorElement } from './Selector';
+import type { SelectorElement, SelectorOptionElement } from './Selector';
 
 export * from './Button';
 export * from './Checkbox';
@@ -33,4 +33,5 @@ export type StandardFormElement =
   | OptionElement
   | RadioElement
   | RadioGroupElement
-  | SelectorElement;
+  | SelectorElement
+  | SelectorOptionElement;

--- a/packages/snaps-sdk/src/jsx/components/form/index.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/index.ts
@@ -8,6 +8,7 @@ import type { InputElement } from './Input';
 import type { OptionElement } from './Option';
 import type { RadioElement } from './Radio';
 import type { RadioGroupElement } from './RadioGroup';
+import type { SelectorElement } from './Selector';
 
 export * from './Button';
 export * from './Checkbox';
@@ -19,6 +20,7 @@ export * from './Field';
 export * from './FileInput';
 export * from './Form';
 export * from './Input';
+export * from './Selector';
 
 export type StandardFormElement =
   | ButtonElement
@@ -30,4 +32,5 @@ export type StandardFormElement =
   | DropdownElement
   | OptionElement
   | RadioElement
-  | RadioGroupElement;
+  | RadioGroupElement
+  | SelectorElement;

--- a/packages/snaps-sdk/src/jsx/components/form/index.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/index.ts
@@ -8,7 +8,8 @@ import type { InputElement } from './Input';
 import type { OptionElement } from './Option';
 import type { RadioElement } from './Radio';
 import type { RadioGroupElement } from './RadioGroup';
-import type { SelectorElement, SelectorOptionElement } from './Selector';
+import type { SelectorElement } from './Selector';
+import type { SelectorOptionElement } from './SelectorOption';
 
 export * from './Button';
 export * from './Checkbox';
@@ -21,6 +22,7 @@ export * from './FileInput';
 export * from './Form';
 export * from './Input';
 export * from './Selector';
+export * from './SelectorOption';
 
 export type StandardFormElement =
   | ButtonElement

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -29,6 +29,7 @@ import {
   Container,
   Card,
   Icon,
+  Selector,
 } from './components';
 import {
   AddressStruct,
@@ -63,6 +64,7 @@ import {
   TooltipStruct,
   ValueStruct,
   IconStruct,
+  SelectorStruct,
 } from './validation';
 
 describe('KeyStruct', () => {
@@ -791,6 +793,41 @@ describe('FileInputStruct', () => {
     </Row>,
   ])('does not validate "%p"', (value) => {
     expect(is(value, FileInputStruct)).toBe(false);
+  });
+});
+
+describe('SelectorStruct', () => {
+  it.each([
+    <Selector name="foo" title="Title">
+      <Selector.Option value="option1">
+        <Card title="Foo" value="$1" />
+      </Selector.Option>
+      <Selector.Option value="option2">
+        <Card title="bar" value="$1" />
+      </Selector.Option>
+    </Selector>,
+  ])('validates a selector element', (value) => {
+    expect(is(value, SelectorStruct)).toBe(true);
+  });
+
+  it.each([
+    'foo',
+    42,
+    null,
+    undefined,
+    {},
+    [],
+    // @ts-expect-error - Invalid props.
+    <Spinner>foo</Spinner>,
+    <Text>foo</Text>,
+    <Box>
+      <Text>foo</Text>
+    </Box>,
+    <Row label="label">
+      <Image src="<svg />" alt="alt" />
+    </Row>,
+  ])('does not validate "%p"', (value) => {
+    expect(is(value, SelectorStruct)).toBe(false);
   });
 });
 

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -250,6 +250,16 @@ describe('FieldStruct', () => {
     <Field label="foo">
       <Checkbox name="foo" />
     </Field>,
+    <Field label="foo">
+      <Selector name="foo" title="Choose an option">
+        <Selector.Option value="option1">
+          <Card title="Foo" value="$1" />
+        </Selector.Option>
+        <Selector.Option value="option2">
+          <Card title="bar" value="$1" />
+        </Selector.Option>
+      </Selector>
+    </Field>,
   ])('validates a field element', (value) => {
     expect(is(value, FieldStruct)).toBe(true);
   });
@@ -818,7 +828,25 @@ describe('SelectorStruct', () => {
     {},
     [],
     // @ts-expect-error - Invalid props.
-    <Spinner>foo</Spinner>,
+    <Selector>foo</Selector>,
+    // @ts-expect-error - Invalid props.
+    <Selector>
+      <Selector.Option value="foo">
+        <Card title="Foo" value="$1" />
+      </Selector.Option>
+    </Selector>,
+    // @ts-expect-error - Invalid props.
+    <Selector title="Choose an option">
+      <Selector.Option value="foo">
+        <Card title="Foo" value="$1" />
+      </Selector.Option>
+    </Selector>,
+    // @ts-expect-error - Invalid props.
+    <Selector name="foo">
+      <Selector.Option value="foo">
+        <Card title="Foo" value="$1" />
+      </Selector.Option>
+    </Selector>,
     <Text>foo</Text>,
     <Box>
       <Text>foo</Text>

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -30,6 +30,7 @@ import {
   Card,
   Icon,
   Selector,
+  SelectorOption,
 } from './components';
 import {
   AddressStruct,
@@ -252,12 +253,12 @@ describe('FieldStruct', () => {
     </Field>,
     <Field label="foo">
       <Selector name="foo" title="Choose an option">
-        <Selector.Option value="option1">
+        <SelectorOption value="option1">
           <Card title="Foo" value="$1" />
-        </Selector.Option>
-        <Selector.Option value="option2">
+        </SelectorOption>
+        <SelectorOption value="option2">
           <Card title="bar" value="$1" />
-        </Selector.Option>
+        </SelectorOption>
       </Selector>
     </Field>,
   ])('validates a field element', (value) => {
@@ -809,12 +810,12 @@ describe('FileInputStruct', () => {
 describe('SelectorStruct', () => {
   it.each([
     <Selector name="foo" title="Title">
-      <Selector.Option value="option1">
+      <SelectorOption value="option1">
         <Card title="Foo" value="$1" />
-      </Selector.Option>
-      <Selector.Option value="option2">
+      </SelectorOption>
+      <SelectorOption value="option2">
         <Card title="bar" value="$1" />
-      </Selector.Option>
+      </SelectorOption>
     </Selector>,
   ])('validates a selector element', (value) => {
     expect(is(value, SelectorStruct)).toBe(true);
@@ -831,21 +832,21 @@ describe('SelectorStruct', () => {
     <Selector>foo</Selector>,
     // @ts-expect-error - Invalid props.
     <Selector>
-      <Selector.Option value="foo">
+      <SelectorOption value="foo">
         <Card title="Foo" value="$1" />
-      </Selector.Option>
+      </SelectorOption>
     </Selector>,
     // @ts-expect-error - Invalid props.
     <Selector title="Choose an option">
-      <Selector.Option value="foo">
+      <SelectorOption value="foo">
         <Card title="Foo" value="$1" />
-      </Selector.Option>
+      </SelectorOption>
     </Selector>,
     // @ts-expect-error - Invalid props.
     <Selector name="foo">
-      <Selector.Option value="foo">
+      <SelectorOption value="foo">
         <Card title="Foo" value="$1" />
-      </Selector.Option>
+      </SelectorOption>
     </Selector>,
     <Text>foo</Text>,
     <Box>

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -17,7 +17,6 @@ import {
   record,
   string,
   tuple,
-  any,
 } from '@metamask/superstruct';
 import {
   hasProperty,
@@ -70,6 +69,7 @@ import {
   type FooterElement,
   type IconElement,
   type SelectorElement,
+  type SelectorOptionElement,
   IconName,
 } from './components';
 
@@ -204,10 +204,9 @@ export const InputStruct: Describe<InputElement> = element('Input', {
 /**
  * A struct for the {@link OptionElement} type.
  */
-// @ts-expect-error ignore any for now
 export const OptionStruct: Describe<OptionElement> = element('Option', {
   value: string(),
-  children: nullUnion([string(), any()]),
+  children: nullUnion([string()]),
 });
 
 /**
@@ -220,12 +219,35 @@ export const DropdownStruct: Describe<DropdownElement> = element('Dropdown', {
 });
 
 /**
+ * A struct for the {@link CardElement} type.
+ */
+export const CardStruct: Describe<CardElement> = element('Card', {
+  image: optional(string()),
+  title: string(),
+  description: optional(string()),
+  value: string(),
+  extra: optional(string()),
+});
+
+/**
+ * A struct for the {@link SelectorOptionElement} type.
+ */
+export const SelectorOptionStruct: Describe<SelectorOptionElement> = element(
+  'Option',
+  {
+    value: string(),
+    children: CardStruct,
+  },
+);
+
+/**
  * A struct for the {@link SelectorElement} type.
  */
 export const SelectorStruct: Describe<SelectorElement> = element('Selector', {
   name: string(),
+  title: string(),
   value: optional(string()),
-  children: children([OptionStruct]),
+  children: children([SelectorOptionStruct]),
 });
 
 /**
@@ -443,17 +465,6 @@ export const DividerStruct: Describe<DividerElement> = element('Divider');
 export const ValueStruct: Describe<ValueElement> = element('Value', {
   value: string(),
   extra: string(),
-});
-
-/**
- * A struct for the {@link CardElement} type.
- */
-export const CardStruct: Describe<CardElement> = element('Card', {
-  image: optional(string()),
-  title: string(),
-  description: optional(string()),
-  value: string(),
-  extra: optional(string()),
 });
 
 /**

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -17,6 +17,7 @@ import {
   record,
   string,
   tuple,
+  any,
 } from '@metamask/superstruct';
 import {
   hasProperty,
@@ -68,6 +69,7 @@ import {
   type ContainerElement,
   type FooterElement,
   type IconElement,
+  type SelectorElement,
   IconName,
 } from './components';
 
@@ -202,15 +204,25 @@ export const InputStruct: Describe<InputElement> = element('Input', {
 /**
  * A struct for the {@link OptionElement} type.
  */
+// @ts-expect-error ignore any for now
 export const OptionStruct: Describe<OptionElement> = element('Option', {
   value: string(),
-  children: string(),
+  children: nullUnion([string(), any()]),
 });
 
 /**
  * A struct for the {@link DropdownElement} type.
  */
 export const DropdownStruct: Describe<DropdownElement> = element('Dropdown', {
+  name: string(),
+  value: optional(string()),
+  children: children([OptionStruct]),
+});
+
+/**
+ * A struct for the {@link SelectorElement} type.
+ */
+export const SelectorStruct: Describe<SelectorElement> = element('Selector', {
   name: string(),
   value: optional(string()),
   children: children([OptionStruct]),
@@ -265,12 +277,14 @@ const FIELD_CHILDREN_ARRAY = [
   RadioGroupStruct,
   FileInputStruct,
   CheckboxStruct,
+  SelectorStruct,
 ] as [
   typeof InputStruct,
   typeof DropdownStruct,
   typeof RadioGroupStruct,
   typeof FileInputStruct,
   typeof CheckboxStruct,
+  typeof SelectorStruct,
 ];
 
 /**
@@ -563,6 +577,7 @@ export const BoxChildStruct = typedUnion([
   CheckboxStruct,
   CardStruct,
   IconStruct,
+  SelectorStruct,
 ]);
 
 /**
@@ -606,6 +621,7 @@ export const JSXElementStruct: Describe<JSXElement> = typedUnion([
   ContainerStruct,
   CardStruct,
   IconStruct,
+  SelectorStruct,
 ]);
 
 /**

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -233,7 +233,7 @@ export const CardStruct: Describe<CardElement> = element('Card', {
  * A struct for the {@link SelectorOptionElement} type.
  */
 export const SelectorOptionStruct: Describe<SelectorOptionElement> = element(
-  'Option',
+  'SelectorOption',
   {
     value: string(),
     children: CardStruct,
@@ -633,6 +633,7 @@ export const JSXElementStruct: Describe<JSXElement> = typedUnion([
   CardStruct,
   IconStruct,
   SelectorStruct,
+  SelectorOptionStruct,
 ]);
 
 /**


### PR DESCRIPTION
Adds a new type of form component called `Selector`. It can be used as a "rich" dropdown that allows displaying more than just text. Otherwise functions very similarly to a dropdown from the Snaps platform perspective.

It can be used as such:
```jsx
      <Selector name="selector" value="foo" title="Choose an option">
        <SelectorOption value="foo">
          <Card title="Foo" value="$1" />
        </SelectorOption>
        <SelectorOption value="bar">
          <Card title="Bar" value="$1" />
        </SelectorOption>
      </Selector>
```

Each client will have a different implementation of how the selector is shown, but for reference the extension will show a modal that lets the user pick between the options of the selector.