### PR TITLE
Rename hideHeader flag to hideSnapBranding

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -5097,7 +5097,7 @@ describe('SnapController', () => {
       snapController.destroy();
     });
 
-    it('supports preinstalled Snaps specifying the hideHeader flag', async () => {
+    it('supports preinstalled Snaps specifying the hideSnapBranding flag', async () => {
       const rootMessenger = getControllerMessenger();
       jest.spyOn(rootMessenger, 'call');
 
@@ -5111,7 +5111,7 @@ describe('SnapController', () => {
         {
           snapId: MOCK_SNAP_ID,
           manifest: getSnapManifest(),
-          hideHeader: true,
+          hideSnapBranding: true,
           files: [
             {
               path: DEFAULT_SOURCE_PATH,
@@ -5131,7 +5131,7 @@ describe('SnapController', () => {
       });
       const [snapController] = getSnapControllerWithEES(snapControllerOptions);
 
-      expect(snapController.get(MOCK_SNAP_ID)?.hideHeader).toBe(true);
+      expect(snapController.get(MOCK_SNAP_ID)?.hideSnapBranding).toBe(true);
 
       snapController.destroy();
     });

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -182,7 +182,7 @@ export interface PreinstalledSnap {
   files: PreinstalledSnapFile[];
   removable?: boolean;
   hidden?: boolean;
-  hideHeader?: boolean;
+  hideSnapBranding?: boolean;
 }
 
 type SnapRpcHandler = (
@@ -719,7 +719,7 @@ type SetSnapArgs = Omit<AddSnapArgs, 'location' | 'versionRange'> & {
   removable?: boolean;
   preinstalled?: boolean;
   hidden?: boolean;
-  hideHeader?: boolean;
+  hideSnapBranding?: boolean;
 };
 
 const defaultState: SnapControllerState = {
@@ -1127,7 +1127,7 @@ export class SnapController extends BaseController<
       files,
       removable,
       hidden,
-      hideHeader,
+      hideSnapBranding,
     } of preinstalledSnaps) {
       const existingSnap = this.get(snapId);
       const isAlreadyInstalled = existingSnap !== undefined;
@@ -1198,7 +1198,7 @@ export class SnapController extends BaseController<
         files: filesObject,
         removable,
         hidden,
-        hideHeader,
+        hideSnapBranding,
         preinstalled: true,
       });
 
@@ -2869,7 +2869,7 @@ export class SnapController extends BaseController<
       removable,
       preinstalled,
       hidden,
-      hideHeader,
+      hideSnapBranding,
     } = args;
 
     const {
@@ -2926,7 +2926,7 @@ export class SnapController extends BaseController<
       removable,
       preinstalled,
       hidden,
-      hideHeader,
+      hideSnapBranding,
 
       id: snapId,
       initialConnections: manifest.result.initialConnections,

--- a/packages/snaps-utils/src/snaps.ts
+++ b/packages/snaps-utils/src/snaps.ts
@@ -155,9 +155,9 @@ export type Snap = TruncatedSnap & {
   hidden?: boolean;
 
   /**
-   * Flag to signal whether this snap should hide the header in the UI or not.
+   * Flag to signal whether this snap should hide the Snap branding like header or avatar in the UI or not.
    */
-  hideHeader?: boolean;
+  hideSnapBranding?: boolean;
 };
 
 export type TruncatedSnapFields =


### PR DESCRIPTION
We made a conclusion that there are more things we should hide for preinstalled Snaps, like SnapIcon inside Snap custom footer button or maybe even something else in the future. 
So the decision is made to make this flag name more generic. 

Flag `hideHeader` is renamed to `hideSnapBranding`.