### PR TITLE
Fix missing build step in publish workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -70,6 +70,7 @@ jobs:
         run: |
           yarn install --immutable
           yarn build
+          yarn workspace @metamask/snaps-execution-environments run build:lavamoat
       - uses: actions/cache@v4
         id: restore-build
         with:


### PR DESCRIPTION
The execution environment wasn't built in de publish workflow, resulting in the execution bundles not being part of the NPM package.