### PR TITLE
Refactor `AccountSelector`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@types/glob@*": "patch:@types/glob@npm%3A7.1.4#./.yarn/patches/@types-glob-npm-7.1.4-d45247eaa2.patch",
     "@types/glob@^7.1.1": "patch:@types/glob@npm%3A7.1.4#./.yarn/patches/@types-glob-npm-7.1.4-d45247eaa2.patch",
     "@types/mocha@^10.0.1": "patch:@types/mocha@npm:10.0.1#.yarn/patches/@types-mocha-npm-10.0.1-7c94e9e170.patch",
-    "@types/readable-stream": "^4.0.15",
     "find-babel-config": "^2.0.0",
     "got": "^13.0.0",
     "inline-source-map@~0.6.0": "patch:inline-source-map@npm%3A0.6.2#./.yarn/patches/inline-source-map-npm-0.6.2-96902459a0.patch",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/glob@*": "patch:@types/glob@npm%3A7.1.4#./.yarn/patches/@types-glob-npm-7.1.4-d45247eaa2.patch",
     "@types/glob@^7.1.1": "patch:@types/glob@npm%3A7.1.4#./.yarn/patches/@types-glob-npm-7.1.4-d45247eaa2.patch",
     "@types/mocha@^10.0.1": "patch:@types/mocha@npm:10.0.1#.yarn/patches/@types-mocha-npm-10.0.1-7c94e9e170.patch",
+    "@types/readable-stream": "^4.0.15",
     "find-babel-config": "^2.0.0",
     "got": "^13.0.0",
     "inline-source-map@~0.6.0": "patch:inline-source-map@npm%3A0.6.2#./.yarn/patches/inline-source-map-npm-0.6.2-96902459a0.patch",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "SdptlLDUW9lSgLU6GndRksW8Y4fZAx178nM21wbOzCk=",
+    "shasum": "YIcYmzogamvxSWdDo1eR/cd46w4wMeWDRYxD1PnDK6Q=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "BbaKbj8YVe957H1cnhBBv8X4ITiFjgmmor7/Rp9b/Yc=",
+    "shasum": "SdptlLDUW9lSgLU6GndRksW8Y4fZAx178nM21wbOzCk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "YIcYmzogamvxSWdDo1eR/cd46w4wMeWDRYxD1PnDK6Q=",
+    "shasum": "Zz0TOSOi5y3LENV6h1cfCOLs/aLOQ/6D8P/AuKpoyYs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "j5111I9EFtd21hrAQ1CIU41NgKleyEr7AiW4Gj3yHLg=",
+    "shasum": "eLjU5oO9qB6xQFy0NVVOppSPMtf/H/4oc8iWlqdJH5c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "t9ms5NFUQn3t06QvDGvAiGfhiQEwHUvTWpVD928mvt8=",
+    "shasum": "gFgHRuy6RPtFnVe3ei6Zs8Wo6nEVtGLFYmp2mcWoo6E=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "eLjU5oO9qB6xQFy0NVVOppSPMtf/H/4oc8iWlqdJH5c=",
+    "shasum": "t9ms5NFUQn3t06QvDGvAiGfhiQEwHUvTWpVD928mvt8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "v2oIs3UY5j/3dXW5eRh3rg7Tv5qcVzHon7qzPQeRsAE=",
+    "shasum": "2zWUxxB/+eDTLsR2g4G4XNyJceFBNZWtl0xstsMXRH0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "z4vMdrs40TdVE+vk7sPruIvWi0q669V+p3jc6WQIib4=",
+    "shasum": "5xW9p4wOMkPOhWz8v74UFpQrIVhUYPyiGl+NyQqC4KA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "emnlXHvrhsGBMi/y1IPhiQPX9ogHmjmOU/iujBu5GB8=",
+    "shasum": "AthRr1C0N2RNkpXEiUaTGsOa8RNgBWbfgmyYVpLKVxU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Q2JcD7CoRLqjextX7QhYK6SOIK6ROF4NpvbUEwtITe8=",
+    "shasum": "20Q31RRwlRIjZ5QnHbjBzwnqv2TXu/ziW9xQgRfsXpU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3U9+Lvmmdc9JRmaHLcwGgi9lpnaj25joBF9+zXY4644=",
+    "shasum": "H+DxVktIoedt5Bm+wf4EaF68o5lDnrK6gmHlIDIxTYo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/send-flow/snap.manifest.json
+++ b/packages/examples/packages/send-flow/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "PTmRKwKUzSGr2ZBWOMDRHn1HTmmgk32dzd7zqmvcoMo=",
+    "shasum": "kayurDPL+WaZEvBcfnjph6mqz1Xxz2RACxD7OKJdt1o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 92.64,
+  "branches": 92.69,
   "functions": 96.65,
-  "lines": 97.97,
-  "statements": 97.67
+  "lines": 97.98,
+  "statements": 97.68
 }

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -115,7 +115,7 @@
     "@metamask/eslint-config-jest": "^12.1.0",
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
-    "@metamask/keyring-controller": "^17.0.0",
+    "@metamask/keyring-controller": "^17.2.2",
     "@metamask/template-snap": "^0.7.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -79,6 +79,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@metamask/accounts-controller": "^18.2.2",
     "@metamask/approval-controller": "^7.0.2",
     "@metamask/base-controller": "^6.0.2",
     "@metamask/json-rpc-engine": "^9.0.2",
@@ -114,6 +115,7 @@
     "@metamask/eslint-config-jest": "^12.1.0",
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
+    "@metamask/keyring-controller": "^17.0.0",
     "@metamask/template-snap": "^0.7.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",

--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.test.tsx
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.test.tsx
@@ -1,6 +1,7 @@
 import type { SnapId } from '@metamask/snaps-sdk';
 import { form, image, input, panel, text } from '@metamask/snaps-sdk';
 import {
+  AccountSelector,
   Box,
   Field,
   FileInput,
@@ -91,6 +92,13 @@ describe('SnapInterfaceController', () => {
             <Link href="https://foo.bar">foo</Link>
           </Text>
           <Form name="foo">
+            <Field label="Baz">
+              <AccountSelector name="foobar" />
+            </Field>
+            <AccountSelector
+              name="barbaz"
+              selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
+            />
             <Field label="Bar">
               <Input name="bar" type="text" />
             </Field>
@@ -121,8 +129,31 @@ describe('SnapInterfaceController', () => {
         'foo.bar',
       );
 
+      expect(rootMessenger.call).toHaveBeenNthCalledWith(
+        4,
+        'AccountsController:getSelectedMultichainAccount',
+      );
+
+      expect(rootMessenger.call).toHaveBeenNthCalledWith(
+        5,
+        'AccountsController:getAccount',
+        '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+      );
+
       expect(content).toStrictEqual(element);
-      expect(state).toStrictEqual({ foo: { bar: null } });
+      expect(state).toStrictEqual({
+        foo: {
+          bar: null,
+          foobar: {
+            address: '0x1234567891234567891234567891234567891234',
+            id: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+          },
+          barbaz: {
+            address: '0x1234567891234567891234567891234567891234',
+            id: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+          },
+        },
+      });
     });
 
     it('supports providing interface context', async () => {

--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
@@ -1,4 +1,7 @@
-import type { AccountsControllerGetSelectedMultichainAccountAction } from '@metamask/accounts-controller';
+import type {
+  AccountsControllerGetAccountAction,
+  AccountsControllerGetSelectedMultichainAccountAction,
+} from '@metamask/accounts-controller';
 import type {
   AcceptRequest,
   HasApprovalRequest,
@@ -78,7 +81,8 @@ export type SnapInterfaceControllerAllowedActions =
   | HasApprovalRequest
   | AcceptRequest
   | GetSnap
-  | AccountsControllerGetSelectedMultichainAccountAction;
+  | AccountsControllerGetSelectedMultichainAccountAction
+  | AccountsControllerGetAccountAction;
 
 export type SnapInterfaceControllerActions =
   | CreateInterface
@@ -201,6 +205,7 @@ export class SnapInterfaceController extends BaseController<
       {},
       element,
       this.#getSelectedAccount.bind(this),
+      this.#getAccount.bind(this),
     );
 
     this.update((draftState) => {
@@ -251,6 +256,7 @@ export class SnapInterfaceController extends BaseController<
       oldState,
       element,
       this.#getSelectedAccount.bind(this),
+      this.#getAccount.bind(this),
     );
 
     this.update((draftState) => {
@@ -384,6 +390,16 @@ export class SnapInterfaceController extends BaseController<
     return this.messagingSystem.call(
       'AccountsController:getSelectedMultichainAccount',
     );
+  }
+
+  /**
+   * Get an account by ID.
+   *
+   * @param id - The account ID.
+   * @returns The account.
+   */
+  #getAccount(id: string) {
+    return this.messagingSystem.call('AccountsController:getAccount', id);
   }
 
   /**

--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
@@ -1,3 +1,4 @@
+import type { AccountsControllerGetSelectedMultichainAccountAction } from '@metamask/accounts-controller';
 import type {
   AcceptRequest,
   HasApprovalRequest,
@@ -76,7 +77,8 @@ export type SnapInterfaceControllerAllowedActions =
   | MaybeUpdateState
   | HasApprovalRequest
   | AcceptRequest
-  | GetSnap;
+  | GetSnap
+  | AccountsControllerGetSelectedMultichainAccountAction;
 
 export type SnapInterfaceControllerActions =
   | CreateInterface

--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
@@ -197,7 +197,11 @@ export class SnapInterfaceController extends BaseController<
     validateInterfaceContext(context);
 
     const id = nanoid();
-    const componentState = constructState({}, element);
+    const componentState = constructState(
+      {},
+      element,
+      this.#getSelectedAccount.bind(this),
+    );
 
     this.update((draftState) => {
       // @ts-expect-error - TS2589: Type instantiation is excessively deep and
@@ -243,7 +247,11 @@ export class SnapInterfaceController extends BaseController<
     await this.#validateContent(element);
 
     const oldState = this.state.interfaces[id].state;
-    const newState = constructState(oldState, element);
+    const newState = constructState(
+      oldState,
+      element,
+      this.#getSelectedAccount.bind(this),
+    );
 
     this.update((draftState) => {
       draftState.interfaces[id].state = newState;
@@ -364,6 +372,17 @@ export class SnapInterfaceController extends BaseController<
       'ApprovalController:acceptRequest',
       id,
       value,
+    );
+  }
+
+  /**
+   * Get the currently selected account in Extension.
+   *
+   * @returns The currently selected account.
+   */
+  #getSelectedAccount() {
+    return this.messagingSystem.call(
+      'AccountsController:getSelectedMultichainAccount',
     );
   }
 

--- a/packages/snaps-controllers/src/interface/utils.test.tsx
+++ b/packages/snaps-controllers/src/interface/utils.test.tsx
@@ -65,6 +65,8 @@ describe('assertNameIsUnique', () => {
 });
 
 describe('constructState', () => {
+  const getSelectedAccount = jest.fn();
+
   it('can construct a new component state', () => {
     const element = (
       <Box>
@@ -77,7 +79,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
 
     expect(result).toStrictEqual({ foo: { bar: null } });
   });
@@ -95,7 +97,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
 
     expect(result).toStrictEqual({ foo: { bar: null } });
   });
@@ -117,7 +119,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState(state, element);
+    const result = constructState(state, element, getSelectedAccount);
     expect(result).toStrictEqual({ foo: { bar: 'test', baz: null } });
   });
 
@@ -138,7 +140,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState(state, element);
+    const result = constructState(state, element, getSelectedAccount);
     expect(result).toStrictEqual({ form: { bar: 'test', baz: null } });
   });
 
@@ -170,7 +172,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState(state, element);
+    const result = constructState(state, element, getSelectedAccount);
 
     expect(result).toStrictEqual({
       form1: { bar: 'test', baz: null },
@@ -198,7 +200,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState(state, element);
+    const result = constructState(state, element, getSelectedAccount);
     expect(result).toStrictEqual({
       form1: { bar: 'test', baz: null },
     });
@@ -236,7 +238,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState(state, element);
+    const result = constructState(state, element, getSelectedAccount);
     expect(result).toStrictEqual({
       form1: { bar: 'test', baz: null },
       form2: { bar: 'def', baz: null },
@@ -250,7 +252,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       foo: 'bar',
     });
@@ -263,7 +265,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       foo: null,
     });
@@ -279,7 +281,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       foo: 'option1',
     });
@@ -295,7 +297,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       foo: 'option2',
     });
@@ -315,7 +317,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       form: { foo: 'option1' },
     });
@@ -335,7 +337,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       form: { foo: 'option2' },
     });
