### PR TITLE
Update test scripts to match `MetaMask/core`

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -296,7 +296,7 @@ jobs:
       - name: Build snap
         run: yarn workspace ${{ matrix.package-name }} run build
       - name: Run E2E test
-        run: yarn workspace ${{ matrix.package-name }} run test:e2e
+        run: yarn workspace ${{ matrix.package-name }} run test
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -217,7 +217,7 @@ jobs:
         run: yarn install-chrome
       - run: yarn workspace @metamask/snaps-sdk run build
         if: ${{ matrix.package-name == '@metamask/snaps-cli' }}
-      - run: yarn workspace ${{ matrix.package-name }} run test:ci
+      - run: yarn workspace ${{ matrix.package-name }} run test
       - name: Get coverage folder
         id: get-coverage-folder
         run: |

--- a/.yarn/plugins/local/plugin-lifecycle-scripts.js
+++ b/.yarn/plugins/local/plugin-lifecycle-scripts.js
@@ -3,8 +3,8 @@
 /**
  * Run an array of tasks in sequence.
  *
- * @param tasks {Array<Function>} - An array of functions that return a promise
- * that resolves to an exit code.
+ * @param tasks {Array<() => Promise<number>>} - An array of functions that
+ * return a promise that resolves to an exit code.
  * @returns {Promise<number>} - The exit code of the first task that returns a
  * non-zero exit code, or 0 if all tasks return 0.
  */

