### PR TITLE
Improve `validateLink` error handling

### DIFF
--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -2,5 +2,5 @@
   "branches": 99.73,
   "functions": 98.9,
   "lines": 99.43,
-  "statements": 96.32
+  "statements": 96.33
 }

--- a/packages/snaps-utils/src/ui.tsx
+++ b/packages/snaps-utils/src/ui.tsx
@@ -33,7 +33,6 @@ import {
 import {
   assert,
   assertExhaustive,
-  AssertionError,
   hasProperty,
   isPlainObject,
 } from '@metamask/utils';
@@ -332,7 +331,7 @@ function getMarkdownLinks(text: string) {
  * @param isOnPhishingList - The function that checks the link against the
  * phishing list.
  */
-function validateLink(
+export function validateLink(
   link: string,
   isOnPhishingList: (url: string) => boolean,
 ) {
@@ -350,7 +349,7 @@ function validateLink(
   } catch (error) {
     throw new Error(
       `Invalid URL: ${
-        error instanceof AssertionError ? error.message : 'Unable to parse URL.'
+        error?.code === 'ERR_ASSERTION' ? error.message : 'Unable to parse URL.'
       }`,
     );
   }


### PR DESCRIPTION
This improves the error handling of `validateLink` in case of assertion errors. Previously we used `instanceof`, which can cause false negatives when importing from libraries. I've changed it to look at the error code instead.