### PR TITLE
Fix test-snaps after yarn upgrade

### DIFF
--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -14,7 +14,7 @@
     "test": "jest --passWithNoTests && yarn posttest",
     "posttest": "jest-it-up",
     "test:ci": "yarn test",
-    "start": "yarn workspaces foreach --worktree --parallel --verbose --interlaced --all --include \"@metamask/test-snaps\" --include \"@metamask/example-snaps\" run start:test",
+    "start": "yarn workspaces foreach --parallel --verbose --interlaced --all --include \"@metamask/test-snaps\" --include \"@metamask/example-snaps\" run start:test",
     "start:test": "cross-env NODE_ENV=development webpack serve",
     "build": "cross-env NODE_ENV=production webpack",
     "build:clean": "yarn clean && yarn build",


### PR DESCRIPTION
`--all` can't be used with `--worktree` anymore