### PR TITLE
Revert "Release 64.0.0 (#2705)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "64.0.0",
+  "version": "63.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/create-snap/CHANGELOG.md
+++ b/packages/create-snap/CHANGELOG.md
@@ -6,12 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.0.3]
-### Fixed
-- Fix ESM version of the package ([#2682](https://github.com/MetaMask/snaps/pull/2682))
-  - This fixes the ESM version of the package to be fully compliant with the ESM
-    standard.
-
 ## [4.0.2]
 ### Fixed
 - Fix detection of minimum Node.js version ([#2292](https://github.com/MetaMask/snaps/pull/2292))
@@ -69,8 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@4.0.3...HEAD
-[4.0.3]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@4.0.2...@metamask/create-snap@4.0.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@4.0.2...HEAD
 [4.0.2]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@4.0.1...@metamask/create-snap@4.0.2
 [4.0.1]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@4.0.0...@metamask/create-snap@4.0.1
 [4.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/create-snap@3.1.1...@metamask/create-snap@4.0.0

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/create-snap",
-  "version": "4.0.3",
+  "version": "4.0.2",
   "description": "A CLI for creating MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/example-snaps",
-  "version": "3.8.1",
+  "version": "3.8.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/examples/packages/bip32/CHANGELOG.md
+++ b/packages/examples/packages/bip32/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.2.1]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.2.0]
 ### Added
 - Add support for `ed25519Bip32` to the BIP-32 example snap ([#2428](https://github.com/MetaMask/snaps/pull/2428))
@@ -55,8 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@2.2.1...HEAD
-[2.2.1]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@2.2.0...@metamask/bip32-example-snap@2.2.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@2.2.0...HEAD
 [2.2.0]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@2.1.2...@metamask/bip32-example-snap@2.2.0
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@2.1.1...@metamask/bip32-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/bip32-example-snap@2.1.0...@metamask/bip32-example-snap@2.1.1

--- a/packages/examples/packages/bip32/package.json
+++ b/packages/examples/packages/bip32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/bip32-example-snap",
-  "version": "2.2.1",
+  "version": "2.2.0",
   "description": "MetaMask example snap demonstrating the use of `snap_getBip32Entropy`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.1",
+  "version": "2.2.0",
   "description": "MetaMask example snap demonstrating the use of `snap_getBip32Entropy`.",
   "proposedName": "BIP-32 Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "PxNHa0ebJ1qA/LXiY4vTzUsBKNl3rdfbHwg198YtOH4=",
+    "shasum": "5o3Zg3/1/23XKZdIzzo1Sbwmp2uQNF1EpnzyLYqhfqo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/CHANGELOG.md
+++ b/packages/examples/packages/bip44/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -56,8 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@2.1.3...HEAD
-[2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@2.1.2...@metamask/bip44-example-snap@2.1.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@2.1.2...HEAD
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@2.1.1...@metamask/bip44-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@2.1.0...@metamask/bip44-example-snap@2.1.1
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/bip44-example-snap@2.0.1...@metamask/bip44-example-snap@2.1.0

--- a/packages/examples/packages/bip44/package.json
+++ b/packages/examples/packages/bip44/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/bip44-example-snap",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating the use of `snap_getBip44Entropy`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating the use of `snap_getBip44Entropy`.",
   "proposedName": "BIP-44 Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Nb4y6u121k+rnDRGblkG77S7s9IFt1TZTQeSZOXNdyY=",
+    "shasum": "K0uZKIJkRUzXrIrbcNY/hjouFPSEVScyeJc0D5SvuIs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/CHANGELOG.md
+++ b/packages/examples/packages/browserify-plugin/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -46,8 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@2.1.3...HEAD
-[2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@2.1.2...@metamask/browserify-plugin-example-snap@2.1.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@2.1.2...HEAD
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@2.1.1...@metamask/browserify-plugin-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@2.1.0...@metamask/browserify-plugin-example-snap@2.1.1
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-plugin-example-snap@2.0.1...@metamask/browserify-plugin-example-snap@2.1.0

--- a/packages/examples/packages/browserify-plugin/package.json
+++ b/packages/examples/packages/browserify-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/browserify-plugin-example-snap",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating how to use the Browserify plugin to bundle a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating how to use the Browserify plugin to bundle a snap.",
   "proposedName": "Browserify Plugin Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "A3JhkncC8nBdzAEjqVa3RtSFRAGpaO+T0ABpCA0CKpM=",
+    "shasum": "zjj26VuJEMPd17W0vAdpVONDt/JeYPacP5GwbRAiQZo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/CHANGELOG.md
+++ b/packages/examples/packages/browserify/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -45,8 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Browserify example snap ([#1632](https://github.com/MetaMask/snaps/pull/1632))
   - This snap demonstrates how to use the deprecated Browserify configuration format.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@2.1.3...HEAD
-[2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@2.1.2...@metamask/browserify-example-snap@2.1.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@2.1.2...HEAD
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@2.1.1...@metamask/browserify-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@2.1.0...@metamask/browserify-example-snap@2.1.1
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/browserify-example-snap@2.0.1...@metamask/browserify-example-snap@2.1.0

--- a/packages/examples/packages/browserify/package.json
+++ b/packages/examples/packages/browserify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/browserify-example-snap",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating how to use Browserify to bundle a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating how to use the Browserify plugin to bundle a snap.",
   "proposedName": "Browserify Plugin Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "I4QX3z8+PVtiPoI5o9VcKsb4rSI2kDC6DiS+ybY/ycA=",
+    "shasum": "WEO5ozYWnfy690WSCYKkexaQnlkDbks1f+vXrRVQRTM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/CHANGELOG.md
+++ b/packages/examples/packages/client-status/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [1.0.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -22,8 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `snap_getClientStatus` example snap ([#2159](https://github.com/MetaMask/snaps/pull/2159))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/client-status-example-snap@1.0.3...HEAD
-[1.0.3]: https://github.com/MetaMask/snaps/compare/@metamask/client-status-example-snap@1.0.2...@metamask/client-status-example-snap@1.0.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/client-status-example-snap@1.0.2...HEAD
 [1.0.2]: https://github.com/MetaMask/snaps/compare/@metamask/client-status-example-snap@1.0.1...@metamask/client-status-example-snap@1.0.2
 [1.0.1]: https://github.com/MetaMask/snaps/compare/@metamask/client-status-example-snap@1.0.0...@metamask/client-status-example-snap@1.0.1
 [1.0.0]: https://github.com/MetaMask/snaps/releases/tag/@metamask/client-status-example-snap@1.0.0

--- a/packages/examples/packages/client-status/package.json
+++ b/packages/examples/packages/client-status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/client-status-example-snap",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "MetaMask example snap demonstrating the use of `snap_getClientStatus`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "MetaMask example snap demonstrating the use of `snap_getClientStatus`",
   "proposedName": "Client Status Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "fyBeeuYGaIpBnxm6MVoRe19JR+8QiIeFtJM+nlOWnsU=",
+    "shasum": "igAdAUtow5JI5MOgNqhdcqlpBo67XhupsT3Ns8tTbto=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/CHANGELOG.md
+++ b/packages/examples/packages/cronjobs/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.4]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.3]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -55,8 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@2.1.4...HEAD
-[2.1.4]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@2.1.3...@metamask/cronjob-example-snap@2.1.4
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@2.1.3...HEAD
 [2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@2.1.2...@metamask/cronjob-example-snap@2.1.3
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@2.1.1...@metamask/cronjob-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/cronjob-example-snap@2.1.0...@metamask/cronjob-example-snap@2.1.1

--- a/packages/examples/packages/cronjobs/package.json
+++ b/packages/examples/packages/cronjobs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/cronjob-example-snap",
-  "version": "2.1.4",
+  "version": "2.1.3",
   "description": "MetaMask example snap demonstrating the use of cronjobs in snaps.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.4",
+  "version": "2.1.3",
   "description": "MetaMask example snap demonstrating the use of cronjobs in snaps.",
   "proposedName": "Cronjob Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "52lYQY0bh6ZtKx4ZNtQNO17ustuhQBewko/WzQkS68A=",
+    "shasum": "jcA6NL+j9BPrnOiv5FOl+KnTyxAJ5UdThThk4zCoiu8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/CHANGELOG.md
+++ b/packages/examples/packages/dialogs/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.3.1]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.3.0]
 ### Added
 - Add support for fully custom dialogs ([#2526](https://github.com/MetaMask/snaps/pull/2526))
@@ -63,8 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@2.3.1...HEAD
-[2.3.1]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@2.3.0...@metamask/dialog-example-snap@2.3.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@2.3.0...HEAD
 [2.3.0]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@2.2.1...@metamask/dialog-example-snap@2.3.0
 [2.2.1]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@2.2.0...@metamask/dialog-example-snap@2.2.1
 [2.2.0]: https://github.com/MetaMask/snaps/compare/@metamask/dialog-example-snap@2.1.0...@metamask/dialog-example-snap@2.2.0

--- a/packages/examples/packages/dialogs/package.json
+++ b/packages/examples/packages/dialogs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/dialog-example-snap",
-  "version": "2.3.1",
+  "version": "2.3.0",
   "description": "MetaMask example snap demonstrating the use of `snap_dialog`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.1",
+  "version": "2.3.0",
   "description": "MetaMask example snap demonstrating the use of `snap_dialog`.",
   "proposedName": "Dialog Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "v2oIs3UY5j/3dXW5eRh3rg7Tv5qcVzHon7qzPQeRsAE=",
+    "shasum": "P+jpppDqo3e+Dsyk2KP+26NlKDyGwW+CxztRYiDkqnQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/errors/CHANGELOG.md
+++ b/packages/examples/packages/errors/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -54,8 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@2.1.3...HEAD
-[2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@2.1.2...@metamask/error-example-snap@2.1.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@2.1.2...HEAD
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@2.1.1...@metamask/error-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@2.1.0...@metamask/error-example-snap@2.1.1
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/error-example-snap@2.0.1...@metamask/error-example-snap@2.1.0

--- a/packages/examples/packages/errors/package.json
+++ b/packages/examples/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/error-example-snap",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating the use of error handling in snaps.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/errors/snap.manifest.json
+++ b/packages/examples/packages/errors/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating the use of error handling in snaps.",
   "proposedName": "Error Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "yBkP0yx/0fYCe3r3hglrIJJAXuxTgMpCsR0HMJ/KV7o=",
+    "shasum": "6sJsnsPeGr45rdXrBtKhdNhbqBJhatSFzMWHP8gcWQ0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/CHANGELOG.md
+++ b/packages/examples/packages/ethereum-provider/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -54,8 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@2.1.3...HEAD
-[2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@2.1.2...@metamask/ethereum-provider-example-snap@2.1.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@2.1.2...HEAD
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@2.1.1...@metamask/ethereum-provider-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@2.1.0...@metamask/ethereum-provider-example-snap@2.1.1
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/ethereum-provider-example-snap@2.0.1...@metamask/ethereum-provider-example-snap@2.1.0

--- a/packages/examples/packages/ethereum-provider/package.json
+++ b/packages/examples/packages/ethereum-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ethereum-provider-example-snap",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating the use of the Ethereum Provider API and `endowment:ethereum-provider` permission.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating the use of the Ethereum Provider API and `endowment:ethereum-provider` permission.",
   "proposedName": "Ethereum Provider Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "pSiTZjO5nox8zYh+fQtQfZLp5HwbxKByu+WOo+tAAH0=",
+    "shasum": "UjXjIPRsp5mK1VwBQL8eRaGjIX1pW7E+KPMls3BGXRA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/CHANGELOG.md
+++ b/packages/examples/packages/ethers-js/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -54,8 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@2.1.3...HEAD
-[2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@2.1.2...@metamask/ethers-js-example-snap@2.1.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@2.1.2...HEAD
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@2.1.1...@metamask/ethers-js-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@2.1.0...@metamask/ethers-js-example-snap@2.1.1
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/ethers-js-example-snap@2.0.1...@metamask/ethers-js-example-snap@2.1.0

--- a/packages/examples/packages/ethers-js/package.json
+++ b/packages/examples/packages/ethers-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ethers-js-example-snap",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating how to use Ethers.js inside a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating how to use Ethers.js inside a snap.",
   "proposedName": "Ethers.js Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3ec/uMXW2lAaVxSJJRjsAmQ1oSqVJpHUkF4i4YTa9Gk=",
+    "shasum": "ARrlf69swjj7vnhGGRLajr4MFr4hbKbh9G5R987WFoo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/CHANGELOG.md
+++ b/packages/examples/packages/file-upload/CHANGELOG.md
@@ -6,14 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.1]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [1.0.0]
 ### Added
 - Add file input example Snap ([#2469](https://github.com/MetaMask/snaps/pull/2469), [#2494](https://github.com/MetaMask/snaps/pull/2494), [#2504](https://github.com/MetaMask/snaps/pull/2504))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/file-upload-example-snap@1.0.1...HEAD
-[1.0.1]: https://github.com/MetaMask/snaps/compare/@metamask/file-upload-example-snap@1.0.0...@metamask/file-upload-example-snap@1.0.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/file-upload-example-snap@1.0.0...HEAD
 [1.0.0]: https://github.com/MetaMask/snaps/releases/tag/@metamask/file-upload-example-snap@1.0.0

--- a/packages/examples/packages/file-upload/package.json
+++ b/packages/examples/packages/file-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/file-upload-example-snap",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating file inputs and handling file uploads",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "MetaMask example snap demonstrating file inputs and handling file uploads",
   "proposedName": "File Upload Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "z4vMdrs40TdVE+vk7sPruIvWi0q669V+p3jc6WQIib4=",
+    "shasum": "314nMSBFTIeG+Z7RGc9D/FZPRk/vQjaZfzo8rMFMSmY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/CHANGELOG.md
+++ b/packages/examples/packages/get-entropy/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -56,8 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@2.1.3...HEAD
-[2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@2.1.2...@metamask/get-entropy-example-snap@2.1.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@2.1.2...HEAD
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@2.1.1...@metamask/get-entropy-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@2.1.0...@metamask/get-entropy-example-snap@2.1.1
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/get-entropy-example-snap@2.0.1...@metamask/get-entropy-example-snap@2.1.0

--- a/packages/examples/packages/get-entropy/package.json
+++ b/packages/examples/packages/get-entropy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/get-entropy-example-snap",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating the use of `snap_getEntropy`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating the use of `snap_getEntropy`.",
   "proposedName": "Get Entropy Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OYSzxQ1qHApZ2MHWvQ/XYWRwKJptpyVQ5VgyhgFEmmo=",
+    "shasum": "dPssrjujrDEsuDMxogdHlFNJbGtuZjTpwwU5Lirbr6A=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/CHANGELOG.md
+++ b/packages/examples/packages/get-file/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [1.1.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -32,8 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `snap_getFile` example Snap ([#1836](https://github.com/MetaMask/snaps/pull/1836), [#1858](https://github.com/MetaMask/snaps/pull/1858))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/get-file-example-snap@1.1.3...HEAD
-[1.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/get-file-example-snap@1.1.2...@metamask/get-file-example-snap@1.1.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/get-file-example-snap@1.1.2...HEAD
 [1.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/get-file-example-snap@1.1.1...@metamask/get-file-example-snap@1.1.2
 [1.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/get-file-example-snap@1.1.0...@metamask/get-file-example-snap@1.1.1
 [1.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/get-file-example-snap@1.0.1...@metamask/get-file-example-snap@1.1.0

--- a/packages/examples/packages/get-file/package.json
+++ b/packages/examples/packages/get-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/get-file-example-snap",
-  "version": "1.1.3",
+  "version": "1.1.2",
   "description": "MetaMask example snap demonstrating the use of `snap_getFile`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.3",
+  "version": "1.1.2",
   "description": "MetaMask example snap demonstrating the use of `snap_getFile`.",
   "proposedName": "Get File Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "aTuxZCIXcq/FP7XjSoBY4e4pHQbuoDJ1U6FUe/rAfiQ=",
+    "shasum": "z8vSlRUXBdgkLnThLXk0CxPylXp3zeK0MG70lTqyrHc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/CHANGELOG.md
+++ b/packages/examples/packages/home-page/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [1.1.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -28,8 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release ([#1918](https://github.com/MetaMask/snaps/pull/1918))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/home-page-example-snap@1.1.3...HEAD
-[1.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/home-page-example-snap@1.1.2...@metamask/home-page-example-snap@1.1.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/home-page-example-snap@1.1.2...HEAD
 [1.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/home-page-example-snap@1.1.1...@metamask/home-page-example-snap@1.1.2
 [1.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/home-page-example-snap@1.1.0...@metamask/home-page-example-snap@1.1.1
 [1.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/home-page-example-snap@1.0.0...@metamask/home-page-example-snap@1.1.0

--- a/packages/examples/packages/home-page/package.json
+++ b/packages/examples/packages/home-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/home-page-example-snap",
-  "version": "1.1.3",
+  "version": "1.1.2",
   "description": "MetaMask example snap demonstrating the use of home pages.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.3",
+  "version": "1.1.2",
   "description": "MetaMask example snap demonstrating the use of home pages.",
   "proposedName": "Home Page Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "emnlXHvrhsGBMi/y1IPhiQPX9ogHmjmOU/iujBu5GB8=",
+    "shasum": "tOQyZkJPX1hUaoCfBlAV+4vl7Tbt9DcPCquAh84IGP4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/CHANGELOG.md
+++ b/packages/examples/packages/images/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.1]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [1.1.0]
 ### Changed
 - Add example showing how to import and use images ([#2284](https://github.com/MetaMask/snaps/pull/2284))
@@ -19,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add images example Snap ([#2002](https://github.com/MetaMask/snaps/pull/2002))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/images-example-snap@1.1.1...HEAD
-[1.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/images-example-snap@1.1.0...@metamask/images-example-snap@1.1.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/images-example-snap@1.1.0...HEAD
 [1.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/images-example-snap@1.0.0...@metamask/images-example-snap@1.1.0
 [1.0.0]: https://github.com/MetaMask/snaps/releases/tag/@metamask/images-example-snap@1.0.0

--- a/packages/examples/packages/images/package.json
+++ b/packages/examples/packages/images/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/images-example-snap",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "description": "MetaMask example Snap demonstrating how to render images in Snaps UI.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.1",
+  "version": "1.1.0",
   "description": "MetaMask example Snap demonstrating how to render images in Snaps UI.",
   "proposedName": "Images Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "kbuZtLjZiY9+HOtc7DIpuGUjMes2id67dES3Ze/Z3dY=",
+    "shasum": "lNV3t5b0qgpl6fMuTUdFA75wWL3zFzm3MvEokB8VF5U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/CHANGELOG.md
+++ b/packages/examples/packages/interactive-ui/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.2.1]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.2.0]
 ### Added
 - Add `RadioGroup` to interactive UI example ([#2592](https://github.com/MetaMask/snaps/pull/2592))
@@ -35,8 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add interactive UI example Snap ([#2171](https://github.com/MetaMask/snaps/pull/2171))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/interactive-ui-example-snap@2.2.1...HEAD
-[2.2.1]: https://github.com/MetaMask/snaps/compare/@metamask/interactive-ui-example-snap@2.2.0...@metamask/interactive-ui-example-snap@2.2.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/interactive-ui-example-snap@2.2.0...HEAD
 [2.2.0]: https://github.com/MetaMask/snaps/compare/@metamask/interactive-ui-example-snap@2.1.0...@metamask/interactive-ui-example-snap@2.2.0
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/interactive-ui-example-snap@2.0.0...@metamask/interactive-ui-example-snap@2.1.0
 [2.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/interactive-ui-example-snap@1.0.2...@metamask/interactive-ui-example-snap@2.0.0

--- a/packages/examples/packages/interactive-ui/package.json
+++ b/packages/examples/packages/interactive-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/interactive-ui-example-snap",
-  "version": "2.2.1",
+  "version": "2.2.0",
   "description": "MetaMask example snap demonstrating the use of interactive UI.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.1",
+  "version": "2.2.0",
   "description": "MetaMask example snap demonstrating the use of interactive UI",
   "proposedName": "Interactive UI Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "uOuMArCEwmOmCl0Bl1WnRRm+DKcq0Y+O+5n8Z1KBMr8=",
+    "shasum": "QIFPu6VwYTRWVGIS5fHeoOWuV7RxLhn7wYFtrcc5pKM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/package.json
+++ b/packages/examples/packages/invoke-snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/invoke-snap-example-snap",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "private": true,
   "description": "MetaMask example snaps demonstrating the use of `wallet_invokeSnap` to call a snap from another snap.",
   "repository": {

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/CHANGELOG.md
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -54,8 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@2.1.3...HEAD
-[2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@2.1.2...@metamask/consumer-signer-example-snap@2.1.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@2.1.2...HEAD
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@2.1.1...@metamask/consumer-signer-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@2.1.0...@metamask/consumer-signer-example-snap@2.1.1
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/consumer-signer-example-snap@2.0.1...@metamask/consumer-signer-example-snap@2.1.0

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/consumer-signer-example-snap",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
   "proposedName": "Consumer Signer Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "/u819uX9E/KqrWqvlPDhZjkKs/ylbrPwtJxiMob7VI8=",
+    "shasum": "NEGArtJf6+X6DHqr3WyxoQCVhGEEAhqcoRUGKNqgKn0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/CHANGELOG.md
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -56,8 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@2.1.3...HEAD
-[2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@2.1.2...@metamask/core-signer-example-snap@2.1.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@2.1.2...HEAD
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@2.1.1...@metamask/core-signer-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@2.1.0...@metamask/core-signer-example-snap@2.1.1
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/core-signer-example-snap@2.0.1...@metamask/core-signer-example-snap@2.1.0

--- a/packages/examples/packages/invoke-snap/packages/core-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-signer-example-snap",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
   "proposedName": "Core Signer Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "EMv6OrPDoNKIb8YjY5cbjumuwN8Oz3x6ASB1AODM/jM=",
+    "shasum": "nBYyvFGnEv4kGTgEAvmhbfAafd85Z1dxbQTczGahxvA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/CHANGELOG.md
+++ b/packages/examples/packages/json-rpc/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -46,8 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@2.1.3...HEAD
-[2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@2.1.2...@metamask/json-rpc-example-snap@2.1.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@2.1.2...HEAD
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@2.1.1...@metamask/json-rpc-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@2.1.0...@metamask/json-rpc-example-snap@2.1.1
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/json-rpc-example-snap@2.0.1...@metamask/json-rpc-example-snap@2.1.0

--- a/packages/examples/packages/json-rpc/package.json
+++ b/packages/examples/packages/json-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/json-rpc-example-snap",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating the use of the `endowment:rpc` permission.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "An example snap to test JSON-RPC permissions.",
   "proposedName": "JSON-RPC Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "loHXuvuW/Zb4kMSSdekMiV20UVtxXYyoDC0iRZbV274=",
+    "shasum": "yDlo/WglB5Cvdeqx9JDwRm/iIiE6TiOpoIkITW2kCzk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/CHANGELOG.md
+++ b/packages/examples/packages/jsx/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.1]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [1.2.0]
 ### Added
 - Made JSX example use Card component ([#2665](https://github.com/MetaMask/snaps/pull/2665))
@@ -26,8 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add JSX example Snap ([#2258](https://github.com/MetaMask/snaps/pull/2258))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/jsx-example-snap@1.2.1...HEAD
-[1.2.1]: https://github.com/MetaMask/snaps/compare/@metamask/jsx-example-snap@1.2.0...@metamask/jsx-example-snap@1.2.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/jsx-example-snap@1.2.0...HEAD
 [1.2.0]: https://github.com/MetaMask/snaps/compare/@metamask/jsx-example-snap@1.1.1...@metamask/jsx-example-snap@1.2.0
 [1.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/jsx-example-snap@1.1.0...@metamask/jsx-example-snap@1.1.1
 [1.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/jsx-example-snap@1.0.0...@metamask/jsx-example-snap@1.1.0

--- a/packages/examples/packages/jsx/package.json
+++ b/packages/examples/packages/jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/jsx-example-snap",
-  "version": "1.2.1",
+  "version": "1.2.0",
   "description": "MetaMask example snap demonstrating the use of JSX for UI components.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.1",
+  "version": "1.2.0",
   "description": "MetaMask example snap demonstrating the use of JSX for UI components.",
   "proposedName": "JSX Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3U9+Lvmmdc9JRmaHLcwGgi9lpnaj25joBF9+zXY4644=",
+    "shasum": "HP/m3FdQ1hzjaQMMPLCLGwY1pxwth35ZyLolPC7PyOE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
+++ b/packages/examples/packages/lifecycle-hooks/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -45,8 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add lifecycle hooks example snap ([#1645](https://github.com/MetaMask/snaps/pull/1645))
   - This snap demonstrates how to use the `onInstall` and `onUpdate` lifecycle hooks.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@2.1.3...HEAD
-[2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@2.1.2...@metamask/lifecycle-hooks-example-snap@2.1.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@2.1.2...HEAD
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@2.1.1...@metamask/lifecycle-hooks-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@2.1.0...@metamask/lifecycle-hooks-example-snap@2.1.1
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/lifecycle-hooks-example-snap@2.0.1...@metamask/lifecycle-hooks-example-snap@2.1.0

--- a/packages/examples/packages/lifecycle-hooks/package.json
+++ b/packages/examples/packages/lifecycle-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/lifecycle-hooks-example-snap",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating the use of the `onInstall` and `onUpdate` lifecycle hooks.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating the use of the `onInstall` and `onUpdate` lifecycle hooks.",
   "proposedName": "Lifecycle Hooks Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TSu0FIqVXvJG6WzqtKPx5kN2fjveQ8EypKCk/jAShmM=",
+    "shasum": "Mgf0SLyA7yvGJ3+3y8f/Nf2GuMUzLHt4zRj8ZwVoC08=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/CHANGELOG.md
+++ b/packages/examples/packages/localization/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.4]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [1.1.3]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -35,8 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release ([#1889](https://github.com/MetaMask/snaps/pull/1889))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/localization-example-snap@1.1.4...HEAD
-[1.1.4]: https://github.com/MetaMask/snaps/compare/@metamask/localization-example-snap@1.1.3...@metamask/localization-example-snap@1.1.4
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/localization-example-snap@1.1.3...HEAD
 [1.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/localization-example-snap@1.1.2...@metamask/localization-example-snap@1.1.3
 [1.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/localization-example-snap@1.1.1...@metamask/localization-example-snap@1.1.2
 [1.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/localization-example-snap@1.1.0...@metamask/localization-example-snap@1.1.1

--- a/packages/examples/packages/localization/package.json
+++ b/packages/examples/packages/localization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/localization-example-snap",
-  "version": "1.1.4",
+  "version": "1.1.3",
   "description": "MetaMask example snap demonstrating how to localize a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.3",
   "description": "{{ description }}",
   "proposedName": "{{ name }}",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "KHrWdamfUEJ10ak4/oE/C4/oTO9BRnLSLjOiS9RFlHw=",
+    "shasum": "k/mLclt6BlGiW6jEiOMBRrlrIaZ5L4fwuz8/48PdQ7s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/CHANGELOG.md
+++ b/packages/examples/packages/manage-state/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.2.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.2.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -60,8 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@2.2.3...HEAD
-[2.2.3]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@2.2.2...@metamask/manage-state-example-snap@2.2.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@2.2.2...HEAD
 [2.2.2]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@2.2.1...@metamask/manage-state-example-snap@2.2.2
 [2.2.1]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@2.2.0...@metamask/manage-state-example-snap@2.2.1
 [2.2.0]: https://github.com/MetaMask/snaps/compare/@metamask/manage-state-example-snap@2.1.0...@metamask/manage-state-example-snap@2.2.0

--- a/packages/examples/packages/manage-state/package.json
+++ b/packages/examples/packages/manage-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/manage-state-example-snap",
-  "version": "2.2.3",
+  "version": "2.2.2",
   "description": "MetaMask example snap demonstrating the use of `snap_manageState`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.3",
+  "version": "2.2.2",
   "description": "MetaMask example snap demonstrating the use of `snap_manageState`.",
   "proposedName": "Manage State Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5FNiUEpsrVxG3rTbJvhx/IBZ/jIYYu0ZbnCX9A6dAPE=",
+    "shasum": "saGtVCiivJDm47hobzzC6Z7jFLXYu94N3hUPn+WEu9A=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/name-lookup/CHANGELOG.md
+++ b/packages/examples/packages/name-lookup/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.1.1]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [3.1.0]
 ### Changed
 - Update `onNameLookup` response to include `domainName` ([#2484](https://github.com/MetaMask/snaps/pull/2484))
@@ -45,8 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add name lookup example snap ([#1768](https://github.com/MetaMask/snaps/pull/1768), [#1754](https://github.com/MetaMask/snaps/pull/1754))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/name-lookup-example-snap@3.1.1...HEAD
-[3.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/name-lookup-example-snap@3.1.0...@metamask/name-lookup-example-snap@3.1.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/name-lookup-example-snap@3.1.0...HEAD
 [3.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/name-lookup-example-snap@3.0.2...@metamask/name-lookup-example-snap@3.1.0
 [3.0.2]: https://github.com/MetaMask/snaps/compare/@metamask/name-lookup-example-snap@3.0.1...@metamask/name-lookup-example-snap@3.0.2
 [3.0.1]: https://github.com/MetaMask/snaps/compare/@metamask/name-lookup-example-snap@3.0.0...@metamask/name-lookup-example-snap@3.0.1

--- a/packages/examples/packages/name-lookup/package.json
+++ b/packages/examples/packages/name-lookup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/name-lookup-example-snap",
-  "version": "3.1.1",
+  "version": "3.1.0",
   "description": "MetaMask example snap demonstrating the use of the `endowment:name-lookup` permission.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/name-lookup/snap.manifest.json
+++ b/packages/examples/packages/name-lookup/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.1.1",
+  "version": "3.1.0",
   "description": "MetaMask example snap demonstrating the use of the `endowment:name-lookup` permission.",
   "proposedName": "Name Lookup Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xk7O5itVsuV3Dfldq3rI3WgggHa3z7HX7e17jzheE8w=",
+    "shasum": "NiLwtU8hXtIh2Z53Zf8PiuRasUjJolMfEB+dMAUfxqk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/CHANGELOG.md
+++ b/packages/examples/packages/network-access/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -58,8 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@2.1.3...HEAD
-[2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@2.1.2...@metamask/network-example-snap@2.1.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@2.1.2...HEAD
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@2.1.1...@metamask/network-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@2.1.0...@metamask/network-example-snap@2.1.1
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/network-example-snap@2.0.1...@metamask/network-example-snap@2.1.0

--- a/packages/examples/packages/network-access/package.json
+++ b/packages/examples/packages/network-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/network-example-snap",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating the use of the `endowment:network-access` permission in snaps.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating the use of the `endowment:network-access` permission in snaps.",
   "proposedName": "Network Access Test Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+V4EDf0266FOJDTVrhQ91ZaycBruUesJqSoAzohWnO0=",
+    "shasum": "Vrn0u7Fn353VA0BJgRb7y/hvwYxbZLHO63Y1wytPC8g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/CHANGELOG.md
+++ b/packages/examples/packages/notifications/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.4]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.3]
 ### Fixed
 - Fix native notifications not working reliably ([#2310](https://github.com/MetaMask/snaps/pull/2310))
@@ -60,8 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@2.1.4...HEAD
-[2.1.4]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@2.1.3...@metamask/notification-example-snap@2.1.4
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@2.1.3...HEAD
 [2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@2.1.2...@metamask/notification-example-snap@2.1.3
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@2.1.1...@metamask/notification-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/notification-example-snap@2.1.0...@metamask/notification-example-snap@2.1.1

--- a/packages/examples/packages/notifications/package.json
+++ b/packages/examples/packages/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/notification-example-snap",
-  "version": "2.1.4",
+  "version": "2.1.3",
   "description": "MetaMask example snap demonstrating the use of `snap_notify`.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.4",
+  "version": "2.1.3",
   "description": "MetaMask example snap demonstrating the use of `snap_notify`.",
   "proposedName": "Notifications Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "S3wZGdkOLX7tdJYssmy+UxBXe+VuwZaNUQNqK+G3hu4=",
+    "shasum": "I7oitI3EFjnd0V8Gv9Cmcp53Vbx5d2KJxMpRC7iOmyY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/CHANGELOG.md
+++ b/packages/examples/packages/rollup-plugin/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -46,8 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/rollup-plugin-example-snap@2.1.3...HEAD
-[2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/rollup-plugin-example-snap@2.1.2...@metamask/rollup-plugin-example-snap@2.1.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/rollup-plugin-example-snap@2.1.2...HEAD
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/rollup-plugin-example-snap@2.1.1...@metamask/rollup-plugin-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/rollup-plugin-example-snap@2.1.0...@metamask/rollup-plugin-example-snap@2.1.1
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/rollup-plugin-example-snap@2.0.1...@metamask/rollup-plugin-example-snap@2.1.0

--- a/packages/examples/packages/rollup-plugin/package.json
+++ b/packages/examples/packages/rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/rollup-plugin-example-snap",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating how to use the Rollup plugin to bundle a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating how to use the Rollup plugin to bundle a snap.",
   "proposedName": "Rollup Plugin Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FvkhD/R3iN0i/0P4OTlD0rPX+697OZ0a5kns8T669Jk=",
+    "shasum": "Oe6qk8RKXcAG9EU/rPVLq8p14YgP9yOv+dWFEleGHaI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/CHANGELOG.md
+++ b/packages/examples/packages/signature-insights/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [1.0.2]
 ### Changed
 - Re-release after multiple changes in the monorepo ([#2295](https://github.com/MetaMask/snaps/pull/2295))
@@ -22,8 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add signature insights example ([#2114](https://github.com/MetaMask/snaps/pull/2079))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/signature-insights-example-snap@1.0.3...HEAD
-[1.0.3]: https://github.com/MetaMask/snaps/compare/@metamask/signature-insights-example-snap@1.0.2...@metamask/signature-insights-example-snap@1.0.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/signature-insights-example-snap@1.0.2...HEAD
 [1.0.2]: https://github.com/MetaMask/snaps/compare/@metamask/signature-insights-example-snap@1.0.1...@metamask/signature-insights-example-snap@1.0.2
 [1.0.1]: https://github.com/MetaMask/snaps/compare/@metamask/signature-insights-example-snap@1.0.0...@metamask/signature-insights-example-snap@1.0.1
 [1.0.0]: https://github.com/MetaMask/snaps/releases/tag/@metamask/signature-insights-example-snap@1.0.0

--- a/packages/examples/packages/signature-insights/package.json
+++ b/packages/examples/packages/signature-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/signature-insights-example-snap",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "MetaMask example snap demonstrating the use of the Signature Insights API.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "MetaMask example snap demonstrating the use of the Signature Insights API.",
   "proposedName": "Signature Insights Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vmG4CkJldpjtLV4k1d4vQAPcZXeXlDYVj5cODyu6CLE=",
+    "shasum": "DdjMLFOqo+SfRA4nNJflLvSX3v/IwM23QtjPYzOLG1o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/CHANGELOG.md
+++ b/packages/examples/packages/transaction-insights/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.2.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.2.2]
 ### Fixed
 - Fix address validation in row component ([#2257](https://github.com/MetaMask/snaps/pull/2257))
@@ -64,8 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@2.2.3...HEAD
-[2.2.3]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@2.2.2...@metamask/insights-example-snap@2.2.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@2.2.2...HEAD
 [2.2.2]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@2.2.1...@metamask/insights-example-snap@2.2.2
 [2.2.1]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@2.2.0...@metamask/insights-example-snap@2.2.1
 [2.2.0]: https://github.com/MetaMask/snaps/compare/@metamask/insights-example-snap@2.1.0...@metamask/insights-example-snap@2.2.0

--- a/packages/examples/packages/transaction-insights/package.json
+++ b/packages/examples/packages/transaction-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/insights-example-snap",
-  "version": "2.2.3",
+  "version": "2.2.2",
   "description": "MetaMask example snap demonstrating the use of the Transaction Insights API.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.3",
+  "version": "2.2.2",
   "description": "MetaMask example snap demonstrating the use of the Transaction Insights API.",
   "proposedName": "Insights Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "oKKYF+AERJAyRBABHRf4nsfQ6IrhKele+Fei+JXxGzA=",
+    "shasum": "psh5WYTtiqN1PD18OI3JLmBiMFuo8Uw0V56yiBMVZ4M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/CHANGELOG.md
+++ b/packages/examples/packages/wasm/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.4]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.3]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -50,8 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@2.1.4...HEAD
-[2.1.4]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@2.1.3...@metamask/wasm-example-snap@2.1.4
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@2.1.3...HEAD
 [2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@2.1.2...@metamask/wasm-example-snap@2.1.3
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@2.1.1...@metamask/wasm-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/wasm-example-snap@2.1.0...@metamask/wasm-example-snap@2.1.1

--- a/packages/examples/packages/wasm/package.json
+++ b/packages/examples/packages/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/wasm-example-snap",
-  "version": "2.1.4",
+  "version": "2.1.3",
   "description": "MetaMask example snap demonstrating the use of WebAssembly and the `endowment:webassembly` permission.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.4",
+  "version": "2.1.3",
   "description": "MetaMask example snap demonstrating the use of WebAssembly and the `endowment:webassembly` permission.",
   "proposedName": "WebAssembly Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "rNBULIRBi45r+MXpWUNwkSaWog2pNTfG5VYKZ676w6g=",
+    "shasum": "1G7IG92NOe39Qcwed55/zGCaez0SKpR0ScihXdWZz5s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/CHANGELOG.md
+++ b/packages/examples/packages/webpack-plugin/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.3]
-### Fixed
-- Bump MetaMask dependencies
-
 ## [2.1.2]
 ### Changed
 - Use error wrappers ([#2178](https://github.com/MetaMask/snaps/pull/2178))
@@ -46,8 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@2.1.3...HEAD
-[2.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@2.1.2...@metamask/webpack-plugin-example-snap@2.1.3
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@2.1.2...HEAD
 [2.1.2]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@2.1.1...@metamask/webpack-plugin-example-snap@2.1.2
 [2.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@2.1.0...@metamask/webpack-plugin-example-snap@2.1.1
 [2.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/webpack-plugin-example-snap@2.0.1...@metamask/webpack-plugin-example-snap@2.1.0

--- a/packages/examples/packages/webpack-plugin/package.json
+++ b/packages/examples/packages/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/webpack-plugin-example-snap",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating how to use the Webpack plugin to bundle a snap.",
   "repository": {
     "type": "git",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "MetaMask example snap demonstrating how to use the Webpack plugin to bundle a snap.",
   "proposedName": "Webpack Plugin Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "YvikqvHw0838qOaBrqjfegOyMSFM4ZwdyOH2qXode5M=",
+    "shasum": "uVDLdocB0sDfvyV0zieKT53u9irH18ZynErd8QYWL+U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-browserify-plugin/CHANGELOG.md
+++ b/packages/snaps-browserify-plugin/CHANGELOG.md
@@ -6,12 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.1.1]
-### Fixed
-- Fix ESM version of the package ([#2682](https://github.com/MetaMask/snaps/pull/2682))
-  - This fixes the ESM version of the package to be fully compliant with the ESM
-    standard.
-
 ## [4.1.0]
 ### Changed
 - Improve manifest validation output ([#2572](https://github.com/MetaMask/snaps/pull/2572))
@@ -54,8 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@4.1.1...HEAD
-[4.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@4.1.0...@metamask/snaps-browserify-plugin@4.1.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@4.1.0...HEAD
 [4.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@4.0.1...@metamask/snaps-browserify-plugin@4.1.0
 [4.0.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@4.0.0...@metamask/snaps-browserify-plugin@4.0.1
 [4.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-browserify-plugin@3.0.3...@metamask/snaps-browserify-plugin@4.0.0

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-browserify-plugin",
-  "version": "4.1.1",
+  "version": "4.1.0",
   "keywords": [
     "browserify-plugin"
   ],

--- a/packages/snaps-cli/CHANGELOG.md
+++ b/packages/snaps-cli/CHANGELOG.md
@@ -6,13 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [6.3.2]
-### Fixed
-- Fix ESM version of the package ([#2682](https://github.com/MetaMask/snaps/pull/2682))
-  - This fixes the ESM version of the package to be fully compliant with the ESM
-    standard.
-- Bump `@metamask/utils` from `^9.1.0` to `^9.2.1` ([#2680](https://github.com/MetaMask/snaps/pull/2680))
-
 ## [6.3.1]
 ### Fixed
 - Hide browserlist warning where applicable ([#2664](https://github.com/MetaMask/snaps/pull/2664))
@@ -177,8 +170,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@6.3.2...HEAD
-[6.3.2]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@6.3.1...@metamask/snaps-cli@6.3.2
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@6.3.1...HEAD
 [6.3.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@6.3.0...@metamask/snaps-cli@6.3.1
 [6.3.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@6.2.1...@metamask/snaps-cli@6.3.0
 [6.2.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-cli@6.2.0...@metamask/snaps-cli@6.2.1

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-cli",
-  "version": "6.3.2",
+  "version": "6.3.1",
   "description": "A CLI for developing MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-controllers/CHANGELOG.md
+++ b/packages/snaps-controllers/CHANGELOG.md
@@ -6,17 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [9.6.0]
-### Added
-- Add `stopAllSnaps` function to `SnapController` ([#2674](https://github.com/MetaMask/snaps/pull/2674))
-
-### Fixed
-- Fix ESM version of the package ([#2682](https://github.com/MetaMask/snaps/pull/2682))
-  - This fixes the ESM version of the package to be fully compliant with the ESM
-    standard.
-- Bump `@metamask/utils` from `^9.1.0` to `^9.2.1` ([#2680](https://github.com/MetaMask/snaps/pull/2680))
-- Bump other MetaMask dependencies ([#2703](https://github.com/MetaMask/snaps/pull/2703))
-
 ## [9.5.0]
 ### Added
 - Add `Selector` component ([#2645](https://github.com/MetaMask/snaps/pull/2645))
@@ -367,8 +356,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@9.6.0...HEAD
-[9.6.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@9.5.0...@metamask/snaps-controllers@9.6.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@9.5.0...HEAD
 [9.5.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@9.4.0...@metamask/snaps-controllers@9.5.0
 [9.4.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@9.3.1...@metamask/snaps-controllers@9.4.0
 [9.3.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@9.3.0...@metamask/snaps-controllers@9.3.1

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-controllers",
-  "version": "9.6.0",
+  "version": "9.5.0",
   "description": "Controllers for MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-execution-environments/CHANGELOG.md
+++ b/packages/snaps-execution-environments/CHANGELOG.md
@@ -6,17 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [6.7.0]
-### Changed
-- Unblock `wallet_requestSnaps` ([#2661](https://github.com/MetaMask/snaps/pull/2661))
-
-### Fixed
-- Fix ESM version of the package ([#2682](https://github.com/MetaMask/snaps/pull/2682))
-  - This fixes the ESM version of the package to be fully compliant with the ESM
-    standard.
-- Bump `@metamask/utils` from `^9.1.0` to `^9.2.1` ([#2680](https://github.com/MetaMask/snaps/pull/2680))
-- Bump other MetaMask dependencies ([#2703](https://github.com/MetaMask/snaps/pull/2703))
-
 ## [6.6.2]
 ### Changed
 - Bump `@metamask/json-rpc-engine` from `^9.0.0` to `^9.0.2` ([#2593](https://github.com/metamask/snaps/pull/2593))
@@ -251,8 +240,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@6.7.0...HEAD
-[6.7.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@6.6.2...@metamask/snaps-execution-environments@6.7.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@6.6.2...HEAD
 [6.6.2]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@6.6.1...@metamask/snaps-execution-environments@6.6.2
 [6.6.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@6.6.0...@metamask/snaps-execution-environments@6.6.1
 [6.6.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-execution-environments@6.5.0...@metamask/snaps-execution-environments@6.6.0

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-execution-environments",
-  "version": "6.7.0",
+  "version": "6.6.2",
   "description": "Snap sandbox environments for executing SES javascript",
   "repository": {
     "type": "git",

--- a/packages/snaps-jest/CHANGELOG.md
+++ b/packages/snaps-jest/CHANGELOG.md
@@ -6,14 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [8.3.1]
-### Fixed
-- Fix ESM version of the package ([#2682](https://github.com/MetaMask/snaps/pull/2682))
-  - This fixes the ESM version of the package to be fully compliant with the ESM
-    standard.
-- Bump `@metamask/utils` from `^9.1.0` to `^9.2.1` ([#2680](https://github.com/MetaMask/snaps/pull/2680))
-- Bump other MetaMask dependencies ([#2703](https://github.com/MetaMask/snaps/pull/2703))
-
 ## [8.3.0]
 ### Added
 - Add support for `snap_getPreferences` ([#2607](https://github.com/MetaMask/snaps/pull/2607))
@@ -189,8 +181,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@8.3.1...HEAD
-[8.3.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@8.3.0...@metamask/snaps-jest@8.3.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@8.3.0...HEAD
 [8.3.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@8.2.0...@metamask/snaps-jest@8.3.0
 [8.2.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@8.1.3...@metamask/snaps-jest@8.2.0
 [8.1.3]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-jest@8.1.2...@metamask/snaps-jest@8.1.3

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-jest",
-  "version": "8.3.1",
+  "version": "8.3.0",
   "description": "A Jest preset for end-to-end testing MetaMask Snaps, including a Jest environment, and a set of Jest matchers.",
   "sideEffects": false,
   "exports": {

--- a/packages/snaps-rollup-plugin/CHANGELOG.md
+++ b/packages/snaps-rollup-plugin/CHANGELOG.md
@@ -6,12 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.1.1]
-### Fixed
-- Fix ESM version of the package ([#2682](https://github.com/MetaMask/snaps/pull/2682))
-  - This fixes the ESM version of the package to be fully compliant with the ESM
-    standard.
-
 ## [4.1.0]
 ### Changed
 - Improve manifest validation output ([#2572](https://github.com/MetaMask/snaps/pull/2572))
@@ -50,8 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@4.1.1...HEAD
-[4.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@4.1.0...@metamask/snaps-rollup-plugin@4.1.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@4.1.0...HEAD
 [4.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@4.0.1...@metamask/snaps-rollup-plugin@4.1.0
 [4.0.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@4.0.0...@metamask/snaps-rollup-plugin@4.0.1
 [4.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rollup-plugin@3.0.2...@metamask/snaps-rollup-plugin@4.0.0

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-rollup-plugin",
-  "version": "4.1.1",
+  "version": "4.1.0",
   "keywords": [
     "rollup",
     "rollup-plugin"

--- a/packages/snaps-rpc-methods/CHANGELOG.md
+++ b/packages/snaps-rpc-methods/CHANGELOG.md
@@ -6,18 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.1.0]
-### Changed
-- Improve error messaging ([#2696](https://github.com/MetaMask/snaps/pull/2696))
-- Increase character limit for in-app notification messages ([#2684](https://github.com/MetaMask/snaps/pull/2684))
-
-### Fixed
-- Fix ESM version of the package ([#2682](https://github.com/MetaMask/snaps/pull/2682))
-  - This fixes the ESM version of the package to be fully compliant with the ESM
-    standard.
-- Bump `@metamask/utils` from `^9.1.0` to `^9.2.1` ([#2680](https://github.com/MetaMask/snaps/pull/2680))
-- Bump other MetaMask dependencies ([#2703](https://github.com/MetaMask/snaps/pull/2703))
-
 ## [11.0.0]
 ### Added
 - **BREAKING:** Add `snap_getPreferences` ([#2607](https://github.com/MetaMask/snaps/pull/2607))
@@ -201,8 +189,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rpc-methods@11.1.0...HEAD
-[11.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rpc-methods@11.0.0...@metamask/snaps-rpc-methods@11.1.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rpc-methods@11.0.0...HEAD
 [11.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rpc-methods@10.0.1...@metamask/snaps-rpc-methods@11.0.0
 [10.0.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rpc-methods@10.0.0...@metamask/snaps-rpc-methods@10.0.1
 [10.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-rpc-methods@9.1.4...@metamask/snaps-rpc-methods@10.0.0

--- a/packages/snaps-rpc-methods/package.json
+++ b/packages/snaps-rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-rpc-methods",
-  "version": "11.1.0",
+  "version": "11.0.0",
   "description": "MetaMask Snaps JSON-RPC method implementations.",
   "repository": {
     "type": "git",

--- a/packages/snaps-sdk/CHANGELOG.md
+++ b/packages/snaps-sdk/CHANGELOG.md
@@ -6,24 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [6.4.0]
-### Added
-- Add `Section` component ([#2672](https://github.com/MetaMask/snaps/pull/2672))
-- Add support for element before input in the `Field` component ([#2699](https://github.com/MetaMask/snaps/pull/2699))
-
-### Changed
-- Allow CAIP-10 addresses in the `Address` component ([#2680](https://github.com/MetaMask/snaps/pull/2680))
-- Improve error messaging ([#2696](https://github.com/MetaMask/snaps/pull/2696), [#2693](https://github.com/MetaMask/snaps/pull/2693))
-
-### Fixed
-- Allow any element as the child of the `Container` component ([#2698](https://github.com/MetaMask/snaps/pull/2698))
-- Disallow images and icons in footers ([#2676](https://github.com/MetaMask/snaps/pull/2676))
-- Fix ESM version of the package ([#2682](https://github.com/MetaMask/snaps/pull/2682))
-  - This fixes the ESM version of the package to be fully compliant with the ESM
-    standard.
-- Bump `@metamask/utils` from `^9.1.0` to `^9.2.1` ([#2680](https://github.com/MetaMask/snaps/pull/2680))
-- Bump other MetaMask dependencies ([#2703](https://github.com/MetaMask/snaps/pull/2703))
-
 ## [6.3.0]
 ### Added
 - Add `Selector` component ([#2645](https://github.com/MetaMask/snaps/pull/2645))
@@ -242,8 +224,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release of this package.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-sdk@6.4.0...HEAD
-[6.4.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-sdk@6.3.0...@metamask/snaps-sdk@6.4.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-sdk@6.3.0...HEAD
 [6.3.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-sdk@6.2.1...@metamask/snaps-sdk@6.3.0
 [6.2.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-sdk@6.2.0...@metamask/snaps-sdk@6.2.1
 [6.2.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-sdk@6.1.1...@metamask/snaps-sdk@6.2.0

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-sdk",
-  "version": "6.4.0",
+  "version": "6.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-utils/CHANGELOG.md
+++ b/packages/snaps-utils/CHANGELOG.md
@@ -6,20 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [8.1.0]
-### Added
-- Add Bitcoin Taproot derivation paths ([#2695](https://github.com/MetaMask/snaps/pull/2695))
-
-### Changed
-- Improve `validateLink` error handling ([#2702](https://github.com/MetaMask/snaps/pull/2702))
-
-### Fixed
-- Fix ESM version of the package ([#2682](https://github.com/MetaMask/snaps/pull/2682))
-  - This fixes the ESM version of the package to be fully compliant with the ESM
-    standard.
-- Bump `@metamask/utils` from `^9.1.0` to `^9.2.1` ([#2680](https://github.com/MetaMask/snaps/pull/2680))
-- Bump other MetaMask dependencies ([#2703](https://github.com/MetaMask/snaps/pull/2703))
-
 ## [8.0.1]
 ### Changed
 - Bump `@metamask/slip44` to 4.0.0 ([#2624](https://github.com/MetaMask/snaps/pull/2624))
@@ -311,8 +297,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@8.1.0...HEAD
-[8.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@8.0.1...@metamask/snaps-utils@8.1.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@8.0.1...HEAD
 [8.0.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@8.0.0...@metamask/snaps-utils@8.0.1
 [8.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@7.8.1...@metamask/snaps-utils@8.0.0
 [7.8.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-utils@7.8.0...@metamask/snaps-utils@7.8.1

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-utils",
-  "version": "8.1.0",
+  "version": "8.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-webpack-plugin/CHANGELOG.md
+++ b/packages/snaps-webpack-plugin/CHANGELOG.md
@@ -6,13 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.1.1]
-### Fixed
-- Fix ESM version of the package ([#2682](https://github.com/MetaMask/snaps/pull/2682))
-  - This fixes the ESM version of the package to be fully compliant with the ESM
-    standard.
-- Bump `@metamask/utils` from `^9.1.0` to `^9.2.1` ([#2680](https://github.com/MetaMask/snaps/pull/2680))
-
 ## [4.1.0]
 ### Changed
 - Improve manifest validation output ([#2572](https://github.com/MetaMask/snaps/pull/2572), [#2605](https://github.com/MetaMask/snaps/pull/2605))
@@ -73,8 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@4.1.1...HEAD
-[4.1.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@4.1.0...@metamask/snaps-webpack-plugin@4.1.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@4.1.0...HEAD
 [4.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@4.0.1...@metamask/snaps-webpack-plugin@4.1.0
 [4.0.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@4.0.0...@metamask/snaps-webpack-plugin@4.0.1
 [4.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-webpack-plugin@3.2.0...@metamask/snaps-webpack-plugin@4.0.0

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-webpack-plugin",
-  "version": "4.1.1",
+  "version": "4.1.0",
   "keywords": [
     "webpack",
     "plugin"

--- a/packages/test-snaps/CHANGELOG.md
+++ b/packages/test-snaps/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.13.1]
-### Changed
-- Use latest versions of example Snaps ([#2705](https://github.com/MetaMask/snaps/pull/2705))
-
 ## [2.13.0]
 ### Changed
 - Use latest versions of example Snaps ([#2670](https://github.com/MetaMask/snaps/pull/2670))
@@ -142,8 +138,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix NPM package name of the network access snap ([#1621](https://github.com/MetaMask/snaps/pull/1621))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@2.13.1...HEAD
-[2.13.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@2.13.0...@metamask/test-snaps@2.13.1
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@2.13.0...HEAD
 [2.13.0]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@2.12.0...@metamask/test-snaps@2.13.0
 [2.12.0]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@2.11.0...@metamask/test-snaps@2.12.0
 [2.11.0]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@2.10.0...@metamask/test-snaps@2.11.0

--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-snaps",
-  "version": "2.13.1",
+  "version": "2.13.0",
   "private": true,
   "description": "The test snaps website for MetaMask Snaps, used for end-to-end testing.",
   "repository": {


### PR DESCRIPTION
This reverts commit 452dfe643fb5559ac8ca57e6b65e337429b9d9b8.

The release failed because of an issue with the NPM publish workflow.