### PR TITLE
fix: `span` element inside `button` causes test flakiness in extension repo e2e, interfering with the click and scroll actions

### DIFF
--- a/packages/test-snaps/src/components/Connect.tsx
+++ b/packages/test-snaps/src/components/Connect.tsx
@@ -62,9 +62,7 @@ export const Connect: FunctionComponent<ConnectProps> = ({
         {isLoading ? (
           <ButtonSpinner>Connecting</ButtonSpinner>
         ) : (
-          <span>
-            {isInstalled ? 'Reconnect' : 'Connect'} to {name}
-          </span>
+          `${isInstalled ? 'Reconnect' : 'Connect'} to ${name}`
         )}
       </Button>
     </Form>


### PR DESCRIPTION
## Description
In the snaps test dapp, all the Connect buttons have a nested span inside it, that causes test flakiness when we try to click the button.
The problem is that we are trying to click the button by its id, but inside it, there is a span element which interferes with the click.
You can see this behaviour in the videos below and an example of failure [here](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/102974/workflows/b7dff65d-661f-4bb6-a8d5-d32ff34be250/jobs/3837339/tests).


This causes a lot of flakiness on any snap test that tries to click/scroll to buttons from the test dapp snap page. Any snap e2e failure that looks like this, is due to the span inside the button:

`ElementNotInteractableError: Element <button id="connectcronjobs" class="btn btn-primary" type="submit"> could not be scrolled into view`


![Screenshot from 2024-10-02 11-02-36](https://github.com/user-attachments/assets/e694d888-ee59-4666-b120-66e450e8eed3)


## Screenshots
### Before

https://github.com/user-attachments/assets/fc2c858e-d35a-47c1-8bec-af7ea0813e3b


### After

https://github.com/user-attachments/assets/070559d4-2b3e-4c86-9cb2-631962db09e9

