### PR TITLE
Hide browserlist warning in the CLI

### DIFF
--- a/packages/snaps-cli/src/main.ts
+++ b/packages/snaps-cli/src/main.ts
@@ -5,6 +5,17 @@ import { logError } from '@metamask/snaps-utils';
 import { cli } from './cli';
 import commands from './commands';
 
+/*
+ * Disable the following error, we target an old version
+ * of a browser, and this error is not useful to our users.
+ *
+ * Browserslist: caniuse-lite is outdated. Please run:
+ *  npx update-browserslist-db@latest
+ *  Why you should do it regularly: https://github.com/browserslist/update-db#readme
+ */
+// eslint-disable-next-line n/no-process-env
+process.env.BROWSERSLIST_IGNORE_OLD_DATA = '1';
+
 cli(process.argv, commands).catch((error) => {
   logError(error);
   process.exitCode = 1;


### PR DESCRIPTION
This PR hides browserlist warning when using our CLI. This error is not useful to our users.

fixes #2614