### PR TITLE
feat: add `hideHeader` flag for preinstalled Snaps

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -5097,6 +5097,45 @@ describe('SnapController', () => {
       snapController.destroy();
     });
 
+    it('supports preinstalled Snaps specifying the hideHeader flag', async () => {
+      const rootMessenger = getControllerMessenger();
+      jest.spyOn(rootMessenger, 'call');
+
+      // The snap should not have permission initially
+      rootMessenger.registerActionHandler(
+        'PermissionController:getPermissions',
+        () => ({}),
+      );
+
+      const preinstalledSnaps = [
+        {
+          snapId: MOCK_SNAP_ID,
+          manifest: getSnapManifest(),
+          hideHeader: true,
+          files: [
+            {
+              path: DEFAULT_SOURCE_PATH,
+              value: stringToBytes(DEFAULT_SNAP_BUNDLE),
+            },
+            {
+              path: DEFAULT_ICON_PATH,
+              value: stringToBytes(DEFAULT_SNAP_ICON),
+            },
+          ],
+        },
+      ];
+
+      const snapControllerOptions = getSnapControllerWithEESOptions({
+        preinstalledSnaps,
+        rootMessenger,
+      });
+      const [snapController] = getSnapControllerWithEES(snapControllerOptions);
+
+      expect(snapController.get(MOCK_SNAP_ID)?.hideHeader).toBe(true);
+
+      snapController.destroy();
+    });
+
     it('authorizes permissions needed for snaps', async () => {
       const manifest = getSnapManifest();
       const rootMessenger = getControllerMessenger();

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -182,6 +182,7 @@ export interface PreinstalledSnap {
   files: PreinstalledSnapFile[];
   removable?: boolean;
   hidden?: boolean;
+  hideHeader?: boolean;
 }
 
 type SnapRpcHandler = (
@@ -718,6 +719,7 @@ type SetSnapArgs = Omit<AddSnapArgs, 'location' | 'versionRange'> & {
   removable?: boolean;
   preinstalled?: boolean;
   hidden?: boolean;
+  hideHeader?: boolean;
 };
 
 const defaultState: SnapControllerState = {
@@ -1125,6 +1127,7 @@ export class SnapController extends BaseController<
       files,
       removable,
       hidden,
+      hideHeader,
     } of preinstalledSnaps) {
       const existingSnap = this.get(snapId);
       const isAlreadyInstalled = existingSnap !== undefined;
@@ -1195,6 +1198,7 @@ export class SnapController extends BaseController<
         files: filesObject,
         removable,
         hidden,
+        hideHeader,
         preinstalled: true,
       });
 
@@ -2865,6 +2869,7 @@ export class SnapController extends BaseController<
       removable,
       preinstalled,
       hidden,
+      hideHeader,
     } = args;
 
     const {
@@ -2921,6 +2926,7 @@ export class SnapController extends BaseController<
       removable,
       preinstalled,
       hidden,
+      hideHeader,
 
       id: snapId,
       initialConnections: manifest.result.initialConnections,

--- a/packages/snaps-utils/src/snaps.ts
+++ b/packages/snaps-utils/src/snaps.ts
@@ -153,6 +153,11 @@ export type Snap = TruncatedSnap & {
    * Flag to signal whether this snap should be hidden from the user or not.
    */
   hidden?: boolean;
+
+  /**
+   * Flag to signal whether this snap should hide the header in the UI or not.
+   */
+  hideHeader?: boolean;
 };
 
 export type TruncatedSnapFields =


### PR DESCRIPTION
Adds a `hideHeader` flag that preinstalled Snaps can use to signal whether they should be displaying a header in the UI or not.