### PR TITLE
Validate list of emails in `validateLink` function

### DIFF
--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 99.73,
   "functions": 98.9,
-  "lines": 99.43,
-  "statements": 96.33
+  "lines": 99.44,
+  "statements": 96.34
 }

--- a/packages/snaps-utils/src/ui.test.tsx
+++ b/packages/snaps-utils/src/ui.test.tsx
@@ -554,6 +554,19 @@ describe('validateLink', () => {
     expect(fn).toHaveBeenCalledWith('bar.com');
   });
 
+  it('passes for a valid list of emails', () => {
+    const fn = jest.fn().mockReturnValue(false);
+
+    expect(() =>
+      validateLink('mailto:foo@bar.com,bar@baz.com,baz@qux.com', fn),
+    ).not.toThrow();
+
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(fn).toHaveBeenCalledWith('bar.com');
+    expect(fn).toHaveBeenCalledWith('baz.com');
+    expect(fn).toHaveBeenCalledWith('qux.com');
+  });
+
   it('throws an error for an invalid protocol', () => {
     const fn = jest.fn().mockReturnValue(false);
 
@@ -590,6 +603,23 @@ describe('validateLink', () => {
 
     expect(() =>
       validateLink('mailto:foo@test.metamask-phishing.io', fn),
+    ).toThrow('Invalid URL: The specified URL is not allowed.');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('test.metamask-phishing.io');
+  });
+
+  it('throws an error for a phishing email when using multiple emails', () => {
+    const fn = jest.fn().mockImplementation((email) => {
+      if (email === 'test.metamask-phishing.io') {
+        return true;
+      }
+
+      return false;
+    });
+
+    expect(() =>
+      validateLink('mailto:foo@test.metamask-phishing.io,foo@bar.com', fn),
     ).toThrow('Invalid URL: The specified URL is not allowed.');
 
     expect(fn).toHaveBeenCalledTimes(1);

--- a/packages/snaps-utils/src/ui.test.tsx
+++ b/packages/snaps-utils/src/ui.test.tsx
@@ -567,6 +567,17 @@ describe('validateLink', () => {
     expect(fn).toHaveBeenCalledWith('qux.com');
   });
 
+  it('passes for a valid email with a parameter', () => {
+    const fn = jest.fn().mockReturnValue(false);
+
+    expect(() =>
+      validateLink('mailto:foo@bar.com?subject=Subject', fn),
+    ).not.toThrow();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('bar.com');
+  });
+
   it('throws an error for an invalid protocol', () => {
     const fn = jest.fn().mockReturnValue(false);
 
@@ -623,6 +634,27 @@ describe('validateLink', () => {
     ).toThrow('Invalid URL: The specified URL is not allowed.');
 
     expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('test.metamask-phishing.io');
+  });
+
+  it('throws an error for a phishing email when using parameters', () => {
+    const fn = jest.fn().mockImplementation((email) => {
+      if (email === 'test.metamask-phishing.io') {
+        return true;
+      }
+
+      return false;
+    });
+
+    expect(() =>
+      validateLink(
+        'mailto:foo@bar.com,foo@test.metamask-phishing.io?subject=Subject',
+        fn,
+      ),
+    ).toThrow('Invalid URL: The specified URL is not allowed.');
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenCalledWith('bar.com');
     expect(fn).toHaveBeenCalledWith('test.metamask-phishing.io');
   });
 });

--- a/packages/snaps-utils/src/ui.tsx
+++ b/packages/snaps-utils/src/ui.tsx
@@ -342,10 +342,23 @@ export function validateLink(
       `Protocol must be one of: ${ALLOWED_PROTOCOLS.join(', ')}.`,
     );
 
-    const hostname =
-      url.protocol === 'mailto:' ? url.pathname.split('@')[1] : url.hostname;
+    if (url.protocol === 'mailto:') {
+      const emails = url.pathname.split(',');
+      for (const email of emails) {
+        const hostname = email.split('@')[1];
+        assert(
+          !isOnPhishingList(hostname),
+          'The specified URL is not allowed.',
+        );
+      }
 
-    assert(!isOnPhishingList(hostname), 'The specified URL is not allowed.');
+      return;
+    }
+
+    assert(
+      !isOnPhishingList(url.hostname),
+      'The specified URL is not allowed.',
+    );
   } catch (error) {
     throw new Error(
       `Invalid URL: ${


### PR DESCRIPTION
This improves the hostname validation when using a list of emails rather than a single email.