### PR TITLE
Add `since-latest-release` script to match `MetaMask/core`

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -251,6 +251,13 @@ gen_enforced_field(WorkspaceCwd, 'scripts.changelog:update', ChangelogUpdateScri
   relative_path(WorkspaceCwd, 'scripts/update-changelog.sh', BaseChangelogUpdateScript),
   atomic_list_concat([BaseChangelogUpdateScript, ' ', WorkspacePackageName], ChangelogUpdateScript).
 
+% The "since-latest-release" script for each published package must run a common
+% script.
+gen_enforced_field(WorkspaceCwd, 'scripts.since-latest-release', SinceLatestReleaseScript) :-
+  \+ workspace_field(WorkspaceCwd, 'private', true),
+  workspace_field(WorkspaceCwd, 'name', WorkspacePackageName),
+  relative_path(WorkspaceCwd, 'scripts/since-latest-release.sh', SinceLatestReleaseScript).
+
 % The "lint:dependencies" script must be the same for all packages.
 gen_enforced_field(WorkspaceCwd, 'scripts.lint:dependencies', 'depcheck') :-
   WorkspaceCwd \= '.'.

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -43,12 +43,12 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:package": "../../scripts/publish-package.sh",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-utils": "workspace:^",

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -47,7 +47,8 @@
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-utils": "workspace:^",

--- a/packages/examples/packages/bip32/package.json
+++ b/packages/examples/packages/bip32/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",

--- a/packages/examples/packages/bip32/package.json
+++ b/packages/examples/packages/bip32/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",

--- a/packages/examples/packages/bip44/package.json
+++ b/packages/examples/packages/bip44/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",

--- a/packages/examples/packages/bip44/package.json
+++ b/packages/examples/packages/bip44/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",

--- a/packages/examples/packages/browserify-plugin/package.json
+++ b/packages/examples/packages/browserify-plugin/package.json
@@ -26,11 +26,11 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/browserify-plugin/package.json
+++ b/packages/examples/packages/browserify-plugin/package.json
@@ -29,7 +29,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/browserify/package.json
+++ b/packages/examples/packages/browserify/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/browserify/package.json
+++ b/packages/examples/packages/browserify/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/client-status/package.json
+++ b/packages/examples/packages/client-status/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/client-status/package.json
+++ b/packages/examples/packages/client-status/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/cronjobs/package.json
+++ b/packages/examples/packages/cronjobs/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/cronjobs/package.json
+++ b/packages/examples/packages/cronjobs/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/dialogs/package.json
+++ b/packages/examples/packages/dialogs/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/dialogs/package.json
+++ b/packages/examples/packages/dialogs/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/errors/package.json
+++ b/packages/examples/packages/errors/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/errors/package.json
+++ b/packages/examples/packages/errors/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/ethereum-provider/package.json
+++ b/packages/examples/packages/ethereum-provider/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/ethereum-provider/package.json
+++ b/packages/examples/packages/ethereum-provider/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/ethers-js/package.json
+++ b/packages/examples/packages/ethers-js/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/ethers-js/package.json
+++ b/packages/examples/packages/ethers-js/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/file-upload/package.json
+++ b/packages/examples/packages/file-upload/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/file-upload/package.json
+++ b/packages/examples/packages/file-upload/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/get-entropy/package.json
+++ b/packages/examples/packages/get-entropy/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/get-entropy/package.json
+++ b/packages/examples/packages/get-entropy/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/get-file/package.json
+++ b/packages/examples/packages/get-file/package.json
@@ -31,7 +31,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/get-file/package.json
+++ b/packages/examples/packages/get-file/package.json
@@ -27,12 +27,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/home-page/package.json
+++ b/packages/examples/packages/home-page/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/home-page/package.json
+++ b/packages/examples/packages/home-page/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/images/package.json
+++ b/packages/examples/packages/images/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/images/package.json
+++ b/packages/examples/packages/images/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/interactive-ui/package.json
+++ b/packages/examples/packages/interactive-ui/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/interactive-ui/package.json
+++ b/packages/examples/packages/interactive-ui/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
@@ -26,6 +26,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/package.json
@@ -26,6 +26,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",

--- a/packages/examples/packages/json-rpc/package.json
+++ b/packages/examples/packages/json-rpc/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/json-rpc/package.json
+++ b/packages/examples/packages/json-rpc/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/jsx/package.json
+++ b/packages/examples/packages/jsx/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.3.1",

--- a/packages/examples/packages/jsx/package.json
+++ b/packages/examples/packages/jsx/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.3.1",

--- a/packages/examples/packages/lifecycle-hooks/package.json
+++ b/packages/examples/packages/lifecycle-hooks/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/lifecycle-hooks/package.json
+++ b/packages/examples/packages/lifecycle-hooks/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/localization/package.json
+++ b/packages/examples/packages/localization/package.json
@@ -31,7 +31,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/localization/package.json
+++ b/packages/examples/packages/localization/package.json
@@ -27,12 +27,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/manage-state/package.json
+++ b/packages/examples/packages/manage-state/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/manage-state/package.json
+++ b/packages/examples/packages/manage-state/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/name-lookup/package.json
+++ b/packages/examples/packages/name-lookup/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/name-lookup/package.json
+++ b/packages/examples/packages/name-lookup/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/network-access/package.json
+++ b/packages/examples/packages/network-access/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/network-access/package.json
+++ b/packages/examples/packages/network-access/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/notifications/package.json
+++ b/packages/examples/packages/notifications/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/notifications/package.json
+++ b/packages/examples/packages/notifications/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/preinstalled/package.json
+++ b/packages/examples/packages/preinstalled/package.json
@@ -31,7 +31,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/preinstalled/package.json
+++ b/packages/examples/packages/preinstalled/package.json
@@ -27,12 +27,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/rollup-plugin/package.json
+++ b/packages/examples/packages/rollup-plugin/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/rollup-plugin/package.json
+++ b/packages/examples/packages/rollup-plugin/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "yarn build --watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/send-flow/package.json
+++ b/packages/examples/packages/send-flow/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.3.1",

--- a/packages/examples/packages/send-flow/package.json
+++ b/packages/examples/packages/send-flow/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.3.1",

--- a/packages/examples/packages/signature-insights/package.json
+++ b/packages/examples/packages/signature-insights/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/signature-insights/package.json
+++ b/packages/examples/packages/signature-insights/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/transaction-insights/package.json
+++ b/packages/examples/packages/transaction-insights/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/transaction-insights/package.json
+++ b/packages/examples/packages/transaction-insights/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/wasm/package.json
+++ b/packages/examples/packages/wasm/package.json
@@ -31,7 +31,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/wasm/package.json
+++ b/packages/examples/packages/wasm/package.json
@@ -27,12 +27,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "yarn build:wasm && mm-snap watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/webpack-plugin/package.json
+++ b/packages/examples/packages/webpack-plugin/package.json
@@ -26,12 +26,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "webpack watch",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/webpack-plugin/package.json
+++ b/packages/examples/packages/webpack-plugin/package.json
@@ -30,7 +30,8 @@
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -39,12 +39,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-utils": "workspace:^",

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -43,7 +43,8 @@
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-utils": "workspace:^",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -46,12 +46,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@babel/core": "^7.23.2",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -50,7 +50,8 @@
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@babel/core": "^7.23.2",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -59,14 +59,14 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
     "test": "jest --reporters=jest-silent-reporter && yarn test:browser",
     "test:browser": "wdio run wdio.config.js",
     "test:clean": "jest --clearCache",
     "test:post": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",
     "test:pre": "yarn mkdirp test/fixtures && ./scripts/generate-fixtures.sh",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/approval-controller": "^7.0.2",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -65,7 +65,8 @@
     "test:post": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",
     "test:pre": "yarn mkdirp test/fixtures && ./scripts/generate-fixtures.sh",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/approval-controller": "^7.0.2",

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -47,14 +47,14 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ./.prettierignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
     "start": "node scripts/start.js",
     "test": "jest --reporters=jest-silent-reporter && yarn test:browser",
     "test:browser": "wdio run wdio.config.js",
     "test:clean": "jest --clearCache",
     "test:post": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/json-rpc-engine": "^9.0.2",

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -53,7 +53,8 @@
     "test:clean": "jest --clearCache",
     "test:post": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/json-rpc-engine": "^9.0.2",

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -39,7 +39,8 @@
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@jest/environment": "^29.5.0",

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -35,12 +35,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@jest/environment": "^29.5.0",

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -44,7 +44,8 @@
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-utils": "workspace:^"

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -40,12 +40,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-utils": "workspace:^"

--- a/packages/snaps-rpc-methods/package.json
+++ b/packages/snaps-rpc-methods/package.json
@@ -37,12 +37,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",

--- a/packages/snaps-rpc-methods/package.json
+++ b/packages/snaps-rpc-methods/package.json
@@ -41,7 +41,8 @@
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -76,7 +76,8 @@
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -72,12 +72,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",

--- a/packages/snaps-simulation/package.json
+++ b/packages/snaps-simulation/package.json
@@ -41,7 +41,8 @@
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/base-controller": "^6.0.2",

--- a/packages/snaps-simulation/package.json
+++ b/packages/snaps-simulation/package.json
@@ -37,12 +37,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/base-controller": "^6.0.2",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -57,13 +57,13 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
     "test": "jest --reporters=jest-silent-reporter && yarn test:browser",
     "test:browser": "wdio run wdio.config.js",
     "test:clean": "jest --clearCache",
     "test:post": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@babel/core": "^7.23.2",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -62,7 +62,8 @@
     "test:clean": "jest --clearCache",
     "test:post": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@babel/core": "^7.23.2",

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -40,12 +40,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "since-latest-release": "../../scripts/since-latest-release.sh"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -44,7 +44,8 @@
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "since-latest-release": "../../scripts/since-latest-release.sh"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/scripts/since-latest-release.sh
+++ b/scripts/since-latest-release.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+red() {
+  printf "\x1B[31m"
+  echo -n "$@"
+  printf "\x1B[0m"
+}
+
+magenta() {
+  printf "\x1B[35m"
+  echo -n "$@"
+  printf "\x1B[0m"
+}
+
+bold() {
+  printf "\x1B[1m"
+  echo -n "$@"
+  printf "\x1B[22m"
+}
+
+print-usage() {
+  cat <<EOT
+USAGE: $0 [--include-head] [-- GIT_COMMAND GIT_COMMAND_ARGS...]"
+
+View changes for a package since its latest release.
+
+Examples:
+
+  yarn workspace @metamask/accounts-controller run since-latest-release
+  yarn workspace @metamask/accounts-controller run since-latest-release diff
+  yarn workspace @metamask/accounts-controller run since-latest-release log -p
+  yarn workspace @metamask/accounts-controller run since-latest-release --include-head -- log -p
+
+EOT
+}
+
+latest-release-commit() {
+  local package_name="$1"
+  git tag --sort=version:refname --list "$package_name@*" | tail -n 1
+}
+
+determine-commit-range() {
+  local branch_name
+  local include_head
+  local git_command_name
+
+  branch_name="$1"
+  include_head="$2"
+  git_command_name="$3"
+
+  if [[ "$branch_name" =~ ^release/ && $include_head -eq 0 ]]; then
+    echo "$latest_release_commit..main"
+  elif [[ "$git_command_name" == "diff" ]]; then
+    echo "$latest_release_commit"
+  else
+    echo "$latest_release_commit..HEAD"
+  fi
+}
+
+main() {
+  local force_head_as_final_branch_name
+  local any_options_given
+  local start_processing_git_command
+  local package_name
+  local package_directory
+  local given_git_command=()
+  local git_command=()
+  local current_branch
+  local latest_release_commit
+  local commit_range
+
+  any_options_given=0
+  force_head_as_final_branch_name=0
+  start_processing_git_command=0
+  if [[ -f package.json ]]; then
+    package_name="$(jq --raw-output '.name' < package.json)"
+  fi
+  package_directory="$PWD"
+  magenta "$(bold "Directory:")" "$package_directory" $'\n'
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --include-head)
+        any_options_given=1
+        force_head_as_final_branch_name=1
+        shift
+        ;;
+      --help | -h)
+        print-usage
+        exit 0
+        ;;
+      --)
+        start_processing_git_command=1
+        shift
+        ;;
+      -*)
+        if [[ $start_processing_git_command -eq 0 ]]; then
+          red "ERROR: Unknown option '$1'." $'\n'
+          echo
+          print-usage
+          exit 1
+        else
+          given_git_command+=("$1")
+        fi
+        ;;
+      *)
+        if [[ $any_options_given -eq 1 ]]; then
+          red "ERROR: Unknown argument '$1'. (Tip: When specifying options to this script and \`git\` at the same time, use \`--\` to divide git options.)" $'\n'
+          echo
+          print-usage
+          exit 1
+        else
+          given_git_command+=("$1")
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  if [[ -z "$package_name" ]]; then
+    red "ERROR: Could not determine package name. Are you in a package?" $'\n'
+    exit 1
+  fi
+  magenta "$(bold "Package:")" "$package_name" $'\n'
+
+  if [[ ${#given_git_command[@]} -eq 0 ]]; then
+    git_command=(log --oneline)
+  else
+    git_command=("${given_git_command[@]}")
+  fi
+
+  current_branch="$(git branch --show-current)"
+  latest_release_commit="$(latest-release-commit "$package_name")"
+  if [[ -z "$latest_release_commit" ]]; then
+    red "ERROR: Could not determine latest release commit." $'\n'
+    exit 1
+  fi
+  commit_range="$(determine-commit-range "$current_branch" "$force_head_as_final_branch_name" "${git_command[0]}")"
+  magenta "$(bold "Commit range:")" "$commit_range" $'\n'
+
+  echo
+  git "${git_command[@]}" "$commit_range" -- "$package_directory"
+}
+
+main "$@"


### PR DESCRIPTION
This adds the `since-latest-release` script, which is a copy of the script in `MetaMask/core`. See MetaMask/core#1390 for more info.