### PR TITLE
Add support for more customizable input

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "68/sKEwMON4NdJa0RA07xMfJMG+lViWztrnMZuIiLuc=",
+    "shasum": "UfiN9PZ5f622z4tz0NI6ldfPDtFhKKRYKPr6j+VIncE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "UfiN9PZ5f622z4tz0NI6ldfPDtFhKKRYKPr6j+VIncE=",
+    "shasum": "R8Of/lcLuLbr2AAcUsDD6e0cdbOdHHvHlwxs+BoAHtE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "eGQ6Df8XxUy7H+BzRY0ejWy9Q0sIA5R2Nw0iBTq+de8=",
+    "shasum": "68/sKEwMON4NdJa0RA07xMfJMG+lViWztrnMZuIiLuc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "nX6HGVCdxTxTLiNPjLNQzpJ+fTtkp5xAIcU1b/APImg=",
+    "shasum": "zx2BRnayXcEwncfa1zQ5jUC9kCjeI6KFG9+ChCF5qJQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5AIqSyFzeQ182uZPA/RjaHzMV0rsvNY9u3TqIkN3VcA=",
+    "shasum": "8Iyfr16llKRg4UoML6rvo+76L+R6KhKxg8p0GdAczts=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "zx2BRnayXcEwncfa1zQ5jUC9kCjeI6KFG9+ChCF5qJQ=",
+    "shasum": "5AIqSyFzeQ182uZPA/RjaHzMV0rsvNY9u3TqIkN3VcA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5pXHzJ6KuE+xZELL2OTS1kE5v8gA1EMrqY/PlTgU4EI=",
+    "shasum": "iBG2W2Lur0vdRxHUfDQ8b6vLD5SI8+qcYIg8ARbkiE4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "iBG2W2Lur0vdRxHUfDQ8b6vLD5SI8+qcYIg8ARbkiE4=",
+    "shasum": "27ak99bFxoi5UmR0mvMhQWYJfsyZjeYva4kPd2sklgc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "33evXsKKimuz+hkPv+Rxa5Ng9IKOINWwEgHU9vBK63E=",
+    "shasum": "5pXHzJ6KuE+xZELL2OTS1kE5v8gA1EMrqY/PlTgU4EI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "MbxvpziG1Zu7JA123hfDXa0sQpCeiA0KIrFDqCbPWAk=",
+    "shasum": "JC3FDjGJH8FKdZThmBLQh3pmLiTS4IjwDu2rn/bKINY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "JC3FDjGJH8FKdZThmBLQh3pmLiTS4IjwDu2rn/bKINY=",
+    "shasum": "f/RSumnRBLYDElSvfXJ98Q+k3qOxINGvpiwGhxe+TFA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3PKsX/N6a6kXY30gtpgti4NEeGiSwxZEV6e+U5HP6Iw=",
+    "shasum": "MbxvpziG1Zu7JA123hfDXa0sQpCeiA0KIrFDqCbPWAk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "fFtbo7U1pKoqTQF0r7QZikEs8Nafav3ou/Wm1raUVA4=",
+    "shasum": "1pFYlq2+F70tWoWWVFt1XmA0+rlrKTjUL2cdJeahty8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1pFYlq2+F70tWoWWVFt1XmA0+rlrKTjUL2cdJeahty8=",
+    "shasum": "e29ytKW/Qa9WQjE/O5F1FhxwJOedexdXpyKAtQqIpVs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "e29ytKW/Qa9WQjE/O5F1FhxwJOedexdXpyKAtQqIpVs=",
+    "shasum": "LPHBZ8HaW5f2snnJ+7932mfqASK7jcXejfFjVyJ/VXA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "fpbYVs+LQIwr+Vik3bmeXdaCmF05W6fX99lzQsBljNc=",
+    "shasum": "UDkFbOMBRfWLD2oh0hlFurcqT3W33ysAIjUOBaEx/+k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "w+B1RqkBFWE58H6Aq6HuVRQc4Elu/qFyaI16ZSVVFoQ=",
+    "shasum": "fpbYVs+LQIwr+Vik3bmeXdaCmF05W6fX99lzQsBljNc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TDGaiphTZ8OS6xph5aIa97SPOVXjJN0ORMflp1XHQoY=",
+    "shasum": "w+B1RqkBFWE58H6Aq6HuVRQc4Elu/qFyaI16ZSVVFoQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0e3VKgdEVDR0mawVcesNxoW5xnBYaRhZ1AIqYoBvTl4=",
+    "shasum": "p5gJBZHmW0i2W+4UQzWu67vSHxY9Gr+JWoxzoGBv1Eg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cW20+wD/Lveazji0PKSrfzgWmKjt30kxvSY9Na2JSfQ=",
+    "shasum": "0e3VKgdEVDR0mawVcesNxoW5xnBYaRhZ1AIqYoBvTl4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "p5gJBZHmW0i2W+4UQzWu67vSHxY9Gr+JWoxzoGBv1Eg=",
+    "shasum": "klyP48icUHenhFEjXT4cvgSPT30ZFMqUTFBb2YqS4lI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OByr1eLCHi0/a+RMkq8dRas1Eog4ggzXQ4vsjbMgfyg=",
+    "shasum": "JEzbBhfMpDTP2UXiwBGFgnJUUZaGAnfkZR7s0nQ+1YE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9RGytF98DSIh9XEKnE1qIZyP9YMDgZ+FulzEr0/brF0=",
+    "shasum": "OByr1eLCHi0/a+RMkq8dRas1Eog4ggzXQ4vsjbMgfyg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "JEzbBhfMpDTP2UXiwBGFgnJUUZaGAnfkZR7s0nQ+1YE=",
+    "shasum": "pqp9lYbT/4A1Z2vgozgLu/kxvjdmlfFjmowIMOEsD0k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "WkJL2n6iaJJaNdytMBZUMuDXAt14mq6/5+/8PbsrIdw=",
+    "shasum": "4axxesHYkwj3K+iZMLpnAdD+nL3jT0uF+/RtgsV+Qs0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4axxesHYkwj3K+iZMLpnAdD+nL3jT0uF+/RtgsV+Qs0=",
+    "shasum": "67T01rKZp7nNoKiDJ/Hvqk8KRo4FWEVOyMB2uTFNZHA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "67T01rKZp7nNoKiDJ/Hvqk8KRo4FWEVOyMB2uTFNZHA=",
+    "shasum": "E+ijMmCKNfgzuyCynS6PHT0c2F+22NlJpAE0cbNSlcM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "XyKVl8VB/EVeJdvHOIbEuERJ5FLwi6xHhjJCrN8Iq8M=",
+    "shasum": "UvAKkgLp43SSDI/mUdvjehfLGrQq1rB5lPfETxDTqT4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "U1HtU+2ib2qDOgovRtZAiIjA+rnC7OueDjls6Ebl6TM=",
+    "shasum": "1J6Zt9hXa6xws0rDYmvrAHqwWl9X7zheqzTEnEhtOYw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1J6Zt9hXa6xws0rDYmvrAHqwWl9X7zheqzTEnEhtOYw=",
+    "shasum": "XyKVl8VB/EVeJdvHOIbEuERJ5FLwi6xHhjJCrN8Iq8M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "XC050OJz7nsZVKSGBl+4HWt8sER2rzlKyMnpIOUeDWM=",
+    "shasum": "GXJcuL0Bz7RCGE39iUk1v6QSmlMaA0gXJSekaE2l0cw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "D+ItCb37EwIUZc58Nq8czmYcAwpllqd2FKgVTfuAvwY=",
+    "shasum": "bV0wRt/wHyvalmH/EwdPvlgjwj29fErJ3b+zZoZYTaE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "bV0wRt/wHyvalmH/EwdPvlgjwj29fErJ3b+zZoZYTaE=",
+    "shasum": "XC050OJz7nsZVKSGBl+4HWt8sER2rzlKyMnpIOUeDWM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "tcRkELTKAi+uzxgWfpowHJhUZVqYQXv9kU8W+vJjIxk=",
+    "shasum": "BzCYiUBdWeViyl4Ux80SGv2kVJapohrpC/dTW5yM+iA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "40c2pSabTPy+uyAxwXcG5hNCAmWLbTQgIJmQSNQi5xo=",
+    "shasum": "tcRkELTKAi+uzxgWfpowHJhUZVqYQXv9kU8W+vJjIxk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9hRIxvPEetJVFo3Ed+2BdZ7DANNVUw0Tjo+5UK5mefc=",
+    "shasum": "40c2pSabTPy+uyAxwXcG5hNCAmWLbTQgIJmQSNQi5xo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "uMxUoB2cAH4/GhOZNPiXzFhewC91WsmCK4LobP/Jrpo=",
+    "shasum": "dZ9WgkIrRPAi7nKbYBSeaD3xV9rKf0VT9/5FgrrK4QE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3GbEr0X/OdmIjnLHCNdFuvBmmVYg7OtgJoiD0L9RvmU=",
+    "shasum": "uMxUoB2cAH4/GhOZNPiXzFhewC91WsmCK4LobP/Jrpo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Q6hggrSrhxfVVa/QCBV43ZKj52rtINLPRgDEyIZmjZw=",
+    "shasum": "3GbEr0X/OdmIjnLHCNdFuvBmmVYg7OtgJoiD0L9RvmU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+Lbdb2xMhdt2SiG4bOWlHzvB/qeGm8pJowIYSRXVDrI=",
+    "shasum": "HSeXTPkmSI9ezeG5xPs3W2jY2OP2ZOzWnYWbOeWLizA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "f4Y1cNVB6h/jOCkIpIMjSls1URfQQWecUjAPTguv3MA=",
+    "shasum": "+Lbdb2xMhdt2SiG4bOWlHzvB/qeGm8pJowIYSRXVDrI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "HSeXTPkmSI9ezeG5xPs3W2jY2OP2ZOzWnYWbOeWLizA=",
+    "shasum": "r+Vr5LYfHiuQZuvypm1jQNfQzdp7unl6AgskaGCFJnM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "n3C0SodKAbIFuNiRkoMROZ+SZvOYDRdqO6b9dFzUwI0=",
+    "shasum": "FqvdKLCkHZIbUtUTDj6ltPJq0+MMQ36mPj63p95q9v8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FqvdKLCkHZIbUtUTDj6ltPJq0+MMQ36mPj63p95q9v8=",
+    "shasum": "Gp9C2rx9CMdllQh0A34KxuuoZ0LRXXFiy2l3UBj6/W8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Gp9C2rx9CMdllQh0A34KxuuoZ0LRXXFiy2l3UBj6/W8=",
+    "shasum": "/Xgz50XZhm49exI9MtCOtWRox1N894/sLTYZIGYrFX4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "awa6GvnLTq3455FcrOHjgEbdA08A2PMmKw8Jqv/BwR0=",
+    "shasum": "n3C0SodKAbIFuNiRkoMROZ+SZvOYDRdqO6b9dFzUwI0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xKqurVfpdlotaOEodz5X5LbAp343Mcu8JXQ+zfTiyUU=",
+    "shasum": "03nxpMZIyNpwaYnMfM8LvV8DskMb+JQyM+Ae9HDsRas=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "03nxpMZIyNpwaYnMfM8LvV8DskMb+JQyM+Ae9HDsRas=",
+    "shasum": "+rrOKuc7v1wU5LGx5cVo+RX5SXDuzGVITSMTnHBSNPA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+rrOKuc7v1wU5LGx5cVo+RX5SXDuzGVITSMTnHBSNPA=",
+    "shasum": "sDb0ugSBJGrdF7ObFjJ3GKVkE/8cManTyFxzE+27wzg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "BoL6X/BzHLVMASCxnwAUAw+2XzD9B8gSvE7GcbJjfug=",
+    "shasum": "/XkF9oEKdXZOw+dImBARMTnvWZ7v2BHUDNpNH1yB5o8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "/XkF9oEKdXZOw+dImBARMTnvWZ7v2BHUDNpNH1yB5o8=",
+    "shasum": "1f0U3e2rIR6R+ou87ljYJbDWrlUz5eXzqFhChsqjjnc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1f0U3e2rIR6R+ou87ljYJbDWrlUz5eXzqFhChsqjjnc=",
+    "shasum": "xPa7zpGbgq01EtWw8qxQFqzteqMYxDXn2nevqoVzJJs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4o9JeKs362YeZenNSIdZXH/x/3rmeEd3XEPEoDZGGG8=",
+    "shasum": "XgbjBxwNlGsjmdztBI22Z+gYQ1/NKI7yEBmlVxgOpMg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "R1rq0U1MY5dGg9b4ECvQqELVlZWq7adMHYTu/bQRSWs=",
+    "shasum": "lFzSdGVkH8mrdW8k94F4kBy/e0Bfm//OeF2TIS9ygx4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "lFzSdGVkH8mrdW8k94F4kBy/e0Bfm//OeF2TIS9ygx4=",
+    "shasum": "4o9JeKs362YeZenNSIdZXH/x/3rmeEd3XEPEoDZGGG8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TVBMyFvE1DTy0N9dDM5lXoOvJ1hkyDWTZNRWzBDWUyY=",
+    "shasum": "FBlxEU07ioxYzM0+S+xQSQmJ9nMxtsnkQNv9oTp9AdU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FT62FWsImEz4/CQmTb+dcnajSNtt4sGW/o3GaN+4y10=",
+    "shasum": "TVBMyFvE1DTy0N9dDM5lXoOvJ1hkyDWTZNRWzBDWUyY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FBlxEU07ioxYzM0+S+xQSQmJ9nMxtsnkQNv9oTp9AdU=",
+    "shasum": "T+A3hsNIIBcFZnfBu0PBzJm2oapEixpCGjNV4nMgnzg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "pHznDqyNDQJVW/67EPL4loI0OGVBlQwTFJp5aJSaPtc=",
+    "shasum": "MNSdE7seQVY/J2CgiR1ui5S3+EqhaWWUI2sWCQ8UMNs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "03JcFdOq8QrQMsXuIN5f2cstVxYOGaKF2F5lw5vdAsQ=",
+    "shasum": "pHznDqyNDQJVW/67EPL4loI0OGVBlQwTFJp5aJSaPtc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4CGq8+febvnopYV5vM1P6LYNxTyuJPAzVkuShodxhQM=",
+    "shasum": "03JcFdOq8QrQMsXuIN5f2cstVxYOGaKF2F5lw5vdAsQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Vb5vXT1zeAnRnMkpu+eBdd9k1D6K35Mf6UffAIrgfhQ=",
+    "shasum": "KfK4DGqhbJMdNPfbc94Dq+nhcVg+goBxxqr1o8isedU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "e2fGLS7bK7QTemBMPYvmExYJcQXyLFd6JsteSQxJ6QI=",
+    "shasum": "Vb5vXT1zeAnRnMkpu+eBdd9k1D6K35Mf6UffAIrgfhQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "KfK4DGqhbJMdNPfbc94Dq+nhcVg+goBxxqr1o8isedU=",
+    "shasum": "mONCNm5xmhuk1QcfKLaOAs7Uql/eh5G2Yo0jSPyIzXg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TjIsLYT+nNhjP8w1e6xC4QbhYTEjV4B+KGNvBN1vpTI=",
+    "shasum": "h4cy+HXLICucv6IwzuQHVTWwrtlsZ7KOX7fddeCEj4o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cFtWQhdKCF3oiI4eqhdRtIqykRfTXQdsptauPSLv91k=",
+    "shasum": "98vhPnaWHkUPD18HSxKy5vFYKNRYOdRqwkihnGcT00A=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "h4cy+HXLICucv6IwzuQHVTWwrtlsZ7KOX7fddeCEj4o=",
+    "shasum": "cFtWQhdKCF3oiI4eqhdRtIqykRfTXQdsptauPSLv91k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8XMJ7DXnyg4X4WDRU6RPB/bzPzHuYDJb7+5MGk4YKwk=",
+    "shasum": "43/FOUjIa7N9trMI54h2h02nZCO2HTZG9tlMwdeRilQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FyvQt1zj68l33It4Yi3q517QabwIB4YV4bSkaaV82m4=",
+    "shasum": "8XMJ7DXnyg4X4WDRU6RPB/bzPzHuYDJb7+5MGk4YKwk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "CxXZf7wwJM7Q7hGx7a/eEM2p2pWwW2wSmwKcY90Bfh0=",
+    "shasum": "FyvQt1zj68l33It4Yi3q517QabwIB4YV4bSkaaV82m4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "C9YLV/bHuQCZcm4K/29syIy+Xm3p7g7/g5rm4yiVn1Y=",
+    "shasum": "LGJJjBHbbUE4+MdIk0c7EqItgJKaKNZgroPaURABxyI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5ZXSsw6KSGESsxBUuSBZ1DAyPKK7FP6gJel2yACceVE=",
+    "shasum": "C9YLV/bHuQCZcm4K/29syIy+Xm3p7g7/g5rm4yiVn1Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "/ncEYiTIVVmxnRpsDZ0JbQcSxkX23775dkIttFQtFNA=",
+    "shasum": "5ZXSsw6KSGESsxBUuSBZ1DAyPKK7FP6gJel2yACceVE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ATImuKWW6l2q04LJ+2i+gMQZA+jDoGY1GldCWvNhbxk=",
+    "shasum": "e9GW5yikDXBrFSQ093QImMcpmfVQ5z1458TbTkJqBWY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "e9GW5yikDXBrFSQ093QImMcpmfVQ5z1458TbTkJqBWY=",
+    "shasum": "g3e2k0lQsDN/0bZJW5y4sQGWNYHAs8KUK91edExDGhY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "SfJnA+DmyIJKA/iR9vJULwikVGkjH7A3juLxrckRgxE=",
+    "shasum": "ATImuKWW6l2q04LJ+2i+gMQZA+jDoGY1GldCWvNhbxk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "nKPQePbMmLpb42WMUL5m5vHRV8O6FZTestD1rbbUC5Y=",
+    "shasum": "lVBEoTo90Uqgvi19KaemXi7Di4BSngCBukRN9opy2ng=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "lnCxV63MnFH988PfAoI2H5stf/Z+CbLSlzcMKFdEitY=",
+    "shasum": "nKPQePbMmLpb42WMUL5m5vHRV8O6FZTestD1rbbUC5Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "bfY+b/o23zP4aCEUzOsoysnpJBxtiLxPWD8BqcZNduo=",
+    "shasum": "lnCxV63MnFH988PfAoI2H5stf/Z+CbLSlzcMKFdEitY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Oit4iXUgdpU2eNXka0E9ACJyre+iaN1hZbOtM/Bp27Q=",
+    "shasum": "puhtWziN4FFQebCCBzast5YSptnAZGpJFHpytBi44nk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "KzNuP4IpARsXGw9Atgmsig27SYR8kxzv7K45p3XTeVQ=",
+    "shasum": "Oit4iXUgdpU2eNXka0E9ACJyre+iaN1hZbOtM/Bp27Q=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "puhtWziN4FFQebCCBzast5YSptnAZGpJFHpytBi44nk=",
+    "shasum": "fDFhZfuLUwjFDFdCpgLW02M/c6BKa8rr6gVaOb7EE9g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TGmhAkRTYVqUd/GXYJ+RvI4ZPDw+4sx2bxxyNt0+9oI=",
+    "shasum": "3tIqXdqpvmt567LIMpb3XvkpScyqw8kIIi6RiRVztMU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hFB/Mja1BmI3iRWUyZ8j4jy0D0ztmyUpPKMkwTCCWuM=",
+    "shasum": "GveQv7vX09cdHS/joDV6HsGhuKPx4z9HqeSd4/HBR00=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3tIqXdqpvmt567LIMpb3XvkpScyqw8kIIi6RiRVztMU=",
+    "shasum": "hFB/Mja1BmI3iRWUyZ8j4jy0D0ztmyUpPKMkwTCCWuM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cPfkHhRCwFLhlD07HLugG+b4VliW7v9JAe75iA4lwKg=",
+    "shasum": "vXQ+C775aVuVAP42b7pZ9HfDgrt3//YON5lUOlExgzY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "e9RpXCYrEZfBhsk7sGPCqyMSWolBVKbc2tABCfIqck0=",
+    "shasum": "cPfkHhRCwFLhlD07HLugG+b4VliW7v9JAe75iA4lwKg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vXQ+C775aVuVAP42b7pZ9HfDgrt3//YON5lUOlExgzY=",
+    "shasum": "ZEPqntjeYnKUDvoKSfQ5NiRaRoG5PJWoD+kK3G4ebUs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-sdk/src/jsx/components/form/Field.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/Field.test.tsx
@@ -1,3 +1,5 @@
+import { Box } from '../Box';
+import { Text } from '../Text';
 import { Button } from './Button';
 import { Dropdown } from './Dropdown';
 import { Field } from './Field';
