### PR TITLE
fix: packageJsonStruct to allow `repository.directory`

### DIFF
--- a/packages/snaps-utils/src/types.ts
+++ b/packages/snaps-utils/src/types.ts
@@ -42,7 +42,7 @@ export const NpmSnapPackageJsonStruct = type({
   name: NameStruct,
   main: optional(size(string(), 1, Infinity)),
   repository: optional(
-    object({
+    type({
       type: size(string(), 1, Infinity),
       url: size(string(), 1, Infinity),
     }),


### PR DESCRIPTION
When releasing a package from a monorepo the `repository.directory` is used to identify which package is been released. This is used for the Github build provenance.