--- a/.yarn/plugins/local/plugin-lifecycle-scripts.js
+++ b/.yarn/plugins/local/plugin-lifecycle-scripts.js
@@ -1,0 +1,72 @@
+// @ts-check
+
+/**
+ * Run an array of tasks in sequence.
+ *
+ * @param tasks {Array<Function>} - An array of functions that return a function
+ * that returns a Promise.
+ * @returns {Promise<number>} - The exit code of the first task that returns a
+ * non-zero exit code, or 0 if all tasks return 0.
+ */
+async function sequence(tasks) {
+  for (const task of tasks) {
+    const exitCode = await task();
+
+    if (exitCode !== 0) {
+      return exitCode;
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Run a lifecycle script.
+ *
+ * @param {import('@yarnpkg/core').Workspace} workspace - The workspace to run
+ * the script in.
+ * @param {string} scriptName - The name of the script to run.
+ * @param {Function} require - The require function to use.
+ */
+function getLifecycleTask(workspace, scriptName, require) {
+  const { scriptUtils } = require('@yarnpkg/core');
+
+  return async () => {
+    if (scriptUtils.hasWorkspaceScript(workspace, scriptName)) {
+      return scriptUtils.executeWorkspaceScript(workspace, scriptName, [], {
+        cwd: workspace.cwd,
+      });
+    }
+
+    return 0;
+  };
+}
+
+/**
+ * A Yarn plugin that calls lifecycle scripts before and after running a script.
+ * The scripts are expected to be named `${scriptName}:pre` and
+ * `${scriptName}:post`.
+ *
+ * @type {import('@yarnpkg/core').PluginConfiguration}
+ */
+module.exports = {
+  name: 'plugin-lifecycle-scripts',
+  factory: (require) => {
+    return {
+      default: {
+        hooks: {
+          wrapScriptExecution: async (script, project, locator, scriptName) => {
+            return async () => {
+              const workspace = project.getWorkspaceByLocator(locator);
+              return await sequence([
+                getLifecycleTask(workspace, `${scriptName}:pre`, require),
+                script,
+                getLifecycleTask(workspace, `${scriptName}:post`, require),
+              ])
+            };
+          }
+        }
+      }
+    }
+  }
+};

--- a/.yarn/plugins/local/plugin-lifecycle-scripts.js
+++ b/.yarn/plugins/local/plugin-lifecycle-scripts.js
@@ -26,7 +26,7 @@ async function sequence(tasks) {
  * @param {import('@yarnpkg/core').Workspace} workspace - The workspace to run
  * the script in.
  * @param {string} scriptName - The name of the script to run.
- * @param {Record<string, string>} extra - Extra options to pass to the execute
+ * @param {Record<string, *>} extra - Extra options to pass to the execute
  * function.
  * @param {Function} require - The require function to use.
  */

--- a/.yarn/plugins/local/plugin-lifecycle-scripts.js
+++ b/.yarn/plugins/local/plugin-lifecycle-scripts.js
@@ -3,8 +3,8 @@
 /**
  * Run an array of tasks in sequence.
  *
- * @param tasks {Array<Function>} - An array of functions that return a function
- * that returns a Promise.
+ * @param tasks {Array<Function>} - An array of functions that return a promise
+ * that resolves to an exit code.
  * @returns {Promise<number>} - The exit code of the first task that returns a
  * non-zero exit code, or 0 if all tasks return 0.
  */

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -21,5 +21,6 @@ plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
     spec: 'https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js'
   - path: .yarn/plugins/local/plugin-workspaces-filter.js
+  - path: .yarn/plugins/local/plugin-lifecycle-scripts.js
 
 yarnPath: .yarn/releases/yarn-4.4.1.cjs

--- a/constraints.pro
+++ b/constraints.pro
@@ -293,7 +293,13 @@ gen_enforced_field(WorkspaceCwd, 'scripts.start', 'mm-snap watch') :-
   WorkspaceCwd \= 'packages/examples/packages/webpack-plugin'.
 gen_enforced_field(WorkspaceCwd, 'scripts.clean', 'rimraf "dist"') :-
   is_example(WorkspaceCwd).
-gen_enforced_field(WorkspaceCwd, 'scripts.test', 'yarn test:e2e') :-
+gen_enforced_field(WorkspaceCwd, 'scripts.test', 'jest --reporters=jest-silent-reporter') :-
+  is_example(WorkspaceCwd).
+gen_enforced_field(WorkspaceCwd, 'scripts.test:clean', 'jest --clearCache') :-
+  is_example(WorkspaceCwd).
+gen_enforced_field(WorkspaceCwd, 'scripts.test:verbose', 'jest --verbose') :-
+  is_example(WorkspaceCwd).
+gen_enforced_field(WorkspaceCwd, 'scripts.test:watch', 'jest --watch') :-
   is_example(WorkspaceCwd).
 gen_enforced_field(WorkspaceCwd, 'scripts.lint', 'yarn lint:eslint && yarn lint:misc --check && yarn changelog:validate && yarn lint:dependencies') :-
   is_example(WorkspaceCwd).

--- a/constraints.pro
+++ b/constraints.pro
@@ -258,7 +258,16 @@ gen_enforced_field(WorkspaceCwd, 'scripts.lint:dependencies', 'depcheck') :-
 % The test scripts must be the same for all packages.
 gen_enforced_field(WorkspaceCwd, 'scripts.test', 'jest --reporters=jest-silent-reporter && yarn test:post') :-
   WorkspaceCwd \= '.',
+  WorkspaceCwd \= 'packages/snaps-controllers',
+  WorkspaceCwd \= 'packages/snaps-execution-environments',
+  WorkspaceCwd \= 'packages/snaps-utils',
   \+ is_example(WorkspaceCwd).
+gen_enforced_field(WorkspaceCwd, 'scripts.test', 'jest --reporters=jest-silent-reporter && yarn test:browser && yarn test:post') :-
+  WorkspaceCwd == 'packages/snaps-controllers'.
+gen_enforced_field(WorkspaceCwd, 'scripts.test', 'jest --reporters=jest-silent-reporter && yarn test:browser && yarn test:post') :-
+  WorkspaceCwd == 'packages/snaps-execution-environments'.
+gen_enforced_field(WorkspaceCwd, 'scripts.test', 'jest --reporters=jest-silent-reporter && yarn test:browser && yarn test:post') :-
+  WorkspaceCwd == 'packages/snaps-utils'.
 gen_enforced_field(WorkspaceCwd, 'scripts.test:clean', 'jest --clearCache') :-
   WorkspaceCwd \= '.',
   \+ is_example(WorkspaceCwd).
@@ -270,7 +279,16 @@ gen_enforced_field(WorkspaceCwd, 'scripts.test:watch', 'jest --watch') :-
   \+ is_example(WorkspaceCwd).
 gen_enforced_field(WorkspaceCwd, 'scripts.test:post', 'jest-it-up') :-
   WorkspaceCwd \= '.',
+  WorkspaceCwd \= 'packages/snaps-controllers',
+  WorkspaceCwd \= 'packages/snaps-execution-environments',
+  WorkspaceCwd \= 'packages/snaps-utils',
   \+ is_example(WorkspaceCwd).
+gen_enforced_field(WorkspaceCwd, 'scripts.test:post', 'ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio') :-
+  WorkspaceCwd == 'packages/snaps-controllers'.
+gen_enforced_field(WorkspaceCwd, 'scripts.test:post', 'ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio') :-
+  WorkspaceCwd == 'packages/snaps-execution-environments'.
+gen_enforced_field(WorkspaceCwd, 'scripts.test:post', 'ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio') :-
+  WorkspaceCwd == 'packages/snaps-utils'.
 
 % The "engines.node" field must be the same for all packages.
 gen_enforced_field(WorkspaceCwd, 'engines.node', '^18.16 || >=20').

--- a/constraints.pro
+++ b/constraints.pro
@@ -255,6 +255,23 @@ gen_enforced_field(WorkspaceCwd, 'scripts.changelog:update', ChangelogUpdateScri
 gen_enforced_field(WorkspaceCwd, 'scripts.lint:dependencies', 'depcheck') :-
   WorkspaceCwd \= '.'.
 
+% The test scripts must be the same for all packages.
+gen_enforced_field(WorkspaceCwd, 'scripts.test', 'jest --reporters=jest-silent-reporter && yarn test:post') :-
+  WorkspaceCwd \= '.',
+  \+ is_example(WorkspaceCwd).
+gen_enforced_field(WorkspaceCwd, 'scripts.test:clean', 'jest --clearCache') :-
+  WorkspaceCwd \= '.',
+  \+ is_example(WorkspaceCwd).
+gen_enforced_field(WorkspaceCwd, 'scripts.test:verbose', 'jest --verbose') :-
+  WorkspaceCwd \= '.',
+  \+ is_example(WorkspaceCwd).
+gen_enforced_field(WorkspaceCwd, 'scripts.test:watch', 'jest --watch') :-
+  WorkspaceCwd \= '.',
+  \+ is_example(WorkspaceCwd).
+gen_enforced_field(WorkspaceCwd, 'scripts.test:post', 'jest-it-up') :-
+  WorkspaceCwd \= '.',
+  \+ is_example(WorkspaceCwd).
+
 % The "engines.node" field must be the same for all packages.
 gen_enforced_field(WorkspaceCwd, 'engines.node', '^18.16 || >=20').
 
@@ -277,8 +294,6 @@ gen_enforced_field(WorkspaceCwd, 'scripts.start', 'mm-snap watch') :-
 gen_enforced_field(WorkspaceCwd, 'scripts.clean', 'rimraf "dist"') :-
   is_example(WorkspaceCwd).
 gen_enforced_field(WorkspaceCwd, 'scripts.test', 'yarn test:e2e') :-
-  is_example(WorkspaceCwd).
-gen_enforced_field(WorkspaceCwd, 'scripts.test:e2e', 'jest') :-
   is_example(WorkspaceCwd).
 gen_enforced_field(WorkspaceCwd, 'scripts.lint', 'yarn lint:eslint && yarn lint:misc --check && yarn changelog:validate && yarn lint:dependencies') :-
   is_example(WorkspaceCwd).

--- a/constraints.pro
+++ b/constraints.pro
@@ -256,17 +256,17 @@ gen_enforced_field(WorkspaceCwd, 'scripts.lint:dependencies', 'depcheck') :-
   WorkspaceCwd \= '.'.
 
 % The test scripts must be the same for all packages.
-gen_enforced_field(WorkspaceCwd, 'scripts.test', 'jest --reporters=jest-silent-reporter && yarn test:post') :-
+gen_enforced_field(WorkspaceCwd, 'scripts.test', 'jest --reporters=jest-silent-reporter') :-
   WorkspaceCwd \= '.',
   WorkspaceCwd \= 'packages/snaps-controllers',
   WorkspaceCwd \= 'packages/snaps-execution-environments',
   WorkspaceCwd \= 'packages/snaps-utils',
   \+ is_example(WorkspaceCwd).
-gen_enforced_field(WorkspaceCwd, 'scripts.test', 'jest --reporters=jest-silent-reporter && yarn test:browser && yarn test:post') :-
+gen_enforced_field(WorkspaceCwd, 'scripts.test', 'jest --reporters=jest-silent-reporter && yarn test:browser') :-
   WorkspaceCwd == 'packages/snaps-controllers'.
-gen_enforced_field(WorkspaceCwd, 'scripts.test', 'jest --reporters=jest-silent-reporter && yarn test:browser && yarn test:post') :-
+gen_enforced_field(WorkspaceCwd, 'scripts.test', 'jest --reporters=jest-silent-reporter && yarn test:browser') :-
   WorkspaceCwd == 'packages/snaps-execution-environments'.
-gen_enforced_field(WorkspaceCwd, 'scripts.test', 'jest --reporters=jest-silent-reporter && yarn test:browser && yarn test:post') :-
+gen_enforced_field(WorkspaceCwd, 'scripts.test', 'jest --reporters=jest-silent-reporter && yarn test:browser') :-
   WorkspaceCwd == 'packages/snaps-utils'.
 gen_enforced_field(WorkspaceCwd, 'scripts.test:clean', 'jest --clearCache') :-
   WorkspaceCwd \= '.',

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "publish-previews": "yarn workspaces foreach --all --parallel --verbose run publish:preview",
     "test": "yarn workspaces foreach --all --parallel --verbose run test",
     "test:browser": "yarn workspaces foreach --all --verbose run test:browser",
-    "test:e2e": "yarn workspaces foreach --all --verbose --exclude root run test:e2e",
     "update-readme-content": "tsx ./scripts/update-readme-content.mts"
   },
   "simple-git-hooks": {
@@ -95,6 +94,7 @@
     "favicons": "^7.1.2",
     "geckodriver": "^4.2.0",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "lint-staged": "^12.4.1",
     "minimatch": "^7.4.1",
     "prettier": "^2.8.8",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "publish-previews": "yarn workspaces foreach --all --parallel --verbose run publish:preview",
     "test": "yarn workspaces foreach --all --parallel --verbose run test",
     "test:browser": "yarn workspaces foreach --all --verbose run test:browser",
+    "test:clean": "yarn workspaces foreach --all --parallel --verbose run test:clean",
+    "test:verbose": "yarn workspaces foreach --all --parallel --verbose run test:verbose",
+    "test:watch": "yarn workspaces foreach --all --parallel --verbose run test:watch",
     "update-readme-content": "tsx ./scripts/update-readme-content.mts"
   },
   "simple-git-hooks": {

--- a/packages/create-snap/.depcheckrc.json
+++ b/packages/create-snap/.depcheckrc.json
@@ -10,6 +10,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -43,10 +43,11 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:package": "../../scripts/publish-package.sh",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest && yarn posttest",
-    "posttest": "jest-it-up",
-    "test:ci": "yarn test",
-    "test:watch": "yarn test --watch"
+    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test:clean": "jest --clearCache",
+    "test:post": "jest-it-up",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-utils": "workspace:^",
@@ -80,6 +81,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
     "jest-it-up": "^2.0.0",
+    "jest-silent-reporter": "^0.6.0",
     "memfs": "^3.4.13",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -43,7 +43,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:package": "../../scripts/publish-package.sh",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",

--- a/packages/examples/.depcheckrc.json
+++ b/packages/examples/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -24,7 +24,11 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!packages/**\" --ignore-path ../../.gitignore",
     "start": "yarn workspaces foreach --worktree --parallel --verbose --interlaced --no-private --jobs unlimited run start",
     "start:test": "yarn start",
-    "test": "yarn workspaces foreach --worktree --parallel --verbose --interlaced --no-private run test"
+    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test:clean": "jest --clearCache",
+    "test:post": "jest-it-up",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.4",
@@ -44,6 +48,7 @@
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -24,7 +24,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!packages/**\" --ignore-path ../../.gitignore",
     "start": "yarn workspaces foreach --worktree --parallel --verbose --interlaced --no-private --jobs unlimited run start",
     "start:test": "yarn start",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",

--- a/packages/examples/packages/bip32/.depcheckrc.json
+++ b/packages/examples/packages/bip32/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/bip32/package.json
+++ b/packages/examples/packages/bip32/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",
@@ -62,6 +61,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/bip32/package.json
+++ b/packages/examples/packages/bip32/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",

--- a/packages/examples/packages/bip44/.depcheckrc.json
+++ b/packages/examples/packages/bip44/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/bip44/package.json
+++ b/packages/examples/packages/bip44/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",

--- a/packages/examples/packages/bip44/package.json
+++ b/packages/examples/packages/bip44/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",
@@ -61,6 +60,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "rimraf": "^4.1.2",

--- a/packages/examples/packages/browserify-plugin/.depcheckrc.json
+++ b/packages/examples/packages/browserify-plugin/.depcheckrc.json
@@ -10,6 +10,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/browserify-plugin/package.json
+++ b/packages/examples/packages/browserify-plugin/package.json
@@ -26,8 +26,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -59,6 +58,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/browserify-plugin/package.json
+++ b/packages/examples/packages/browserify-plugin/package.json
@@ -26,7 +26,10 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/browserify/.depcheckrc.json
+++ b/packages/examples/packages/browserify/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/browserify/package.json
+++ b/packages/examples/packages/browserify/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -58,6 +57,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "rimraf": "^4.1.2",

--- a/packages/examples/packages/browserify/package.json
+++ b/packages/examples/packages/browserify/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/client-status/.depcheckrc.json
+++ b/packages/examples/packages/client-status/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/client-status/package.json
+++ b/packages/examples/packages/client-status/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -58,6 +57,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "rimraf": "^4.1.2",

--- a/packages/examples/packages/client-status/package.json
+++ b/packages/examples/packages/client-status/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/cronjobs/.depcheckrc.json
+++ b/packages/examples/packages/cronjobs/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/cronjobs/package.json
+++ b/packages/examples/packages/cronjobs/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -58,6 +57,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "rimraf": "^4.1.2",

--- a/packages/examples/packages/cronjobs/package.json
+++ b/packages/examples/packages/cronjobs/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/dialogs/.depcheckrc.json
+++ b/packages/examples/packages/dialogs/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/dialogs/package.json
+++ b/packages/examples/packages/dialogs/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/dialogs/package.json
+++ b/packages/examples/packages/dialogs/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -58,6 +57,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/errors/.depcheckrc.json
+++ b/packages/examples/packages/errors/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/errors/package.json
+++ b/packages/examples/packages/errors/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/errors/package.json
+++ b/packages/examples/packages/errors/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -58,6 +57,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/ethereum-provider/.depcheckrc.json
+++ b/packages/examples/packages/ethereum-provider/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/ethereum-provider/package.json
+++ b/packages/examples/packages/ethereum-provider/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/ethereum-provider/package.json
+++ b/packages/examples/packages/ethereum-provider/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",
@@ -59,6 +58,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/ethers-js/.depcheckrc.json
+++ b/packages/examples/packages/ethers-js/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/ethers-js/package.json
+++ b/packages/examples/packages/ethers-js/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/ethers-js/package.json
+++ b/packages/examples/packages/ethers-js/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",
@@ -59,6 +58,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/file-upload/.depcheckrc.json
+++ b/packages/examples/packages/file-upload/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/file-upload/package.json
+++ b/packages/examples/packages/file-upload/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/file-upload/package.json
+++ b/packages/examples/packages/file-upload/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",
@@ -59,6 +58,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "rimraf": "^4.1.2",

--- a/packages/examples/packages/get-entropy/.depcheckrc.json
+++ b/packages/examples/packages/get-entropy/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/get-entropy/package.json
+++ b/packages/examples/packages/get-entropy/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/get-entropy/package.json
+++ b/packages/examples/packages/get-entropy/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",
@@ -60,6 +59,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/get-file/.depcheckrc.json
+++ b/packages/examples/packages/get-file/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/get-file/package.json
+++ b/packages/examples/packages/get-file/package.json
@@ -28,8 +28,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -59,6 +58,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/get-file/package.json
+++ b/packages/examples/packages/get-file/package.json
@@ -28,7 +28,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/home-page/.depcheckrc.json
+++ b/packages/examples/packages/home-page/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/home-page/package.json
+++ b/packages/examples/packages/home-page/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/home-page/package.json
+++ b/packages/examples/packages/home-page/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -58,6 +57,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/images/.depcheckrc.json
+++ b/packages/examples/packages/images/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/images/package.json
+++ b/packages/examples/packages/images/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/images/package.json
+++ b/packages/examples/packages/images/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",
@@ -59,6 +58,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/interactive-ui/.depcheckrc.json
+++ b/packages/examples/packages/interactive-ui/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/interactive-ui/package.json
+++ b/packages/examples/packages/interactive-ui/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/interactive-ui/package.json
+++ b/packages/examples/packages/interactive-ui/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",
@@ -59,6 +58,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "rimraf": "^4.1.2",

--- a/packages/examples/packages/invoke-snap/.depcheckrc.json
+++ b/packages/examples/packages/invoke-snap/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/invoke-snap/package.json
+++ b/packages/examples/packages/invoke-snap/package.json
@@ -22,7 +22,11 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" \"!packages/**\" --ignore-path ../../../../.gitignore",
     "start": "yarn workspaces foreach --worktree --parallel --verbose --interlaced --jobs unlimited run start",
-    "test": "yarn workspaces foreach --worktree --parallel --verbose --interlaced run test"
+    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test:clean": "jest --clearCache",
+    "test:post": "jest-it-up",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.4",
@@ -42,6 +46,7 @@
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/invoke-snap/package.json
+++ b/packages/examples/packages/invoke-snap/package.json
@@ -22,7 +22,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" \"!packages/**\" --ignore-path ../../../../.gitignore",
     "start": "yarn workspaces foreach --worktree --parallel --verbose --interlaced --jobs unlimited run start",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/.depcheckrc.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",
@@ -61,6 +60,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/.depcheckrc.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",
@@ -63,6 +62,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/json-rpc/.depcheckrc.json
+++ b/packages/examples/packages/json-rpc/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/json-rpc/package.json
+++ b/packages/examples/packages/json-rpc/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/json-rpc/package.json
+++ b/packages/examples/packages/json-rpc/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -58,6 +57,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/jsx/.depcheckrc.json
+++ b/packages/examples/packages/jsx/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/jsx/package.json
+++ b/packages/examples/packages/jsx/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.3.1",

--- a/packages/examples/packages/jsx/package.json
+++ b/packages/examples/packages/jsx/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.3.1",
@@ -60,6 +59,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/lifecycle-hooks/.depcheckrc.json
+++ b/packages/examples/packages/lifecycle-hooks/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/lifecycle-hooks/package.json
+++ b/packages/examples/packages/lifecycle-hooks/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/lifecycle-hooks/package.json
+++ b/packages/examples/packages/lifecycle-hooks/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -58,6 +57,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/localization/.depcheckrc.json
+++ b/packages/examples/packages/localization/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/localization/package.json
+++ b/packages/examples/packages/localization/package.json
@@ -28,8 +28,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -59,6 +58,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/localization/package.json
+++ b/packages/examples/packages/localization/package.json
@@ -28,7 +28,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/manage-state/.depcheckrc.json
+++ b/packages/examples/packages/manage-state/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/manage-state/package.json
+++ b/packages/examples/packages/manage-state/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/manage-state/package.json
+++ b/packages/examples/packages/manage-state/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -58,6 +57,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/name-lookup/.depcheckrc.json
+++ b/packages/examples/packages/name-lookup/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/name-lookup/package.json
+++ b/packages/examples/packages/name-lookup/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/name-lookup/package.json
+++ b/packages/examples/packages/name-lookup/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -58,6 +57,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/network-access/.depcheckrc.json
+++ b/packages/examples/packages/network-access/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/network-access/package.json
+++ b/packages/examples/packages/network-access/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/network-access/package.json
+++ b/packages/examples/packages/network-access/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",
@@ -60,6 +59,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/notifications/.depcheckrc.json
+++ b/packages/examples/packages/notifications/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/notifications/package.json
+++ b/packages/examples/packages/notifications/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/notifications/package.json
+++ b/packages/examples/packages/notifications/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -58,6 +57,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/preinstalled/.depcheckrc.json
+++ b/packages/examples/packages/preinstalled/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/preinstalled/package.json
+++ b/packages/examples/packages/preinstalled/package.json
@@ -28,8 +28,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -61,6 +60,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/preinstalled/package.json
+++ b/packages/examples/packages/preinstalled/package.json
@@ -28,7 +28,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/rollup-plugin/.depcheckrc.json
+++ b/packages/examples/packages/rollup-plugin/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/rollup-plugin/package.json
+++ b/packages/examples/packages/rollup-plugin/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "yarn build --watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/rollup-plugin/package.json
+++ b/packages/examples/packages/rollup-plugin/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "yarn build --watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -65,6 +64,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "rollup": "^2.73.0",

--- a/packages/examples/packages/send-flow/.depcheckrc.json
+++ b/packages/examples/packages/send-flow/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/send-flow/package.json
+++ b/packages/examples/packages/send-flow/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.3.1",

--- a/packages/examples/packages/send-flow/package.json
+++ b/packages/examples/packages/send-flow/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/rpc-errors": "^6.3.1",
@@ -59,6 +58,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/signature-insights/.depcheckrc.json
+++ b/packages/examples/packages/signature-insights/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/signature-insights/package.json
+++ b/packages/examples/packages/signature-insights/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/signature-insights/package.json
+++ b/packages/examples/packages/signature-insights/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -58,6 +57,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/transaction-insights/.depcheckrc.json
+++ b/packages/examples/packages/transaction-insights/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/transaction-insights/package.json
+++ b/packages/examples/packages/transaction-insights/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",

--- a/packages/examples/packages/transaction-insights/package.json
+++ b/packages/examples/packages/transaction-insights/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",
@@ -59,6 +58,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/wasm/.depcheckrc.json
+++ b/packages/examples/packages/wasm/.depcheckrc.json
@@ -10,6 +10,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/examples/packages/wasm/package.json
+++ b/packages/examples/packages/wasm/package.json
@@ -28,7 +28,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "yarn build:wasm && mm-snap watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/wasm/package.json
+++ b/packages/examples/packages/wasm/package.json
@@ -28,8 +28,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "yarn build:wasm && mm-snap watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -60,6 +59,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-node": "^10.9.1",

--- a/packages/examples/packages/webpack-plugin/.depcheckrc.json
+++ b/packages/examples/packages/webpack-plugin/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "swc-loader",
     "ts-node",

--- a/packages/examples/packages/webpack-plugin/package.json
+++ b/packages/examples/packages/webpack-plugin/package.json
@@ -27,7 +27,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "webpack watch",
-    "test": "yarn test:e2e"
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"

--- a/packages/examples/packages/webpack-plugin/package.json
+++ b/packages/examples/packages/webpack-plugin/package.json
@@ -27,8 +27,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "webpack watch",
-    "test": "yarn test:e2e",
-    "test:e2e": "jest"
+    "test": "yarn test:e2e"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^"
@@ -59,6 +58,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "swc-loader": "^0.2.3",

--- a/packages/snaps-browserify-plugin/.depcheckrc.json
+++ b/packages/snaps-browserify-plugin/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -39,7 +39,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -39,9 +39,11 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest && yarn posttest",
-    "posttest": "jest-it-up",
-    "test:ci": "yarn test"
+    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test:clean": "jest --clearCache",
+    "test:post": "jest-it-up",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-utils": "workspace:^",
@@ -77,6 +79,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
     "jest-it-up": "^2.0.0",
+    "jest-silent-reporter": "^0.6.0",
     "memfs": "^3.4.13",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",

--- a/packages/snaps-cli/.depcheckrc.json
+++ b/packages/snaps-cli/.depcheckrc.json
@@ -13,6 +13,7 @@
     "buffer",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "events",
     "is-core-module",
     "prettier-plugin-packagejson",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -46,10 +46,11 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest --runInBand && yarn posttest",
-    "posttest": "jest-it-up",
-    "test:ci": "yarn test",
-    "test:watch": "yarn test --watch"
+    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test:clean": "jest --clearCache",
+    "test:post": "jest-it-up",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@babel/core": "^7.23.2",
@@ -132,6 +133,7 @@
     "execa": "^5.1.1",
     "jest": "^29.0.2",
     "jest-it-up": "^2.0.0",
+    "jest-silent-reporter": "^0.6.0",
     "memfs": "^3.4.13",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -46,7 +46,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",

--- a/packages/snaps-controllers/.depcheckrc.json
+++ b/packages/snaps-controllers/.depcheckrc.json
@@ -10,6 +10,7 @@
     "@wdio/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "expect-webdriverio",
     "prettier-plugin-packagejson",
     "ts-node",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -59,11 +59,11 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:browser && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter && yarn test:browser",
     "test:browser": "wdio run wdio.config.js",
     "test:clean": "jest --clearCache",
     "test:post": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",
-    "test:prepare": "yarn mkdirp test/fixtures && ./scripts/generate-fixtures.sh",
+    "test:pre": "yarn mkdirp test/fixtures && ./scripts/generate-fixtures.sh",
     "test:verbose": "jest --verbose",
     "test:watch": "jest --watch"
   },

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -59,10 +59,10 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter && yarn test:browser && yarn test:post",
     "test:browser": "wdio run wdio.config.js",
     "test:clean": "jest --clearCache",
-    "test:post": "jest-it-up",
+    "test:post": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",
     "test:prepare": "yarn mkdirp test/fixtures && ./scripts/generate-fixtures.sh",
     "test:verbose": "jest --verbose",
     "test:watch": "jest --watch"

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -59,11 +59,13 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "rimraf coverage && yarn test:prepare && jest && yarn test:browser && yarn posttest",
-    "posttest": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",
+    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
     "test:browser": "wdio run wdio.config.js",
-    "test:ci": "yarn test",
-    "test:prepare": "yarn mkdirp test/fixtures && ./scripts/generate-fixtures.sh"
+    "test:clean": "jest --clearCache",
+    "test:post": "jest-it-up",
+    "test:prepare": "yarn mkdirp test/fixtures && ./scripts/generate-fixtures.sh",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/approval-controller": "^7.0.2",
@@ -138,6 +140,7 @@
     "istanbul-reports": "^3.1.5",
     "jest": "^29.0.2",
     "jest-fetch-mock": "^3.0.3",
+    "jest-silent-reporter": "^0.6.0",
     "mkdirp": "^1.0.4",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",

--- a/packages/snaps-execution-environments/.depcheckrc.json
+++ b/packages/snaps-execution-environments/.depcheckrc.json
@@ -10,6 +10,7 @@
     "@wdio/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "expect-webdriverio",
     "prettier-plugin-packagejson",
     "ts-node",

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -48,10 +48,10 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ./.prettierignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "node scripts/start.js",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter && yarn test:browser && yarn test:post",
     "test:browser": "wdio run wdio.config.js",
     "test:clean": "jest --clearCache",
-    "test:post": "jest-it-up",
+    "test:post": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",
     "test:verbose": "jest --verbose",
     "test:watch": "jest --watch"
   },

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -48,7 +48,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ./.prettierignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "node scripts/start.js",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:browser && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter && yarn test:browser",
     "test:browser": "wdio run wdio.config.js",
     "test:clean": "jest --clearCache",
     "test:post": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -48,10 +48,11 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ./.prettierignore",
     "publish:preview": "yarn npm publish --tag preview",
     "start": "node scripts/start.js",
-    "test": "rimraf coverage && jest && yarn test:browser && yarn posttest",
-    "posttest": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",
+    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
     "test:browser": "wdio run wdio.config.js",
-    "test:ci": "yarn test",
+    "test:clean": "jest --clearCache",
+    "test:post": "jest-it-up",
+    "test:verbose": "jest --verbose",
     "test:watch": "jest --watch"
   },
   "dependencies": {
@@ -116,6 +117,7 @@
     "jest": "^29.0.2",
     "jest-environment-node": "^29.5.0",
     "jest-fetch-mock": "^3.0.3",
+    "jest-silent-reporter": "^0.6.0",
     "lavamoat": "^8.0.4",
     "lavamoat-browserify": "^17.0.5",
     "prettier": "^2.8.8",

--- a/packages/snaps-jest/.depcheckrc.json
+++ b/packages/snaps-jest/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "redux",
     "ts-node",

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -35,7 +35,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -35,9 +35,11 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest --passWithNoTests && yarn posttest",
-    "posttest": "jest-it-up",
-    "test:ci": "yarn test"
+    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test:clean": "jest --clearCache",
+    "test:post": "jest-it-up",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@jest/environment": "^29.5.0",
@@ -81,6 +83,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
     "jest-it-up": "^2.0.0",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "typescript": "~5.3.3"

--- a/packages/snaps-rollup-plugin/.depcheckrc.json
+++ b/packages/snaps-rollup-plugin/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -40,9 +40,11 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest && yarn posttest",
-    "posttest": "jest-it-up",
-    "test:ci": "yarn test"
+    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test:clean": "jest --clearCache",
+    "test:post": "jest-it-up",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-utils": "workspace:^"
@@ -73,6 +75,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
     "jest-it-up": "^2.0.0",
+    "jest-silent-reporter": "^0.6.0",
     "memfs": "^3.4.13",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -40,7 +40,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",

--- a/packages/snaps-rpc-methods/.depcheckrc.json
+++ b/packages/snaps-rpc-methods/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -11,9 +11,9 @@ module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 92.62,
-      functions: 96.96,
-      lines: 97.51,
-      statements: 96.97,
+      functions: 97.17,
+      lines: 97.67,
+      statements: 97.16,
     },
   },
 });

--- a/packages/snaps-rpc-methods/package.json
+++ b/packages/snaps-rpc-methods/package.json
@@ -37,7 +37,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",

--- a/packages/snaps-rpc-methods/package.json
+++ b/packages/snaps-rpc-methods/package.json
@@ -37,9 +37,11 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest && yarn posttest",
-    "posttest": "jest-it-up --margin 0.25",
-    "test:ci": "yarn test"
+    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test:clean": "jest --clearCache",
+    "test:post": "jest-it-up",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",
@@ -77,6 +79,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
     "jest-it-up": "^2.0.0",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "typescript": "~5.3.3"

--- a/packages/snaps-sdk/.depcheckrc.json
+++ b/packages/snaps-sdk/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -72,7 +72,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -72,9 +72,11 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest && yarn posttest",
-    "posttest": "jest-it-up --margin 0.25",
-    "test:ci": "yarn test"
+    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test:clean": "jest --clearCache",
+    "test:post": "jest-it-up",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/key-tree": "^9.1.2",
@@ -108,6 +110,7 @@
     "jest": "^29.0.2",
     "jest-fetch-mock": "^3.0.3",
     "jest-it-up": "^2.0.0",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-jest": "^29.1.1",

--- a/packages/snaps-simulation/.depcheckrc.json
+++ b/packages/snaps-simulation/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-jest",
     "ts-node",

--- a/packages/snaps-simulation/package.json
+++ b/packages/snaps-simulation/package.json
@@ -37,7 +37,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",

--- a/packages/snaps-simulation/package.json
+++ b/packages/snaps-simulation/package.json
@@ -37,9 +37,11 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest && yarn posttest",
-    "posttest": "jest-it-up --margin 0.25",
-    "test:ci": "yarn test"
+    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test:clean": "jest --clearCache",
+    "test:post": "jest-it-up",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/base-controller": "^6.0.2",
@@ -87,6 +89,7 @@
     "express": "^4.18.2",
     "jest": "^29.0.2",
     "jest-it-up": "^2.0.0",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",
     "ts-jest": "^29.1.1",

--- a/packages/snaps-simulator/.depcheckrc.json
+++ b/packages/snaps-simulator/.depcheckrc.json
@@ -12,6 +12,7 @@
     "css-loader",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "process",
     "style-loader",

--- a/packages/snaps-simulator/jest.config.js
+++ b/packages/snaps-simulator/jest.config.js
@@ -7,10 +7,10 @@ delete baseConfig.transform;
 module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
-      branches: 54.18,
+      branches: 54.33,
       functions: 60.76,
-      lines: 80.49,
-      statements: 80.83,
+      lines: 80.54,
+      statements: 80.87,
     },
   },
   setupFiles: ['./jest.setup.js'],

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -20,8 +20,10 @@
     "publish:preview": "yarn npm publish --tag preview",
     "start": "webpack serve --config-name main --mode development",
     "start:e2e": "webpack serve --config-name test --mode development",
-    "test": "jest && jest-it-up --margin 0.5",
-    "test:ci": "yarn test",
+    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test:clean": "jest --clearCache",
+    "test:post": "jest-it-up",
+    "test:verbose": "jest --verbose",
     "test:watch": "jest --watch"
   },
   "dependencies": {
@@ -111,6 +113,7 @@
     "jest-environment-jsdom": "^29.5.0",
     "jest-fetch-mock": "^3.0.3",
     "jest-it-up": "^2.0.0",
+    "jest-silent-reporter": "^0.6.0",
     "monaco-editor-webpack-plugin": "^7.0.1",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -20,7 +20,7 @@
     "publish:preview": "yarn npm publish --tag preview",
     "start": "webpack serve --config-name main --mode development",
     "start:e2e": "webpack serve --config-name test --mode development",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",

--- a/packages/snaps-utils/.depcheckrc.json
+++ b/packages/snaps-utils/.depcheckrc.json
@@ -10,6 +10,7 @@
     "@wdio/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "expect-webdriverio",
     "prettier-plugin-packagejson",
     "ts-node",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -57,10 +57,10 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter && yarn test:browser && yarn test:post",
     "test:browser": "wdio run wdio.config.js",
     "test:clean": "jest --clearCache",
-    "test:post": "jest-it-up",
+    "test:post": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",
     "test:verbose": "jest --verbose",
     "test:watch": "jest --watch"
   },

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -57,7 +57,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:browser && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter && yarn test:browser",
     "test:browser": "wdio run wdio.config.js",
     "test:clean": "jest --clearCache",
     "test:post": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -57,10 +57,12 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "rimraf coverage && jest && yarn test:browser && yarn posttest",
-    "posttest": "ts-node scripts/coverage.ts && rimraf coverage/jest coverage/wdio",
+    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
     "test:browser": "wdio run wdio.config.js",
-    "test:ci": "yarn test"
+    "test:clean": "jest --clearCache",
+    "test:post": "jest-it-up",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@babel/core": "^7.23.2",
@@ -130,6 +132,7 @@
     "istanbul-lib-report": "^3.0.0",
     "istanbul-reports": "^3.1.5",
     "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
     "memfs": "^3.4.13",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",

--- a/packages/snaps-webpack-plugin/.depcheckrc.json
+++ b/packages/snaps-webpack-plugin/.depcheckrc.json
@@ -9,6 +9,7 @@
     "@typescript-eslint/*",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "ts-node",
     "typedoc",

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -40,9 +40,11 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest && yarn posttest",
-    "posttest": "jest-it-up",
-    "test:ci": "yarn test"
+    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test:clean": "jest --clearCache",
+    "test:post": "jest-it-up",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/snaps-sdk": "workspace:^",
@@ -76,6 +78,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.0.2",
     "jest-it-up": "^2.0.0",
+    "jest-silent-reporter": "^0.6.0",
     "memfs": "^3.4.13",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.2",

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -40,7 +40,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "publish:preview": "yarn npm publish --tag preview",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",

--- a/packages/test-snaps/.depcheckrc.json
+++ b/packages/test-snaps/.depcheckrc.json
@@ -11,6 +11,7 @@
     "css-loader",
     "eslint-config-*",
     "eslint-plugin-*",
+    "jest-silent-reporter",
     "prettier-plugin-packagejson",
     "process",
     "style-loader",

--- a/packages/test-snaps/jest.config.js
+++ b/packages/test-snaps/jest.config.js
@@ -3,6 +3,7 @@ const deepmerge = require('deepmerge');
 const baseConfig = require('../../jest.config.base');
 
 module.exports = deepmerge(baseConfig, {
+  passWithNoTests: true,
   coverageThreshold: {
     global: {
       branches: 0,

--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -24,9 +24,11 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "start": "yarn workspaces foreach --parallel --verbose --interlaced --all --include \"@metamask/test-snaps\" --include \"@metamask/example-snaps\" run start:test",
     "start:test": "cross-env NODE_ENV=development webpack serve",
-    "test": "jest --passWithNoTests && yarn posttest",
-    "posttest": "jest-it-up",
-    "test:ci": "yarn test"
+    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test:clean": "jest --clearCache",
+    "test:post": "jest-it-up",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/bip32-example-snap": "workspace:^",
@@ -101,6 +103,7 @@
     "html-webpack-plugin": "^5.5.0",
     "jest": "^29.0.2",
     "jest-it-up": "^2.0.0",
+    "jest-silent-reporter": "^0.6.0",
     "prettier": "^2.8.8",
     "style-loader": "^3.3.2",
     "swc-loader": "^0.2.3",

--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -24,7 +24,7 @@
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "start": "yarn workspaces foreach --parallel --verbose --interlaced --all --include \"@metamask/test-snaps\" --include \"@metamask/example-snaps\" run start:test",
     "start:test": "cross-env NODE_ENV=development webpack serve",
-    "test": "jest --reporters=jest-silent-reporter && yarn test:post",
+    "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:post": "jest-it-up",
     "test:verbose": "jest --verbose",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3607,6 +3607,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/types@npm:^26.6.2":
+  version: 26.6.2
+  resolution: "@jest/types@npm:26.6.2"
+  dependencies:
+    "@types/istanbul-lib-coverage": "npm:^2.0.0"
+    "@types/istanbul-reports": "npm:^3.0.0"
+    "@types/node": "npm:*"
+    "@types/yargs": "npm:^15.0.0"
+    chalk: "npm:^4.0.0"
+  checksum: 10/02d42749c8c6dc7e3184d0ff0293dd91c97233c2e6dc3708d61ef33d3162d4f07ad38d2d8a39abd94cf2fced69b92a87565c7099137c4529809242ca327254af
+  languageName: node
+  linkType: hard
+
 "@jest/types@npm:^27.5.1":
   version: 27.5.1
   resolution: "@jest/types@npm:27.5.1"
@@ -3924,6 +3937,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -3963,6 +3977,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     rimraf: "npm:^4.1.2"
@@ -4009,6 +4024,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     rimraf: "npm:^4.1.2"
@@ -4048,6 +4064,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -4084,6 +4101,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     rimraf: "npm:^4.1.2"
@@ -4124,6 +4142,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -4182,6 +4201,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -4242,6 +4262,7 @@ __metadata:
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
     jest-it-up: "npm:^2.0.0"
+    jest-silent-reporter: "npm:^0.6.0"
     memfs: "npm:^3.4.13"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
@@ -4284,6 +4305,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     rimraf: "npm:^4.1.2"
@@ -4321,6 +4343,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -4357,6 +4380,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -4523,6 +4547,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -4560,6 +4585,7 @@ __metadata:
     eslint-plugin-promise: "npm:^6.1.1"
     ethers: "npm:^6.3.0"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -4601,6 +4627,7 @@ __metadata:
     eslint-plugin-n: "npm:^15.7.0"
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -4638,6 +4665,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     rimraf: "npm:^4.1.2"
@@ -4677,6 +4705,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -4713,6 +4742,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -4749,6 +4779,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -4785,6 +4816,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -4823,6 +4855,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -4860,6 +4893,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     rimraf: "npm:^4.1.2"
@@ -4889,6 +4923,7 @@ __metadata:
     eslint-plugin-n: "npm:^15.7.0"
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -4936,6 +4971,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -4986,6 +5022,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -5035,6 +5072,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -5071,6 +5109,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -5107,6 +5146,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -5143,6 +5183,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -5181,6 +5222,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -5217,6 +5259,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -5320,6 +5363,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -5386,6 +5430,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     rollup: "npm:^2.73.0"
@@ -5451,6 +5496,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -5487,6 +5533,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -5535,6 +5582,7 @@ __metadata:
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
     jest-it-up: "npm:^2.0.0"
+    jest-silent-reporter: "npm:^0.6.0"
     memfs: "npm:^3.4.13"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
@@ -5602,6 +5650,7 @@ __metadata:
     https-browserify: "npm:^1.0.0"
     jest: "npm:^29.0.2"
     jest-it-up: "npm:^2.0.0"
+    jest-silent-reporter: "npm:^0.6.0"
     memfs: "npm:^3.4.13"
     ora: "npm:^5.4.1"
     os-browserify: "npm:^0.3.0"
@@ -5706,6 +5755,7 @@ __metadata:
     istanbul-reports: "npm:^3.1.5"
     jest: "npm:^29.0.2"
     jest-fetch-mock: "npm:^3.0.3"
+    jest-silent-reporter: "npm:^0.6.0"
     mkdirp: "npm:^1.0.4"
     nanoid: "npm:^3.1.31"
     prettier: "npm:^2.8.8"
@@ -5790,6 +5840,7 @@ __metadata:
     jest: "npm:^29.0.2"
     jest-environment-node: "npm:^29.5.0"
     jest-fetch-mock: "npm:^3.0.3"
+    jest-silent-reporter: "npm:^0.6.0"
     lavamoat: "npm:^8.0.4"
     lavamoat-browserify: "npm:^17.0.5"
     nanoid: "npm:^3.1.31"
@@ -5853,6 +5904,7 @@ __metadata:
     jest-environment-node: "npm:^29.5.0"
     jest-it-up: "npm:^2.0.0"
     jest-matcher-utils: "npm:^29.5.0"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     redux: "npm:^4.2.1"
@@ -5902,6 +5954,7 @@ __metadata:
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
     jest-it-up: "npm:^2.0.0"
+    jest-silent-reporter: "npm:^0.6.0"
     memfs: "npm:^3.4.13"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
@@ -5947,6 +6000,7 @@ __metadata:
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
     jest-it-up: "npm:^2.0.0"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     typescript: "npm:~5.3.3"
@@ -5986,6 +6040,7 @@ __metadata:
     jest: "npm:^29.0.2"
     jest-fetch-mock: "npm:^3.0.3"
     jest-it-up: "npm:^2.0.0"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-jest: "npm:^29.1.1"
@@ -6037,6 +6092,7 @@ __metadata:
     express: "npm:^4.18.2"
     jest: "npm:^29.0.2"
     jest-it-up: "npm:^2.0.0"
+    jest-silent-reporter: "npm:^0.6.0"
     mime: "npm:^3.0.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
@@ -6122,6 +6178,7 @@ __metadata:
     jest-environment-jsdom: "npm:^29.5.0"
     jest-fetch-mock: "npm:^3.0.3"
     jest-it-up: "npm:^2.0.0"
+    jest-silent-reporter: "npm:^0.6.0"
     lodash.debounce: "npm:^4.0.8"
     lodash.memoize: "npm:^4.1.2"
     lodash.throttle: "npm:^4.1.1"
@@ -6220,6 +6277,7 @@ __metadata:
     istanbul-lib-report: "npm:^3.0.0"
     istanbul-reports: "npm:^3.1.5"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     marked: "npm:^12.0.1"
     memfs: "npm:^3.4.13"
     prettier: "npm:^2.8.8"
@@ -6271,6 +6329,7 @@ __metadata:
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
     jest-it-up: "npm:^2.0.0"
+    jest-silent-reporter: "npm:^0.6.0"
     memfs: "npm:^3.4.13"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
@@ -6363,6 +6422,7 @@ __metadata:
     html-webpack-plugin: "npm:^5.5.0"
     jest: "npm:^29.0.2"
     jest-it-up: "npm:^2.0.0"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     react: "npm:^18.2.0"
     react-bootstrap: "npm:^2.5.0"
@@ -6428,6 +6488,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     ts-node: "npm:^10.9.1"
@@ -6465,6 +6526,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     prettier: "npm:^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.2"
     swc-loader: "npm:^0.2.3"
@@ -8142,6 +8204,15 @@ __metadata:
   version: 20.2.0
   resolution: "@types/yargs-parser@npm:20.2.0"
   checksum: 10/7351eecdee7e109ec0b6755b327ee3d6ed534a2f4e5351b44e3fa320a9b30c645b92de4d6250b52b1b67e6bc7870bfbba45138853cf0aa2098ae4717546747eb
+  languageName: node
+  linkType: hard
+
+"@types/yargs@npm:^15.0.0":
+  version: 15.0.19
+  resolution: "@types/yargs@npm:15.0.19"
+  dependencies:
+    "@types/yargs-parser": "npm:*"
+  checksum: 10/c3abcd3472c32c02702f365dc1702a0728562deb8a8c61f3ce2161958d756cc033f7d78567565b4eba62f5869e9b5eac93d4c1dcb2c97af17aafda8f9f892b4b
   languageName: node
   linkType: hard
 
@@ -10513,6 +10584,13 @@ __metadata:
   peerDependencies:
     devtools-protocol: "*"
   checksum: 10/83e887d878601ad5004b201782e0ce66c09468b03fe5a29cd48ea410be4e1ec359d2560ab49f98c131baef9508abbe640b84f4a625e0610e0dd790e0ebcd3883
+  languageName: node
+  linkType: hard
+
+"ci-info@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "ci-info@npm:2.0.0"
+  checksum: 10/3b374666a85ea3ca43fa49aa3a048d21c9b475c96eb13c133505d2324e7ae5efd6a454f41efe46a152269e9b6a00c9edbe63ec7fa1921957165aae16625acd67
   languageName: node
   linkType: hard
 
@@ -15166,6 +15244,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-ci@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "is-ci@npm:2.0.0"
+  dependencies:
+    ci-info: "npm:^2.0.0"
+  bin:
+    is-ci: bin.js
+  checksum: 10/77b869057510f3efa439bbb36e9be429d53b3f51abd4776eeea79ab3b221337fe1753d1e50058a9e2c650d38246108beffb15ccfd443929d77748d8c0cc90144
+  languageName: node
+  linkType: hard
+
 "is-core-module@npm:^2.11.0, is-core-module@npm:^2.12.0, is-core-module@npm:^2.13.0, is-core-module@npm:^2.8.1, is-core-module@npm:^2.9.0":
   version: 2.13.0
   resolution: "is-core-module@npm:2.13.0"
@@ -16052,6 +16141,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-silent-reporter@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "jest-silent-reporter@npm:0.6.0"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    jest-util: "npm:^26.0.0"
+  checksum: 10/443e0abaf5a6dc8c17da1e8495b7a55f813224adc39b6d1954bf49ff7fe70533b1020571453180dbb8388ace87f8e1dfc79610a4554bb93334f6c4154231c292
+  languageName: node
+  linkType: hard
+
 "jest-snapshot@npm:^29.5.0":
   version: 29.5.0
   resolution: "jest-snapshot@npm:29.5.0"
@@ -16094,6 +16193,20 @@ __metadata:
     graceful-fs: "npm:^4.2.9"
     picomatch: "npm:^2.2.3"
   checksum: 10/455af2b5e064213b33b837a18ddd3d31878aee31ad40bbd599de2a4977f860a797e491cb94894e38bbd352cb7b31d41448b7ec3b346408613015411cd88ed57f
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:^26.0.0":
+  version: 26.6.2
+  resolution: "jest-util@npm:26.6.2"
+  dependencies:
+    "@jest/types": "npm:^26.6.2"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.0.0"
+    graceful-fs: "npm:^4.2.4"
+    is-ci: "npm:^2.0.0"
+    micromatch: "npm:^4.0.2"
+  checksum: 10/4502bc699f147d2fa43274af18174b55fd5b956becd1347665217e35a5354e929206abaef580f967ed239587be926c835eb3ca9b5c361205df1988bc8d58a462
   languageName: node
   linkType: hard
 
@@ -20276,6 +20389,7 @@ __metadata:
     favicons: "npm:^7.1.2"
     geckodriver: "npm:^4.2.0"
     jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
     lint-staged: "npm:^12.4.1"
     minimatch: "npm:^7.4.1"
     prettier: "npm:^2.8.8"


### PR DESCRIPTION
This updates the test scripts to match the scripts in `MetaMask/core`. Primarily, it introduces a couple new test scripts:

- `test`: Runs Jest with `jest-silent-reporter` to only show failed tests.
- `test:clean`: Clears the Jest cache before running tests.
- `test:verbose`: Runs Jest with verbose logging.
- `test:watch`: Runs Jest in watch mode.