### PR TITLE
feat: Add `href` prop to display a link in `Address`

### DIFF
--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Kn7XJHg0P1YYLU+sZF9pon4NXLadxLmUETLuLAn1qkw=",
+    "shasum": "NwOD0OZI2M0c/vyOkfYLJtGqjMl6ElDBq/nJWyvQs0c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xvq90PFxbF6rSf1t2+LeGCP5oeby0u7bobCT2ySxpF0=",
+    "shasum": "bMX4V7AYR/1NYmknawtr09WKkgLgahrCoAFRf2XO+VI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-sdk/src/jsx/components/Address.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/Address.test.tsx
@@ -14,4 +14,22 @@ describe('Address', () => {
       },
     });
   });
+
+  it('renders an address with a link', () => {
+    const result = (
+      <Address
+        address="0x1234567890123456789012345678901234567890"
+        href="https://foo.bar"
+      />
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Address',
+      key: null,
+      props: {
+        address: '0x1234567890123456789012345678901234567890',
+        href: 'https://foo.bar',
+      },
+    });
+  });
 });

--- a/packages/snaps-sdk/src/jsx/components/Address.ts
+++ b/packages/snaps-sdk/src/jsx/components/Address.ts
@@ -7,9 +7,11 @@ import { createSnapComponent } from '../component';
  *
  * @property address - The (Ethereum) address to display. This should be a
  * valid Ethereum address, starting with `0x`, or a valid CAIP-10 address.
+ * @property href - The optional URL to link to.
  */
 export type AddressProps = {
   address: `0x${string}` | CaipAccountId;
+  href?: string | undefined;
 };
 
 const TYPE = 'Address';
@@ -22,6 +24,7 @@ const TYPE = 'Address';
  * @param props - The props of the component.
  * @param props.address - The address to display. This should be a
  * valid Ethereum address, starting with `0x`, or a valid CAIP-10 address.
+ * @param props.href - The optional URL to link to.
  * @returns An address element.
  * @example
  * <Address address="0x1234567890123456789012345678901234567890" />
@@ -29,6 +32,8 @@ const TYPE = 'Address';
  * <Address address="eip155:1:0x1234567890123456789012345678901234567890" />
  * @example
  * <Address address="bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6" />
+ * @example
+ * <Address address="0x1234567890123456789012345678901234567890" href="https://foo.bar" />
  */
 export const Address = createSnapComponent<AddressProps, typeof TYPE>(TYPE);
 

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -438,6 +438,10 @@ describe('AddressStruct', () => {
     <Address address="eip155:1:0x1234567890abcdef1234567890abcdef12345678" />,
     <Address address="bip122:000000000019d6689c085ae165831e93:128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6" />,
     <Address address="cosmos:cosmoshub-3:cosmos1t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0" />,
+    <Address
+      address="0x1234567890abcdef1234567890abcdef12345678"
+      href="https://foo.bar"
+    />,
   ])('validates an address element', (value) => {
     expect(is(value, AddressStruct)).toBe(true);
   });

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -471,6 +471,7 @@ export const FormattingStruct: Describe<StandardFormattingElement> = typedUnion(
  */
 export const AddressStruct: Describe<AddressElement> = element('Address', {
   address: nullUnion([HexChecksumAddressStruct, CaipAccountIdStruct]),
+  href: optional(string()),
 });
 
 export const BoxChildrenStruct = children(

--- a/packages/snaps-utils/src/ui.test.tsx
+++ b/packages/snaps-utils/src/ui.test.tsx
@@ -811,6 +811,21 @@ describe('validateJsxLinks', () => {
     ).not.toThrow();
   });
 
+  it('does not throw for an Address component with a link', async () => {
+    const isOnPhishingList = () => false;
+
+    expect(() =>
+      validateJsxLinks(
+        <Address
+          address="0x4bbeeb066ed09b7aed07bf39eee0460dfa261520"
+          href="https://foo.bar"
+        />,
+        isOnPhishingList,
+        jest.fn(),
+      ),
+    ).not.toThrow();
+  });
+
   it('does not throw for a JSX component with a link outside of a Link component', async () => {
     const isOnPhishingList = () => true;
 

--- a/packages/snaps-utils/src/ui.tsx
+++ b/packages/snaps-utils/src/ui.tsx
@@ -405,7 +405,7 @@ export function validateTextLinks(
 }
 
 /**
- * Walk a JSX tree and validate each {@link LinkElement} node against the
+ * Walk a JSX tree and validate each {@link LinkElement} node or {@link AddressElement} with the href prop set against the
  * phishing list.
  *
  * @param node - The JSX node to walk.
@@ -419,11 +419,12 @@ export function validateJsxLinks(
   getSnap: (id: string) => Snap | undefined,
 ) {
   walkJsx(node, (childNode) => {
-    if (childNode.type !== 'Link') {
-      return;
+    if (
+      childNode.type === 'Link' ||
+      (childNode.type === 'Address' && childNode.props.href)
+    ) {
+      validateLink(childNode.props.href as string, isOnPhishingList, getSnap);
     }
-
-    validateLink(childNode.props.href, isOnPhishingList, getSnap);
   });
 }
 


### PR DESCRIPTION
This PR adds a new optional `href` prop to `Address` . It will allow an `Address` component to display a link out next to the address.

Fixes: #2757