### PR TITLE
feat: Add experimental provider request RPC method

### DIFF
--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hvi0QzsvwnbiFtw2bTGJojg09b8Y/RAlmDm1/H3MaYk=",
+    "shasum": "BbaKbj8YVe957H1cnhBBv8X4ITiFjgmmor7/Rp9b/Yc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "YWLgNvM8qJee2ZAhuSD3UcYdUqlQ7OX1cYgW8HYYiTI=",
+    "shasum": "j5111I9EFtd21hrAQ1CIU41NgKleyEr7AiW4Gj3yHLg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -10,10 +10,10 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 92.77,
-      functions: 97.2,
-      lines: 97.76,
-      statements: 97.26,
+      branches: 92.91,
+      functions: 97.23,
+      lines: 97.83,
+      statements: 97.32,
     },
   },
 });

--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -13,7 +13,7 @@ module.exports = deepmerge(baseConfig, {
       branches: 92.91,
       functions: 97.23,
       lines: 97.83,
-      statements: 97.32,
+      statements: 97.35,
     },
   },
 });

--- a/packages/snaps-rpc-methods/src/permitted/experimentalProviderRequest.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/experimentalProviderRequest.test.ts
@@ -1,0 +1,282 @@
+import { JsonRpcEngine } from '@metamask/json-rpc-engine';
+import { rpcErrors, serializeError } from '@metamask/rpc-errors';
+import type { ProviderRequestParams } from '@metamask/snaps-sdk';
+import { type ProviderRequestResult } from '@metamask/snaps-sdk';
+import type {
+  JsonRpcFailure,
+  JsonRpcRequest,
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
+
+import { providerRequestHandler } from './experimentalProviderRequest';
+
+describe('snap_experimentalProviderRequest', () => {
+  describe('providerRequestHandler', () => {
+    it('has the expected shape', () => {
+      expect(providerRequestHandler).toMatchObject({
+        methodNames: ['snap_experimentalProviderRequest'],
+        implementation: expect.any(Function),
+        hookNames: {
+          hasPermission: true,
+          getNetworkConfigurationByChainId: true,
+          getNetworkClientById: true,
+        },
+      });
+    });
+  });
+
+  describe('implementation', () => {
+    const getMockHooks = () =>
+      ({
+        hasPermission: jest.fn().mockImplementation(() => true),
+        getNetworkConfigurationByChainId: jest.fn().mockImplementation(() => ({
+          defaultRpcEndpointIndex: 0,
+          rpcEndpoints: [{ networkClientId: 'foo' }],
+        })),
+        getNetworkClientById: jest.fn().mockImplementation(() => ({
+          provider: { request: jest.fn().mockResolvedValue('0x1') },
+        })),
+      } as any);
+
+    it('returns the result from the network client', async () => {
+      const { implementation } = providerRequestHandler;
+
+      const hooks = getMockHooks();
+
+      const engine = new JsonRpcEngine();
+
+      engine.push((request, response, next, end) => {
+        const result = implementation(
+          request as JsonRpcRequest<ProviderRequestParams>,
+          response as PendingJsonRpcResponse<ProviderRequestResult>,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'snap_experimentalProviderRequest',
+        params: {
+          chainId: 'eip155:1',
+          request: {
+            method: 'eth_chainId',
+          },
+        },
+      });
+
+      expect(response).toStrictEqual({ jsonrpc: '2.0', id: 1, result: '0x1' });
+    });
+
+    it('returns an error if the Snap does not have permission', async () => {
+      const { implementation } = providerRequestHandler;
+
+      const hooks = getMockHooks();
+      hooks.hasPermission.mockImplementation(() => false);
+
+      const engine = new JsonRpcEngine();
+
+      engine.push((request, response, next, end) => {
+        const result = implementation(
+          request as JsonRpcRequest<ProviderRequestParams>,
+          response as PendingJsonRpcResponse<ProviderRequestResult>,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = (await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'snap_experimentalProviderRequest',
+        params: {
+          chainId: 'eip155:1',
+          request: {
+            method: 'eth_chainId',
+          },
+        },
+      })) as JsonRpcFailure;
+
+      expect(response.error).toStrictEqual({
+        ...rpcErrors.methodNotFound().serialize(),
+        stack: expect.any(String),
+      });
+    });
+
+    it('returns an error if the request is for a non-EVM network', async () => {
+      const { implementation } = providerRequestHandler;
+
+      const hooks = getMockHooks();
+
+      const engine = new JsonRpcEngine();
+
+      engine.push((request, response, next, end) => {
+        const result = implementation(
+          request as JsonRpcRequest<ProviderRequestParams>,
+          response as PendingJsonRpcResponse<ProviderRequestResult>,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = (await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'snap_experimentalProviderRequest',
+        params: {
+          chainId: 'bip122:000000000019d6689c085ae165831e93',
+          request: {
+            method: 'eth_chainId',
+          },
+        },
+      })) as JsonRpcFailure;
+
+      expect(response.error).toStrictEqual({
+        ...rpcErrors
+          .invalidParams({
+            message: 'Only EVM networks are currently supported.',
+          })
+          .serialize(),
+        stack: expect.any(String),
+      });
+    });
+
+    it('returns an error if the network is not available', async () => {
+      const { implementation } = providerRequestHandler;
+
+      const hooks = getMockHooks();
+
+      hooks.getNetworkConfigurationByChainId.mockImplementation(() => null);
+
+      const engine = new JsonRpcEngine();
+
+      engine.push((request, response, next, end) => {
+        const result = implementation(
+          request as JsonRpcRequest<ProviderRequestParams>,
+          response as PendingJsonRpcResponse<ProviderRequestResult>,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = (await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'snap_experimentalProviderRequest',
+        params: {
+          chainId: 'eip155:123',
+          request: {
+            method: 'eth_chainId',
+          },
+        },
+      })) as JsonRpcFailure;
+
+      expect(response.error).toStrictEqual({
+        ...rpcErrors
+          .invalidParams({
+            message: 'The requested network is not available.',
+          })
+          .serialize(),
+        stack: expect.any(String),
+      });
+    });
+
+    it('returns an error if the provider throws', async () => {
+      const { implementation } = providerRequestHandler;
+
+      const hooks = getMockHooks();
+
+      hooks.getNetworkClientById.mockImplementation(() => ({
+        provider: { request: jest.fn().mockRejectedValue('Invalid params') },
+      }));
+
+      const engine = new JsonRpcEngine();
+
+      engine.push((request, response, next, end) => {
+        const result = implementation(
+          request as JsonRpcRequest<ProviderRequestParams>,
+          response as PendingJsonRpcResponse<ProviderRequestResult>,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = (await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'snap_experimentalProviderRequest',
+        params: {
+          chainId: 'eip155:123',
+          request: {
+            method: 'eth_chainId',
+          },
+        },
+      })) as JsonRpcFailure;
+
+      expect(response.error).toStrictEqual({
+        ...serializeError(
+          rpcErrors.internal({ data: { cause: 'Invalid params' } }),
+          { shouldIncludeStack: false },
+        ),
+      });
+    });
+
+    it('returns an error if the parameters are invalid', async () => {
+      const { implementation } = providerRequestHandler;
+
+      const hooks = getMockHooks();
+
+      const engine = new JsonRpcEngine();
+
+      engine.push((request, response, next, end) => {
+        const result = implementation(
+          request as JsonRpcRequest<ProviderRequestParams>,
+          response as PendingJsonRpcResponse<ProviderRequestResult>,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = (await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'snap_experimentalProviderRequest',
+        params: {
+          chainId: 'abcdefg',
+          request: {
+            method: 'eth_chainId',
+          },
+        },
+      })) as JsonRpcFailure;
+
+      expect(response.error).toStrictEqual({
+        ...rpcErrors
+          .invalidParams({
+            message:
+              'Invalid params: At path: chainId -- Expected a string matching `/^(?<namespace>[-a-z0-9]{3,8}):(?<reference>[-_a-zA-Z0-9]{1,32})$/` but received "abcdefg".',
+          })
+          .serialize(),
+        stack: expect.any(String),
+      });
+    });
+  });
+});

--- a/packages/snaps-rpc-methods/src/permitted/experimentalProviderRequest.ts
+++ b/packages/snaps-rpc-methods/src/permitted/experimentalProviderRequest.ts
@@ -1,0 +1,169 @@
+import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
+import type { PermittedHandlerExport } from '@metamask/permission-controller';
+import { rpcErrors } from '@metamask/rpc-errors';
+import type {
+  JsonRpcRequest,
+  ProviderRequestParams,
+  ProviderRequestResult,
+} from '@metamask/snaps-sdk';
+import { type InferMatching } from '@metamask/snaps-utils';
+import {
+  StructError,
+  create,
+  object,
+  optional,
+  string,
+} from '@metamask/superstruct';
+import {
+  numberToHex,
+  parseCaipChainId,
+  type PendingJsonRpcResponse,
+  type Json,
+  CaipChainIdStruct,
+  JsonRpcParamsStruct,
+} from '@metamask/utils';
+
+import { SnapEndowments } from '../endowments';
+import type { MethodHooksObject } from '../utils';
+
+const hookNames: MethodHooksObject<ProviderRequestMethodHooks> = {
+  hasPermission: true,
+  getNetworkConfigurationByChainId: true,
+  getNetworkClientById: true,
+};
+
+type NetworkConfiguration = {
+  defaultRpcEndpointIndex: number;
+  rpcEndpoints: { networkClientId: string }[];
+};
+
+export type ProviderRequestMethodHooks = {
+  hasPermission: (permissionName: string) => boolean;
+
+  getNetworkConfigurationByChainId: (
+    chainId: string,
+  ) => NetworkConfiguration | undefined;
+
+  getNetworkClientById: (id: string) => {
+    provider: { request: (request: Json) => Promise<Json> };
+  };
+};
+
+export const providerRequestHandler: PermittedHandlerExport<
+  ProviderRequestMethodHooks,
+  ProviderRequestParameters,
+  ProviderRequestResult
+> = {
+  methodNames: ['snap_experimentalProviderRequest'],
+  implementation: providerRequestImplementation,
+  hookNames,
+};
+
+const ProviderRequestParametersStruct = object({
+  chainId: CaipChainIdStruct,
+  request: object({
+    method: string(),
+    params: optional(JsonRpcParamsStruct),
+  }),
+});
+
+export type ProviderRequestParameters = InferMatching<
+  typeof ProviderRequestParametersStruct,
+  ProviderRequestParams
+>;
+
+/**
+ * The `snap_experimentalProviderRequest` method implementation.
+ *
+ * @param req - The JSON-RPC request object.
+ * @param res - The JSON-RPC response object.
+ * @param _next - The `json-rpc-engine` "next" callback. Not used by this
+ * function.
+ * @param end - The `json-rpc-engine` "end" callback.
+ * @param hooks - The RPC method hooks.
+ * @param hooks.hasPermission - Checks whether a given origin has a given permission.
+ * @param hooks.getNetworkConfigurationByChainId - Get a network configuration for a given chain ID.
+ * @param hooks.getNetworkClientById - Get a network client for a given ID.
+ * @returns Nothing.
+ */
+async function providerRequestImplementation(
+  req: JsonRpcRequest<ProviderRequestParams>,
+  res: PendingJsonRpcResponse<ProviderRequestResult>,
+  _next: unknown,
+  end: JsonRpcEngineEndCallback,
+  {
+    hasPermission,
+    getNetworkConfigurationByChainId,
+    getNetworkClientById,
+  }: ProviderRequestMethodHooks,
+): Promise<void> {
+  if (!hasPermission(SnapEndowments.EthereumProvider)) {
+    return end(rpcErrors.methodNotFound());
+  }
+
+  const { params } = req;
+
+  try {
+    const { chainId, request } = getValidatedParams(params);
+
+    const parsedChainId = parseCaipChainId(chainId);
+
+    if (parsedChainId.namespace !== 'eip155') {
+      return end(
+        rpcErrors.invalidParams({
+          message: 'Only EVM networks are currently supported.',
+        }),
+      );
+    }
+
+    const numericalChainId = parseInt(parsedChainId.reference, 10);
+
+    const networkConfiguration = getNetworkConfigurationByChainId(
+      numberToHex(numericalChainId),
+    );
+
+    if (!networkConfiguration) {
+      return end(
+        rpcErrors.invalidParams({
+          message: 'The requested network is not available.',
+        }),
+      );
+    }
+
+    const rpc =
+      networkConfiguration.rpcEndpoints[
+        networkConfiguration.defaultRpcEndpointIndex
+      ];
+
+    const networkClient = getNetworkClientById(rpc.networkClientId);
+
+    const { provider } = networkClient;
+
+    res.result = await provider.request(request);
+  } catch (error) {
+    return end(error);
+  }
+
+  return end();
+}
+
+/**
+ * Validate the method `params` and returns them cast to the correct
+ * type. Throws if validation fails.
+ *
+ * @param params - The unvalidated params object from the method request.
+ * @returns The validated updateInterface method parameter object.
+ */
+function getValidatedParams(params: unknown): ProviderRequestParameters {
+  try {
+    return create(params, ProviderRequestParametersStruct);
+  } catch (error) {
+    if (error instanceof StructError) {
+      throw rpcErrors.invalidParams({
+        message: `Invalid params: ${error.message}.`,
+      });
+    }
+    /* istanbul ignore next */
+    throw rpcErrors.internal();
+  }
+}

--- a/packages/snaps-rpc-methods/src/permitted/experimentalProviderRequest.ts
+++ b/packages/snaps-rpc-methods/src/permitted/experimentalProviderRequest.ts
@@ -13,6 +13,7 @@ import {
   object,
   optional,
   string,
+  type,
 } from '@metamask/superstruct';
 import {
   numberToHex,
@@ -61,7 +62,7 @@ export const providerRequestHandler: PermittedHandlerExport<
 
 const ProviderRequestParametersStruct = object({
   chainId: CaipChainIdStruct,
-  request: object({
+  request: type({
     method: string(),
     params: optional(JsonRpcParamsStruct),
   }),
@@ -74,6 +75,12 @@ export type ProviderRequestParameters = InferMatching<
 
 /**
  * The `snap_experimentalProviderRequest` method implementation.
+ *
+ * This RPC method lets Snaps make requests to MetaMask networks that are not currently selected in the UI.
+ *
+ * The RPC method requires the caller to have the endowment:ethereum-provider permission.
+ *
+ * NOTE: This implementation is experimental and may be removed or changed without warning.
  *
  * @param req - The JSON-RPC request object.
  * @param res - The JSON-RPC response object.

--- a/packages/snaps-rpc-methods/src/permitted/experimentalProviderRequest.ts
+++ b/packages/snaps-rpc-methods/src/permitted/experimentalProviderRequest.ts
@@ -27,6 +27,54 @@ import {
 import { SnapEndowments } from '../endowments';
 import type { MethodHooksObject } from '../utils';
 
+// Read-only methods that are currently allowed for this RPC method.
+const METHOD_ALLOWLIST = Object.freeze([
+  'eth_blockNumber',
+  'eth_call',
+  'eth_chainId',
+  'eth_coinbase',
+  'eth_estimateGas',
+  'eth_feeHistory',
+  'eth_gasPrice',
+  'eth_getBalance',
+  'eth_getBlockByHash',
+  'eth_getBlockByNumber',
+  'eth_getBlockTransactionCountByHash',
+  'eth_getBlockTransactionCountByNumber',
+  'eth_getCode',
+  'eth_getFilterChanges',
+  'eth_getFilterLogs',
+  'eth_getLogs',
+  'eth_getProof',
+  'eth_getStorageAt',
+  'eth_getTransactionByBlockHashAndIndex',
+  'eth_getTransactionByBlockNumberAndIndex',
+  'eth_getTransactionByHash',
+  'eth_getTransactionCount',
+  'eth_getTransactionReceipt',
+  'eth_getUncleByBlockHashAndIndex',
+  'eth_getUncleByBlockNumberAndIndex',
+  'eth_getUncleCountByBlockHash',
+  'eth_getUncleCountByBlockNumber',
+  'eth_getWork',
+  'eth_hashrate',
+  'eth_mining',
+  'eth_newBlockFilter',
+  'eth_newFilter',
+  'eth_newPendingTransactionFilter',
+  'eth_protocolVersion',
+  'eth_sendRawTransaction',
+  'eth_submitHashrate',
+  'eth_submitWork',
+  'eth_syncing',
+  'eth_uninstallFilter',
+  'net_listening',
+  'net_peerCount',
+  'net_version',
+  'web3_clientVersion',
+  'web3_sha3',
+]);
+
 const hookNames: MethodHooksObject<ProviderRequestMethodHooks> = {
   hasPermission: true,
   getNetworkConfigurationByChainId: true,
@@ -112,6 +160,10 @@ async function providerRequestImplementation(
 
   try {
     const { chainId, request } = getValidatedParams(params);
+
+    if (!METHOD_ALLOWLIST.includes(request.method)) {
+      return end(rpcErrors.methodNotFound());
+    }
 
     const parsedChainId = parseCaipChainId(chainId);
 

--- a/packages/snaps-rpc-methods/src/permitted/handlers.ts
+++ b/packages/snaps-rpc-methods/src/permitted/handlers.ts
@@ -1,4 +1,5 @@
 import { createInterfaceHandler } from './createInterface';
+import { providerRequestHandler } from './experimentalProviderRequest';
 import { getAllSnapsHandler } from './getAllSnaps';
 import { getClientStatusHandler } from './getClientStatus';
 import { getCurrencyRateHandler } from './getCurrencyRate';
@@ -25,6 +26,7 @@ export const methodHandlers = {
   snap_getInterfaceState: getInterfaceStateHandler,
   snap_resolveInterface: resolveInterfaceHandler,
   snap_getCurrencyRate: getCurrencyRateHandler,
+  snap_experimentalProviderRequest: providerRequestHandler,
 };
 /* eslint-enable @typescript-eslint/naming-convention */
 

--- a/packages/snaps-rpc-methods/src/permitted/index.ts
+++ b/packages/snaps-rpc-methods/src/permitted/index.ts
@@ -1,4 +1,5 @@
 import type { CreateInterfaceMethodHooks } from './createInterface';
+import type { ProviderRequestMethodHooks } from './experimentalProviderRequest';
 import type { GetAllSnapsHooks } from './getAllSnaps';
 import type { GetClientStatusHooks } from './getClientStatus';
 import type { GetCurrencyRateMethodHooks } from './getCurrencyRate';
@@ -16,7 +17,8 @@ export type PermittedRpcMethodHooks = GetAllSnapsHooks &
   UpdateInterfaceMethodHooks &
   GetInterfaceStateMethodHooks &
   ResolveInterfaceMethodHooks &
-  GetCurrencyRateMethodHooks;
+  GetCurrencyRateMethodHooks &
+  ProviderRequestMethodHooks;
 
 export * from './handlers';
 export * from './middleware';

--- a/packages/snaps-sdk/src/types/methods/index.ts
+++ b/packages/snaps-sdk/src/types/methods/index.ts
@@ -20,3 +20,4 @@ export * from './request-snaps';
 export * from './update-interface';
 export * from './resolve-interface';
 export * from './get-currency-rate';
+export * from './provider-request';

--- a/packages/snaps-sdk/src/types/methods/provider-request.ts
+++ b/packages/snaps-sdk/src/types/methods/provider-request.ts
@@ -1,17 +1,21 @@
-import type { CaipChainId, Json, JsonRpcRequest } from '@metamask/utils';
+import type { CaipChainId, Json, JsonRpcParams } from '@metamask/utils';
 
 /**
  * The request parameters for the `snap_experimentalProviderRequest` method.
+ *
+ * NOTE: This implementation is experimental and may be removed or changed without warning.
  *
  * @property chainId - The CAIP-2 chain ID to make the request to.
  * @property request - The JSON-RPC request.
  */
 export type ProviderRequestParams = {
   chainId: CaipChainId;
-  request: JsonRpcRequest;
+  request: { method: string; params: JsonRpcParams } | { method: string };
 };
 
 /**
  * The result returned by the `snap_experimentalProviderRequest` method, which will be a JSON serializable value.
+ *
+ * NOTE: This implementation is experimental and may be removed or changed without warning.
  */
 export type ProviderRequestResult = Json;

--- a/packages/snaps-sdk/src/types/methods/provider-request.ts
+++ b/packages/snaps-sdk/src/types/methods/provider-request.ts
@@ -1,0 +1,17 @@
+import type { CaipChainId, Json, JsonRpcRequest } from '@metamask/utils';
+
+/**
+ * The request parameters for the `snap_experimentalProviderRequest` method.
+ *
+ * @property chainId - The CAIP-2 chain ID to make the request to.
+ * @property request - The JSON-RPC request.
+ */
+export type ProviderRequestParams = {
+  chainId: CaipChainId;
+  request: JsonRpcRequest;
+};
+
+/**
+ * The result returned by the `snap_experimentalProviderRequest` method, which will be a JSON serializable value.
+ */
+export type ProviderRequestResult = Json;


### PR DESCRIPTION
Adds an experimental RPC method that lets Snaps make requests to networks that are not currently selected in the MetaMask UI. This is a large improvement for Snaps that want to leverage MetaMask RPC as previously the only access to RPC was given through `endowment:ethereum-provider` which strictly uses the currently selected network. This change would effectively let Snaps make requests to any networks added by the user and is a temporary stopgap solution until the MetaMask multichain API ships. **This means that this API may break at any time, use accordingly.**

Snaps with `endowment:ethereum-provider` would now be able to make requests like this:
```js
const chainId = await snap.request({
  method: 'snap_experimentalProviderRequest',
  params: {
    chainId: 'eip155:59144',
    request: { method: 'eth_chainId' },
  },
});
```

The RPC method requires the `endowment:ethereum-provider` permission and enforces an allowlist to only allow access to certain RPC methods (mostly read methods).