### PR TITLE
Bump `ts-bridge` to `0.5.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/utils": "^9.2.1",
     "@swc/core": "1.3.78",
-    "@ts-bridge/cli": "^0.4.4",
+    "@ts-bridge/cli": "^0.5.1",
     "@types/jest": "^27.5.1",
     "@types/node": "18.14.2",
     "@typescript-eslint/eslint-plugin": "^5.42.1",

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -61,7 +61,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.4.4",
+    "@ts-bridge/cli": "^0.5.1",
     "@types/jest": "^27.5.1",
     "@types/node": "18.14.2",
     "@types/yargs": "^17.0.24",

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -56,7 +56,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.4.4",
+    "@ts-bridge/cli": "^0.5.1",
     "@types/browserify": "^12.0.37",
     "@types/convert-source-map": "^1.5.2",
     "@types/jest": "^27.5.1",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -109,7 +109,7 @@
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.4.4",
+    "@ts-bridge/cli": "^0.5.1",
     "@types/browserify": "^12.0.37",
     "@types/jest": "^27.5.1",
     "@types/node": "18.14.2",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -103,7 +103,7 @@
     "@metamask/template-snap": "^0.7.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.4.4",
+    "@ts-bridge/cli": "^0.5.1",
     "@types/chrome": "^0.0.237",
     "@types/concat-stream": "^2.0.0",
     "@types/gunzip-maybe": "^1.4.0",

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -82,7 +82,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.4.4",
+    "@ts-bridge/cli": "^0.5.1",
     "@types/express": "^4.17.17",
     "@types/jest": "^27.5.1",
     "@types/node": "18.14.2",

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -75,7 +75,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.4.4",
+    "@ts-bridge/cli": "^0.5.1",
     "@types/jest": "^27.5.1",
     "@types/mime": "^3.0.0",
     "@types/semver": "^7.5.0",

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -56,7 +56,7 @@
     "@rollup/plugin-virtual": "^2.1.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.4.4",
+    "@ts-bridge/cli": "^0.5.1",
     "@types/jest": "^27.5.1",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^6.21.0",

--- a/packages/snaps-rpc-methods/package.json
+++ b/packages/snaps-rpc-methods/package.json
@@ -60,7 +60,7 @@
     "@metamask/json-rpc-engine": "^9.0.2",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.4.4",
+    "@ts-bridge/cli": "^0.5.1",
     "@types/node": "18.14.2",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^6.21.0",

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -89,7 +89,7 @@
     "@metamask/eslint-config-jest": "^12.1.0",
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
-    "@ts-bridge/cli": "^0.4.4",
+    "@ts-bridge/cli": "^0.5.1",
     "@types/jest": "^27.5.1",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^6.21.0",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -98,7 +98,7 @@
     "@metamask/post-message-stream": "^8.1.1",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.4.4",
+    "@ts-bridge/cli": "^0.5.1",
     "@types/jest": "^27.5.1",
     "@types/mocha": "^10.0.1",
     "@types/node": "18.14.2",

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -58,7 +58,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.4.4",
+    "@ts-bridge/cli": "^0.5.1",
     "@types/jest": "^27.5.1",
     "@types/webpack-sources": "^3.2.0",
     "@typescript-eslint/eslint-plugin": "^5.42.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4056,7 +4056,7 @@ __metadata:
     "@metamask/snaps-utils": "workspace:^"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.4.4"
+    "@ts-bridge/cli": "npm:^0.5.1"
     "@types/jest": "npm:^27.5.1"
     "@types/node": "npm:18.14.2"
     "@types/yargs": "npm:^17.0.24"
@@ -5269,7 +5269,7 @@ __metadata:
     "@metamask/snaps-utils": "workspace:^"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.4.4"
+    "@ts-bridge/cli": "npm:^0.5.1"
     "@types/browserify": "npm:^12.0.37"
     "@types/convert-source-map": "npm:^1.5.2"
     "@types/jest": "npm:^27.5.1"
@@ -5323,7 +5323,7 @@ __metadata:
     "@metamask/utils": "npm:^9.2.1"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.4.4"
+    "@ts-bridge/cli": "npm:^0.5.1"
     "@types/browserify": "npm:^12.0.37"
     "@types/jest": "npm:^27.5.1"
     "@types/node": "npm:18.14.2"
@@ -5421,7 +5421,7 @@ __metadata:
     "@metamask/utils": "npm:^9.2.1"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.4.4"
+    "@ts-bridge/cli": "npm:^0.5.1"
     "@types/chrome": "npm:^0.0.237"
     "@types/concat-stream": "npm:^2.0.0"
     "@types/gunzip-maybe": "npm:^1.4.0"
@@ -5512,7 +5512,7 @@ __metadata:
     "@metamask/utils": "npm:^9.2.1"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.4.4"
+    "@ts-bridge/cli": "npm:^0.5.1"
     "@types/express": "npm:^4.17.17"
     "@types/jest": "npm:^27.5.1"
     "@types/node": "npm:18.14.2"
@@ -5597,7 +5597,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:^1.9.5"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.4.4"
+    "@ts-bridge/cli": "npm:^0.5.1"
     "@types/jest": "npm:^27.5.1"
     "@types/mime": "npm:^3.0.0"
     "@types/semver": "npm:^7.5.0"
@@ -5654,7 +5654,7 @@ __metadata:
     "@rollup/plugin-virtual": "npm:^2.1.0"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.4.4"
+    "@ts-bridge/cli": "npm:^0.5.1"
     "@types/jest": "npm:^27.5.1"
     "@typescript-eslint/eslint-plugin": "npm:^5.42.1"
     "@typescript-eslint/parser": "npm:^6.21.0"
@@ -5699,7 +5699,7 @@ __metadata:
     "@noble/hashes": "npm:^1.3.1"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.4.4"
+    "@ts-bridge/cli": "npm:^0.5.1"
     "@types/node": "npm:18.14.2"
     "@typescript-eslint/eslint-plugin": "npm:^5.42.1"
     "@typescript-eslint/parser": "npm:^6.21.0"
@@ -5736,7 +5736,7 @@ __metadata:
     "@metamask/rpc-errors": "npm:^6.3.1"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^9.2.1"
-    "@ts-bridge/cli": "npm:^0.4.4"
+    "@ts-bridge/cli": "npm:^0.5.1"
     "@types/jest": "npm:^27.5.1"
     "@typescript-eslint/eslint-plugin": "npm:^5.42.1"
     "@typescript-eslint/parser": "npm:^6.21.0"
@@ -5898,7 +5898,7 @@ __metadata:
     "@scure/base": "npm:^1.1.1"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.4.4"
+    "@ts-bridge/cli": "npm:^0.5.1"
     "@types/jest": "npm:^27.5.1"
     "@types/mocha": "npm:^10.0.1"
     "@types/node": "npm:18.14.2"
@@ -5968,7 +5968,7 @@ __metadata:
     "@metamask/utils": "npm:^9.2.1"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.4.4"
+    "@ts-bridge/cli": "npm:^0.5.1"
     "@types/jest": "npm:^27.5.1"
     "@types/webpack-sources": "npm:^3.2.0"
     "@typescript-eslint/eslint-plugin": "npm:^5.42.1"
@@ -7086,9 +7086,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ts-bridge/cli@npm:^0.4.4":
-  version: 0.4.4
-  resolution: "@ts-bridge/cli@npm:0.4.4"
+"@ts-bridge/cli@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "@ts-bridge/cli@npm:0.5.1"
   dependencies:
     "@ts-bridge/resolver": "npm:^0.1.2"
     chalk: "npm:^5.3.0"
@@ -7099,7 +7099,7 @@ __metadata:
   bin:
     ts-bridge: ./dist/index.js
     tsbridge: ./dist/index.js
-  checksum: 10/a904945e6d65cc75fadacdabbb7e92ecbb8f8c916f88e7887f0e9f340f36dadd1033d89867b0b4500983de43a15b09f118225a6542bbde2c4c77da43f07e9ba4
+  checksum: 10/691abe737617597c6ec0a296a67eedf47fc93cc2682658970326ad8f5c63376f987ee92502191ed3e81e917515d101bab7ca83f06b3b489449c3b674356cc306
   languageName: node
   linkType: hard
 
@@ -19881,7 +19881,7 @@ __metadata:
     "@metamask/eslint-config-typescript": "npm:^12.1.0"
     "@metamask/utils": "npm:^9.2.1"
     "@swc/core": "npm:1.3.78"
-    "@ts-bridge/cli": "npm:^0.4.4"
+    "@ts-bridge/cli": "npm:^0.5.1"
     "@types/jest": "npm:^27.5.1"
     "@types/node": "npm:18.14.2"
     "@typescript-eslint/eslint-plugin": "npm:^5.42.1"


### PR DESCRIPTION
This bumps `ts-bridge` to `0.5.1`, which fixes several issues compared to the current version.