@@ -351,7 +353,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       foo: 'option1',
     });
@@ -367,7 +369,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       foo: 'option2',
     });
@@ -387,7 +389,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       form: { foo: 'option1' },
     });
@@ -407,7 +409,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       form: { foo: 'option2' },
     });
@@ -420,7 +422,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       foo: true,
     });
@@ -437,7 +439,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       form: { foo: false },
     });
@@ -454,7 +456,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       form: { foo: true },
     });
@@ -474,7 +476,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       foo: 'option1',
     });
@@ -494,7 +496,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       foo: 'option2',
     });
@@ -518,7 +520,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       form: { foo: 'option1' },
     });
@@ -542,7 +544,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       form: { foo: 'option2' },
     });
@@ -559,7 +561,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       foo: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
     });
@@ -576,7 +578,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       foo: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
     });
@@ -595,7 +597,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       form: { foo: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed' },
     });
@@ -614,9 +616,42 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       form: { foo: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed' },
+    });
+  });
+
+  it('supports getting the selected account from extension', () => {
+    getSelectedAccount.mockReturnValue('1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed');
+
+    const element = (
+      <Box>
+        <Form name="form">
+          <AccountSelector name="foo" />
+        </Form>
+      </Box>
+    );
+
+    const result = constructState({}, element, getSelectedAccount);
+    expect(result).toStrictEqual({
+      form: { foo: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed' },
+    });
+  });
+
+  it('supports setting the selected account to `null` if there is no currently selected account', () => {
+    getSelectedAccount.mockReturnValue(undefined);
+    const element = (
+      <Box>
+        <Form name="form">
+          <AccountSelector name="foo" />
+        </Form>
+      </Box>
+    );
+
+    const result = constructState({}, element, getSelectedAccount);
+    expect(result).toStrictEqual({
+      form: { foo: null },
     });
   });
 
@@ -637,7 +672,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       form: { bar: 'option2' },
     });
@@ -668,7 +703,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       form: { baz: 'option4' },
       form2: { bar: 'option2' },
@@ -682,7 +717,11 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({ foo: null, bar: null }, element);
+    const result = constructState(
+      { foo: null, bar: null },
+      element,
+      getSelectedAccount,
+    );
     expect(result).toStrictEqual({
       foo: null,
     });
@@ -699,7 +738,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState(state, element);
+    const result = constructState(state, element, getSelectedAccount);
     expect(result).toStrictEqual({
       foo: 'bar',
     });
@@ -712,7 +751,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, getSelectedAccount);
     expect(result).toStrictEqual({
       foo: null,
     });
@@ -730,7 +769,7 @@ describe('constructState', () => {
       </Form>
     );
 
-    expect(() => constructState({}, element)).toThrow(
+    expect(() => constructState({}, element, getSelectedAccount)).toThrow(
       `Duplicate component names are not allowed, found multiple instances of: "foo".`,
     );
   });
@@ -743,7 +782,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    expect(() => constructState({}, element)).toThrow(
+    expect(() => constructState({}, element, getSelectedAccount)).toThrow(
       `Duplicate component names are not allowed, found multiple instances of: "test".`,
     );
   });
@@ -760,7 +799,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    expect(() => constructState({}, element)).toThrow(
+    expect(() => constructState({}, element, getSelectedAccount)).toThrow(
       `Duplicate component names are not allowed, found multiple instances of: "test".`,
     );
   });

--- a/packages/snaps-controllers/src/interface/utils.test.tsx
+++ b/packages/snaps-controllers/src/interface/utils.test.tsx
@@ -66,6 +66,7 @@ describe('assertNameIsUnique', () => {
 
 describe('constructState', () => {
   const getSelectedAccount = jest.fn();
+  const getAccount = jest.fn();
 
   it('can construct a new component state', () => {
     const element = (
@@ -79,7 +80,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
 
     expect(result).toStrictEqual({ foo: { bar: null } });
   });
@@ -97,7 +98,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
 
     expect(result).toStrictEqual({ foo: { bar: null } });
   });
@@ -119,7 +120,12 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState(state, element, getSelectedAccount);
+    const result = constructState(
+      state,
+      element,
+      getSelectedAccount,
+      getAccount,
+    );
     expect(result).toStrictEqual({ foo: { bar: 'test', baz: null } });
   });
 
@@ -140,7 +146,12 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState(state, element, getSelectedAccount);
+    const result = constructState(
+      state,
+      element,
+      getSelectedAccount,
+      getAccount,
+    );
     expect(result).toStrictEqual({ form: { bar: 'test', baz: null } });
   });
 
@@ -172,7 +183,12 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState(state, element, getSelectedAccount);
+    const result = constructState(
+      state,
+      element,
+      getSelectedAccount,
+      getAccount,
+    );
 
     expect(result).toStrictEqual({
       form1: { bar: 'test', baz: null },
@@ -200,7 +216,12 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState(state, element, getSelectedAccount);
+    const result = constructState(
+      state,
+      element,
+      getSelectedAccount,
+      getAccount,
+    );
     expect(result).toStrictEqual({
       form1: { bar: 'test', baz: null },
     });
@@ -238,7 +259,12 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState(state, element, getSelectedAccount);
+    const result = constructState(
+      state,
+      element,
+      getSelectedAccount,
+      getAccount,
+    );
     expect(result).toStrictEqual({
       form1: { bar: 'test', baz: null },
       form2: { bar: 'def', baz: null },
@@ -252,7 +278,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       foo: 'bar',
     });
@@ -265,7 +291,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       foo: null,
     });
@@ -281,7 +307,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       foo: 'option1',
     });
@@ -297,7 +323,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       foo: 'option2',
     });
@@ -317,7 +343,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       form: { foo: 'option1' },
     });
@@ -337,7 +363,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       form: { foo: 'option2' },
     });
@@ -353,7 +379,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       foo: 'option1',
     });
@@ -369,7 +395,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       foo: 'option2',
     });
@@ -389,7 +415,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       form: { foo: 'option1' },
     });
@@ -409,7 +435,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       form: { foo: 'option2' },
     });
@@ -422,7 +448,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       foo: true,
     });
@@ -439,7 +465,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       form: { foo: false },
     });
@@ -456,7 +482,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       form: { foo: true },
     });
@@ -476,7 +502,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       foo: 'option1',
     });
@@ -496,7 +522,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       foo: 'option2',
     });
@@ -520,7 +546,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       form: { foo: 'option1' },
     });
@@ -544,13 +570,18 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       form: { foo: 'option2' },
     });
   });
 
   it('sets default value for root level Account selector', () => {
+    getAccount.mockReturnValue({
+      id: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+      address: '0x1234567891234567891234567891234567891234',
+    });
+
     const element = (
       <Box>
         <AccountSelector
@@ -561,30 +592,41 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
-      foo: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+      foo: {
+        id: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+        address: '0x1234567891234567891234567891234567891234',
+      },
     });
   });
 
   it('supports root level Account selector', () => {
+    getSelectedAccount.mockReturnValue({
+      id: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+      address: '0x1234567891234567891234567891234567891234',
+    });
+
     const element = (
       <Box>
-        <AccountSelector
-          name="foo"
-          chainIds={['eip155:1']}
-          selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
-        />
+        <AccountSelector name="foo" chainIds={['eip155:1']} />
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
-      foo: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+      foo: {
+        id: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+        address: '0x1234567891234567891234567891234567891234',
+      },
     });
   });
 
   it('sets default value for Account selector in form', () => {
+    getAccount.mockReturnValue({
+      id: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+      address: '0x1234567891234567891234567891234567891234',
+    });
     const element = (
       <Box>
         <Form name="form">
@@ -597,33 +639,46 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
-      form: { foo: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed' },
+      form: {
+        foo: {
+          id: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+          address: '0x1234567891234567891234567891234567891234',
+        },
+      },
     });
   });
 
   it('supports Account selector in form', () => {
+    getSelectedAccount.mockReturnValue({
+      id: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+      address: '0x1234567891234567891234567891234567891234',
+    });
     const element = (
       <Box>
         <Form name="form">
-          <AccountSelector
-            name="foo"
-            chainIds={['eip155:1']}
-            selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
-          />
+          <AccountSelector name="foo" chainIds={['eip155:1']} />
         </Form>
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
-      form: { foo: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed' },
+      form: {
+        foo: {
+          id: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+          address: '0x1234567891234567891234567891234567891234',
+        },
+      },
     });
   });
 
   it('supports getting the selected account from extension', () => {
-    getSelectedAccount.mockReturnValue('1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed');
+    getSelectedAccount.mockReturnValue({
+      id: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+      address: '0x1234567891234567891234567891234567891234',
+    });
 
     const element = (
       <Box>
@@ -633,9 +688,14 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
-      form: { foo: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed' },
+      form: {
+        foo: {
+          id: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+          address: '0x1234567891234567891234567891234567891234',
+        },
+      },
     });
   });
 
@@ -649,10 +709,30 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       form: { foo: null },
     });
+  });
+
+  it('throws if the selected account does not exist', () => {
+    getAccount.mockReturnValue(undefined);
+    const element = (
+      <Box>
+        <Form name="form">
+          <AccountSelector
+            name="foo"
+            selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
+          />
+        </Form>
+      </Box>
+    );
+
+    expect(() =>
+      constructState({}, element, getSelectedAccount, getAccount),
+    ).toThrow(
+      `Account with ID 1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed not found.`,
+    );
   });
 
   it('supports nested fields', () => {
@@ -672,7 +752,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       form: { bar: 'option2' },
     });
@@ -703,7 +783,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       form: { baz: 'option4' },
       form2: { bar: 'option2' },
@@ -721,6 +801,7 @@ describe('constructState', () => {
       { foo: null, bar: null },
       element,
       getSelectedAccount,
+      getAccount,
     );
     expect(result).toStrictEqual({
       foo: null,
@@ -738,7 +819,12 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState(state, element, getSelectedAccount);
+    const result = constructState(
+      state,
+      element,
+      getSelectedAccount,
+      getAccount,
+    );
     expect(result).toStrictEqual({
       foo: 'bar',
     });
@@ -751,7 +837,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element, getSelectedAccount);
+    const result = constructState({}, element, getSelectedAccount, getAccount);
     expect(result).toStrictEqual({
       foo: null,
     });
@@ -769,7 +855,9 @@ describe('constructState', () => {
       </Form>
     );
 
-    expect(() => constructState({}, element, getSelectedAccount)).toThrow(
+    expect(() =>
+      constructState({}, element, getSelectedAccount, getAccount),
+    ).toThrow(
       `Duplicate component names are not allowed, found multiple instances of: "foo".`,
     );
   });
@@ -782,7 +870,9 @@ describe('constructState', () => {
       </Box>
     );
 
-    expect(() => constructState({}, element, getSelectedAccount)).toThrow(
+    expect(() =>
+      constructState({}, element, getSelectedAccount, getAccount),
+    ).toThrow(
       `Duplicate component names are not allowed, found multiple instances of: "test".`,
     );
   });
@@ -799,7 +889,9 @@ describe('constructState', () => {
       </Box>
     );
 
-    expect(() => constructState({}, element, getSelectedAccount)).toThrow(
+    expect(() =>
+      constructState({}, element, getSelectedAccount, getAccount),
+    ).toThrow(
       `Duplicate component names are not allowed, found multiple instances of: "test".`,
     );
   });

--- a/packages/snaps-controllers/src/interface/utils.test.tsx
+++ b/packages/snaps-controllers/src/interface/utils.test.tsx
@@ -553,16 +553,15 @@ describe('constructState', () => {
       <Box>
         <AccountSelector
           name="foo"
-          title="Choose an account"
-          chainId="eip155:1"
-          selectedAddress="0x1234567890123456789012345678901234567890"
+          chainIds={['eip155:1']}
+          selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
         />
       </Box>
     );
 
     const result = constructState({}, element);
     expect(result).toStrictEqual({
-      foo: '0x1234567890123456789012345678901234567890',
+      foo: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
     });
   });
 
@@ -571,16 +570,15 @@ describe('constructState', () => {
       <Box>
         <AccountSelector
           name="foo"
-          title="Choose an account"
-          chainId="eip155:1"
-          selectedAddress="0x1234567890123456789012345678901234567890"
+          chainIds={['eip155:1']}
+          selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
         />
       </Box>
     );
 
     const result = constructState({}, element);
     expect(result).toStrictEqual({
-      foo: '0x1234567890123456789012345678901234567890',
+      foo: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
     });
   });
 
