### PR TITLE
Set target back to ES2020

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LuXOhRdmn89LRmEXXd8AK7v7eVXu2SyVtMzULS4ACMk=",
+    "shasum": "PxNHa0ebJ1qA/LXiY4vTzUsBKNl3rdfbHwg198YtOH4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "O6FPRlzRFwL75krFoTlK6z1Q5kEIacl0dzc3sMIwey0=",
+    "shasum": "Nb4y6u121k+rnDRGblkG77S7s9IFt1TZTQeSZOXNdyY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hU2i377FhKzvwrx4y28hc5XFO3KccCUq7bAJdsQ2CD0=",
+    "shasum": "xgOEOeRZ2iYTZYeRAnfZG3l9yoo8ovVLUAdCml94hFs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VCd6NkT2lPRvH5tKtzCqtW4dO8zEA3/zagYxhhv1mBI=",
+    "shasum": "9dsfk6vfqlgxdoelqn+HupcCYfJRJZS4mQNsWg0u93s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "X7NS6ffELF9frs/p8Rjh+ONFpuNaH2Lh6619WvcxAgM=",
+    "shasum": "fyBeeuYGaIpBnxm6MVoRe19JR+8QiIeFtJM+nlOWnsU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "J5VObnrGaizdxndXU5I0uJwOiSOrsALWooVdsVFHF2I=",
+    "shasum": "52lYQY0bh6ZtKx4ZNtQNO17ustuhQBewko/WzQkS68A=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "kd+dbldJz3E/CEBpyAKLNdDeWIFpCr82kiWdppUuHZs=",
+    "shasum": "v2oIs3UY5j/3dXW5eRh3rg7Tv5qcVzHon7qzPQeRsAE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AeQGUB/gYAimmkOFG9V+IG6bY7uqDP2kasrEVBVqKrA=",
+    "shasum": "pSiTZjO5nox8zYh+fQtQfZLp5HwbxKByu+WOo+tAAH0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZNNxJcjyj2Vp+QCCppbyvNjyCYwDkdFSOA4juVFMmdM=",
+    "shasum": "3ec/uMXW2lAaVxSJJRjsAmQ1oSqVJpHUkF4i4YTa9Gk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "fMCzsVeIHGNsXt1bxG6e98NbIdAxsYErMBzobBfZ0mU=",
+    "shasum": "z4vMdrs40TdVE+vk7sPruIvWi0q669V+p3jc6WQIib4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "M9v7nbpcv+JY/qhuPGKhl8QLQ/8IN1AgfOMAXex3nGY=",
+    "shasum": "OYSzxQ1qHApZ2MHWvQ/XYWRwKJptpyVQ5VgyhgFEmmo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "V90EeVXVWOvazC0imXYnn8Aq5MH5sZaqdiY/hwKK4R0=",
+    "shasum": "aTuxZCIXcq/FP7XjSoBY4e4pHQbuoDJ1U6FUe/rAfiQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "q1kz7iw8Wxp3x271M1+Kvh+YhigRONpTsCPfFqfrqT4=",
+    "shasum": "kbuZtLjZiY9+HOtc7DIpuGUjMes2id67dES3Ze/Z3dY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1sEjG59gm8iGvsIT9oa2WLRjcr7XQz5k6gkNXjBvuPg=",
+    "shasum": "Q2JcD7CoRLqjextX7QhYK6SOIK6ROF4NpvbUEwtITe8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "kiYt0ao6vDqjIv70xB4249U1RN76ADgNwkSzqxJF7x8=",
+    "shasum": "/u819uX9E/KqrWqvlPDhZjkKs/ylbrPwtJxiMob7VI8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Akj01OidCW1Tiz/5zzPHKHqyv5wPuqzdZuk1e+B9KdU=",
+    "shasum": "EMv6OrPDoNKIb8YjY5cbjumuwN8Oz3x6ASB1AODM/jM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9/sGrOYHYwVafC1zp0Qzbog2DMBiLllvaafL2bBPClg=",
+    "shasum": "loHXuvuW/Zb4kMSSdekMiV20UVtxXYyoDC0iRZbV274=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "9eu5Ui37X2QCGhfMZvnF8dzBrlqr1bvA+ETvIRqX3VM=",
+    "shasum": "KHrWdamfUEJ10ak4/oE/C4/oTO9BRnLSLjOiS9RFlHw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "UY4KWE5Y6mZrDe0fP2l15FRLB9xUPLvLZw8vB9DT1z8=",
+    "shasum": "5FNiUEpsrVxG3rTbJvhx/IBZ/jIYYu0ZbnCX9A6dAPE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "qq6xArVwrsuBA5dRMjx4aB0iv+EJtm/bVbxjoM0zYk8=",
+    "shasum": "+V4EDf0266FOJDTVrhQ91ZaycBruUesJqSoAzohWnO0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LP9+Cs9fkJElLWpBeq59ni6tiZoD6OAO7asMmqbR2j4=",
+    "shasum": "S3wZGdkOLX7tdJYssmy+UxBXe+VuwZaNUQNqK+G3hu4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/preinstalled/snap.manifest.json
+++ b/packages/examples/packages/preinstalled/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "JJohjumamDrbOFHJ844bMg8V9njO0HxMy1mZ+KQR/6s=",
+    "shasum": "NzLP9BfbhyGMuOG5TgjxLkvOUQUKJI58t+dTOoY+ylE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "RGZlvGILZupU38Thd0MtYs1UQKNH01DwNqjseSjOEY0=",
+    "shasum": "FvkhD/R3iN0i/0P4OTlD0rPX+697OZ0a5kns8T669Jk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+PxKeiyyQhVyNHGTDJdjkHAUBA16KoypW7QH8tWY6T4=",
+    "shasum": "rNBULIRBi45r+MXpWUNwkSaWog2pNTfG5VYKZ676w6g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cafeFwJO2hKmquvRtGvGNV9P29elusQAXXNDnWrvAFo=",
+    "shasum": "YvikqvHw0838qOaBrqjfegOyMSFM4ZwdyOH2qXode5M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -18,7 +18,7 @@
     },
     "resolveJsonModule": true,
     "strict": true,
-    "target": "ES2022",
+    "target": "ES2020",
     "useUnknownInCatchVariables": false
   }
 }


### PR DESCRIPTION
I thought we could target ES2022 since we use that in the extension, but doing so apparently breaks Browserify...