### PR TITLE
Use `metamask-snaps-deployments` channel for deployment messages

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,7 +6,7 @@ on:
       slack-channel:
         required: false
         type: string
-        default: 'metamask-snaps'
+        default: 'metamask-snaps-deployments'
       slack-icon-url:
         required: false
         type: string
@@ -101,7 +101,7 @@ jobs:
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: ${{ inputs.slack-subteam }}
-          channel: metamask-snaps
+          channel: metamask-snaps-deployments
 
   npm-publish:
     name: Publish to NPM


### PR DESCRIPTION
This updates the publish workflows to send a Slack message in `metamask-snaps-deployments`.