@@ -590,9 +588,8 @@ describe('constructState', () => {
         <Form name="form">
           <AccountSelector
             name="foo"
-            title="Choose an account"
-            chainId="eip155:1"
-            selectedAddress="0x1234567890123456789012345678901234567890"
+            chainIds={['eip155:1']}
+            selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
           />
         </Form>
       </Box>
@@ -600,7 +597,7 @@ describe('constructState', () => {
 
     const result = constructState({}, element);
     expect(result).toStrictEqual({
-      form: { foo: '0x1234567890123456789012345678901234567890' },
+      form: { foo: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed' },
     });
   });
 
@@ -610,9 +607,8 @@ describe('constructState', () => {
         <Form name="form">
           <AccountSelector
             name="foo"
-            title="Choose an account"
-            chainId="eip155:1"
-            selectedAddress="0x1234567890123456789012345678901234567890"
+            chainIds={['eip155:1']}
+            selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
           />
         </Form>
       </Box>
@@ -620,7 +616,7 @@ describe('constructState', () => {
 
     const result = constructState({}, element);
     expect(result).toStrictEqual({
-      form: { foo: '0x1234567890123456789012345678901234567890' },
+      form: { foo: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed' },
     });
   });
 

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -121,7 +121,7 @@ function getComponentStateValue(
       return element.props.checked;
 
     case 'AccountSelector':
-      return element.props.selectedAddress;
+      return element.props.selectedAccount;
 
     default:
       return element.props.value;

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -761,6 +761,8 @@ export const getRestrictedSnapInterfaceControllerMessenger = (
       'PhishingController:maybeUpdateState',
       'ApprovalController:hasRequest',
       'ApprovalController:acceptRequest',
+      'AccountsController:getSelectedMultichainAccount',
+      'AccountsController:getAccount',
     ],
     allowedEvents: [],
   });
@@ -775,6 +777,38 @@ export const getRestrictedSnapInterfaceControllerMessenger = (
       result: false,
       type: 'all',
     }));
+
+    messenger.registerActionHandler(
+      'AccountsController:getSelectedMultichainAccount',
+      () => ({
+        id: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+        address: '0x1234567891234567891234567891234567891234',
+        type: 'eip155:eoa',
+        options: { foo: 'bar' },
+        methods: [],
+        metadata: {
+          name: 'foo',
+          importTime: 1,
+          keyring: { type: 'foo' },
+        },
+      }),
+    );
+
+    messenger.registerActionHandler(
+      'AccountsController:getAccount',
+      (id: string) => ({
+        id,
+        address: '0x1234567891234567891234567891234567891234',
+        type: 'eip155:eoa',
+        options: { foo: 'bar' },
+        methods: [],
+        metadata: {
+          name: 'foo',
+          importTime: 1,
+          keyring: { type: 'foo' },
+        },
+      }),
+    );
   }
 
   return snapInterfaceControllerMessenger;

--- a/packages/snaps-sdk/src/jsx/components/form/AccountSelector.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/AccountSelector.test.tsx
@@ -1,7 +1,25 @@
 import { AccountSelector } from './AccountSelector';
 
 describe('AccountSelector', () => {
-  it('returns an account selector element', () => {
+  it('returns an account selector element without filter props', () => {
+    const result = (
+      <AccountSelector
+        name="account"
+        selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
+      />
+    );
+
+    expect(result).toStrictEqual({
+      type: 'AccountSelector',
+      props: {
+        name: 'account',
+        selectedAccount: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+      },
+      key: null,
+    });
+  });
+
+  it('returns an account selector element with the chainIds filter prop', () => {
     const result = (
       <AccountSelector
         name="account"
@@ -15,6 +33,26 @@ describe('AccountSelector', () => {
       props: {
         name: 'account',
         chainIds: ['bip122:p2wpkh'],
+        selectedAccount: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+      },
+      key: null,
+    });
+  });
+
+  it('returns an account selector element with the hideExternalAccounts filter prop', () => {
+    const result = (
+      <AccountSelector
+        name="account"
+        hideExternalAccounts={true}
+        selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
+      />
+    );
+
+    expect(result).toStrictEqual({
+      type: 'AccountSelector',
+      props: {
+        name: 'account',
+        hideExternalAccounts: true,
         selectedAccount: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
       },
       key: null,

--- a/packages/snaps-sdk/src/jsx/components/form/AccountSelector.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/AccountSelector.test.tsx
@@ -2,18 +2,12 @@ import { AccountSelector } from './AccountSelector';
 
 describe('AccountSelector', () => {
   it('returns an account selector element without filter props', () => {
-    const result = (
-      <AccountSelector
-        name="account"
-        selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
-      />
-    );
+    const result = <AccountSelector name="account" />;
 
     expect(result).toStrictEqual({
       type: 'AccountSelector',
       props: {
         name: 'account',
-        selectedAccount: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
       },
       key: null,
     });
@@ -23,8 +17,7 @@ describe('AccountSelector', () => {
     const result = (
       <AccountSelector
         name="account"
-        chainIds={['bip122:p2wpkh']}
-        selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
+        chainIds={['bip122:000000000019d6689c085ae165831e93']}
       />
     );
 
@@ -32,8 +25,7 @@ describe('AccountSelector', () => {
       type: 'AccountSelector',
       props: {
         name: 'account',
-        chainIds: ['bip122:p2wpkh'],
-        selectedAccount: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+        chainIds: ['bip122:000000000019d6689c085ae165831e93'],
       },
       key: null,
     });
@@ -41,9 +33,38 @@ describe('AccountSelector', () => {
 
   it('returns an account selector element with the hideExternalAccounts filter prop', () => {
     const result = (
+      <AccountSelector name="account" hideExternalAccounts={true} />
+    );
+
+    expect(result).toStrictEqual({
+      type: 'AccountSelector',
+      props: {
+        name: 'account',
+        hideExternalAccounts: true,
+      },
+      key: null,
+    });
+  });
+
+  it('returns an account selector element with the switchGlobalAccount filter prop', () => {
+    const result = (
+      <AccountSelector name="account" switchGlobalAccount={true} />
+    );
+
+    expect(result).toStrictEqual({
+      type: 'AccountSelector',
+      props: {
+        name: 'account',
+        switchGlobalAccount: true,
+      },
+      key: null,
+    });
+  });
+
+  it('returns an account selector element with a selectedAccount prop', () => {
+    const result = (
       <AccountSelector
         name="account"
-        hideExternalAccounts={true}
         selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
       />
     );
@@ -52,7 +73,30 @@ describe('AccountSelector', () => {
       type: 'AccountSelector',
       props: {
         name: 'account',
+        selectedAccount: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+      },
+      key: null,
+    });
+  });
+
+  it('returns an account selector element with all props', () => {
+    const result = (
+      <AccountSelector
+        name="account"
+        chainIds={['bip122:000000000019d6689c085ae165831e93']}
+        hideExternalAccounts={true}
+        switchGlobalAccount={true}
+        selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
+      />
+    );
+
+    expect(result).toStrictEqual({
+      type: 'AccountSelector',
+      props: {
+        name: 'account',
+        chainIds: ['bip122:000000000019d6689c085ae165831e93'],
         hideExternalAccounts: true,
+        switchGlobalAccount: true,
         selectedAccount: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
       },
       key: null,

--- a/packages/snaps-sdk/src/jsx/components/form/AccountSelector.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/AccountSelector.test.tsx
@@ -6,7 +6,7 @@ describe('AccountSelector', () => {
       <AccountSelector
         name="account"
         chainIds={['bip122:p2wpkh']}
-        selectedAddress="bc1qc8dwyqua9elc3mzcxk93c70kjz8tcc92x0a8a6"
+        selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
       />
     );
 
@@ -15,7 +15,7 @@ describe('AccountSelector', () => {
       props: {
         name: 'account',
         chainIds: ['bip122:p2wpkh'],
-        selectedAddress: 'bc1qc8dwyqua9elc3mzcxk93c70kjz8tcc92x0a8a6',
+        selectedAccount: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
       },
       key: null,
     });

--- a/packages/snaps-sdk/src/jsx/components/form/AccountSelector.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/AccountSelector.ts
@@ -9,6 +9,7 @@ import { createSnapComponent } from '../../component';
  * state in the form data.
  * @property chainIds - The chain IDs of the account selector. This should be a valid CAIP-2 chain ID array.
  * @property hideExternalAccounts - Whether to hide accounts not owned by the snap. Defaults to `false`.
+ * @property switchGlobalAccount - Whether to switch the currently selected account in MetaMask. Defaults to `false`.
  * @property selectedAccount - The default selected account of the account selector. This should be a
  * valid account ID.
  */
@@ -16,7 +17,8 @@ export type AccountSelectorProps = {
   name: string;
   chainIds?: CaipChainId[] | undefined;
   hideExternalAccounts?: boolean | undefined;
-  selectedAccount: string;
+  switchGlobalAccount?: boolean | undefined;
+  selectedAccount?: string | undefined;
 };
 
 const TYPE = 'AccountSelector';
@@ -31,6 +33,7 @@ const TYPE = 'AccountSelector';
  * state in the form data.
  * @param props.chainIds - The chain IDs of the account selector. This should be a valid CAIP-2 chain ID array.
  * @param props.hideExternalAccounts - Whether to hide accounts not owned by the snap. Defaults to `false`.
+ * @param props.switchGlobalAccount - Whether to switch the currently selected account in MetaMask. Defaults to `false`.
  * @param props.selectedAccount - The default selected account of the account selector. This should be a
  * valid account ID.
  * @returns An account selector element.

--- a/packages/snaps-sdk/src/jsx/components/form/AccountSelector.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/AccountSelector.ts
@@ -8,12 +8,14 @@ import { createSnapComponent } from '../../component';
  * @property name - The name of the account selector. This is used to identify the
  * state in the form data.
  * @property chainIds - The chain IDs of the account selector. This should be a valid CAIP-2 chain ID array.
+ * @property hideExternalAccounts - Whether to hide accounts not owned by the snap. Defaults to `false`.
  * @property selectedAccount - The default selected account of the account selector. This should be a
  * valid account ID.
  */
 export type AccountSelectorProps = {
   name: string;
-  chainIds: CaipChainId[];
+  chainIds?: CaipChainId[] | undefined;
+  hideExternalAccounts?: boolean | undefined;
   selectedAccount: string;
 };
 
@@ -28,13 +30,14 @@ const TYPE = 'AccountSelector';
  * @param props.name - The name of the account selector field. This is used to identify the
  * state in the form data.
  * @param props.chainIds - The chain IDs of the account selector. This should be a valid CAIP-2 chain ID array.
+ * @param props.hideExternalAccounts - Whether to hide accounts not owned by the snap. Defaults to `false`.
  * @param props.selectedAccount - The default selected account of the account selector. This should be a
  * valid account ID.
  * @returns An account selector element.
  * @example
  * <AccountSelector name="account" chainIds={["eip155:1"]} selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed" />
  * @example
- * <AccountSelector name="account" chainIds={["bip122:000000000019d6689c085ae165831e93"]} selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed" />
+ * <AccountSelector name="account" chainIds={["bip122:000000000019d6689c085ae165831e93"]} selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed" hideExternalAccounts />
  */
 export const AccountSelector = createSnapComponent<
   AccountSelectorProps,

--- a/packages/snaps-sdk/src/jsx/components/form/AccountSelector.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/AccountSelector.ts
@@ -1,4 +1,4 @@
-import type { CaipAccountAddress, CaipChainId } from '@metamask/utils';
+import type { CaipChainId } from '@metamask/utils';
 
 import { createSnapComponent } from '../../component';
 
@@ -8,13 +8,13 @@ import { createSnapComponent } from '../../component';
  * @property name - The name of the account selector. This is used to identify the
  * state in the form data.
  * @property chainIds - The chain IDs of the account selector. This should be a valid CAIP-2 chain ID array.
- * @property selectedAddress - The default selected address of the account selector. This should be a
- * valid CAIP-10 account address.
+ * @property selectedAccount - The default selected account of the account selector. This should be a
+ * valid account ID.
  */
 export type AccountSelectorProps = {
   name: string;
   chainIds: CaipChainId[];
-  selectedAddress: CaipAccountAddress;
+  selectedAccount: string;
 };
 
 const TYPE = 'AccountSelector';
@@ -28,13 +28,13 @@ const TYPE = 'AccountSelector';
  * @param props.name - The name of the account selector field. This is used to identify the
  * state in the form data.
  * @param props.chainIds - The chain IDs of the account selector. This should be a valid CAIP-2 chain ID array.
- * @param props.selectedAddress - The selected address of the account selector. This should be a
- * valid CAIP-10 account address.
+ * @param props.selectedAccount - The default selected account of the account selector. This should be a
+ * valid account ID.
  * @returns An account selector element.
  * @example
- * <AccountSelector name="account" chainIds={["eip155:1"]} selectedAddress="0x1234567890123456789012345678901234567890" />
+ * <AccountSelector name="account" chainIds={["eip155:1"]} selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed" />
  * @example
- * <AccountSelector name="account" chainIds={["bip122:000000000019d6689c085ae165831e93"]} selectedAddress="128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6" />
+ * <AccountSelector name="account" chainIds={["bip122:000000000019d6689c085ae165831e93"]} selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed" />
  */
 export const AccountSelector = createSnapComponent<
   AccountSelectorProps,

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -974,7 +974,7 @@ describe('AccountSelectorStruct', () => {
     />,
     <AccountSelector
       name="account"
-      chainIds={['eip155:1']}
+      hideExternalAccounts={true}
       selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
     />,
   ])('validates an account picker element', (value) => {
@@ -1004,6 +1004,13 @@ describe('AccountSelectorStruct', () => {
       name="account"
       chainIds={['foo:bar']}
       selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
+    />,
+    <AccountSelector
+      name="account"
+      chainIds={['foo:bar']}
+      selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
+      // @ts-expect-error - Invalid props.
+      hideExternalAccounts={42}
     />,
     <Text>foo</Text>,
     <Box>

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -967,14 +967,22 @@ describe('FileInputStruct', () => {
 
 describe('AccountSelectorStruct', () => {
   it.each([
+    <AccountSelector name="account" />,
     <AccountSelector
       name="account"
       chainIds={['bip122:000000000019d6689c085ae165831e93']}
+    />,
+    <AccountSelector name="account" hideExternalAccounts />,
+    <AccountSelector name="account" switchGlobalAccount />,
+    <AccountSelector
+      name="account"
       selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
     />,
     <AccountSelector
       name="account"
-      hideExternalAccounts={true}
+      chainIds={['foo:bar']}
+      hideExternalAccounts
+      switchGlobalAccount
       selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
     />,
   ])('validates an account picker element', (value) => {
@@ -995,7 +1003,7 @@ describe('AccountSelectorStruct', () => {
       <Text>foo</Text>
     </AccountSelector>,
     // @ts-expect-error - Invalid props.
-    <AccountSelector name="account" />,
+    <AccountSelector switchGlobalAccount="foo" />,
     // @ts-expect-error - Invalid props.
     <AccountSelector chainIds={['bip122:000000000019d6689c085ae165831e93']} />,
     // @ts-expect-error - Invalid props.

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -301,7 +301,7 @@ describe('FieldStruct', () => {
       <AccountSelector
         name="foo"
         chainIds={['eip155:1']}
-        selectedAddress="0x1234567890abcdef1234567890abcdef12345678"
+        selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
       />
     </Field>,
   ])('validates a field element', (value) => {
@@ -970,12 +970,12 @@ describe('AccountSelectorStruct', () => {
     <AccountSelector
       name="account"
       chainIds={['bip122:000000000019d6689c085ae165831e93']}
-      selectedAddress="128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6"
+      selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
     />,
     <AccountSelector
       name="account"
       chainIds={['eip155:1']}
-      selectedAddress="0x1234567890123456789012345678901234567890"
+      selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
     />,
   ])('validates an account picker element', (value) => {
     expect(is(value, AccountSelectorStruct)).toBe(true);
@@ -999,16 +999,11 @@ describe('AccountSelectorStruct', () => {
     // @ts-expect-error - Invalid props.
     <AccountSelector chainIds={['bip122:000000000019d6689c085ae165831e93']} />,
     // @ts-expect-error - Invalid props.
-    <AccountSelector selectedAddress="128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6" />,
+    <AccountSelector selectedAddress={42} />,
     <AccountSelector
       name="account"
       chainIds={['foo:bar']}
-      selectedAddress="0x1234567890123456789012345678901234567890"
-    />,
-    <AccountSelector
-      name="account"
-      chainIds={['eip155:1']}
-      selectedAddress="0x123"
+      selectedAccount="1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
     />,
     <Text>foo</Text>,
     <Box>

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -345,7 +345,8 @@ export const AccountSelectorStruct: Describe<AccountSelectorElement> = element(
       null
     >,
     hideExternalAccounts: optional(boolean()),
-    selectedAccount: string(),
+    switchGlobalAccount: optional(boolean()),
+    selectedAccount: optional(string()),
   },
 );
 

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -340,12 +340,11 @@ export const AccountSelectorStruct: Describe<AccountSelectorElement> = element(
   'AccountSelector',
   {
     name: string(),
-    chainIds: array(
-      CaipChainIdStruct as unknown as Struct<
-        Infer<typeof CaipChainIdStruct>,
-        Infer<typeof CaipChainIdStruct>
-      >,
-    ),
+    chainIds: optional(array(CaipChainIdStruct)) as unknown as Struct<
+      Infer<typeof CaipChainIdStruct>[] | undefined,
+      null
+    >,
+    hideExternalAccounts: optional(boolean()),
     selectedAccount: string(),
   },
 );

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -20,7 +20,6 @@ import {
   refine,
 } from '@metamask/superstruct';
 import {
-  CaipAccountAddressStruct,
   CaipAccountIdStruct,
   CaipChainIdStruct,
   hasProperty,
@@ -347,7 +346,7 @@ export const AccountSelectorStruct: Describe<AccountSelectorElement> = element(
         Infer<typeof CaipChainIdStruct>
       >,
     ),
-    selectedAddress: CaipAccountAddressStruct,
+    selectedAccount: string(),
   },
 );
 

--- a/packages/snaps-sdk/src/types/handlers/user-input.ts
+++ b/packages/snaps-sdk/src/types/handlers/user-input.ts
@@ -12,10 +12,7 @@ import {
   boolean,
 } from '@metamask/superstruct';
 
-import {
-  AccountSelectorValueStruct,
-  type InterfaceContext,
-} from '../interface';
+import { type InterfaceContext } from '../interface';
 
 /**
  * The type of user input event fired.
@@ -55,6 +52,19 @@ export const ButtonClickEventStruct = assign(
  * @property name - The optional component name that fired the event.
  */
 export type ButtonClickEvent = Infer<typeof ButtonClickEventStruct>;
+
+/**
+ * The value of an `AccountSelector` component in state.
+ *
+ * @property id - The account ID of the account.
+ * @property address - The address of the account.
+ */
+export const AccountSelectorValueStruct = object({
+  id: string(),
+  address: string(),
+});
+
+export type AccountSelectorValue = Infer<typeof AccountSelectorValueStruct>;
 
 export const FileStruct = object({
   name: string(),

--- a/packages/snaps-sdk/src/types/handlers/user-input.ts
+++ b/packages/snaps-sdk/src/types/handlers/user-input.ts
@@ -12,7 +12,10 @@ import {
   boolean,
 } from '@metamask/superstruct';
 
-import type { InterfaceContext } from '../interface';
+import {
+  AccountSelectorValueStruct,
+  type InterfaceContext,
+} from '../interface';
 
 /**
  * The type of user input event fired.
@@ -75,7 +78,12 @@ export const FormSubmitEventStruct = assign(
   GenericEventStruct,
   object({
     type: literal(UserInputEventType.FormSubmitEvent),
-    value: record(string(), nullable(union([string(), FileStruct, boolean()]))),
+    value: record(
+      string(),
+      nullable(
+        union([string(), FileStruct, AccountSelectorValueStruct, boolean()]),
+      ),
+    ),
     name: string(),
   }),
 );
@@ -100,7 +108,7 @@ export const InputChangeEventStruct = assign(
   object({
     type: literal(UserInputEventType.InputChangeEvent),
     name: string(),
-    value: union([string(), boolean()]),
+    value: union([string(), boolean(), AccountSelectorValueStruct]),
   }),
 );
 

--- a/packages/snaps-sdk/src/types/interface.ts
+++ b/packages/snaps-sdk/src/types/interface.ts
@@ -2,6 +2,7 @@ import type { Infer } from '@metamask/superstruct';
 import {
   boolean,
   nullable,
+  object,
   record,
   string,
   union,
@@ -16,13 +17,29 @@ import { ComponentStruct } from '../ui';
 import { FileStruct } from './handlers';
 
 /**
+ * The state of an `AccountSelector` component.
+ *
+ * @property id - The account ID of the account.
+ * @property address - The address of the account.
+ */
+export const AccountSelectorStateStruct = object({
+  id: string(),
+  address: string(),
+});
+
+/**
  * To avoid typing problems with the interface state when manipulating it we
  * have to differentiate the state of a form (that will be contained inside the
  * root state) and the root state since a key in the root stat can contain
  * either the value of an input or a sub-state of a form.
  */
 
-export const StateStruct = union([FileStruct, string(), boolean()]);
+export const StateStruct = union([
+  FileStruct,
+  AccountSelectorStateStruct,
+  string(),
+  boolean(),
+]);
 
 export const FormStateStruct = record(string(), nullable(StateStruct));
 

--- a/packages/snaps-sdk/src/types/interface.ts
+++ b/packages/snaps-sdk/src/types/interface.ts
@@ -17,15 +17,17 @@ import { ComponentStruct } from '../ui';
 import { FileStruct } from './handlers';
 
 /**
- * The state of an `AccountSelector` component.
+ * The value of an `AccountSelector` component in state.
  *
  * @property id - The account ID of the account.
  * @property address - The address of the account.
  */
-export const AccountSelectorStateStruct = object({
+export const AccountSelectorValueStruct = object({
   id: string(),
   address: string(),
 });
+
+export type AccountSelectorValue = Infer<typeof AccountSelectorValueStruct>;
 
 /**
  * To avoid typing problems with the interface state when manipulating it we
@@ -36,7 +38,7 @@ export const AccountSelectorStateStruct = object({
 
 export const StateStruct = union([
   FileStruct,
-  AccountSelectorStateStruct,
+  AccountSelectorValueStruct,
   string(),
   boolean(),
 ]);

--- a/packages/snaps-sdk/src/types/interface.ts
+++ b/packages/snaps-sdk/src/types/interface.ts
@@ -2,7 +2,6 @@ import type { Infer } from '@metamask/superstruct';
 import {
   boolean,
   nullable,
-  object,
   record,
   string,
   union,
@@ -14,20 +13,7 @@ import type { JSXElement } from '../jsx';
 import { RootJSXElementStruct } from '../jsx';
 import type { Component } from '../ui';
 import { ComponentStruct } from '../ui';
-import { FileStruct } from './handlers';
-
-/**
- * The value of an `AccountSelector` component in state.
- *
- * @property id - The account ID of the account.
- * @property address - The address of the account.
- */
-export const AccountSelectorValueStruct = object({
-  id: string(),
-  address: string(),
-});
-
-export type AccountSelectorValue = Infer<typeof AccountSelectorValueStruct>;
+import { AccountSelectorValueStruct, FileStruct } from './handlers';
 
 /**
  * To avoid typing problems with the interface state when manipulating it we

--- a/packages/snaps-webpack-plugin/src/__snapshots__/plugin.test.ts.snap
+++ b/packages/snaps-webpack-plugin/src/__snapshots__/plugin.test.ts.snap
@@ -7,13 +7,6 @@ exports[`SnapsWebpackPlugin applies a transform 1`] = `
 })();"
 `;
 
-exports[`SnapsWebpackPlugin applies a transform 2`] = `
-"(() => {
-  var __webpack_exports__ = {};
-  const foo = 'bar';
-})();"
-`;
-
 exports[`SnapsWebpackPlugin forwards the options 1`] = `
 "/******/(() => {
   // webpackBootstrap

--- a/packages/snaps-webpack-plugin/src/__snapshots__/plugin.test.ts.snap
+++ b/packages/snaps-webpack-plugin/src/__snapshots__/plugin.test.ts.snap
@@ -7,6 +7,13 @@ exports[`SnapsWebpackPlugin applies a transform 1`] = `
 })();"
 `;
 
+exports[`SnapsWebpackPlugin applies a transform 2`] = `
+"(() => {
+  var __webpack_exports__ = {};
+  const foo = 'bar';
+})();"
+`;
+
 exports[`SnapsWebpackPlugin forwards the options 1`] = `
 "/******/(() => {
   // webpackBootstrap

--- a/yarn.lock
+++ b/yarn.lock
@@ -5193,7 +5193,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-controller@npm:^17.0.0":
+"@metamask/keyring-controller@npm:^17.2.2":
   version: 17.2.2
   resolution: "@metamask/keyring-controller@npm:17.2.2"
   dependencies:
@@ -5906,7 +5906,7 @@ __metadata:
     "@metamask/eslint-config-typescript": "npm:^12.1.0"
     "@metamask/json-rpc-engine": "npm:^9.0.2"
     "@metamask/json-rpc-middleware-stream": "npm:^8.0.2"
-    "@metamask/keyring-controller": "npm:^17.0.0"
+    "@metamask/keyring-controller": "npm:^17.2.2"
     "@metamask/object-multiplex": "npm:^2.0.0"
     "@metamask/permission-controller": "npm:^11.0.0"
     "@metamask/phishing-controller": "npm:^12.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3208,7 +3208,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereumjs/tx@npm:^4.2.0":
+"@ethereumjs/tx@npm:^4.0.2, @ethereumjs/tx@npm:^4.2.0":
   version: 4.2.0
   resolution: "@ethereumjs/tx@npm:4.2.0"
   dependencies:
@@ -3220,7 +3220,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereumjs/util@npm:^8.1.0":
+"@ethereumjs/util@npm:^8.0.0, @ethereumjs/util@npm:^8.1.0":
   version: 8.1.0
   resolution: "@ethereumjs/util@npm:8.1.0"
   dependencies:
@@ -3740,6 +3740,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@keystonehq/alias-sampling@npm:^0.1.1":
+  version: 0.1.2
+  resolution: "@keystonehq/alias-sampling@npm:0.1.2"
+  checksum: 10/4dfdfb91e070b1d9f28058c92b5b8fad81696ac63bd432cd6bd359f2ab92eb50df75e8c5da1f75a351756387e9902f043b3ecc2cbf662c9c9456ecacc848abfd
+  languageName: node
+  linkType: hard
+
+"@keystonehq/base-eth-keyring@npm:^0.14.1":
+  version: 0.14.1
+  resolution: "@keystonehq/base-eth-keyring@npm:0.14.1"
+  dependencies:
+    "@ethereumjs/tx": "npm:^4.0.2"
+    "@ethereumjs/util": "npm:^8.0.0"
+    "@keystonehq/bc-ur-registry-eth": "npm:^0.19.1"
+    hdkey: "npm:^2.0.1"
+    rlp: "npm:^3.0.0"
+    uuid: "npm:^8.3.2"
+  checksum: 10/07516e967fc5c618ef0ce67b155ba69c04f8fd84d5a6fd35f025f989c41256c9e6fa0375cfb0318da42876a61c64839e312d910e4b9fa801f86179df826adc69
+  languageName: node
+  linkType: hard
+
+"@keystonehq/bc-ur-registry-eth@npm:^0.19.1":
+  version: 0.19.1
+  resolution: "@keystonehq/bc-ur-registry-eth@npm:0.19.1"
+  dependencies:
+    "@ethereumjs/util": "npm:^8.0.0"
+    "@keystonehq/bc-ur-registry": "npm:^0.6.0"
+    hdkey: "npm:^2.0.1"
+    uuid: "npm:^8.3.2"
+  checksum: 10/7e64e6a754e6b66fc83a8f3880b54828c5b37f4eaaea3287eee31bd9d9b5ac0ba4cd4b8e751af9bd2f66e6f19291eaf02f46cd177d05ed9b30c1349cdd04572f
+  languageName: node
+  linkType: hard
+
+"@keystonehq/bc-ur-registry@npm:^0.6.0":
+  version: 0.6.4
+  resolution: "@keystonehq/bc-ur-registry@npm:0.6.4"
+  dependencies:
+    "@ngraveio/bc-ur": "npm:^1.1.5"
+    bs58check: "npm:^2.1.2"
+    tslib: "npm:^2.3.0"
+  checksum: 10/d4cdbefc14f3305543340d509564e1a795eb458327d46aad8665927999150df7e282939dcb714b81fea386061019e3b9f41eedbbb09a59d404355711c33159b2
+  languageName: node
+  linkType: hard
+
+"@keystonehq/metamask-airgapped-keyring@npm:^0.14.1":
+  version: 0.14.1
+  resolution: "@keystonehq/metamask-airgapped-keyring@npm:0.14.1"
+  dependencies:
+    "@ethereumjs/tx": "npm:^4.0.2"
+    "@keystonehq/base-eth-keyring": "npm:^0.14.1"
+    "@keystonehq/bc-ur-registry-eth": "npm:^0.19.1"
+    "@metamask/obs-store": "npm:^9.0.0"
+    rlp: "npm:^2.2.6"
+    uuid: "npm:^8.3.2"
+  checksum: 10/8e34be8813c51488c7dc9b641ed17258740dda45fb72fe48670b077ecfb92273e0c5a2fbbab121b01d7e0906a3ec512f261fceb95da8089550021ab6a0c89c6b
+  languageName: node
+  linkType: hard
+
 "@lavamoat/aa@npm:^4.1.0, @lavamoat/aa@npm:^4.2.0":
   version: 4.2.0
   resolution: "@lavamoat/aa@npm:4.2.0"
@@ -3831,6 +3889,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/accounts-controller@npm:^18.2.2":
+  version: 18.2.2
+  resolution: "@metamask/accounts-controller@npm:18.2.2"
+  dependencies:
+    "@ethereumjs/util": "npm:^8.1.0"
+    "@metamask/base-controller": "npm:^7.0.1"
+    "@metamask/eth-snap-keyring": "npm:^4.3.6"
+    "@metamask/keyring-api": "npm:^8.1.3"
+    "@metamask/snaps-sdk": "npm:^6.5.0"
+    "@metamask/snaps-utils": "npm:^8.1.1"
+    "@metamask/utils": "npm:^9.1.0"
+    deepmerge: "npm:^4.2.2"
+    ethereum-cryptography: "npm:^2.1.2"
+    immer: "npm:^9.0.6"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@metamask/keyring-controller": ^17.0.0
+    "@metamask/snaps-controllers": ^9.7.0
+  checksum: 10/095be37c94a577304425f80600d4ef847c83c702ccf3d6b1591602d1fe292bdd3273131e336d6108bd713bff38812dfc4d7b21d4075669cde24e12f117f2dd81
+  languageName: node
+  linkType: hard
+
 "@metamask/action-utils@npm:^1.0.0":
   version: 1.1.1
   resolution: "@metamask/action-utils@npm:1.1.1"
@@ -3894,13 +3974,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "@metamask/base-controller@npm:7.0.0"
+"@metamask/base-controller@npm:^7.0.0, @metamask/base-controller@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "@metamask/base-controller@npm:7.0.1"
   dependencies:
     "@metamask/utils": "npm:^9.1.0"
     immer: "npm:^9.0.6"
-  checksum: 10/0ea307da4a7863224fd1fc83039165dbd06d2725922d4d4cf5854f5e7894e789a3c277f1e4592a38ae002de869217a26550f3b9687c259fc29153984dc5b4a4c
+  checksum: 10/774b6d68ac95a5ec187e890d321bede50065f8a6f1ba7b49a19f5971366274054ac0e401548b51d3b014d0bca5d650409fb554dd13ce120e7fb3495b4e8e67b1
   languageName: node
   linkType: hard
 
@@ -3985,6 +4065,15 @@ __metadata:
     typescript: "npm:~5.3.3"
   languageName: unknown
   linkType: soft
+
+"@metamask/browser-passworder@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "@metamask/browser-passworder@npm:4.3.0"
+  dependencies:
+    "@metamask/utils": "npm:^8.2.0"
+  checksum: 10/8ba5c50cd6274b0cc0f90a1ee16b960ee150f14c29083f3515f4abe018a28ead32c21f5f4a62a6e27a946b1228adc2ff1f195e71e38782fa39fa8fff116173e6
+  languageName: node
+  linkType: hard
 
 "@metamask/browser-passworder@npm:^5.0.1":
   version: 5.0.1
@@ -4150,9 +4239,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/controller-utils@npm:^11.0.2, @metamask/controller-utils@npm:^11.2.0":
-  version: 11.2.0
-  resolution: "@metamask/controller-utils@npm:11.2.0"
+"@metamask/controller-utils@npm:^11.0.2, @metamask/controller-utils@npm:^11.2.0, @metamask/controller-utils@npm:^11.3.0":
+  version: 11.3.0
+  resolution: "@metamask/controller-utils@npm:11.3.0"
   dependencies:
     "@ethereumjs/util": "npm:^8.1.0"
     "@metamask/eth-query": "npm:^4.0.0"
@@ -4163,7 +4252,7 @@ __metadata:
     bn.js: "npm:^5.2.1"
     eth-ens-namehash: "npm:^2.0.8"
     fast-deep-equal: "npm:^3.1.3"
-  checksum: 10/8c8630a635c5eeeb8ef46b14a12779a5005d8112668500bfb513186dee3f68b94dcf43ce6eddf42c38382828cd7ba28657b627d0eb617207a25b6ee78eae6b08
+  checksum: 10/3200228d1f4ea5fa095228db4e5050529caf0470e072382eb8f7571bb9b07515516ca9e846b7751388399d9ae967e4985dafd6120902ef6c998e98f4eb36d964
   languageName: node
   linkType: hard
 
@@ -4461,6 +4550,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-hd-keyring@npm:^7.0.4":
+  version: 7.0.4
+  resolution: "@metamask/eth-hd-keyring@npm:7.0.4"
+  dependencies:
+    "@ethereumjs/util": "npm:^8.1.0"
+    "@metamask/eth-sig-util": "npm:^7.0.3"
+    "@metamask/scure-bip39": "npm:^2.1.1"
+    "@metamask/utils": "npm:^9.2.1"
+    ethereum-cryptography: "npm:^2.1.2"
+  checksum: 10/493d06f55225b6f9da48ee001486e18898d6a4a3afd2cf40ff1dcae2ece42d5e96174f6a05b7c39419cb3531b530c8af294d9422195661788c5e0b687a328874
+  languageName: node
+  linkType: hard
+
 "@metamask/eth-json-rpc-middleware@npm:^14.0.0":
   version: 14.0.1
   resolution: "@metamask/eth-json-rpc-middleware@npm:14.0.1"
@@ -4503,7 +4605,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-sig-util@npm:^7.0.3":
+"@metamask/eth-sig-util@npm:^7.0.1, @metamask/eth-sig-util@npm:^7.0.3":
   version: 7.0.3
   resolution: "@metamask/eth-sig-util@npm:7.0.3"
   dependencies:
@@ -4514,6 +4616,38 @@ __metadata:
     ethereum-cryptography: "npm:^2.1.2"
     tweetnacl: "npm:^1.0.3"
   checksum: 10/a71b28607b0815d609cf27ab2d8535393d0a7e7f2c6b7a23d92669b770c664c14e2f539129351147339172b0bb865bb977e7cfb30624870eedab5d7ab700beff
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-simple-keyring@npm:^6.0.5":
+  version: 6.0.5
+  resolution: "@metamask/eth-simple-keyring@npm:6.0.5"
+  dependencies:
+    "@ethereumjs/util": "npm:^8.1.0"
+    "@metamask/eth-sig-util": "npm:^7.0.3"
+    "@metamask/utils": "npm:^9.2.1"
+    ethereum-cryptography: "npm:^2.1.2"
+    randombytes: "npm:^2.1.0"
+  checksum: 10/98b7bd00df25e7630324e2c762e3a03a7f199108a4dfe22e5a1938f1d01c9b2cd64ab4bb6fd242bf898624903d5a68a2e1f61c95f94a141266ab23dae8d97d21
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-snap-keyring@npm:^4.3.6":
+  version: 4.3.6
+  resolution: "@metamask/eth-snap-keyring@npm:4.3.6"
+  dependencies:
+    "@ethereumjs/tx": "npm:^4.2.0"
+    "@metamask/eth-sig-util": "npm:^7.0.3"
+    "@metamask/snaps-controllers": "npm:^9.7.0"
+    "@metamask/snaps-sdk": "npm:^6.5.1"
+    "@metamask/snaps-utils": "npm:^7.8.1"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^9.2.1"
+    "@types/uuid": "npm:^9.0.8"
+    uuid: "npm:^9.0.1"
+  peerDependencies:
+    "@metamask/keyring-api": ^8.1.3
+  checksum: 10/378dce125ba9e38b9ba7d9b7124383b4fd8d2782207dc69e1ae9e262beb83f22044eae5200986d4c353de29e5283c289e56b3acb88c8971a63f9365bdde3d5b4
   languageName: node
   linkType: hard
 
@@ -5043,6 +5177,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/keyring-api@npm:^8.1.3":
+  version: 8.1.3
+  resolution: "@metamask/keyring-api@npm:8.1.3"
+  dependencies:
+    "@metamask/snaps-sdk": "npm:^6.5.1"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^9.2.1"
+    "@types/uuid": "npm:^9.0.8"
+    bech32: "npm:^2.0.0"
+    uuid: "npm:^9.0.1"
+  peerDependencies:
+    "@metamask/providers": ^17.2.0
+  checksum: 10/9857b6286760d22b1b7102ea8bdf03ebf56c71e9f0adee19a2230def6b7a9230561c1a3bfcb308735b79ab9a5afa9afd07a1617c1d165f63d193cd6a6b6e7a15
+  languageName: node
+  linkType: hard
+
+"@metamask/keyring-controller@npm:^17.0.0":
+  version: 17.2.2
+  resolution: "@metamask/keyring-controller@npm:17.2.2"
+  dependencies:
+    "@ethereumjs/util": "npm:^8.1.0"
+    "@keystonehq/metamask-airgapped-keyring": "npm:^0.14.1"
+    "@metamask/base-controller": "npm:^7.0.1"
+    "@metamask/browser-passworder": "npm:^4.3.0"
+    "@metamask/eth-hd-keyring": "npm:^7.0.4"
+    "@metamask/eth-sig-util": "npm:^7.0.1"
+    "@metamask/eth-simple-keyring": "npm:^6.0.5"
+    "@metamask/keyring-api": "npm:^8.1.3"
+    "@metamask/message-manager": "npm:^10.1.1"
+    "@metamask/utils": "npm:^9.1.0"
+    async-mutex: "npm:^0.5.0"
+    ethereumjs-wallet: "npm:^1.0.1"
+    immer: "npm:^9.0.6"
+  checksum: 10/3c3cec4c813de78c889c38b9a5f6201929743544a28c9e734bbf57a3774e3c2bc9432bb3cefa69bb7ed3580933898329c8a5e374c21c07ea204ee19bf094c8ff
+  languageName: node
+  linkType: hard
+
 "@metamask/lifecycle-hooks-example-snap@workspace:^, @metamask/lifecycle-hooks-example-snap@workspace:packages/examples/packages/lifecycle-hooks":
   version: 0.0.0-use.local
   resolution: "@metamask/lifecycle-hooks-example-snap@workspace:packages/examples/packages/lifecycle-hooks"
@@ -5153,6 +5324,21 @@ __metadata:
     typescript: "npm:~5.3.3"
   languageName: unknown
   linkType: soft
+
+"@metamask/message-manager@npm:^10.1.1":
+  version: 10.1.1
+  resolution: "@metamask/message-manager@npm:10.1.1"
+  dependencies:
+    "@metamask/base-controller": "npm:^7.0.1"
+    "@metamask/controller-utils": "npm:^11.3.0"
+    "@metamask/eth-sig-util": "npm:^7.0.1"
+    "@metamask/utils": "npm:^9.1.0"
+    "@types/uuid": "npm:^8.3.0"
+    jsonschema: "npm:^1.2.4"
+    uuid: "npm:^8.3.2"
+  checksum: 10/042484129b82cf0e6f59044fc63607f59e8084d28ff26004ecddb50925aea22f3def8c13846832899fa6933438e77d1b7a37f18207d8d063b60630d642f08850
+  languageName: node
+  linkType: hard
 
 "@metamask/name-lookup-example-snap@workspace:^, @metamask/name-lookup-example-snap@workspace:packages/examples/packages/name-lookup":
   version: 0.0.0-use.local
@@ -5284,6 +5470,16 @@ __metadata:
     once: "npm:^1.4.0"
     readable-stream: "npm:^3.6.2"
   checksum: 10/54baea752a3ac7c2742c376512e00d4902d383e9da8787574d3b21eb0081523309e24e3915a98f3ae0341d65712b6832d2eb7eeb862f4ef0da1ead52dcde5387
+  languageName: node
+  linkType: hard
+
+"@metamask/obs-store@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@metamask/obs-store@npm:9.0.0"
+  dependencies:
+    "@metamask/safe-event-emitter": "npm:^3.0.0"
+    readable-stream: "npm:^3.6.2"
+  checksum: 10/1c202a5bbdc79a6b8b3fba946c09dc5521e87260956d30db6543e7bf3d95bd44ebd958f509e3e7332041845176487fe78d3b40bdedbc213061ba849fd978e468
   languageName: node
   linkType: hard
 
@@ -5541,6 +5737,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@metamask/slip44@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@metamask/slip44@npm:3.1.0"
+  checksum: 10/83f902c455468f1ec252d0554cd4ebf8da1fc9a27ec7199b81e265e5e8710fad86eaa71d86f24500f9db6626007ad71b1380b239e2104e7e558a061393b066fa
+  languageName: node
+  linkType: hard
+
 "@metamask/slip44@npm:^4.0.0":
   version: 4.0.0
   resolution: "@metamask/slip44@npm:4.0.0"
@@ -5685,13 +5888,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/snaps-controllers@workspace:^, @metamask/snaps-controllers@workspace:packages/snaps-controllers":
+"@metamask/snaps-controllers@npm:^9.7.0, @metamask/snaps-controllers@workspace:^, @metamask/snaps-controllers@workspace:packages/snaps-controllers":
   version: 0.0.0-use.local
   resolution: "@metamask/snaps-controllers@workspace:packages/snaps-controllers"
   dependencies:
     "@esbuild-plugins/node-globals-polyfill": "npm:^0.2.3"
     "@esbuild-plugins/node-modules-polyfill": "npm:^0.2.2"
     "@lavamoat/allow-scripts": "npm:^3.0.4"
+    "@metamask/accounts-controller": "npm:^18.2.2"
     "@metamask/approval-controller": "npm:^7.0.2"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^6.0.2"
@@ -5702,6 +5906,7 @@ __metadata:
     "@metamask/eslint-config-typescript": "npm:^12.1.0"
     "@metamask/json-rpc-engine": "npm:^9.0.2"
     "@metamask/json-rpc-middleware-stream": "npm:^8.0.2"
+    "@metamask/keyring-controller": "npm:^17.0.0"
     "@metamask/object-multiplex": "npm:^2.0.0"
     "@metamask/permission-controller": "npm:^11.0.0"
     "@metamask/phishing-controller": "npm:^12.0.2"
@@ -6007,7 +6212,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/snaps-sdk@workspace:^, @metamask/snaps-sdk@workspace:packages/snaps-sdk":
+"@metamask/snaps-sdk@npm:^6.1.0, @metamask/snaps-sdk@npm:^6.5.0, @metamask/snaps-sdk@npm:^6.5.1, @metamask/snaps-sdk@workspace:^, @metamask/snaps-sdk@workspace:packages/snaps-sdk":
   version: 0.0.0-use.local
   resolution: "@metamask/snaps-sdk@workspace:packages/snaps-sdk"
   dependencies:
@@ -6213,7 +6418,38 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/snaps-utils@workspace:^, @metamask/snaps-utils@workspace:packages/snaps-utils":
+"@metamask/snaps-utils@npm:^7.8.1":
+  version: 7.8.1
+  resolution: "@metamask/snaps-utils@npm:7.8.1"
+  dependencies:
+    "@babel/core": "npm:^7.23.2"
+    "@babel/types": "npm:^7.23.0"
+    "@metamask/base-controller": "npm:^6.0.2"
+    "@metamask/key-tree": "npm:^9.1.2"
+    "@metamask/permission-controller": "npm:^11.0.0"
+    "@metamask/rpc-errors": "npm:^6.3.1"
+    "@metamask/slip44": "npm:^3.1.0"
+    "@metamask/snaps-registry": "npm:^3.2.1"
+    "@metamask/snaps-sdk": "npm:^6.1.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^9.1.0"
+    "@noble/hashes": "npm:^1.3.1"
+    "@scure/base": "npm:^1.1.1"
+    chalk: "npm:^4.1.2"
+    cron-parser: "npm:^4.5.0"
+    fast-deep-equal: "npm:^3.1.3"
+    fast-json-stable-stringify: "npm:^2.1.0"
+    fast-xml-parser: "npm:^4.3.4"
+    marked: "npm:^12.0.1"
+    rfdc: "npm:^1.3.0"
+    semver: "npm:^7.5.4"
+    ses: "npm:^1.1.0"
+    validate-npm-package-name: "npm:^5.0.0"
+  checksum: 10/572108aafbad970910ffb3605cf9eb4675ede0d69ff2bd37515da7f071de2065a55c73d6dc44dbe70bbd9c3ff0dfe29d40fd16badd925a4b8504db293265ca2f
+  languageName: node
+  linkType: hard
+
+"@metamask/snaps-utils@npm:^8.1.1, @metamask/snaps-utils@workspace:^, @metamask/snaps-utils@workspace:packages/snaps-utils":
   version: 0.0.0-use.local
   resolution: "@metamask/snaps-utils@workspace:packages/snaps-utils"
   dependencies:
@@ -6339,7 +6575,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/superstruct@npm:^3.1.0":
+"@metamask/superstruct@npm:^3.0.0, @metamask/superstruct@npm:^3.1.0":
   version: 3.1.0
   resolution: "@metamask/superstruct@npm:3.1.0"
   checksum: 10/5066fe228d5f11da387606d7f9545de2b473ab5a9e0f1bb8aea2f52d3e2c9d25e427151acde61f4a2de80a07a9871fe9505ad06abca6a61b7c3b54ed5c403b01
@@ -6440,6 +6676,23 @@ __metadata:
     webpack-dev-server: "npm:^4.15.1"
   languageName: unknown
   linkType: soft
+
+"@metamask/utils@npm:^8.2.0":
+  version: 8.5.0
+  resolution: "@metamask/utils@npm:8.5.0"
+  dependencies:
+    "@ethereumjs/tx": "npm:^4.2.0"
+    "@metamask/superstruct": "npm:^3.0.0"
+    "@noble/hashes": "npm:^1.3.1"
+    "@scure/base": "npm:^1.1.3"
+    "@types/debug": "npm:^4.1.7"
+    debug: "npm:^4.3.4"
+    pony-cause: "npm:^2.1.10"
+    semver: "npm:^7.5.4"
+    uuid: "npm:^9.0.1"
+  checksum: 10/68a42a55f7dc750b75467fb7c05a496c20dac073a2753e0f4d9642c4d8dcb3f9ddf51a09d30337e11637f1777f3dfe22e15b5159dbafb0fdb7bd8c9236056153
+  languageName: node
+  linkType: hard
 
 "@metamask/utils@npm:^9.0.0, @metamask/utils@npm:^9.1.0, @metamask/utils@npm:^9.2.1":
   version: 9.2.1
@@ -6618,6 +6871,21 @@ __metadata:
     hey-listen: "npm:^1.0.8"
     tslib: "npm:^2.3.1"
   checksum: 10/317dd16b9f75c39470ff4aeae29fecea2f205d1276e70e0254d8124e23713634786b4fb4d9dafebc3d731ab235b5c6260016ddde8e0c354af79bd9d64af99b1d
+  languageName: node
+  linkType: hard
+
+"@ngraveio/bc-ur@npm:^1.1.5":
+  version: 1.1.13
+  resolution: "@ngraveio/bc-ur@npm:1.1.13"
+  dependencies:
+    "@keystonehq/alias-sampling": "npm:^0.1.1"
+    assert: "npm:^2.0.0"
+    bignumber.js: "npm:^9.0.1"
+    cbor-sync: "npm:^1.0.4"
+    crc: "npm:^3.8.0"
+    jsbi: "npm:^3.1.5"
+    sha.js: "npm:^2.4.11"
+  checksum: 10/0d3301b673a0bd9a069dae1f017cfd03010fddf19c1449d1a9e986b9b879ee4611f5af690ace9f59b75707573d1d3d6a4983166207db743425974a736689c6a0
   languageName: node
   linkType: hard
 
@@ -7543,12 +7811,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/bn.js@npm:^5.1.5":
-  version: 5.1.5
-  resolution: "@types/bn.js@npm:5.1.5"
+"@types/bn.js@npm:^5.1.0, @types/bn.js@npm:^5.1.5":
+  version: 5.1.6
+  resolution: "@types/bn.js@npm:5.1.6"
   dependencies:
     "@types/node": "npm:*"
-  checksum: 10/9719330c86aeae0a6a447c974cf0f853ba3660ede20de61f435b03d699e30e6d8b35bf71a8dc9fdc8317784438e83177644ba068ed653d0ae0106e1ecbfe289e
+  checksum: 10/db565b5a2af59b09459d74441153bf23a0e80f1fb2d070330786054e7ce1a7285dc40afcd8f289426c61a83166bdd70814f70e2d439744686aac5d3ea75daf13
   languageName: node
   linkType: hard
 
@@ -7966,6 +8234,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/pbkdf2@npm:^3.0.0":
+  version: 3.1.2
+  resolution: "@types/pbkdf2@npm:3.1.2"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/bebe1e596cbbe5f7d2726a58859e61986c5a42459048e29cb7f2d4d764be6bbb0844572fd5d70ca8955a8a17e8b4ed80984fc4903e165d9efb8807a3fbb051aa
+  languageName: node
+  linkType: hard
+
 "@types/prettier@npm:^2.1.5":
   version: 2.3.2
   resolution: "@types/prettier@npm:2.3.2"
@@ -8061,6 +8338,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/secp256k1@npm:^4.0.1":
+  version: 4.0.6
+  resolution: "@types/secp256k1@npm:4.0.6"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/211f823be990b55612e604d620acf0dc3bc942d3836bdd8da604269effabc86d98161e5947487b4e4e128f9180fc1682daae2f89ea7a4d9648fdfe52fba365fc
+  languageName: node
+  linkType: hard
+
 "@types/semver@npm:^7.3.12, @types/semver@npm:^7.3.6, @types/semver@npm:^7.5.0":
   version: 7.5.0
   resolution: "@types/semver@npm:7.5.0"
@@ -8149,6 +8435,20 @@ __metadata:
   version: 0.0.3
   resolution: "@types/use-sync-external-store@npm:0.0.3"
   checksum: 10/161ddb8eec5dbe7279ac971531217e9af6b99f7783213566d2b502e2e2378ea19cf5e5ea4595039d730aa79d3d35c6567d48599f69773a02ffcff1776ec2a44e
+  languageName: node
+  linkType: hard
+
+"@types/uuid@npm:^8.3.0":
+  version: 8.3.4
+  resolution: "@types/uuid@npm:8.3.4"
+  checksum: 10/6f11f3ff70f30210edaa8071422d405e9c1d4e53abbe50fdce365150d3c698fe7bbff65c1e71ae080cbfb8fded860dbb5e174da96fdbbdfcaa3fb3daa474d20f
+  languageName: node
+  linkType: hard
+
+"@types/uuid@npm:^9.0.8":
+  version: 9.0.8
+  resolution: "@types/uuid@npm:9.0.8"
+  checksum: 10/b8c60b7ba8250356b5088302583d1704a4e1a13558d143c549c408bf8920535602ffc12394ede77f8a8083511b023704bc66d1345792714002bfa261b17c5275
   languageName: node
   linkType: hard
 
@@ -9099,6 +9399,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aes-js@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "aes-js@npm:3.1.2"
+  checksum: 10/b65916767034a51375a3ac5aad62af452d89a386c1ae7b607bb9145d0bb8b8823bf2f3eba85bdfa52d61c65d5aed90ba90f677b8c826bfa1a8b7ae2fa3b54d91
+  languageName: node
+  linkType: hard
+
 "agent-base@npm:6, agent-base@npm:^6.0.2":
   version: 6.0.2
   resolution: "agent-base@npm:6.0.2"
@@ -9588,6 +9895,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async-mutex@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "async-mutex@npm:0.5.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/4c6bfce1cc9cd43f723c4d96403ac5f4757f885c953b839cde6956ec8817ff39623b82d67614de10c7933e21626925882fb9bac367db7d15d7cb4f84228722c9
+  languageName: node
+  linkType: hard
+
 "async@npm:^3.2.3, async@npm:^3.2.4":
   version: 3.2.4
   resolution: "async@npm:3.2.4"
@@ -9796,6 +10112,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base-x@npm:^3.0.2":
+  version: 3.0.10
+  resolution: "base-x@npm:3.0.10"
+  dependencies:
+    safe-buffer: "npm:^5.0.1"
+  checksum: 10/52307739559e81d9980889de2359cb4f816cc0eb9a463028fa3ab239ab913d9044a1b47b4520f98e68453df32a457b8ba58b8d0ee7e757fc3fb971f3fa7a1482
+  languageName: node
+  linkType: hard
+
 "base64-js@npm:^1.0.2, base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
@@ -9826,6 +10151,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bech32@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "bech32@npm:2.0.0"
+  checksum: 10/fa15acb270b59aa496734a01f9155677b478987b773bf701f465858bf1606c6a970085babd43d71ce61895f1baa594cb41a2cd1394bd2c6698f03cc2d811300e
+  languageName: node
+  linkType: hard
+
 "big-integer@npm:^1.6.17":
   version: 1.6.51
   resolution: "big-integer@npm:1.6.51"
@@ -9837,6 +10169,13 @@ __metadata:
   version: 5.2.2
   resolution: "big.js@npm:5.2.2"
   checksum: 10/c04416aeb084f4aa1c5857722439c327cc0ada9bd99ab80b650e3f30e2e4f1b92a04527ed1e7df8ffcd7c0ea311745a04af12d53e2f091bf09a06f1292003827
+  languageName: node
+  linkType: hard
+
+"bignumber.js@npm:^9.0.1":
+  version: 9.1.2
+  resolution: "bignumber.js@npm:9.1.2"
+  checksum: 10/d89b8800a987225d2c00dcbf8a69dc08e92aa0880157c851c287b307d31ceb2fc2acb0c62c3e3a3d42b6c5fcae9b004035f13eb4386e56d529d7edac18d5c9d8
   languageName: node
   linkType: hard
 
@@ -9899,6 +10238,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"blakejs@npm:^1.1.0":
+  version: 1.2.1
+  resolution: "blakejs@npm:1.2.1"
+  checksum: 10/0638b1bd058b21892633929c43005aa6a4cc4b2ac5b338a146c3c076622f1b360795bd7a4d1f077c9b01863ed2df0c1504a81c5b520d164179120434847e6cd7
+  languageName: node
+  linkType: hard
+
 "bluebird@npm:~3.4.1":
   version: 3.4.7
   resolution: "bluebird@npm:3.4.7"
@@ -9906,7 +10252,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:5.2.1, bn.js@npm:^5.0.0, bn.js@npm:^5.2.1":
+"bn.js@npm:5.2.1, bn.js@npm:^5.0.0, bn.js@npm:^5.1.2, bn.js@npm:^5.2.0, bn.js@npm:^5.2.1":
   version: 5.2.1
   resolution: "bn.js@npm:5.2.1"
   checksum: 10/7a7e8764d7a6e9708b8b9841b2b3d6019cc154d2fc23716d0efecfe1e16921b7533c6f7361fb05471eab47986c4aa310c270f88e3507172104632ac8df2cfd84
@@ -10035,7 +10381,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserify-aes@npm:^1.0.0, browserify-aes@npm:^1.0.4":
+"browserify-aes@npm:^1.0.0, browserify-aes@npm:^1.0.4, browserify-aes@npm:^1.2.0":
   version: 1.2.0
   resolution: "browserify-aes@npm:1.2.0"
   dependencies:
@@ -10189,6 +10535,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bs58@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "bs58@npm:4.0.1"
+  dependencies:
+    base-x: "npm:^3.0.2"
+  checksum: 10/b3c5365bb9e0c561e1a82f1a2d809a1a692059fae016be233a6127ad2f50a6b986467c3a50669ce4c18929dcccb297c5909314dd347a25a68c21b68eb3e95ac2
+  languageName: node
+  linkType: hard
+
+"bs58check@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "bs58check@npm:2.1.2"
+  dependencies:
+    bs58: "npm:^4.0.0"
+    create-hash: "npm:^1.1.0"
+    safe-buffer: "npm:^5.1.2"
+  checksum: 10/43bdf08a5dd04581b78f040bc4169480e17008da482ffe2a6507327bbc4fc5c28de0501f7faf22901cfe57fbca79cbb202ca529003fedb4cb8dccd265b38e54d
+  languageName: node
+  linkType: hard
+
 "bser@npm:2.1.1":
   version: 2.1.1
   resolution: "bser@npm:2.1.1"
@@ -10226,7 +10592,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:^5.2.1, buffer@npm:^5.5.0":
+"buffer@npm:^5.1.0, buffer@npm:^5.2.1, buffer@npm:^5.5.0":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
   dependencies:
@@ -10461,6 +10827,13 @@ __metadata:
   version: 1.0.30001550
   resolution: "caniuse-lite@npm:1.0.30001550"
   checksum: 10/a5a475bff94109d326760deabb214f9234e908697d12c5d96b4a6fe6f2e960a0d16451df1188fa4d69bff5b5bd6d3de5eb792fd7dfdffb613685223ce9a43567
+  languageName: node
+  linkType: hard
+
+"cbor-sync@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "cbor-sync@npm:1.0.4"
+  checksum: 10/bdad5fbf442b5b2478ba59433cab145ad823f963f674ec42f3b730689e679327ec8a6dfab97724b63295badac915574139984e702475ff8025d7cb175e50e9ae
   languageName: node
   linkType: hard
 
@@ -11163,6 +11536,15 @@ __metadata:
     crc-32: "npm:^1.2.0"
     readable-stream: "npm:^3.4.0"
   checksum: 10/8e5dd04f22f3fbecc623492395107fbed2114f225bd606e39e8ed338f2fc1c454ac02a05741243620ab526473cb867fa86411a44a7ffcd88457cc1c2af82d0bc
+  languageName: node
+  linkType: hard
+
+"crc@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "crc@npm:3.8.0"
+  dependencies:
+    buffer: "npm:^5.1.0"
+  checksum: 10/3a43061e692113d60fbaf5e438c5f6aa3374fe2368244a75cc083ecee6762513bcee8583f67c2c56feea0b0c72b41b7304fbd3c1e26cfcfaec310b9a18543fa8
   languageName: node
   linkType: hard
 
@@ -13198,6 +13580,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ethereum-cryptography@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "ethereum-cryptography@npm:0.1.3"
+  dependencies:
+    "@types/pbkdf2": "npm:^3.0.0"
+    "@types/secp256k1": "npm:^4.0.1"
+    blakejs: "npm:^1.1.0"
+    browserify-aes: "npm:^1.2.0"
+    bs58check: "npm:^2.1.2"
+    create-hash: "npm:^1.2.0"
+    create-hmac: "npm:^1.1.7"
+    hash.js: "npm:^1.1.7"
+    keccak: "npm:^3.0.0"
+    pbkdf2: "npm:^3.0.17"
+    randombytes: "npm:^2.1.0"
+    safe-buffer: "npm:^5.1.2"
+    scrypt-js: "npm:^3.0.0"
+    secp256k1: "npm:^4.0.1"
+    setimmediate: "npm:^1.0.5"
+  checksum: 10/975e476782746acd97d5b37366801ae622a52fb31e5d83f600804be230a61ef7b9d289dcecd9c308fb441967caf3a6e3768dd7c8add6441fcc60c398175d5a96
+  languageName: node
+  linkType: hard
+
 "ethereum-cryptography@npm:^2.0.0, ethereum-cryptography@npm:^2.1.2":
   version: 2.1.2
   resolution: "ethereum-cryptography@npm:2.1.2"
@@ -13207,6 +13612,35 @@ __metadata:
     "@scure/bip32": "npm:1.3.1"
     "@scure/bip39": "npm:1.2.1"
   checksum: 10/78983d01ac95047158ec03237ba318152b2c707ccc6a44225da11c72ed6ca575ca0c1630eaf9878fc82fe26272d6624939ef6f020cc89ddddfb941a7393ab909
+  languageName: node
+  linkType: hard
+
+"ethereumjs-util@npm:^7.1.2":
+  version: 7.1.5
+  resolution: "ethereumjs-util@npm:7.1.5"
+  dependencies:
+    "@types/bn.js": "npm:^5.1.0"
+    bn.js: "npm:^5.1.2"
+    create-hash: "npm:^1.1.2"
+    ethereum-cryptography: "npm:^0.1.3"
+    rlp: "npm:^2.2.4"
+  checksum: 10/f28fc1ebb8f35bf9e418f76f51be737d94d603b912c3e014c4e87cd45ccd1b10bdfef764c8f152574b57e9faa260a18773cbc110f9e0a754d6b3730699e54dc9
+  languageName: node
+  linkType: hard
+
+"ethereumjs-wallet@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "ethereumjs-wallet@npm:1.0.2"
+  dependencies:
+    aes-js: "npm:^3.1.2"
+    bs58check: "npm:^2.1.2"
+    ethereum-cryptography: "npm:^0.1.3"
+    ethereumjs-util: "npm:^7.1.2"
+    randombytes: "npm:^2.1.0"
+    scrypt-js: "npm:^3.0.1"
+    utf8: "npm:^3.0.0"
+    uuid: "npm:^8.3.2"
+  checksum: 10/0a9ad0ac0930627c15e6fa6115dde8d1dd81160e57fbdf81ef0bcd1e0edd750fe9e8b00992651e694cabefee29eef2ad651dce8b24ae5253861927d0e19b6c90
   languageName: node
   linkType: hard
 
@@ -13522,14 +13956,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:^4.4.1":
-  version: 4.4.1
-  resolution: "fast-xml-parser@npm:4.4.1"
+"fast-xml-parser@npm:^4.3.4, fast-xml-parser@npm:^4.4.1":
+  version: 4.5.0
+  resolution: "fast-xml-parser@npm:4.5.0"
   dependencies:
     strnum: "npm:^1.0.5"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10/0c05ab8703630d8c857fafadbd78d0020d3a8e54310c3842179cd4a0d9d97e96d209ce885e91241f4aa9dd8dfc2fd924a682741a423d65153cad34da2032ec44
+  checksum: 10/dc9571c10e7b57b5be54bcd2d92f50c446eb42ea5df347d253e94dd14eb99b5300a6d172e840f151e0721933ca2406165a8d9b316a6d777bf0596dc4fe1df756
   languageName: node
   linkType: hard
 
@@ -14577,7 +15011,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hash.js@npm:^1.0.0, hash.js@npm:^1.0.3":
+"hash.js@npm:^1.0.0, hash.js@npm:^1.0.3, hash.js@npm:^1.1.7":
   version: 1.1.7
   resolution: "hash.js@npm:1.1.7"
   dependencies:
@@ -14593,6 +15027,18 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10/c330f8d93f9d23fe632c719d4db3d698ef7d7c367d51548b836069e06a90fa9151e868c8e67353cfe98d67865bf7354855db28fa36eb1b18fa5d4a3f4e7f1c90
+  languageName: node
+  linkType: hard
+
+"hdkey@npm:^2.0.1":
+  version: 2.1.0
+  resolution: "hdkey@npm:2.1.0"
+  dependencies:
+    bs58check: "npm:^2.1.2"
+    ripemd160: "npm:^2.0.2"
+    safe-buffer: "npm:^5.1.1"
+    secp256k1: "npm:^4.0.0"
+  checksum: 10/c4ee2189ea3d87070ebd14ad7368e292b1e0b30e4d8a107eb8f33624634df6e57b8a3b2cda65b3bd97e88474f6798cfdbe7b63b6037429f0e169321d84a0db58
   languageName: node
   linkType: hard
 
@@ -16363,6 +16809,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsbi@npm:^3.1.5":
+  version: 3.2.5
+  resolution: "jsbi@npm:3.2.5"
+  checksum: 10/2cceb3a06dcb16493e936aa22384d912dd5f0a1fd474b97b5c6705011bd0aac8214d9a392a730b3f3ffb61a8fbe910a34d0fe881329be6a02857520d7a61ace6
+  languageName: node
+  linkType: hard
+
 "jsbn@npm:1.1.0":
   version: 1.1.0
   resolution: "jsbn@npm:1.1.0"
@@ -16561,6 +17014,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsonschema@npm:^1.2.4":
+  version: 1.4.1
+  resolution: "jsonschema@npm:1.4.1"
+  checksum: 10/d7a188da7a3100a2caa362b80e98666d46607b7a7153aac405b8e758132961911c6df02d444d4700691330874e21a62639f550e856b21ddd28423690751ca9c6
+  languageName: node
+  linkType: hard
+
 "jsx-ast-utils@npm:^2.4.1 || ^3.0.0":
   version: 3.3.3
   resolution: "jsx-ast-utils@npm:3.3.3"
@@ -16568,6 +17028,18 @@ __metadata:
     array-includes: "npm:^3.1.5"
     object.assign: "npm:^4.1.3"
   checksum: 10/c85f6f239593e09d8445a7e43412234304addf4bfb5d2114dc19f5ce27dfe3a8f8b12a50ff74e94606d0ad48cf1d5aff2381c939446b3fe48a5d433bb52ccb29
+  languageName: node
+  linkType: hard
+
+"keccak@npm:^3.0.0":
+  version: 3.0.4
+  resolution: "keccak@npm:3.0.4"
+  dependencies:
+    node-addon-api: "npm:^2.0.0"
+    node-gyp: "npm:latest"
+    node-gyp-build: "npm:^4.2.0"
+    readable-stream: "npm:^3.6.0"
+  checksum: 10/45478bb0a57e44d0108646499b8360914b0fbc8b0e088f1076659cb34faaa9eb829c40f6dd9dadb3460bb86cc33153c41fed37fe5ce09465a60e71e78c23fa55
   languageName: node
   linkType: hard
 
@@ -17937,6 +18409,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-addon-api@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "node-addon-api@npm:2.0.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10/e4ce4daac5b2fefa6b94491b86979a9c12d9cceba571d2c6df1eb5859f9da68e5dc198f128798e1785a88aafee6e11f4992dcccd4bf86bec90973927d158bd60
+  languageName: node
+  linkType: hard
+
 "node-addon-api@npm:^6.1.0":
   version: 6.1.0
   resolution: "node-addon-api@npm:6.1.0"
@@ -18000,6 +18481,17 @@ __metadata:
     node-gyp-build-optional: optional.js
     node-gyp-build-test: build-test.js
   checksum: 10/80f410ab412df38e84171d3634a5716b6c6f14ecfa4eb971424d289381fb76f8bcbe1b666419ceb2c81060e558fd7c6d70cc0f60832bcca6a1559098925d9657
+  languageName: node
+  linkType: hard
+
+"node-gyp-build@npm:^4.2.0":
+  version: 4.8.2
+  resolution: "node-gyp-build@npm:4.8.2"
+  bin:
+    node-gyp-build: bin.js
+    node-gyp-build-optional: optional.js
+    node-gyp-build-test: build-test.js
+  checksum: 10/e3a365eed7a2d950864a1daa34527588c16fe43ae189d0aeb8fd1dfec91ba42a0e1b499322bff86c2832029fec4f5901bf26e32005e1e17a781dcd5177b6a657
   languageName: node
   linkType: hard
 
@@ -18794,16 +19286,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pbkdf2@npm:^3.0.3":
-  version: 3.1.1
-  resolution: "pbkdf2@npm:3.1.1"
+"pbkdf2@npm:^3.0.17, pbkdf2@npm:^3.0.3":
+  version: 3.1.2
+  resolution: "pbkdf2@npm:3.1.2"
   dependencies:
     create-hash: "npm:^1.1.2"
     create-hmac: "npm:^1.1.4"
     ripemd160: "npm:^2.0.1"
     safe-buffer: "npm:^5.0.1"
     sha.js: "npm:^2.4.8"
-  checksum: 10/b64c09bd45ca2914ac6b059d78f1e7d12ab08051fe62d897f64d567d6f1ad38bb735e5a61261f7b666e9562e3e5437b3a9aef83bc370b4f3bf676d896d1ece24
+  checksum: 10/40bdf30df1c9bb1ae41ec50c11e480cf0d36484b7c7933bf55e4451d1d0e3f09589df70935c56e7fccc5702779a0d7b842d012be8c08a187b44eb24d55bb9460
   languageName: node
   linkType: hard
 
@@ -20299,13 +20791,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ripemd160@npm:^2.0.0, ripemd160@npm:^2.0.1":
+"ripemd160@npm:^2.0.0, ripemd160@npm:^2.0.1, ripemd160@npm:^2.0.2":
   version: 2.0.2
   resolution: "ripemd160@npm:2.0.2"
   dependencies:
     hash-base: "npm:^3.0.0"
     inherits: "npm:^2.0.1"
   checksum: 10/006accc40578ee2beae382757c4ce2908a826b27e2b079efdcd2959ee544ddf210b7b5d7d5e80467807604244e7388427330f5c6d4cd61e6edaddc5773ccc393
+  languageName: node
+  linkType: hard
+
+"rlp@npm:^2.2.4, rlp@npm:^2.2.6":
+  version: 2.2.7
+  resolution: "rlp@npm:2.2.7"
+  dependencies:
+    bn.js: "npm:^5.2.0"
+  bin:
+    rlp: bin/rlp
+  checksum: 10/cf1919a2dc99f336191b3363b76299db567c192b7ee3c6f5c722728c34f65577883c9c88eeb7a1bfcbc26693c8a4f1fb0662e79ee86f0c98dd258d6987303498
+  languageName: node
+  linkType: hard
+
+"rlp@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "rlp@npm:3.0.0"
+  bin:
+    rlp: bin/rlp
+  checksum: 10/c85549fa5368ef029707d02f0937c0c503b69fb330c5941508c9eef537a4f179fbeecd17149aeb795d430ed5249b68d7c66383a9863068712a191d388786cfc1
   languageName: node
   linkType: hard
 
@@ -20540,6 +21052,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"scrypt-js@npm:^3.0.0, scrypt-js@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "scrypt-js@npm:3.0.1"
+  checksum: 10/2f8aa72b7f76a6f9c446bbec5670f80d47497bccce98474203d89b5667717223eeb04a50492ae685ed7adc5a060fc2d8f9fd988f8f7ebdaf3341967f3aeff116
+  languageName: node
+  linkType: hard
+
+"secp256k1@npm:^4.0.0, secp256k1@npm:^4.0.1":
+  version: 4.0.3
+  resolution: "secp256k1@npm:4.0.3"
+  dependencies:
+    elliptic: "npm:^6.5.4"
+    node-addon-api: "npm:^2.0.0"
+    node-gyp: "npm:latest"
+    node-gyp-build: "npm:^4.2.0"
+  checksum: 10/8b45820cd90fd2f95cc8fdb9bf8a71e572de09f2311911ae461a951ffa9e30c99186a129d0f1afeb380dd67eca0c10493f8a7513c39063fda015e99995088e3b
+  languageName: node
+  linkType: hard
+
 "select-hose@npm:^2.0.0":
   version: 2.0.0
   resolution: "select-hose@npm:2.0.0"
@@ -20711,7 +21242,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"setimmediate@npm:^1.0.4, setimmediate@npm:~1.0.4":
+"setimmediate@npm:^1.0.4, setimmediate@npm:^1.0.5, setimmediate@npm:~1.0.4":
   version: 1.0.5
   resolution: "setimmediate@npm:1.0.5"
   checksum: 10/76e3f5d7f4b581b6100ff819761f04a984fa3f3990e72a6554b57188ded53efce2d3d6c0932c10f810b7c59414f85e2ab3c11521877d1dea1ce0b56dc906f485
@@ -20732,7 +21263,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sha.js@npm:^2.4.0, sha.js@npm:^2.4.8":
+"sha.js@npm:^2.4.0, sha.js@npm:^2.4.11, sha.js@npm:^2.4.8":
   version: 2.4.11
   resolution: "sha.js@npm:2.4.11"
   dependencies:
@@ -22055,7 +22586,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.6.2":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.6.2":
   version: 2.7.0
   resolution: "tslib@npm:2.7.0"
   checksum: 10/9a5b47ddac65874fa011c20ff76db69f97cf90c78cff5934799ab8894a5342db2d17b4e7613a087046bc1d133d21547ddff87ac558abeec31ffa929c88b7fce6
@@ -22515,6 +23046,13 @@ __metadata:
   version: 1.0.0
   resolution: "userhome@npm:1.0.0"
   checksum: 10/78e2c4f4fcdb2349df7024bf94d11af13b8101ee9ca12f1ba8a42f8c17276046bd523e6e09e2f32b119f0216ee5043e3d874e3fd0af0d73cb2231ba1c0987334
+  languageName: node
+  linkType: hard
+
+"utf8@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "utf8@npm:3.0.0"
+  checksum: 10/31d19c4faacbb65b09ebc1c21c32b20bdb0919c6f6773cee5001b99bb83f8e503e7233c08fc71ebb34f7cfebd95cec3243b81d90176097aa2f286cccb4ce866e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This refactors the `AccountSelector`:
- the state format for this component has changed to an object with an `id` and `address` key.
- Adds a new optional prop `switchGlobalAccount` that defaults to `false`. It allows the component to switch the global selected account of the Extension to be switched on selection of an account.
- Adds a new optional prop `hideExternalAccounts` that defaults to `false`. It allows the component to hide the accounts that are not owned by the snap.
- Makes `selectedAccount` prop optional. If it's not provided we will get the selected account in the `AccountsController`, if it is we will try to get the address related to this account and if it doesn't exist we will throw an error.
- Makes the `chainIds` prop optional.
