### PR TITLE
Export `WebViewMessageStream` and related types

### DIFF
--- a/packages/snaps-controllers/src/services/browser.test.ts
+++ b/packages/snaps-controllers/src/services/browser.test.ts
@@ -9,6 +9,7 @@ describe('browser entrypoint', () => {
     'WebWorkerExecutionService',
     'ProxyPostMessageStream',
     'WebViewExecutionService',
+    'WebViewMessageStream',
   ];
 
   it('entrypoint has expected exports', () => {

--- a/packages/snaps-controllers/src/services/webview/WebViewMessageStream.ts
+++ b/packages/snaps-controllers/src/services/webview/WebViewMessageStream.ts
@@ -10,7 +10,7 @@ export type WebViewInterface = {
   unregisterMessageListener(listener: (event: PostMessageEvent) => void): void;
 };
 
-type WebViewStreamArgs = {
+export type WebViewStreamArgs = {
   name: string;
   target: string;
   getWebView: () => Promise<WebViewInterface>;
@@ -19,7 +19,6 @@ type WebViewStreamArgs = {
 /**
  * A special postMessage stream used to interface with a WebView.
  */
-
 export class WebViewMessageStream extends BasePostMessageStream {
   #name;
 

--- a/packages/snaps-controllers/src/services/webview/index.ts
+++ b/packages/snaps-controllers/src/services/webview/index.ts
@@ -1,1 +1,2 @@
 export * from './WebViewExecutionService';
+export * from './WebViewMessageStream';


### PR DESCRIPTION
This exports the `WebViewMessageStream` class and related types from the `react-native` entrypoint in `@metamask/snaps-controllers`.