### PR TITLE
fix(snaps-registry): Define missing `getState` action, `stateChange` event

### DIFF
--- a/packages/snaps-controllers/src/snaps/registry/json.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.ts
@@ -1,4 +1,8 @@
-import type { RestrictedControllerMessenger } from '@metamask/base-controller';
+import type {
+  ControllerGetStateAction,
+  ControllerStateChangeEvent,
+  RestrictedControllerMessenger,
+} from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
 import type { SnapsRegistryDatabase } from '@metamask/snaps-registry';
 import { verify } from '@metamask/snaps-registry';
@@ -65,13 +69,24 @@ export type Update = {
   handler: SnapsRegistry['update'];
 };
 
+export type SnapsRegistryGetStateAction = ControllerGetStateAction<
+  typeof controllerName,
+  SnapsRegistryState
+>;
+
 export type SnapsRegistryActions =
+  | SnapsRegistryGetStateAction
   | GetResult
   | GetMetadata
   | Update
   | ResolveVersion;
 
-export type SnapsRegistryEvents = never;
+export type SnapsRegistryStateChangeEvent = ControllerStateChangeEvent<
+  typeof controllerName,
+  SnapsRegistryState
+>;
+
+export type SnapsRegistryEvents = SnapsRegistryStateChangeEvent;
 
 export type SnapsRegistryMessenger = RestrictedControllerMessenger<
   'SnapsRegistry',


### PR DESCRIPTION
## Explanation

Fixes the `SnapsRegistryMessenger` type and the `JsonSnapsRegistry` class. Currently they do not fulfill their intended specifications correctly. 

- [Define the `*:getState` action using the `ControllerGetStateAction` utility type](https://github.com/MetaMask/core/blob/add-controller-guidelines/docs/writing-controllers.md#define-the-getstate-action-using-the-controllergetstateaction-utility-type)
- [Define the `*:stateChange` event using the `ControllerStateChangeEvent` utility type](https://github.com/MetaMask/core/blob/add-controller-guidelines/docs/writing-controllers.md#define-the-statechange-event-using-the-controllerstatechangeevent-utility-type)
- [Define and export a type union for internal action types](https://github.com/MetaMask/core/blob/add-controller-guidelines/docs/writing-controllers.md#define-and-export-a-type-union-for-internal-action-types)
- [Define and export a type union for internal event types](https://github.com/MetaMask/core/blob/add-controller-guidelines/docs/writing-controllers.md#define-and-export-a-type-union-for-internal-event-types)
- [Define and export a type for the controller's messenger](https://github.com/MetaMask/core/blob/add-controller-guidelines/docs/writing-controllers.md#define-and-export-a-type-for-the-controllers-messenger)

This also resolves downstream errors in mobile caused by `composable-controller` expecting all of its child controllers to have a `stateChange` event.
- See https://github.com/MetaMask/metamask-mobile/pull/10374/commits/4ea1202f41d3d21c94d266bb30a084191c8ac5e1

## References

- Fixes https://github.com/MetaMask/core/issues/4579
- Blocks https://github.com/MetaMask/metamask-mobile/pull/10441

## Changelog

### `@metamask/snaps-controllers`

### Added

- Define and export new types: `SnapsRegistryGetStateAction`, `SnapsRegistryStateChangeEvent` ([#2655](https://github.com/MetaMask/snaps/pull/2655))

### Changed

- `SnapsRegistryActions` is widened to include the `SnapsRegistry:getState` action ([#2655](https://github.com/MetaMask/snaps/pull/2655))
- `SnapsRegistryEvents` is widened to include the `SnapsRegistry:stateChange` event ([#2655](https://github.com/MetaMask/snaps/pull/2655))