### PR TITLE
Update metadata for all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"
   },
+  "files": [],
   "workspaces": [
     "packages/*"
   ],

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/create-snap",
   "version": "4.0.4",
-  "description": "A CLI for creating MetaMask Snaps.",
+  "description": "A CLI for creating MetaMask Snaps",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/create-snap#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -2,11 +2,21 @@
   "name": "@metamask/example-snaps",
   "version": "3.9.0",
   "private": true,
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "license": "(MIT-0 OR Apache-2.0)",
+  "sideEffects": false,
   "files": [],
   "workspaces": [
     "packages/*"
@@ -22,6 +32,7 @@
     "lint:eslint": "eslint . --cache --ext js,ts,jsx,tsx",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!packages/**\" --ignore-path ../../.gitignore",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
     "start": "yarn workspaces foreach --worktree --parallel --verbose --interlaced --no-private --jobs unlimited run start",
     "start:test": "yarn start",
     "test": "jest --reporters=jest-silent-reporter",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -2,6 +2,7 @@
   "name": "@metamask/example-snaps",
   "version": "3.9.0",
   "private": true,
+  "description": "A collection of examples demonstrating how to build MetaMask Snaps",
   "keywords": [
     "MetaMask",
     "Snaps",

--- a/packages/examples/packages/bip32/package.json
+++ b/packages/examples/packages/bip32/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/bip32-example-snap",
   "version": "2.2.1",
-  "description": "MetaMask example snap demonstrating the use of `snap_getBip32Entropy`.",
+  "description": "MetaMask example snap demonstrating the use of `snap_getBip32Entropy`",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/bip32#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/bip44/package.json
+++ b/packages/examples/packages/bip44/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/bip44-example-snap",
   "version": "2.1.3",
-  "description": "MetaMask example snap demonstrating the use of `snap_getBip44Entropy`.",
+  "description": "MetaMask example snap demonstrating the use of `snap_getBip44Entropy`",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/bip44#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/browserify-plugin/package.json
+++ b/packages/examples/packages/browserify-plugin/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/browserify-plugin-example-snap",
   "version": "2.1.3",
-  "description": "MetaMask example snap demonstrating how to use the Browserify plugin to bundle a snap.",
+  "description": "MetaMask example snap demonstrating how to use the Browserify plugin to bundle a snap",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/browserify-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/browserify/package.json
+++ b/packages/examples/packages/browserify/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/browserify-example-snap",
   "version": "2.1.3",
-  "description": "MetaMask example snap demonstrating how to use Browserify to bundle a snap.",
+  "description": "MetaMask example snap demonstrating how to use Browserify to bundle a snap",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/browserify#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/client-status/package.json
+++ b/packages/examples/packages/client-status/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/client-status-example-snap",
   "version": "1.0.3",
-  "description": "MetaMask example snap demonstrating the use of `snap_getClientStatus`.",
+  "description": "MetaMask example snap demonstrating the use of `snap_getClientStatus`",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/client-status#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/cronjobs/package.json
+++ b/packages/examples/packages/cronjobs/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/cronjob-example-snap",
   "version": "2.1.4",
-  "description": "MetaMask example snap demonstrating the use of cronjobs in snaps.",
+  "description": "MetaMask example snap demonstrating the use of cronjobs in snaps",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/cronjobs#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/dialogs/package.json
+++ b/packages/examples/packages/dialogs/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/dialog-example-snap",
   "version": "2.3.1",
-  "description": "MetaMask example snap demonstrating the use of `snap_dialog`.",
+  "description": "MetaMask example snap demonstrating the use of `snap_dialog`",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/dialogs#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/errors/package.json
+++ b/packages/examples/packages/errors/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/error-example-snap",
   "version": "2.1.3",
-  "description": "MetaMask example snap demonstrating the use of error handling in snaps.",
+  "description": "MetaMask example snap demonstrating the use of error handling in snaps",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/errors#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/ethereum-provider/package.json
+++ b/packages/examples/packages/ethereum-provider/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/ethereum-provider-example-snap",
   "version": "2.1.3",
-  "description": "MetaMask example snap demonstrating the use of the Ethereum Provider API and `endowment:ethereum-provider` permission.",
+  "description": "MetaMask example snap demonstrating the use of the Ethereum Provider API and `endowment:ethereum-provider` permission",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/ethereum-provider#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/ethers-js/package.json
+++ b/packages/examples/packages/ethers-js/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/ethers-js-example-snap",
   "version": "2.1.3",
-  "description": "MetaMask example snap demonstrating how to use Ethers.js inside a snap.",
+  "description": "MetaMask example snap demonstrating how to use Ethers.js inside a snap",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/ethers-js#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/file-upload/package.json
+++ b/packages/examples/packages/file-upload/package.json
@@ -2,6 +2,15 @@
   "name": "@metamask/file-upload-example-snap",
   "version": "1.0.1",
   "description": "MetaMask example snap demonstrating file inputs and handling file uploads",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/file-upload#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/get-entropy/package.json
+++ b/packages/examples/packages/get-entropy/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/get-entropy-example-snap",
   "version": "2.1.3",
-  "description": "MetaMask example snap demonstrating the use of `snap_getEntropy`.",
+  "description": "MetaMask example snap demonstrating the use of `snap_getEntropy`",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/get-entropy#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/get-file/package.json
+++ b/packages/examples/packages/get-file/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/get-file-example-snap",
   "version": "1.1.3",
-  "description": "MetaMask example snap demonstrating the use of `snap_getFile`.",
+  "description": "MetaMask example snap demonstrating the use of `snap_getFile`",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/get-file#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/home-page/package.json
+++ b/packages/examples/packages/home-page/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/home-page-example-snap",
   "version": "1.1.3",
-  "description": "MetaMask example snap demonstrating the use of home pages.",
+  "description": "MetaMask example snap demonstrating the use of home pages",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/home-page#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/images/package.json
+++ b/packages/examples/packages/images/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/images-example-snap",
   "version": "1.1.1",
-  "description": "MetaMask example Snap demonstrating how to render images in Snaps UI.",
+  "description": "MetaMask example Snap demonstrating how to render images in Snaps UI",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/images#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/interactive-ui/package.json
+++ b/packages/examples/packages/interactive-ui/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/interactive-ui-example-snap",
   "version": "2.2.1",
-  "description": "MetaMask example snap demonstrating the use of interactive UI.",
+  "description": "MetaMask example snap demonstrating the use of interactive UI",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/interactive-ui#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/invoke-snap/package.json
+++ b/packages/examples/packages/invoke-snap/package.json
@@ -2,12 +2,23 @@
   "name": "@metamask/invoke-snap-example-snap",
   "version": "2.1.3",
   "private": true,
-  "description": "MetaMask example snaps demonstrating the use of `wallet_invokeSnap` to call a snap from another snap.",
+  "description": "MetaMask example snaps demonstrating the use of `wallet_invokeSnap` to call a snap from another snap",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/invoke-snap#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "license": "(MIT-0 OR Apache-2.0)",
+  "sideEffects": false,
+  "files": [],
   "workspaces": [
     "packages/*"
   ],
@@ -21,6 +32,7 @@
     "lint:eslint": "eslint . --cache --ext js,ts,jsx,tsx",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" \"!packages/**\" --ignore-path ../../../../.gitignore",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "yarn workspaces foreach --worktree --parallel --verbose --interlaced --jobs unlimited run start",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
@@ -54,9 +66,5 @@
   },
   "engines": {
     "node": "^18.16 || >=20"
-  },
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/consumer-signer-example-snap",
   "version": "2.1.3",
-  "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
+  "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/invoke-snap/packages/consumer-signer#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/invoke-snap/packages/core-signer/package.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/core-signer-example-snap",
   "version": "2.1.3",
-  "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages.",
+  "description": "MetaMask example snap demonstrating how a snap can communicate with another snap to sign messages",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/invoke-snap/packages/core-signer#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/json-rpc/package.json
+++ b/packages/examples/packages/json-rpc/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/json-rpc-example-snap",
   "version": "2.1.3",
-  "description": "MetaMask example snap demonstrating the use of the `endowment:rpc` permission.",
+  "description": "MetaMask example snap demonstrating the use of the `endowment:rpc` permission",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/json-rpc#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/jsx/package.json
+++ b/packages/examples/packages/jsx/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/jsx-example-snap",
   "version": "1.2.1",
-  "description": "MetaMask example snap demonstrating the use of JSX for UI components.",
+  "description": "MetaMask example snap demonstrating the use of JSX for UI components",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/jsx#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/lifecycle-hooks/package.json
+++ b/packages/examples/packages/lifecycle-hooks/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/lifecycle-hooks-example-snap",
   "version": "2.1.3",
-  "description": "MetaMask example snap demonstrating the use of the `onInstall` and `onUpdate` lifecycle hooks.",
+  "description": "MetaMask example snap demonstrating the use of the `onInstall` and `onUpdate` lifecycle hooks",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/lifecycle-hooks#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/localization/package.json
+++ b/packages/examples/packages/localization/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/localization-example-snap",
   "version": "1.1.4",
-  "description": "MetaMask example snap demonstrating how to localize a snap.",
+  "description": "MetaMask example snap demonstrating how to localize a snap",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/localization#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/manage-state/package.json
+++ b/packages/examples/packages/manage-state/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/manage-state-example-snap",
   "version": "2.2.3",
-  "description": "MetaMask example snap demonstrating the use of `snap_manageState`.",
+  "description": "MetaMask example snap demonstrating the use of `snap_manageState`",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/manage-state#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/name-lookup/package.json
+++ b/packages/examples/packages/name-lookup/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/name-lookup-example-snap",
   "version": "3.1.1",
-  "description": "MetaMask example snap demonstrating the use of the `endowment:name-lookup` permission.",
+  "description": "MetaMask example snap demonstrating the use of the `endowment:name-lookup` permission",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/name-lookup#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/network-access/package.json
+++ b/packages/examples/packages/network-access/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/network-example-snap",
   "version": "2.1.3",
-  "description": "MetaMask example snap demonstrating the use of the `endowment:network-access` permission in snaps.",
+  "description": "MetaMask example snap demonstrating the use of the `endowment:network-access` permission in snaps",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/network-access#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/notifications/package.json
+++ b/packages/examples/packages/notifications/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/notification-example-snap",
   "version": "2.1.4",
-  "description": "MetaMask example snap demonstrating the use of `snap_notify`.",
+  "description": "MetaMask example snap demonstrating the use of `snap_notify`",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/notifications#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/preinstalled/package.json
+++ b/packages/examples/packages/preinstalled/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/preinstalled-example-snap",
   "version": "0.1.0",
-  "description": "MetaMask example snap demonstrating preinstalled Snaps.",
+  "description": "MetaMask example snap demonstrating preinstalled Snaps",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/preinstalled#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/rollup-plugin/package.json
+++ b/packages/examples/packages/rollup-plugin/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/rollup-plugin-example-snap",
   "version": "2.1.3",
-  "description": "MetaMask example snap demonstrating how to use the Rollup plugin to bundle a snap.",
+  "description": "MetaMask example snap demonstrating how to use the Rollup plugin to bundle a snap",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/rollup-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/send-flow/package.json
+++ b/packages/examples/packages/send-flow/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/send-flow-example-snap",
   "version": "0.0.0",
-  "description": "MetaMask example Snap demonstrating a send flow with UI components.",
+  "description": "MetaMask example Snap demonstrating a send flow with UI components",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/send-flow#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/signature-insights/package.json
+++ b/packages/examples/packages/signature-insights/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/signature-insights-example-snap",
   "version": "1.0.3",
-  "description": "MetaMask example snap demonstrating the use of the Signature Insights API.",
+  "description": "MetaMask example snap demonstrating the use of the Signature Insights API",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/signature-insights#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/transaction-insights/package.json
+++ b/packages/examples/packages/transaction-insights/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/insights-example-snap",
   "version": "2.2.3",
-  "description": "MetaMask example snap demonstrating the use of the Transaction Insights API.",
+  "description": "MetaMask example snap demonstrating the use of the Transaction Insights API",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/transaction-insights#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/wasm/package.json
+++ b/packages/examples/packages/wasm/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/wasm-example-snap",
   "version": "2.1.4",
-  "description": "MetaMask example snap demonstrating the use of WebAssembly and the `endowment:webassembly` permission.",
+  "description": "MetaMask example snap demonstrating the use of WebAssembly and the `endowment:webassembly` permission",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/wasm#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/examples/packages/webpack-plugin/package.json
+++ b/packages/examples/packages/webpack-plugin/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/webpack-plugin-example-snap",
   "version": "2.1.3",
-  "description": "MetaMask example snap demonstrating how to use the Webpack plugin to bundle a snap.",
+  "description": "MetaMask example snap demonstrating how to use the Webpack plugin to bundle a snap",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/webpack-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -2,8 +2,16 @@
   "name": "@metamask/snaps-browserify-plugin",
   "version": "4.1.2",
   "keywords": [
-    "browserify-plugin"
+    "MetaMask",
+    "Snaps",
+    "Ethereum",
+    "Browserify",
+    "Plugin"
   ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/snaps-browserify-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@metamask/snaps-browserify-plugin",
   "version": "4.1.2",
+  "description": "A Browserify plugin to build MetaMask Snaps with Browserify",
   "keywords": [
     "MetaMask",
     "Snaps",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/snaps-cli",
   "version": "6.3.3",
-  "description": "A CLI for developing MetaMask Snaps.",
+  "description": "A CLI for developing MetaMask Snaps",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/snaps-cli#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/snaps-controllers",
   "version": "9.7.0",
-  "description": "Controllers for MetaMask Snaps.",
+  "description": "Controllers for MetaMask Snaps",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/snaps-controllers#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -2,6 +2,15 @@
   "name": "@metamask/snaps-execution-environments",
   "version": "6.7.2",
   "description": "Snap sandbox environments for executing SES javascript",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/snaps-execution-environments#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -1,7 +1,20 @@
 {
   "name": "@metamask/snaps-jest",
   "version": "8.4.0",
-  "description": "A Jest preset for end-to-end testing MetaMask Snaps, including a Jest environment, and a set of Jest matchers.",
+  "description": "A Jest preset for end-to-end testing MetaMask Snaps, including a Jest environment, and a set of Jest matchers",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/snaps-jest#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/snaps.git"
+  },
   "license": "ISC",
   "sideEffects": false,
   "exports": {
@@ -90,7 +103,6 @@
     "prettier-plugin-packagejson": "^2.5.2",
     "typescript": "~5.3.3"
   },
-  "packageManager": "yarn@3.4.1",
   "engines": {
     "node": "^18.16 || >=20"
   },

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -2,9 +2,16 @@
   "name": "@metamask/snaps-rollup-plugin",
   "version": "4.1.2",
   "keywords": [
-    "rollup",
-    "rollup-plugin"
+    "MetaMask",
+    "Snaps",
+    "Ethereum",
+    "Rollup",
+    "Plugin"
   ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/snaps-rollup-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@metamask/snaps-rollup-plugin",
   "version": "4.1.2",
+  "description": "A Rollup plugin to build MetaMask Snaps with Rollup",
   "keywords": [
     "MetaMask",
     "Snaps",

--- a/packages/snaps-rpc-methods/package.json
+++ b/packages/snaps-rpc-methods/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@metamask/snaps-rpc-methods",
   "version": "11.1.1",
-  "description": "MetaMask Snaps JSON-RPC method implementations.",
+  "description": "MetaMask Snaps JSON-RPC method implementations",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/snaps-rpc-methods#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@metamask/snaps-sdk",
   "version": "6.5.1",
+  "description": "A library containing the core functionality for building MetaMask Snaps",
   "keywords": [
     "MetaMask",
     "Snaps",

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@metamask/snaps-sdk",
   "version": "6.5.1",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/snaps-sdk#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-simulation/package.json
+++ b/packages/snaps-simulation/package.json
@@ -2,6 +2,15 @@
   "name": "@metamask/snaps-simulation",
   "version": "1.0.0",
   "description": "A simulation framework for MetaMask Snaps, enabling headless testing of Snaps in a controlled environment",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/snaps-simulation#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-simulator/package.json
+++ b/packages/snaps-simulator/package.json
@@ -3,9 +3,22 @@
   "version": "2.5.0",
   "private": true,
   "description": "A simulator for MetaMask Snaps, to be used for testing and development",
-  "homepage": "https://github.com/MetaMask/snaps#readme",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/snaps-simulator#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/snaps.git"
+  },
   "license": "MIT",
   "sideEffects": false,
+  "files": [],
   "scripts": {
     "build": "yarn build:vendor && yarn build:webpack",
     "build:vendor": "webpack --config-name vendor --mode production --progress",
@@ -18,7 +31,7 @@
     "lint:eslint": "eslint . --cache --ext js,ts,jsx,tsx",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:constraints --fix && yarn lint:misc --write && yarn changelog:validate",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
-    "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
     "start": "webpack serve --config-name main --mode development",
     "start:e2e": "webpack serve --config-name test --mode development",
     "test": "jest --reporters=jest-silent-reporter",
@@ -134,7 +147,6 @@
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"
   },
-  "packageManager": "yarn@3.2.1",
   "engines": {
     "node": "^18.16 || >=20"
   }

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@metamask/snaps-utils",
   "version": "8.1.1",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/snaps-utils#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@metamask/snaps-utils",
   "version": "8.1.1",
+  "description": "A collection of utilities for MetaMask Snaps",
   "keywords": [
     "MetaMask",
     "Snaps",

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@metamask/snaps-webpack-plugin",
   "version": "4.1.2",
+  "description": "A Webpack plugin to build MetaMask Snaps with Webpack",
   "keywords": [
     "MetaMask",
     "Snaps",

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -2,9 +2,16 @@
   "name": "@metamask/snaps-webpack-plugin",
   "version": "4.1.2",
   "keywords": [
-    "webpack",
-    "plugin"
+    "MetaMask",
+    "Snaps",
+    "Ethereum",
+    "Webpack",
+    "Plugin"
   ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/snaps-webpack-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"

--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -2,7 +2,16 @@
   "name": "@metamask/test-snaps",
   "version": "2.14.0",
   "private": true,
-  "description": "The test snaps website for MetaMask Snaps, used for end-to-end testing.",
+  "description": "The test snaps website for MetaMask Snaps, used for end-to-end testing",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/test-snaps#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps.git"
@@ -22,6 +31,7 @@
     "lint:eslint": "eslint . --cache --ext js,ts,jsx,tsx",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --loglevel warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
     "start": "yarn workspaces foreach --parallel --verbose --interlaced --all --include \"@metamask/test-snaps\" --include \"@metamask/example-snaps\" run start:test",
     "start:test": "cross-env NODE_ENV=development webpack serve",
     "test": "jest --reporters=jest-silent-reporter",


### PR DESCRIPTION
This updates the metadata for all packages according to the Yarn constraints used in `MetaMask/core`. The notable changes are:

- All packages now have a description.
- All packages now have a `homepage` field pointing to the `README.md` of that package, and a `bugs` field pointing to the issue tracker of this repo.
- All packages now have keywords.