### PR TITLE
Add interface state handling for `AccountSelector`

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 92.6,
+  "branches": 92.64,
   "functions": 96.65,
   "lines": 97.97,
   "statements": 97.67

--- a/packages/snaps-controllers/src/interface/utils.test.tsx
+++ b/packages/snaps-controllers/src/interface/utils.test.tsx
@@ -15,6 +15,7 @@ import {
   Selector,
   Card,
   SelectorOption,
+  AccountSelector,
 } from '@metamask/snaps-sdk/jsx';
 
 import { assertNameIsUnique, constructState, getJsxInterface } from './utils';
@@ -544,6 +545,82 @@ describe('constructState', () => {
     const result = constructState({}, element);
     expect(result).toStrictEqual({
       form: { foo: 'option2' },
+    });
+  });
+
+  it('sets default value for root level Account selector', () => {
+    const element = (
+      <Box>
+        <AccountSelector
+          name="foo"
+          title="Choose an account"
+          chainId="eip155:1"
+          selectedAddress="0x1234567890123456789012345678901234567890"
+        />
+      </Box>
+    );
+
+    const result = constructState({}, element);
+    expect(result).toStrictEqual({
+      foo: '0x1234567890123456789012345678901234567890',
+    });
+  });
+
+  it('supports root level Account selector', () => {
+    const element = (
+      <Box>
+        <AccountSelector
+          name="foo"
+          title="Choose an account"
+          chainId="eip155:1"
+          selectedAddress="0x1234567890123456789012345678901234567890"
+        />
+      </Box>
+    );
+
+    const result = constructState({}, element);
+    expect(result).toStrictEqual({
+      foo: '0x1234567890123456789012345678901234567890',
+    });
+  });
+
+  it('sets default value for Account selector in form', () => {
+    const element = (
+      <Box>
+        <Form name="form">
+          <AccountSelector
+            name="foo"
+            title="Choose an account"
+            chainId="eip155:1"
+            selectedAddress="0x1234567890123456789012345678901234567890"
+          />
+        </Form>
+      </Box>
+    );
+
+    const result = constructState({}, element);
+    expect(result).toStrictEqual({
+      form: { foo: '0x1234567890123456789012345678901234567890' },
+    });
+  });
+
+  it('supports Account selector in form', () => {
+    const element = (
+      <Box>
+        <Form name="form">
+          <AccountSelector
+            name="foo"
+            title="Choose an account"
+            chainId="eip155:1"
+            selectedAddress="0x1234567890123456789012345678901234567890"
+          />
+        </Form>
+      </Box>
+    );
+
+    const result = constructState({}, element);
+    expect(result).toStrictEqual({
+      form: { foo: '0x1234567890123456789012345678901234567890' },
     });
   });
 

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -17,6 +17,7 @@ import type {
   RadioElement,
   SelectorElement,
   SelectorOptionElement,
+  AccountSelectorElement,
 } from '@metamask/snaps-sdk/jsx';
 import { isJSXElementUnsafe } from '@metamask/snaps-sdk/jsx';
 import {
@@ -70,7 +71,8 @@ function constructComponentSpecificDefaultState(
     | DropdownElement
     | RadioGroupElement
     | CheckboxElement
-    | SelectorElement,
+    | SelectorElement
+    | AccountSelectorElement,
 ) {
   switch (element.type) {
     case 'Dropdown': {
@@ -111,11 +113,15 @@ function getComponentStateValue(
     | DropdownElement
     | RadioGroupElement
     | CheckboxElement
-    | SelectorElement,
+    | SelectorElement
+    | AccountSelectorElement,
 ) {
   switch (element.type) {
     case 'Checkbox':
       return element.props.checked;
+
+    case 'AccountSelector':
+      return element.props.selectedAddress;
 
     default:
       return element.props.value;
@@ -138,7 +144,8 @@ function constructInputState(
     | RadioGroupElement
     | FileInputElement
     | CheckboxElement
-    | SelectorElement,
+    | SelectorElement
+    | AccountSelectorElement,
   form?: string,
 ) {
   const oldStateUnwrapped = form ? (oldState[form] as FormState) : oldState;
@@ -196,7 +203,8 @@ export function constructState(
         component.type === 'RadioGroup' ||
         component.type === 'FileInput' ||
         component.type === 'Checkbox' ||
-        component.type === 'Selector')
+        component.type === 'Selector' ||
+        component.type === 'AccountSelector')
     ) {
       const formState = newState[currentForm.name] as FormState;
       assertNameIsUnique(formState, component.props.name);
@@ -215,7 +223,8 @@ export function constructState(
       component.type === 'RadioGroup' ||
       component.type === 'FileInput' ||
       component.type === 'Checkbox' ||
-      component.type === 'Selector'
+      component.type === 'Selector' ||
+      component.type === 'AccountSelector'
     ) {
       assertNameIsUnique(newState, component.props.name);
       newState[component.props.name] = constructInputState(oldState, component);


### PR DESCRIPTION
This PR adds the necessary logic to handle interface state for `AccountSelector`