### PR TITLE
Remove `eth_sign`

### DIFF
--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vmG4CkJldpjtLV4k1d4vQAPcZXeXlDYVj5cODyu6CLE=",
+    "shasum": "hlMIB9kls/72D0A77vdvIkZEbJNUDj3Py9PIxm7aWOM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/src/index.ts
+++ b/packages/examples/packages/signature-insights/src/index.ts
@@ -10,7 +10,7 @@ const MALICIOUS_CONTRACT = '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC';
 
 /**
  * Handle incoming signature requests, sent through one of the following methods:
- * `eth_sign`, `personal_sign`, `eth_signTypedData`, `eth_signTypedData_v3`, `eth_signTypedData_v4`.
+ * `personal_sign`, `eth_signTypedData`, `eth_signTypedData_v3`, `eth_signTypedData_v4`.
  *
  * The `onSignature` handler is different from the `onRpcRequest` handler in
  * that it is called by MetaMask when a signature request is initiated, rather than
@@ -54,17 +54,6 @@ export const onSignature: OnSignatureHandler = async ({ signature }) => {
   };
 
   switch (signatureMethod) {
-    case 'eth_sign':
-      return {
-        content: panel([
-          heading("'About 'eth_sign'"),
-          text(
-            "eth_sign is one of the oldest signing methods that MetaMask still supports. Back in the early days of MetaMask when it was originally designed, web3 was quite different from the present day. There were fewer standards for signatures, so eth_sign was developed with a fairly simple, open-ended structure.\nThe main thing to note about eth_sign is that it allows the website you're on to request that you sign an arbitrary hash. In this mathematical context, 'arbitrary' means unspecified; your signature could be applied by the requesting dapp to pretty much anything. eth_sign is therefore unsuitable to use with sources that you don't trust.\nAdditionally, the way eth_sign is designed means that the contents of the message you're signing are not human-readable. It's impossible to check up on what you're actually signing, making it particularly dangerous.",
-          ),
-        ]),
-        severity: SeverityLevel.Critical,
-      };
-
     case 'personal_sign':
       return {
         content: panel([row('From:', text(from)), row('Data:', text(data))]),

--- a/packages/snaps-execution-environments/src/common/utils.ts
+++ b/packages/snaps-execution-environments/src/common/utils.ts
@@ -88,7 +88,6 @@ export const BLOCKED_RPC_METHODS = Object.freeze([
   'wallet_revokePermissions',
   // We disallow all of these confirmations for now, since the screens are not ready for Snaps.
   'eth_sendTransaction',
-  'eth_sign',
   'eth_signTypedData',
   'eth_signTypedData_v1',
   'eth_signTypedData_v3',

--- a/packages/snaps-sdk/src/types/handlers/signature.ts
+++ b/packages/snaps-sdk/src/types/handlers/signature.ts
@@ -3,19 +3,6 @@ import type { Component } from '../../ui';
 import type { SeverityLevel } from './transaction';
 
 /**
- * An eth_sign signature object.
- *
- * @property from - The address the signature is being sent from.
- * @property data - The data (hex string) that is being signed.
- * @property signatureMethod - The signature method, which in this case is eth_sign
- */
-export type EthSignature = {
-  from: string;
-  data: string;
-  signatureMethod: 'eth_sign';
-};
-
-/**
  * A personal_sign signature object.
  *
  * @property from - The address the signature is being sent from.
@@ -70,14 +57,12 @@ export type SignTypedDataV4Signature = {
 /**
  * A signature object. This can be one of the below signature methods.
  *
- * @see EthSignature
  * @see PersonalSignature
  * @see SignTypedDataSignature
  * @see SignTypedDataV3Signature
  * @see SignTypedDataV4Signature
  */
 export type Signature =
-  | EthSignature
   | PersonalSignature
   | SignTypedDataSignature
   | SignTypedDataV3Signature

--- a/packages/snaps-simulation/src/methods/constants.ts
+++ b/packages/snaps-simulation/src/methods/constants.ts
@@ -48,7 +48,6 @@ export const UNRESTRICTED_METHODS = Object.freeze([
   'eth_protocolVersion',
   'eth_sendRawTransaction',
   'eth_sendTransaction',
-  'eth_sign',
   'eth_signTypedData',
   'eth_signTypedData_v1',
   'eth_signTypedData_v3',

--- a/packages/snaps-simulation/src/structs.ts
+++ b/packages/snaps-simulation/src/structs.ts
@@ -181,7 +181,6 @@ export const SignatureOptionsStruct = object({
    */
   signatureMethod: defaulted(
     union([
-      literal('eth_sign'),
       literal('personal_sign'),
       literal('eth_signTypedData'),
       literal('eth_signTypedData_v3'),

--- a/packages/snaps-simulator/src/features/simulation/snap-permissions.ts
+++ b/packages/snaps-simulator/src/features/simulation/snap-permissions.ts
@@ -51,7 +51,6 @@ export const unrestrictedMethods = Object.freeze([
   'eth_protocolVersion',
   'eth_sendRawTransaction',
   'eth_sendTransaction',
-  'eth_sign',
   'eth_signTypedData',
   'eth_signTypedData_v1',
   'eth_signTypedData_v3',


### PR DESCRIPTION
`eth_sign` has been removed from all MetaMask clients, so we can remove any mention of it from Snaps as well.

Closes https://github.com/MetaMask/snaps/issues/2669