### PR TITLE
chore: Remove Node.js specific crypto logic

### DIFF
--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 80,
+  "branches": 79.28,
   "functions": 90.06,
-  "lines": 90.77,
-  "statements": 90.15
+  "lines": 90.71,
+  "statements": 90
 }

--- a/packages/snaps-execution-environments/src/common/endowments/crypto.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/crypto.test.ts
@@ -1,12 +1,5 @@
 import crypto from './crypto';
 
-jest.mock('crypto', () => ({
-  webcrypto: {
-    mock: true,
-    subtle: { mock: true, constructor: { mock: true } },
-  },
-}));
-
 describe('Crypto endowment', () => {
   it('has expected properties', () => {
     expect(crypto).toMatchObject({
@@ -34,17 +27,6 @@ describe('Crypto endowment', () => {
     Object.assign(globalThis, {
       crypto: undefined,
       SubtleCrypto: undefined,
-    });
-  });
-
-  it('returns Node.js webcrypto module', () => {
-    // eslint-disable-next-line jest/prefer-strict-equal
-    expect(crypto.factory()).toEqual({
-      crypto: {
-        mock: true,
-        subtle: { mock: true, constructor: { mock: true } },
-      },
-      SubtleCrypto: { mock: true },
     });
   });
 });

--- a/packages/snaps-execution-environments/src/common/endowments/crypto.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/crypto.ts
@@ -1,25 +1,10 @@
 import { rootRealmGlobal } from '../globalObject';
 
 export const createCrypto = () => {
-  if (
-    'crypto' in rootRealmGlobal &&
-    typeof rootRealmGlobal.crypto === 'object' &&
-    'SubtleCrypto' in rootRealmGlobal &&
-    typeof rootRealmGlobal.SubtleCrypto === 'function'
-  ) {
-    return {
-      crypto: harden(rootRealmGlobal.crypto),
-      SubtleCrypto: harden(rootRealmGlobal.SubtleCrypto),
-    };
-  }
-  // For now, we expose the experimental webcrypto API for Node.js execution environments
-  // TODO: Figure out if this is enough long-term or if we should use a polyfill.
-  /* eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require */
-  const crypto = require('crypto').webcrypto;
   return {
-    crypto: harden(crypto),
-    SubtleCrypto: harden(crypto.subtle.constructor),
-  } as const;
+    crypto: harden(rootRealmGlobal.crypto),
+    SubtleCrypto: harden(rootRealmGlobal.SubtleCrypto),
+  };
 };
 
 const endowmentModule = {


### PR DESCRIPTION
Removes Node.js specific logic when hardening `crypto`. Since `globalThis.crypto` is available in all the Node versions we support, this is no longer necessary. 