@@ -84,6 +86,148 @@ describe('Field', () => {
             props: {
               type: 'submit',
               children: 'Submit',
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('renders a field element with an input and box on the left', () => {
+    const result = (
+      <Field label="Label">
+        <Box>
+          <Text>Hello</Text>
+        </Box>
+        <Input name="foo" type="text" />
+      </Field>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Field',
+      key: null,
+      props: {
+        label: 'Label',
+        children: [
+          {
+            type: 'Box',
+            key: null,
+            props: {
+              children: {
+                type: 'Text',
+                key: null,
+                props: {
+                  children: 'Hello',
+                },
+              },
+            },
+          },
+          {
+            type: 'Input',
+            key: null,
+            props: {
+              name: 'foo',
+              type: 'text',
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('renders a field element with an input and box on the right', () => {
+    const result = (
+      <Field label="Label">
+        <Input name="foo" type="text" />
+        <Box>
+          <Text>Hello</Text>
+        </Box>
+      </Field>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Field',
+      key: null,
+      props: {
+        label: 'Label',
+        children: [
+          {
+            type: 'Input',
+            key: null,
+            props: {
+              name: 'foo',
+              type: 'text',
+            },
+          },
+          {
+            type: 'Box',
+            key: null,
+            props: {
+              children: {
+                type: 'Text',
+                key: null,
+                props: {
+                  children: 'Hello',
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('renders a field element with an input and box on both sides', () => {
+    const result = (
+      <Field label="Label">
+        <Box>
+          <Text>Hello</Text>
+        </Box>
+        <Input name="foo" type="text" />
+        <Box>
+          <Text>Hello</Text>
+        </Box>
+      </Field>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Field',
+      key: null,
+      props: {
+        label: 'Label',
+        children: [
+          {
+            type: 'Box',
+            key: null,
+            props: {
+              children: {
+                type: 'Text',
+                key: null,
+                props: {
+                  children: 'Hello',
+                },
+              },
+            },
+          },
+          {
+            type: 'Input',
+            key: null,
+            props: {
+              name: 'foo',
+              type: 'text',
+            },
+          },
+          {
+            type: 'Box',
+            key: null,
+            props: {
+              children: {
+                type: 'Text',
+                key: null,
+                props: {
+                  children: 'Hello',
+                },
+              },
             },
           },
         ],

--- a/packages/snaps-sdk/src/jsx/components/form/Field.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Field.ts
@@ -1,4 +1,5 @@
 import { createSnapComponent } from '../../component';
+import type { BoxElement } from '../Box';
 import type { ButtonElement } from './Button';
 import type { CheckboxElement } from './Checkbox';
 import type { DropdownElement } from './Dropdown';
@@ -19,6 +20,9 @@ export type FieldProps = {
   error?: string | undefined;
   children:
     | [InputElement, ButtonElement]
+    | [BoxElement, InputElement]
+    | [InputElement, BoxElement]
+    | [BoxElement, InputElement, BoxElement]
     | DropdownElement
     | RadioGroupElement
     | FileInputElement

--- a/packages/snaps-sdk/src/jsx/components/form/Field.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Field.ts
@@ -1,6 +1,5 @@
+import type { GenericSnapElement } from '../../component';
 import { createSnapComponent } from '../../component';
-import type { BoxElement } from '../Box';
-import type { ButtonElement } from './Button';
 import type { CheckboxElement } from './Checkbox';
 import type { DropdownElement } from './Dropdown';
 import type { FileInputElement } from './FileInput';
@@ -19,10 +18,9 @@ export type FieldProps = {
   label?: string | undefined;
   error?: string | undefined;
   children:
-    | [InputElement, ButtonElement]
-    | [BoxElement, InputElement]
-    | [InputElement, BoxElement]
-    | [BoxElement, InputElement, BoxElement]
+    | [InputElement, GenericSnapElement]
+    | [GenericSnapElement, InputElement]
+    | [GenericSnapElement, InputElement, GenericSnapElement]
     | DropdownElement
     | RadioGroupElement
     | FileInputElement

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -257,6 +257,11 @@ describe('FieldStruct', () => {
       </Box>
     </Field>,
     <Field label="foo">
+      <Text>Hello</Text>
+      <Input name="foo" type="text" />
+      <Text>Hello</Text>
+    </Field>,
+    <Field label="foo">
       <Input name="foo" type="text" />
       <Button>foo</Button>
     </Field>,

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -235,6 +235,31 @@ describe('FieldStruct', () => {
     <Field label="foo">
       <Input name="foo" type="text" />
     </Field>,
+    <Field label="foo">
+      <Box>
+        <Text>Hello</Text>
+      </Box>
+      <Input name="foo" type="text" />
+    </Field>,
+    <Field label="foo">
+      <Input name="foo" type="text" />
+      <Box>
+        <Text>Hello</Text>
+      </Box>
+    </Field>,
+    <Field label="foo">
+      <Box>
+        <Text>Hello</Text>
+      </Box>
+      <Input name="foo" type="text" />
+      <Box>
+        <Text>Hello</Text>
+      </Box>
+    </Field>,
+    <Field label="foo">
+      <Input name="foo" type="text" />
+      <Button>foo</Button>
+    </Field>,
     <Field error="bar">
       <Input name="foo" type="text" />
     </Field>,

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -285,6 +285,28 @@ export const FileInputStruct: Describe<FileInputElement> = element(
   },
 );
 
+export const BoxChildrenStruct = children(
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  [lazy(() => BoxChildStruct)],
+) as unknown as Struct<SnapsChildren<GenericSnapElement>, null>;
+
+/**
+ * A struct for the {@link BoxElement} type.
+ */
+export const BoxStruct: Describe<BoxElement> = element('Box', {
+  children: BoxChildrenStruct,
+  direction: optional(nullUnion([literal('horizontal'), literal('vertical')])),
+  alignment: optional(
+    nullUnion([
+      literal('start'),
+      literal('center'),
+      literal('end'),
+      literal('space-between'),
+      literal('space-around'),
+    ]),
+  ),
+});
+
 /**
  * A subset of JSX elements that represent the tuple Button + Input of the Field children.
  */
@@ -417,28 +439,6 @@ export const FormattingStruct: Describe<StandardFormattingElement> = typedUnion(
  */
 export const AddressStruct: Describe<AddressElement> = element('Address', {
   address: nullUnion([HexChecksumAddressStruct, CaipAccountIdStruct]),
-});
-
-export const BoxChildrenStruct = children(
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  [lazy(() => BoxChildStruct)],
-) as unknown as Struct<SnapsChildren<GenericSnapElement>, null>;
-
-/**
- * A struct for the {@link BoxElement} type.
- */
-export const BoxStruct: Describe<BoxElement> = element('Box', {
-  children: BoxChildrenStruct,
-  direction: optional(nullUnion([literal('horizontal'), literal('vertical')])),
-  alignment: optional(
-    nullUnion([
-      literal('start'),
-      literal('center'),
-      literal('end'),
-      literal('space-between'),
-      literal('space-around'),
-    ]),
-  ),
 });
 
 const FooterButtonStruct = refine(ButtonStruct, 'FooterButton', (value) => {

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -308,37 +308,33 @@ export const BoxStruct: Describe<BoxElement> = element('Box', {
 });
 
 /**
- * A subset of JSX elements that represent the tuple Button + Input of the Field children.
- */
-const BUTTON_INPUT = [InputStruct, ButtonStruct] as [
-  typeof InputStruct,
-  typeof ButtonStruct,
-];
-
-/**
  * A subset of JSX elements that represent the tuple Box + Input of the Field children.
  */
-const BOX_INPUT_LEFT = [BoxStruct, InputStruct] as [
-  typeof BoxStruct,
+// eslint-disable-next-line @typescript-eslint/no-use-before-define
+const BOX_INPUT_LEFT = [lazy(() => BoxChildStruct), InputStruct] as [
+  typeof BoxChildStruct,
   typeof InputStruct,
 ];
 
 /**
  * A subset of JSX elements that represent the tuple Input + Box of the Field children.
  */
-const BOX_INPUT_RIGHT = [InputStruct, BoxStruct] as [
+// eslint-disable-next-line @typescript-eslint/no-use-before-define
+const BOX_INPUT_RIGHT = [InputStruct, lazy(() => BoxChildStruct)] as [
   typeof InputStruct,
-  typeof BoxStruct,
+  typeof BoxChildStruct,
 ];
 
 /**
  * A subset of JSX elements that represent the tuple Box + Input + Box of the Field children.
  */
-const BOX_INPUT_BOTH = [BoxStruct, InputStruct, BoxStruct] as [
-  typeof BoxStruct,
-  typeof InputStruct,
-  typeof BoxStruct,
-];
+const BOX_INPUT_BOTH = [
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  lazy(() => BoxChildStruct),
+  InputStruct,
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  lazy(() => BoxChildStruct),
+] as [typeof BoxChildStruct, typeof InputStruct, typeof BoxChildStruct];
 
 /**
  * A subset of JSX elements that are allowed as single children of the Field component.
@@ -363,21 +359,33 @@ const FIELD_CHILDREN_ARRAY = [
  * A union of the allowed children of the Field component.
  * This is mainly used in the simulator for validation purposes.
  */
-export const FieldChildUnionStruct = typedUnion([
+export const FieldChildUnionStruct = nullUnion([
   ...FIELD_CHILDREN_ARRAY,
-  ...BUTTON_INPUT,
+  ...BOX_INPUT_LEFT,
+  ...BOX_INPUT_RIGHT,
+  ...BOX_INPUT_BOTH,
 ]);
 
 /**
  * A subset of JSX elements that are allowed as children of the Field component.
  */
 const FieldChildStruct = nullUnion([
-  tuple(BUTTON_INPUT),
   tuple(BOX_INPUT_LEFT),
   tuple(BOX_INPUT_RIGHT),
   tuple(BOX_INPUT_BOTH),
   ...FIELD_CHILDREN_ARRAY,
-]);
+]) as unknown as Struct<
+  | [InputElement, GenericSnapElement]
+  | [GenericSnapElement, InputElement]
+  | [GenericSnapElement, InputElement, GenericSnapElement]
+  | DropdownElement
+  | RadioGroupElement
+  | FileInputElement
+  | InputElement
+  | CheckboxElement
+  | SelectorElement,
+  null
+>;
 
 /**
  * A struct for the {@link FieldElement} type.

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -294,6 +294,31 @@ const BUTTON_INPUT = [InputStruct, ButtonStruct] as [
 ];
 
 /**
+ * A subset of JSX elements that represent the tuple Box + Input of the Field children.
+ */
+const BOX_INPUT_LEFT = [BoxStruct, InputStruct] as [
+  typeof BoxStruct,
+  typeof InputStruct,
+];
+
+/**
+ * A subset of JSX elements that represent the tuple Input + Box of the Field children.
+ */
+const BOX_INPUT_RIGHT = [InputStruct, BoxStruct] as [
+  typeof InputStruct,
+  typeof BoxStruct,
+];
+
+/**
+ * A subset of JSX elements that represent the tuple Box + Input + Box of the Field children.
+ */
+const BOX_INPUT_BOTH = [BoxStruct, InputStruct, BoxStruct] as [
+  typeof BoxStruct,
+  typeof InputStruct,
+  typeof BoxStruct,
+];
+
+/**
  * A subset of JSX elements that are allowed as single children of the Field component.
  */
 const FIELD_CHILDREN_ARRAY = [
@@ -326,6 +351,9 @@ export const FieldChildUnionStruct = typedUnion([
  */
 const FieldChildStruct = nullUnion([
   tuple(BUTTON_INPUT),
+  tuple(BOX_INPUT_LEFT),
+  tuple(BOX_INPUT_RIGHT),
+  tuple(BOX_INPUT_BOTH),
   ...FIELD_CHILDREN_ARRAY,
 ]);
 

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -285,28 +285,6 @@ export const FileInputStruct: Describe<FileInputElement> = element(
   },
 );
 
-export const BoxChildrenStruct = children(
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  [lazy(() => BoxChildStruct)],
-) as unknown as Struct<SnapsChildren<GenericSnapElement>, null>;
-
-/**
- * A struct for the {@link BoxElement} type.
- */
-export const BoxStruct: Describe<BoxElement> = element('Box', {
-  children: BoxChildrenStruct,
-  direction: optional(nullUnion([literal('horizontal'), literal('vertical')])),
-  alignment: optional(
-    nullUnion([
-      literal('start'),
-      literal('center'),
-      literal('end'),
-      literal('space-between'),
-      literal('space-around'),
-    ]),
-  ),
-});
-
 /**
  * A subset of JSX elements that represent the tuple Box + Input of the Field children.
  */
@@ -447,6 +425,28 @@ export const FormattingStruct: Describe<StandardFormattingElement> = typedUnion(
  */
 export const AddressStruct: Describe<AddressElement> = element('Address', {
   address: nullUnion([HexChecksumAddressStruct, CaipAccountIdStruct]),
+});
+
+export const BoxChildrenStruct = children(
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  [lazy(() => BoxChildStruct)],
+) as unknown as Struct<SnapsChildren<GenericSnapElement>, null>;
+
+/**
+ * A struct for the {@link BoxElement} type.
+ */
+export const BoxStruct: Describe<BoxElement> = element('Box', {
+  children: BoxChildrenStruct,
+  direction: optional(nullUnion([literal('horizontal'), literal('vertical')])),
+  alignment: optional(
+    nullUnion([
+      literal('start'),
+      literal('center'),
+      literal('end'),
+      literal('space-between'),
+      literal('space-around'),
+    ]),
+  ),
 });
 
 const FooterButtonStruct = refine(ButtonStruct, 'FooterButton', (value) => {

--- a/packages/snaps-simulator/src/features/builder/utils.test.ts
+++ b/packages/snaps-simulator/src/features/builder/utils.test.ts
@@ -55,7 +55,7 @@ describe('isValidFieldChild', () => {
 
   it('returns false for invalid field children', () => {
     const child = Text({ children: 'foo' });
-    expect(isValidFieldChild(child)).toBe(false);
+    expect(isValidFieldChild(child)).toBe(true);
   });
 });
 

--- a/packages/snaps-simulator/src/features/builder/utils.test.ts
+++ b/packages/snaps-simulator/src/features/builder/utils.test.ts
@@ -54,8 +54,11 @@ describe('isValidFieldChild', () => {
   });
 
   it('returns false for invalid field children', () => {
-    const child = Text({ children: 'foo' });
-    expect(isValidFieldChild(child)).toBe(true);
+    const child = Text({
+      // @ts-expect-error invalid field for children is intentional for testing
+      children: Option({ children: 'foo', value: 'foo' }),
+    });
+    expect(isValidFieldChild(child)).toBe(false);
   });
 });
 

--- a/packages/snaps-simulator/src/features/builder/utils.test.ts
+++ b/packages/snaps-simulator/src/features/builder/utils.test.ts
@@ -54,10 +54,7 @@ describe('isValidFieldChild', () => {
   });
 
   it('returns false for invalid field children', () => {
-    const child = Text({
-      // @ts-expect-error invalid field for children is intentional for testing
-      children: Option({ children: 'foo', value: 'foo' }),
-    });
+    const child = Option({ children: 'foo', value: 'foo' });
     expect(isValidFieldChild(child)).toBe(false);
   });
 });


### PR DESCRIPTION
This PR adds changes to support more customizable input.
The primary target for customization are `start` and `end` accessories within the DS Input Component we're using in extension. This PR allows `<Box>` as the left or right accessory. 
Box elements and their children elements are adjacent to the primary Field-compatible child component, just like the support for the `<Button>` we have from previous implementations.

Related task: https://github.com/MetaMask/MetaMask-planning/issues/3067

Notes:
- This PR does not introduce breaking changes, since possibility for adding just simple plain button to the Input field is still supported.

