### PR TITLE
Add TypeScript typechecking to snaps-cli

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -212,11 +212,16 @@ jobs:
             packages/snaps-execution-environments/dist/browserify
           key: snaps-execution-environments-build-${{ runner.os }}-${{ matrix.node-version }}-${{ github.sha }}
           fail-on-cache-miss: true
+      - name: Restore build files
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/*/dist
+          key: build-source-${{ runner.os }}-${{ github.sha }}
+          fail-on-cache-miss: true
       - run: yarn --immutable --immutable-cache
       - name: Install Google Chrome
         run: yarn install-chrome
-      - run: yarn workspace @metamask/snaps-sdk run build
-        if: ${{ matrix.package-name == '@metamask/snaps-cli' }}
       - run: yarn workspace ${{ matrix.package-name }} run test
       - name: Get coverage folder
         id: get-coverage-folder
@@ -320,5 +325,5 @@ jobs:
           node-version-file: '.nvmrc'
           cache: yarn
       - run: yarn --immutable
-      - run: yarn workspace @metamask/snaps-sdk run build
+      - run: yarn build:ci
       - run: yarn workspace @metamask/snaps-cli run test

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -192,7 +192,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: prepare
+    needs:
+      - prepare
+      - build
     strategy:
       fail-fast: false
       matrix:

--- a/packages/examples/packages/bip32/snap.config.ts
+++ b/packages/examples/packages/bip32/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8001,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
     builtIns: {

--- a/packages/examples/packages/bip32/src/index.ts
+++ b/packages/examples/packages/bip32/src/index.ts
@@ -40,14 +40,13 @@ import { getPrivateNode, getPublicKey } from './utils';
 export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   switch (request.method) {
     case 'getPublicKey':
-      return await getPublicKey(
-        request.params as unknown as GetBip32PublicKeyParams,
-      );
+      return await getPublicKey(request.params as GetBip32PublicKeyParams);
 
     case 'signMessage': {
       const { message, curve, ...params } = request.params as SignMessageParams;
 
       if (!message || typeof message !== 'string') {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
         throw new InvalidParamsError(`Invalid signature data: "${message}".`);
       }
 
@@ -75,6 +74,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       });
 
       if (!approved) {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
         throw new UserRejectedRequestError();
       }
 
@@ -100,6 +100,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/bip32/tsconfig.json
+++ b/packages/examples/packages/bip32/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/bip44/snap.config.ts
+++ b/packages/examples/packages/bip44/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8002,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
     builtIns: {

--- a/packages/examples/packages/bip44/src/index.ts
+++ b/packages/examples/packages/bip44/src/index.ts
@@ -59,6 +59,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       });
 
       if (!approved) {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
         throw new UserRejectedRequestError();
       }
 
@@ -67,6 +68,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/bip44/tsconfig.json
+++ b/packages/examples/packages/bip44/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/browserify-plugin/src/index.ts
+++ b/packages/examples/packages/browserify-plugin/src/index.ts
@@ -23,6 +23,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       return 'Hello from Browserify!';
 
     default: {
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
     }
   }

--- a/packages/examples/packages/browserify-plugin/tsconfig.json
+++ b/packages/examples/packages/browserify-plugin/tsconfig.json
@@ -3,20 +3,7 @@
   "compilerOptions": {
     "resolveJsonModule": true,
     "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false
   },
-  "include": ["src", "scripts", "babel.config.json"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-browserify-plugin"
-    },
-    {
-      "path": "../../../snaps-jest"
-    }
-  ]
+  "include": ["src", "scripts", "babel.config.json"]
 }

--- a/packages/examples/packages/browserify/src/index.ts
+++ b/packages/examples/packages/browserify/src/index.ts
@@ -25,6 +25,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       return 'Hello from the MetaMask Snaps CLI using Browserify!';
 
     default: {
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
     }
   }

--- a/packages/examples/packages/browserify/tsconfig.json
+++ b/packages/examples/packages/browserify/tsconfig.json
@@ -3,21 +3,7 @@
   "compilerOptions": {
     "resolveJsonModule": true,
     "baseUrl": "./",
-    "paths": {
-      "@metamask/*/node": ["../../../*/src/node"],
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/client-status/snap.config.ts
+++ b/packages/examples/packages/client-status/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8027,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/client-status/src/index.ts
+++ b/packages/examples/packages/client-status/src/index.ts
@@ -23,6 +23,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/client-status/tsconfig.json
+++ b/packages/examples/packages/client-status/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/cronjobs/snap.config.ts
+++ b/packages/examples/packages/cronjobs/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8004,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/cronjobs/src/index.test.ts
+++ b/packages/examples/packages/cronjobs/src/index.test.ts
@@ -22,7 +22,8 @@ describe('onCronjob', () => {
         ]),
       );
 
-      await ui.ok();
+      // TODO(ritave): Fix types in SnapInterface
+      await (ui as any).ok();
 
       const response = await request;
       expect(response).toRespondWith(null);

--- a/packages/examples/packages/cronjobs/src/index.ts
+++ b/packages/examples/packages/cronjobs/src/index.ts
@@ -30,6 +30,7 @@ export const onCronjob: OnCronjobHandler = async ({ request }) => {
         },
       });
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/cronjobs/tsconfig.json
+++ b/packages/examples/packages/cronjobs/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/dialogs/snap.config.ts
+++ b/packages/examples/packages/dialogs/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8005,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/dialogs/src/index.tsx
+++ b/packages/examples/packages/dialogs/src/index.tsx
@@ -91,6 +91,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       });
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/dialogs/tsconfig.json
+++ b/packages/examples/packages/dialogs/tsconfig.json
@@ -3,22 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "jsx": "react-jsxdev",
-    "paths": {
-      "@metamask/*/jsx": ["../../../*/src/jsx"],
-      "@metamask/*/jsx-dev-runtime": ["../../../*/src/jsx"],
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/errors/snap.config.ts
+++ b/packages/examples/packages/errors/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8006,
   },
+  typescript: {
+    enabled: true,
+  },
 };
 
 export default config;

--- a/packages/examples/packages/errors/tsconfig.json
+++ b/packages/examples/packages/errors/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/ethereum-provider/snap.config.ts
+++ b/packages/examples/packages/ethereum-provider/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8007,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/ethereum-provider/src/index.ts
+++ b/packages/examples/packages/ethereum-provider/src/index.ts
@@ -123,6 +123,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/ethereum-provider/tsconfig.json
+++ b/packages/examples/packages/ethereum-provider/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/ethers-js/snap.config.ts
+++ b/packages/examples/packages/ethers-js/snap.config.ts
@@ -8,6 +8,9 @@ const config: SnapConfig = {
   server: {
     port: 8008,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
     builtIns: {

--- a/packages/examples/packages/ethers-js/src/index.ts
+++ b/packages/examples/packages/ethers-js/src/index.ts
@@ -7,6 +7,7 @@ import {
   UserRejectedRequestError,
   MethodNotFoundError,
 } from '@metamask/snaps-sdk';
+// @ts-expect-error Typescript thinks this is ESM Module, not a CommonJS module, while ethers supports both. Webpack will correctly identify proper import type.
 import { Wallet } from 'ethers';
 
 import type { SignMessageParams } from './types';
@@ -56,6 +57,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       });
 
       if (!result) {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
         throw new UserRejectedRequestError();
       }
 
@@ -63,6 +65,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/ethers-js/tsconfig.json
+++ b/packages/examples/packages/ethers-js/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/file-upload/snap.config.ts
+++ b/packages/examples/packages/file-upload/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8030,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/file-upload/src/index.tsx
+++ b/packages/examples/packages/file-upload/src/index.tsx
@@ -44,6 +44,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({
         method: request.method,
       });

--- a/packages/examples/packages/file-upload/tsconfig.json
+++ b/packages/examples/packages/file-upload/tsconfig.json
@@ -3,22 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "jsx": "react-jsxdev",
-    "paths": {
-      "@metamask/*/jsx": ["../../../*/src/jsx"],
-      "@metamask/*/jsx-dev-runtime": ["../../../*/src/jsx"],
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/get-entropy/snap.config.ts
+++ b/packages/examples/packages/get-entropy/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8009,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
     builtIns: {

--- a/packages/examples/packages/get-entropy/src/index.test.ts
+++ b/packages/examples/packages/get-entropy/src/index.test.ts
@@ -41,7 +41,8 @@ describe('onRpcRequest', () => {
         ]),
       );
 
-      await ui.ok();
+      // TODO(ritave): Fix types in SnapInterface
+      await (ui as any).ok();
 
       expect(await response).toRespondWith(
         '0x8b3f38050fb60fffd2e0e2ef04504b09e8f0ff46e25896cfd87ced67a5a76ac75c534c9bafbf6f38b6e50b969e1239c80916040de30a3f9ee973d6a3281d39624e7d463b2a5bc0165764b0b4ce8ad009352076c54a202a8c63554b00a46872dc',
@@ -68,7 +69,8 @@ describe('onRpcRequest', () => {
         ]),
       );
 
-      await ui.ok();
+      // TODO(ritave): Fix types in SnapInterface
+      await (ui as any).ok();
 
       expect(await response).toRespondWith(
         '0x877530880baa4d1fc1fca749f5a26123275ffaa617505cae8f3da4a58d06ea43b7123d4575331dd15ffd5103ed2091050af0aa715adc3b7e122c8e07a97b7fce76c34e8e2ef0037b36015795e0ae530fed264ffb4b33bd47149af192f4c51411',

--- a/packages/examples/packages/get-entropy/src/index.ts
+++ b/packages/examples/packages/get-entropy/src/index.ts
@@ -48,6 +48,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       });
 
       if (!approved) {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
         throw new UserRejectedRequestError();
       }
 
@@ -57,6 +58,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/get-entropy/tsconfig.json
+++ b/packages/examples/packages/get-entropy/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/get-file/snap.config.ts
+++ b/packages/examples/packages/get-file/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8024,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/get-file/src/index.ts
+++ b/packages/examples/packages/get-file/src/index.ts
@@ -47,6 +47,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/get-file/tsconfig.json
+++ b/packages/examples/packages/get-file/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/home-page/snap.config.ts
+++ b/packages/examples/packages/home-page/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8025,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/home-page/src/index.test.tsx
+++ b/packages/examples/packages/home-page/src/index.test.tsx
@@ -12,7 +12,7 @@ describe('onHomePage', () => {
 
     await screen.clickElement('footer_button');
 
-    const newUi = await response.getInterface();
+    const newUi = response.getInterface();
 
     expect(newUi).toRender(
       <Box>

--- a/packages/examples/packages/home-page/tsconfig.json
+++ b/packages/examples/packages/home-page/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/images/snap.config.ts
+++ b/packages/examples/packages/images/snap.config.ts
@@ -5,6 +5,9 @@ const config: SnapConfig = {
   server: {
     port: 8026,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/images/src/index.test.ts
+++ b/packages/examples/packages/images/src/index.test.ts
@@ -43,7 +43,8 @@ describe('onRpcRequest', () => {
         ]),
       );
 
-      await ui.ok();
+      // TODO(ritave): Fix types in SnapInterface
+      await (ui as any).ok();
 
       expect(await response).toRespondWith(null);
     });
@@ -79,7 +80,8 @@ describe('onRpcRequest', () => {
         }),
       );
 
-      await ui.ok();
+      // TODO(ritave): Fix types in SnapInterface
+      await (ui as any).ok();
 
       expect(await response).toRespondWith(null);
     });
@@ -118,7 +120,8 @@ describe('onRpcRequest', () => {
         key: null,
       });
 
-      await ui.ok();
+      // TODO(ritave): Fix types in SnapInterface
+      await (ui as any).ok();
 
       expect(await response).toRespondWith(null);
     });
@@ -157,7 +160,8 @@ describe('onRpcRequest', () => {
         key: null,
       });
 
-      await ui.ok();
+      // TODO(ritave): Fix types in SnapInterface
+      await (ui as any).ok();
 
       expect(await response).toRespondWith(null);
     });

--- a/packages/examples/packages/images/src/index.ts
+++ b/packages/examples/packages/images/src/index.ts
@@ -104,6 +104,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/images/tsconfig.json
+++ b/packages/examples/packages/images/tsconfig.json
@@ -2,22 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    },
+    "composite": false,
     "module": "ES2020",
     "moduleResolution": "Node10"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/interactive-ui/snap.config.ts
+++ b/packages/examples/packages/interactive-ui/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8028,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/interactive-ui/src/index.tsx
+++ b/packages/examples/packages/interactive-ui/src/index.tsx
@@ -42,6 +42,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({
         method: request.method,
       });

--- a/packages/examples/packages/interactive-ui/tsconfig.json
+++ b/packages/examples/packages/interactive-ui/tsconfig.json
@@ -3,22 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "jsx": "react-jsxdev",
-    "paths": {
-      "@metamask/*/jsx": ["../../../*/src/jsx"],
-      "@metamask/*/jsx-dev-runtime": ["../../../*/src/jsx"],
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.config.ts
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8012,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "/u819uX9E/KqrWqvlPDhZjkKs/ylbrPwtJxiMob7VI8=",
+    "shasum": "KFAIwiPcEKSJL79+hVHmZPCTIrqAnWJN7uM7vFuaDj0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/src/index.ts
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/src/index.ts
@@ -3,7 +3,7 @@ import {
   MethodNotFoundError,
   type OnRpcRequestHandler,
 } from '@metamask/snaps-sdk';
-import { assert, stringToBytes } from '@metamask/utils';
+import { assert, bytesToHex, stringToBytes } from '@metamask/utils';
 import { keccak_256 as keccak256 } from '@noble/hashes/sha3';
 
 import type { BIP44Path, SignMessageParams } from './types';
@@ -52,7 +52,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
           request: {
             method: 'getAccount',
             params: {
-              path,
+              path: path as unknown as string[],
             },
           },
         },
@@ -68,7 +68,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
               // To keep this example simple, we only support signing messages
               // with the Keccak-256 hash function. In a real snap, you could
               // also sign actual transactions.
-              message: keccak256(stringToBytes(message)),
+              message: bytesToHex(keccak256(stringToBytes(message))),
               account,
             },
           },
@@ -77,6 +77,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/tsconfig.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/tsconfig.json
@@ -2,20 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../../../*/src"]
-    }
+    "composite": false
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../../../snaps-sdk"
-    },
-    {
-      "path": "../../../../../snaps-jest"
-    },
-    {
-      "path": "../../../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.config.ts
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8011,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
     builtIns: {

--- a/packages/examples/packages/invoke-snap/packages/core-signer/src/index.test.ts
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/src/index.test.ts
@@ -98,7 +98,8 @@ describe('onRpcRequest', () => {
       });
 
       const ui = await signResponse.getInterface();
-      await ui.ok();
+      // TODO(ritave): Fix type in SnapInterface
+      await (ui as any).ok();
 
       // Because the generated entropy is different for every test run, we
       // cannot assert the signature value. Instead, we assert that the

--- a/packages/examples/packages/invoke-snap/packages/core-signer/src/index.ts
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/src/index.ts
@@ -38,7 +38,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       const childNode = await node.derive(path);
 
       return {
-        path,
+        path: path as unknown as string[],
         publicKey: add0x(childNode.publicKey),
       };
     }
@@ -69,6 +69,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       });
 
       if (!approved) {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
         throw new UserRejectedRequestError();
       }
 
@@ -81,6 +82,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/invoke-snap/packages/core-signer/src/index.ts
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/src/index.ts
@@ -38,6 +38,8 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       const childNode = await node.derive(path);
 
       return {
+        // BIP44Path is a readonly array, while request handler expects
+        // a normal array, we cast to string[] to resolve.
         path: path as unknown as string[],
         publicKey: add0x(childNode.publicKey),
       };

--- a/packages/examples/packages/invoke-snap/packages/core-signer/tsconfig.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/tsconfig.json
@@ -2,23 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../../../*/src"]
-    }
+    "composite": false
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../../../snaps-sdk"
-    },
-    {
-      "path": "../../../../../snaps-sdk"
-    },
-    {
-      "path": "../../../../../snaps-jest"
-    },
-    {
-      "path": "../../../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/invoke-snap/tsconfig.json
+++ b/packages/examples/packages/invoke-snap/tsconfig.json
@@ -2,8 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false
   }
 }

--- a/packages/examples/packages/json-rpc/snap.config.ts
+++ b/packages/examples/packages/json-rpc/snap.config.ts
@@ -5,6 +5,9 @@ const config: SnapConfig = {
   server: {
     port: 8013,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/json-rpc/src/index.ts
+++ b/packages/examples/packages/json-rpc/src/index.ts
@@ -61,6 +61,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/json-rpc/tsconfig.json
+++ b/packages/examples/packages/json-rpc/tsconfig.json
@@ -1,22 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*/node": ["../../../*/src/node"],
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/jsx/snap.config.ts
+++ b/packages/examples/packages/jsx/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8029,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/jsx/src/index.test.tsx
+++ b/packages/examples/packages/jsx/src/index.test.tsx
@@ -32,7 +32,8 @@ describe('onRpcRequest', () => {
       });
 
       const ui = await response.getInterface();
-      assert(ui.type === 'alert');
+      // TODO(ritave): Fix types in SnapInterface
+      assert((ui as any).type === 'alert');
 
       expect(ui).toRender(<Counter count={0} />);
 
@@ -41,7 +42,8 @@ describe('onRpcRequest', () => {
       const updatedUi = await response.getInterface();
       expect(updatedUi).toRender(<Counter count={1} />);
 
-      await updatedUi.ok();
+      // TODO(ritave): Fix types in SnapInterface
+      await (updatedUi as any).ok();
 
       expect(await response).toRespondWith(null);
     });

--- a/packages/examples/packages/jsx/tsconfig.json
+++ b/packages/examples/packages/jsx/tsconfig.json
@@ -3,22 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "jsx": "react-jsxdev",
-    "paths": {
-      "@metamask/*/jsx": ["../../../*/src/jsx"],
-      "@metamask/*/jsx-dev-runtime": ["../../../*/src/jsx"],
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/lifecycle-hooks/snap.config.ts
+++ b/packages/examples/packages/lifecycle-hooks/snap.config.ts
@@ -5,6 +5,9 @@ const config: SnapConfig = {
   server: {
     port: 8022,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/lifecycle-hooks/tsconfig.json
+++ b/packages/examples/packages/lifecycle-hooks/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/localization/snap.config.ts
+++ b/packages/examples/packages/localization/snap.config.ts
@@ -5,6 +5,9 @@ const config: SnapConfig = {
   server: {
     port: 8020,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/localization/src/index.ts
+++ b/packages/examples/packages/localization/src/index.ts
@@ -23,6 +23,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       return await getMessage('hello');
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/localization/tsconfig.json
+++ b/packages/examples/packages/localization/tsconfig.json
@@ -2,20 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false
   },
-  "include": ["src", "locales/*.json", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "locales/*.json", "snap.config.ts"]
 }

--- a/packages/examples/packages/manage-state/snap.config.ts
+++ b/packages/examples/packages/manage-state/snap.config.ts
@@ -5,6 +5,9 @@ const config: SnapConfig = {
   server: {
     port: 8014,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/manage-state/src/index.ts
+++ b/packages/examples/packages/manage-state/src/index.ts
@@ -53,6 +53,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/manage-state/tsconfig.json
+++ b/packages/examples/packages/manage-state/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/name-lookup/snap.config.ts
+++ b/packages/examples/packages/name-lookup/snap.config.ts
@@ -5,6 +5,9 @@ const config: SnapConfig = {
   server: {
     port: 8023,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/name-lookup/tsconfig.json
+++ b/packages/examples/packages/name-lookup/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/network-access/snap.config.ts
+++ b/packages/examples/packages/network-access/snap.config.ts
@@ -5,6 +5,9 @@ const config: SnapConfig = {
   server: {
     port: 8015,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/network-access/src/index.test.ts
+++ b/packages/examples/packages/network-access/src/index.test.ts
@@ -1,9 +1,11 @@
 import { expect } from '@jest/globals';
-import { NodeProcessExecutionService } from '@metamask/snaps-controllers';
+import { NodeProcessExecutionService } from '@metamask/snaps-controllers/node';
 import { installSnap } from '@metamask/snaps-jest';
 
 describe('onRpcRequest', () => {
-  it('throws an error if the requested method does not exist', async () => {
+  // This test is disabled as it does not currently work
+  // TODO(ritave): Fix this test
+  it.skip('throws an error if the requested method does not exist', async () => {
     const { request } = await installSnap({
       executionService: NodeProcessExecutionService,
     });

--- a/packages/examples/packages/network-access/src/index.test.ts
+++ b/packages/examples/packages/network-access/src/index.test.ts
@@ -5,7 +5,7 @@ import { installSnap } from '@metamask/snaps-jest';
 describe('onRpcRequest', () => {
   // This test is disabled as it does not currently work
   // TODO(ritave): Fix this test
-  it.skip('throws an error if the requested method does not exist', async () => {
+  it('throws an error if the requested method does not exist', async () => {
     const { request } = await installSnap({
       executionService: NodeProcessExecutionService,
     });

--- a/packages/examples/packages/network-access/src/index.ts
+++ b/packages/examples/packages/network-access/src/index.ts
@@ -48,6 +48,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/network-access/tsconfig.json
+++ b/packages/examples/packages/network-access/tsconfig.json
@@ -2,23 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false
   },
-  "include": ["src", "package.json", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    },
-    {
-      "path": "../../../snaps-controllers"
-    }
-  ]
+  "include": ["src", "package.json", "snap.config.ts"]
 }

--- a/packages/examples/packages/notifications/snap.config.ts
+++ b/packages/examples/packages/notifications/snap.config.ts
@@ -5,6 +5,9 @@ const config: SnapConfig = {
   server: {
     port: 8016,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/notifications/src/index.ts
+++ b/packages/examples/packages/notifications/src/index.ts
@@ -40,6 +40,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       });
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/notifications/tsconfig.json
+++ b/packages/examples/packages/notifications/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/preinstalled/snap.config.ts
+++ b/packages/examples/packages/preinstalled/snap.config.ts
@@ -5,6 +5,9 @@ const config: SnapConfig = {
   server: {
     port: 8031,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/preinstalled/src/index.tsx
+++ b/packages/examples/packages/preinstalled/src/index.tsx
@@ -27,6 +27,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       });
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/preinstalled/tsconfig.json
+++ b/packages/examples/packages/preinstalled/tsconfig.json
@@ -2,22 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    },
+    "composite": false,
     "module": "NodeNext",
     "moduleResolution": "NodeNext"
   },
-  "include": ["src", "scripts", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "scripts", "snap.config.ts"]
 }

--- a/packages/examples/packages/rollup-plugin/src/index.ts
+++ b/packages/examples/packages/rollup-plugin/src/index.ts
@@ -23,6 +23,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       return 'Hello from Rollup!';
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/rollup-plugin/tsconfig.json
+++ b/packages/examples/packages/rollup-plugin/tsconfig.json
@@ -2,20 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false
   },
-  "include": ["src", "rollup.config.js"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-rollup-plugin"
-    },
-    {
-      "path": "../../../snaps-jest"
-    }
-  ]
+  "include": ["src", "rollup.config.js"]
 }

--- a/packages/examples/packages/send-flow/snap.config.ts
+++ b/packages/examples/packages/send-flow/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8070,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/send-flow/tsconfig.json
+++ b/packages/examples/packages/send-flow/tsconfig.json
@@ -3,24 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./",
     "jsx": "react-jsxdev",
-    "paths": {
-      "@metamask/*/jsx": ["../../../*/src/jsx"],
-      "@metamask/*/jsx-dev-runtime": ["../../../*/src/jsx"],
-      "@metamask/*": ["../../../*/src"]
-    },
+    "composite": false,
     "module": "ES2020",
     "moduleResolution": "Node10"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/signature-insights/snap.config.ts
+++ b/packages/examples/packages/signature-insights/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8017,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/signature-insights/tsconfig.json
+++ b/packages/examples/packages/signature-insights/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/transaction-insights/snap.config.ts
+++ b/packages/examples/packages/transaction-insights/snap.config.ts
@@ -5,6 +5,9 @@ const config: SnapConfig = {
   server: {
     port: 8018,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/transaction-insights/src/index.ts
+++ b/packages/examples/packages/transaction-insights/src/index.ts
@@ -31,8 +31,13 @@ export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
     const type = decodeData(transaction.data);
     return {
       content: panel([
-        row('From', address(transaction.from)),
-        row('To', transaction.to ? address(transaction.to) : text('None')),
+        row('From', address(transaction.from as `0x${string}`)),
+        row(
+          'To',
+          transaction.to
+            ? address(transaction.to as `0x${string}`)
+            : text('None'),
+        ),
         row('Transaction type', text(type)),
       ]),
       severity: SeverityLevel.Critical,

--- a/packages/examples/packages/transaction-insights/tsconfig.json
+++ b/packages/examples/packages/transaction-insights/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/wasm/snap.config.ts
+++ b/packages/examples/packages/wasm/snap.config.ts
@@ -6,6 +6,9 @@ const config: SnapConfig = {
   server: {
     port: 8019,
   },
+  typescript: {
+    enabled: true,
+  },
   stats: {
     buffer: false,
   },

--- a/packages/examples/packages/wasm/src/index.ts
+++ b/packages/examples/packages/wasm/src/index.ts
@@ -50,5 +50,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     return program[method](...params);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-throw-literal
   throw new MethodNotFoundError({ method: request.method });
 };

--- a/packages/examples/packages/wasm/tsconfig.json
+++ b/packages/examples/packages/wasm/tsconfig.json
@@ -1,21 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false,
+    "baseUrl": "./"
   },
-  "include": ["src", "snap.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-jest"
-    },
-    {
-      "path": "../../../snaps-cli"
-    }
-  ]
+  "include": ["src", "snap.config.ts"]
 }

--- a/packages/examples/packages/webpack-plugin/src/index.ts
+++ b/packages/examples/packages/webpack-plugin/src/index.ts
@@ -23,6 +23,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       return 'Hello from Webpack!';
 
     default:
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new MethodNotFoundError({ method: request.method });
   }
 };

--- a/packages/examples/packages/webpack-plugin/tsconfig.json
+++ b/packages/examples/packages/webpack-plugin/tsconfig.json
@@ -2,20 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./",
-    "paths": {
-      "@metamask/*": ["../../../*/src"]
-    }
+    "composite": false
   },
-  "include": ["src", "webpack.config.ts"],
-  "references": [
-    {
-      "path": "../../../snaps-sdk"
-    },
-    {
-      "path": "../../../snaps-webpack-plugin"
-    },
-    {
-      "path": "../../../snaps-jest"
-    }
-  ]
+  "include": ["src", "webpack.config.ts"]
 }

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -142,6 +142,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "execa": "^5.1.1",
+    "fork-ts-checker-webpack-plugin": "^9.0.2",
     "jest": "^29.0.2",
     "jest-it-up": "^2.0.0",
     "jest-silent-reporter": "^0.6.0",

--- a/packages/snaps-cli/src/config.ts
+++ b/packages/snaps-cli/src/config.ts
@@ -416,6 +416,30 @@ export type SnapWebpackConfig = {
       };
 
   /**
+   * Support for TypeScript type-checking feature.
+   *
+   * @example
+   * {
+   *   enabled: true;
+   *   configFile: './path/to/tsconfig.json'
+   * }
+   */
+  typescript?: {
+    /**
+     * Whether to enable TypeScript type-checking feature.
+     *
+     * @default false
+     */
+    enabled?: boolean;
+    /**
+     * Path to tsconfig.json file for the Snap.
+     *
+     * @default 'tsconfig.json'
+     */
+    configFile?: string;
+  };
+
+  /**
    * Optional features to enable in the CLI.
    *
    * @example
@@ -637,6 +661,14 @@ export const SnapsWebpackConfigStruct = object({
       }),
     ]),
     false,
+  ),
+
+  typescript: defaulted(
+    object({
+      enabled: defaulted(boolean(), false),
+      configFile: defaulted(string(), 'tsconfig.json'),
+    }),
+    {},
   ),
 
   features: defaulted(

--- a/packages/snaps-cli/src/config.ts
+++ b/packages/snaps-cli/src/config.ts
@@ -434,8 +434,6 @@ export type SnapWebpackConfig = {
      * @default true
      */
     images?: boolean;
-
-    typechecking: boolean | { configFile: string };
   };
 
   /**

--- a/packages/snaps-cli/src/config.ts
+++ b/packages/snaps-cli/src/config.ts
@@ -434,6 +434,8 @@ export type SnapWebpackConfig = {
      * @default true
      */
     images?: boolean;
+
+    typechecking: boolean | { configFile: string };
   };
 
   /**

--- a/packages/snaps-cli/src/config.ts
+++ b/packages/snaps-cli/src/config.ts
@@ -666,7 +666,7 @@ export const SnapsWebpackConfigStruct = object({
   typescript: defaulted(
     object({
       enabled: defaulted(boolean(), false),
-      configFile: defaulted(string(), 'tsconfig.json'),
+      configFile: defaulted(file(), 'tsconfig.json'),
     }),
     {},
   ),

--- a/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
+++ b/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
@@ -1836,7 +1836,188 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
       "options": {
         "typescript": {
           "build": true,
-          "configFile": "tsconfig.json",
+          "configFile": "/foo/bar/tsconfig.json",
+        },
+      },
+    },
+    SnapsWebpackPlugin {
+      "options": {
+        "eval": true,
+        "manifestPath": "/foo/bar/snap.manifest.json",
+        "writeManifest": true,
+      },
+    },
+    SnapsStatsPlugin {
+      "options": {
+        "verbose": false,
+      },
+    },
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
+      },
+    },
+    ProgressPlugin {
+      "dependenciesCount": 10000,
+      "handler": [Function],
+      "modulesCount": 5000,
+      "percentBy": undefined,
+      "profile": false,
+      "showActiveModules": false,
+      "showDependencies": true,
+      "showEntries": true,
+      "showModules": true,
+    },
+    SnapsBundleWarningsPlugin {
+      "options": {
+        "buffer": true,
+        "builtInResolver": SnapsBuiltInResolver {
+          "options": {
+            "ignore": [],
+          },
+          "unresolvedModules": Set {},
+        },
+        "builtIns": true,
+      },
+    },
+  ],
+  "resolve": {
+    "extensions": [
+      ".js",
+      ".jsx",
+      ".mjs",
+      ".cjs",
+      ".ts",
+      ".tsx",
+    ],
+    "fallback": {
+      "buffer": false,
+      "fs": false,
+      "path": false,
+    },
+    "plugins": [
+      SnapsBuiltInResolver {
+        "options": {
+          "ignore": [],
+        },
+        "unresolvedModules": Set {},
+      },
+    ],
+  },
+  "stats": "none",
+  "target": "browserslist:/foo/bar/.browserslistrc",
+}
+`;
+
+exports[`getDefaultConfiguration returns the default Webpack configuration for the given CLI config 12`] = `
+{
+  "devtool": false,
+  "entry": "/foo/bar/src/index.js",
+  "experiments": {
+    "topLevelAwait": false,
+  },
+  "infrastructureLogging": {
+    "level": "none",
+  },
+  "mode": "production",
+  "module": {
+    "rules": [
+      {
+        "exclude": /node_modules/u,
+        "test": /\\\\\\.\\(js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\)\\$/u,
+        "use": {
+          "loader": "/foo/bar/node_modules/swc-loader/index.js",
+          "options": {
+            "env": {
+              "targets": "chrome >= 90, firefox >= 91",
+            },
+            "jsc": {
+              "parser": {
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "transform": {
+                "react": {
+                  "importSource": "@metamask/snaps-sdk",
+                  "runtime": "automatic",
+                  "useBuiltins": true,
+                },
+              },
+            },
+            "module": {
+              "type": "es6",
+            },
+            "sourceMaps": false,
+            "sync": false,
+          },
+        },
+      },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js\\$/u,
+      },
+      {
+        "test": /\\\\\\.svg\\$/u,
+        "type": "asset/source",
+      },
+      {
+        "generator": {
+          "dataUrl": [Function],
+        },
+        "test": /\\\\\\.png\\$/u,
+        "type": "asset/inline",
+      },
+      {
+        "generator": {
+          "dataUrl": [Function],
+        },
+        "test": /\\\\\\.jpe\\?g\\$/u,
+        "type": "asset/inline",
+      },
+      false,
+    ],
+  },
+  "optimization": {
+    "minimize": true,
+    "minimizer": [
+      TerserPlugin {
+        "options": {
+          "exclude": undefined,
+          "extractComments": true,
+          "include": undefined,
+          "minimizer": {
+            "implementation": [Function],
+            "options": {},
+          },
+          "parallel": true,
+          "test": /\\\\\\.\\[cm\\]\\?js\\(\\\\\\?\\.\\*\\)\\?\\$/i,
+        },
+      },
+    ],
+  },
+  "output": {
+    "chunkFormat": "commonjs",
+    "clean": false,
+    "filename": "bundle.js",
+    "library": {
+      "type": "commonjs",
+    },
+    "path": "/foo/bar/dist",
+    "publicPath": "/",
+  },
+  "performance": {
+    "hints": false,
+  },
+  "plugins": [
+    ForkTsCheckerWebpackPlugin {
+      "options": {
+        "typescript": {
+          "build": true,
+          "configFile": "/foo/bar/foo/bar/tsconfig.json",
         },
       },
     },

--- a/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
+++ b/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
@@ -1730,6 +1730,187 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 }
 `;
 
+exports[`getDefaultConfiguration returns the default Webpack configuration for the given CLI config 11`] = `
+{
+  "devtool": false,
+  "entry": "/foo/bar/src/index.js",
+  "experiments": {
+    "topLevelAwait": false,
+  },
+  "infrastructureLogging": {
+    "level": "none",
+  },
+  "mode": "production",
+  "module": {
+    "rules": [
+      {
+        "exclude": /node_modules/u,
+        "test": /\\\\\\.\\(js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\)\\$/u,
+        "use": {
+          "loader": "/foo/bar/node_modules/swc-loader/index.js",
+          "options": {
+            "env": {
+              "targets": "chrome >= 90, firefox >= 91",
+            },
+            "jsc": {
+              "parser": {
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "transform": {
+                "react": {
+                  "importSource": "@metamask/snaps-sdk",
+                  "runtime": "automatic",
+                  "useBuiltins": true,
+                },
+              },
+            },
+            "module": {
+              "type": "es6",
+            },
+            "sourceMaps": false,
+            "sync": false,
+          },
+        },
+      },
+      {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js\\$/u,
+      },
+      {
+        "test": /\\\\\\.svg\\$/u,
+        "type": "asset/source",
+      },
+      {
+        "generator": {
+          "dataUrl": [Function],
+        },
+        "test": /\\\\\\.png\\$/u,
+        "type": "asset/inline",
+      },
+      {
+        "generator": {
+          "dataUrl": [Function],
+        },
+        "test": /\\\\\\.jpe\\?g\\$/u,
+        "type": "asset/inline",
+      },
+      false,
+    ],
+  },
+  "optimization": {
+    "minimize": true,
+    "minimizer": [
+      TerserPlugin {
+        "options": {
+          "exclude": undefined,
+          "extractComments": true,
+          "include": undefined,
+          "minimizer": {
+            "implementation": [Function],
+            "options": {},
+          },
+          "parallel": true,
+          "test": /\\\\\\.\\[cm\\]\\?js\\(\\\\\\?\\.\\*\\)\\?\\$/i,
+        },
+      },
+    ],
+  },
+  "output": {
+    "chunkFormat": "commonjs",
+    "clean": false,
+    "filename": "bundle.js",
+    "library": {
+      "type": "commonjs",
+    },
+    "path": "/foo/bar/dist",
+    "publicPath": "/",
+  },
+  "performance": {
+    "hints": false,
+  },
+  "plugins": [
+    ForkTsCheckerWebpackPlugin {
+      "options": {
+        "typescript": {
+          "build": true,
+          "configFile": "tsconfig.json",
+        },
+      },
+    },
+    SnapsWebpackPlugin {
+      "options": {
+        "eval": true,
+        "manifestPath": "/foo/bar/snap.manifest.json",
+        "writeManifest": true,
+      },
+    },
+    SnapsStatsPlugin {
+      "options": {
+        "verbose": false,
+      },
+    },
+    DefinePlugin {
+      "definitions": {
+        "process.env.DEBUG": ""false"",
+        "process.env.NODE_DEBUG": ""false"",
+        "process.env.NODE_ENV": ""production"",
+      },
+    },
+    ProgressPlugin {
+      "dependenciesCount": 10000,
+      "handler": [Function],
+      "modulesCount": 5000,
+      "percentBy": undefined,
+      "profile": false,
+      "showActiveModules": false,
+      "showDependencies": true,
+      "showEntries": true,
+      "showModules": true,
+    },
+    SnapsBundleWarningsPlugin {
+      "options": {
+        "buffer": true,
+        "builtInResolver": SnapsBuiltInResolver {
+          "options": {
+            "ignore": [],
+          },
+          "unresolvedModules": Set {},
+        },
+        "builtIns": true,
+      },
+    },
+  ],
+  "resolve": {
+    "extensions": [
+      ".js",
+      ".jsx",
+      ".mjs",
+      ".cjs",
+      ".ts",
+      ".tsx",
+    ],
+    "fallback": {
+      "buffer": false,
+      "fs": false,
+      "path": false,
+    },
+    "plugins": [
+      SnapsBuiltInResolver {
+        "options": {
+          "ignore": [],
+        },
+        "unresolvedModules": Set {},
+      },
+    ],
+  },
+  "stats": "none",
+  "target": "browserslist:/foo/bar/.browserslistrc",
+}
+`;
+
 exports[`getDefaultConfiguration returns the default Webpack configuration for the given CLI config and options 1`] = `
 {
   "devtool": false,

--- a/packages/snaps-cli/src/webpack/config.test.ts
+++ b/packages/snaps-cli/src/webpack/config.test.ts
@@ -175,6 +175,19 @@ describe('getDefaultConfiguration', () => {
         enabled: true,
       },
     }),
+    getMockConfig('webpack', {
+      input: 'src/index.js',
+      output: {
+        path: 'dist',
+      },
+      manifest: {
+        path: 'snap.manifest.json',
+      },
+      typescript: {
+        enabled: true,
+        configFile: './foo/bar/tsconfig.json',
+      },
+    }),
   ])(
     'returns the default Webpack configuration for the given CLI config',
     async (config) => {

--- a/packages/snaps-cli/src/webpack/config.test.ts
+++ b/packages/snaps-cli/src/webpack/config.test.ts
@@ -163,6 +163,18 @@ describe('getDefaultConfiguration', () => {
         images: false,
       },
     }),
+    getMockConfig('webpack', {
+      input: 'src/index.js',
+      output: {
+        path: 'dist',
+      },
+      manifest: {
+        path: 'snap.manifest.json',
+      },
+      typescript: {
+        enabled: true,
+      },
+    }),
   ])(
     'returns the default Webpack configuration for the given CLI config',
     async (config) => {

--- a/packages/snaps-cli/src/webpack/config.ts
+++ b/packages/snaps-cli/src/webpack/config.ts
@@ -1,4 +1,5 @@
 import SnapsWebpackPlugin from '@metamask/snaps-webpack-plugin';
+import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import type { Ora } from 'ora';
 import { resolve } from 'path';
 import TerserPlugin from 'terser-webpack-plugin';
@@ -277,6 +278,16 @@ export async function getDefaultConfiguration(
      * @see https://webpack.js.org/configuration/plugins/
      */
     plugins: [
+      /**
+       * The `ForkTsCheckerWebpackPlugin` is a Webpack plugin that checks
+       * Typescript type definitions, it does this in a separate process for speed.
+       */
+      new ForkTsCheckerWebpackPlugin({
+        typescript: {
+          build: true,
+        },
+      }),
+
       /**
        * The `SnapsWebpackPlugin` is a Webpack plugin that checks and updates
        * the manifest file, and evaluates the bundle in SES. While not strictly

--- a/packages/snaps-cli/src/webpack/config.ts
+++ b/packages/snaps-cli/src/webpack/config.ts
@@ -282,11 +282,13 @@ export async function getDefaultConfiguration(
        * The `ForkTsCheckerWebpackPlugin` is a Webpack plugin that checks
        * Typescript type definitions, it does this in a separate process for speed.
        */
-      new ForkTsCheckerWebpackPlugin({
-        typescript: {
-          build: true,
-        },
-      }),
+      config.typescript.enabled &&
+        new ForkTsCheckerWebpackPlugin({
+          typescript: {
+            build: true,
+            configFile: config.typescript.configFile,
+          },
+        }),
 
       /**
        * The `SnapsWebpackPlugin` is a Webpack plugin that checks and updates

--- a/packages/snaps-execution-environments/lavamoat/build-system/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/build-system/policy.json
@@ -22,6 +22,7 @@
       },
       "packages": {
         "@babel/core>@ampproject/remapping": true,
+        "@babel/core>@babel/code-frame": true,
         "@babel/core>@babel/generator": true,
         "@babel/core>@babel/helper-compilation-targets": true,
         "@babel/core>@babel/helper-module-transforms": true,
@@ -35,8 +36,7 @@
         "depcheck>@babel/parser": true,
         "depcheck>@babel/traverse": true,
         "depcheck>json5": true,
-        "eslint>debug": true,
-        "lavamoat>@babel/code-frame": true
+        "eslint>debug": true
       }
     },
     "@babel/core>@ampproject/remapping": {
@@ -55,6 +55,68 @@
       "packages": {
         "terser>@jridgewell/source-map>@jridgewell/gen-mapping>@jridgewell/set-array": true,
         "terser>@jridgewell/source-map>@jridgewell/gen-mapping>@jridgewell/sourcemap-codec": true
+      }
+    },
+    "@babel/core>@babel/code-frame": {
+      "globals": {
+        "console.warn": true,
+        "process": true
+      },
+      "packages": {
+        "@babel/core>@babel/code-frame>@babel/highlight": true,
+        "vite>postcss>picocolors": true
+      }
+    },
+    "@babel/core>@babel/code-frame>@babel/highlight": {
+      "globals": {
+        "process": true
+      },
+      "packages": {
+        "@babel/core>@babel/code-frame>@babel/highlight>chalk": true,
+        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true,
+        "lavamoat>@babel/highlight>js-tokens": true,
+        "vite>postcss>picocolors": true
+      }
+    },
+    "@babel/core>@babel/code-frame>@babel/highlight>chalk": {
+      "globals": {
+        "process.env.TERM": true,
+        "process.platform": true
+      },
+      "packages": {
+        "@babel/core>@babel/code-frame>@babel/highlight>chalk>ansi-styles": true,
+        "@babel/core>@babel/code-frame>@babel/highlight>chalk>escape-string-regexp": true,
+        "@babel/core>@babel/code-frame>@babel/highlight>chalk>supports-color": true
+      }
+    },
+    "@babel/core>@babel/code-frame>@babel/highlight>chalk>ansi-styles": {
+      "packages": {
+        "@babel/core>@babel/code-frame>@babel/highlight>chalk>ansi-styles>color-convert": true
+      }
+    },
+    "@babel/core>@babel/code-frame>@babel/highlight>chalk>ansi-styles>color-convert": {
+      "packages": {
+        "@babel/core>@babel/code-frame>@babel/highlight>chalk>ansi-styles>color-convert>color-name": true
+      }
+    },
+    "@babel/core>@babel/code-frame>@babel/highlight>chalk>supports-color": {
+      "builtin": {
+        "os.release": true
+      },
+      "globals": {
+        "process.env": true,
+        "process.platform": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.versions.node.split": true
+      },
+      "packages": {
+        "@babel/core>@babel/code-frame>@babel/highlight>chalk>supports-color>has-flag": true
+      }
+    },
+    "@babel/core>@babel/code-frame>@babel/highlight>chalk>supports-color>has-flag": {
+      "globals": {
+        "process.argv": true
       }
     },
     "@babel/core>@babel/generator": {
@@ -156,9 +218,9 @@
     },
     "@babel/core>@babel/template": {
       "packages": {
+        "@babel/core>@babel/code-frame": true,
         "@babel/core>@babel/types": true,
-        "depcheck>@babel/parser": true,
-        "lavamoat>@babel/code-frame": true
+        "depcheck>@babel/parser": true
       }
     },
     "@babel/core>@babel/types": {
@@ -1815,6 +1877,7 @@
         "console.log": true
       },
       "packages": {
+        "@babel/core>@babel/code-frame": true,
         "@babel/core>@babel/generator": true,
         "@babel/core>@babel/types": true,
         "depcheck>@babel/parser": true,
@@ -1823,8 +1886,7 @@
         "depcheck>@babel/traverse>@babel/helper-hoist-variables": true,
         "depcheck>@babel/traverse>@babel/helper-split-export-declaration": true,
         "depcheck>@babel/traverse>globals": true,
-        "eslint>debug": true,
-        "lavamoat>@babel/code-frame": true
+        "eslint>debug": true
       }
     },
     "depcheck>@babel/traverse>@babel/helper-function-name": {
@@ -2081,105 +2143,6 @@
         "readable-stream": true
       }
     },
-    "lavamoat>@babel/code-frame": {
-      "globals": {
-        "console.warn": true,
-        "process.emitWarning": true
-      },
-      "packages": {
-        "lavamoat>@babel/code-frame>chalk": true,
-        "lavamoat>@babel/highlight": true
-      }
-    },
-    "lavamoat>@babel/code-frame>chalk": {
-      "globals": {
-        "process.env.TERM": true,
-        "process.platform": true
-      },
-      "packages": {
-        "lavamoat>@babel/code-frame>chalk>ansi-styles": true,
-        "lavamoat>@babel/code-frame>chalk>escape-string-regexp": true,
-        "lavamoat>@babel/code-frame>chalk>supports-color": true
-      }
-    },
-    "lavamoat>@babel/code-frame>chalk>ansi-styles": {
-      "packages": {
-        "lavamoat>@babel/code-frame>chalk>ansi-styles>color-convert": true
-      }
-    },
-    "lavamoat>@babel/code-frame>chalk>ansi-styles>color-convert": {
-      "packages": {
-        "lavamoat>@babel/code-frame>chalk>ansi-styles>color-convert>color-name": true
-      }
-    },
-    "lavamoat>@babel/code-frame>chalk>supports-color": {
-      "builtin": {
-        "os.release": true
-      },
-      "globals": {
-        "process.env": true,
-        "process.platform": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.versions.node.split": true
-      },
-      "packages": {
-        "lavamoat>@babel/code-frame>chalk>supports-color>has-flag": true
-      }
-    },
-    "lavamoat>@babel/code-frame>chalk>supports-color>has-flag": {
-      "globals": {
-        "process.argv": true
-      }
-    },
-    "lavamoat>@babel/highlight": {
-      "packages": {
-        "lavamoat>@babel/highlight>@babel/helper-validator-identifier": true,
-        "lavamoat>@babel/highlight>chalk": true,
-        "lavamoat>@babel/highlight>js-tokens": true
-      }
-    },
-    "lavamoat>@babel/highlight>chalk": {
-      "globals": {
-        "process.env.TERM": true,
-        "process.platform": true
-      },
-      "packages": {
-        "lavamoat>@babel/highlight>chalk>ansi-styles": true,
-        "lavamoat>@babel/highlight>chalk>escape-string-regexp": true,
-        "lavamoat>@babel/highlight>chalk>supports-color": true
-      }
-    },
-    "lavamoat>@babel/highlight>chalk>ansi-styles": {
-      "packages": {
-        "lavamoat>@babel/highlight>chalk>ansi-styles>color-convert": true
-      }
-    },
-    "lavamoat>@babel/highlight>chalk>ansi-styles>color-convert": {
-      "packages": {
-        "lavamoat>@babel/highlight>chalk>ansi-styles>color-convert>color-name": true
-      }
-    },
-    "lavamoat>@babel/highlight>chalk>supports-color": {
-      "builtin": {
-        "os.release": true
-      },
-      "globals": {
-        "process.env": true,
-        "process.platform": true,
-        "process.stderr": true,
-        "process.stdout": true,
-        "process.versions.node.split": true
-      },
-      "packages": {
-        "lavamoat>@babel/highlight>chalk>supports-color>has-flag": true
-      }
-    },
-    "lavamoat>@babel/highlight>chalk>supports-color>has-flag": {
-      "globals": {
-        "process.argv": true
-      }
-    },
     "lavamoat>@lavamoat/aa": {
       "builtin": {
         "node:fs.lstatSync": true,
@@ -2426,6 +2389,16 @@
     "terser>source-map-support>buffer-from": {
       "globals": {
         "Buffer": true
+      }
+    },
+    "vite>postcss>picocolors": {
+      "builtin": {
+        "tty.isatty": true
+      },
+      "globals": {
+        "process.argv.includes": true,
+        "process.env": true,
+        "process.platform": true
       }
     },
     "yargs": {

--- a/packages/snaps-sdk/src/types/global.ts
+++ b/packages/snaps-sdk/src/types/global.ts
@@ -4,6 +4,10 @@ import type { SnapsEthereumProvider, SnapsProvider } from './provider';
  * Constants that are available globally in the Snap.
  */
 declare global {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore Redeclared in .d.cts file
   const ethereum: SnapsEthereumProvider;
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore Redeclared in .d.cts file
   const snap: SnapsProvider;
 }

--- a/packages/snaps-sdk/src/types/images.ts
+++ b/packages/snaps-sdk/src/types/images.ts
@@ -1,15 +1,21 @@
 // eslint-disable-next-line import/unambiguous
 declare module '*.svg' {
   const content: string;
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore Redeclared in .d.cts file
   export default content;
 }
 
 declare module '*.png' {
   const content: string;
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore Redeclared in .d.cts file
   export default content;
 }
 
 declare module '*.jpg' {
   const content: string;
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore Redeclared in .d.cts file
   export default content;
 }

--- a/packages/snaps-utils/src/snaps.test.ts
+++ b/packages/snaps-utils/src/snaps.test.ts
@@ -2,6 +2,7 @@ import type {
   SubjectPermissions,
   PermissionConstraint,
 } from '@metamask/permission-controller';
+import type { SnapId } from '@metamask/snaps-sdk';
 import { is } from '@metamask/superstruct';
 
 import { SnapCaveatType } from './caveats';

--- a/packages/snaps-utils/src/snaps.test.ts
+++ b/packages/snaps-utils/src/snaps.test.ts
@@ -2,7 +2,6 @@ import type {
   SubjectPermissions,
   PermissionConstraint,
 } from '@metamask/permission-controller';
-import type { SnapId } from '@metamask/snaps-sdk';
 import { is } from '@metamask/superstruct';
 
 import { SnapCaveatType } from './caveats';

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,13 +22,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:7.23.5, @babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.21.4, @babel/code-frame@npm:^7.22.13, @babel/code-frame@npm:^7.23.5":
+"@babel/code-frame@npm:7.23.5":
   version: 7.23.5
   resolution: "@babel/code-frame@npm:7.23.5"
   dependencies:
     "@babel/highlight": "npm:^7.23.4"
     chalk: "npm:^2.4.2"
   checksum: 10/44e58529c9d93083288dc9e649c553c5ba997475a7b0758cc3ddc4d77b8a7d985dbe78cc39c9bbc61f26d50af6da1ddf0a3427eae8cc222a9370619b671ed8f5
+  languageName: node
+  linkType: hard
+
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.21.4, @babel/code-frame@npm:^7.22.13, @babel/code-frame@npm:^7.23.5":
+  version: 7.24.7
+  resolution: "@babel/code-frame@npm:7.24.7"
+  dependencies:
+    "@babel/highlight": "npm:^7.24.7"
+    picocolors: "npm:^1.0.0"
+  checksum: 10/4812e94885ba7e3213d49583a155fdffb05292330f0a9b2c41b49288da70cf3c746a3fda0bf1074041a6d741c33f8d7be24be5e96f41ef77395eeddc5c9ff624
   languageName: node
   linkType: hard
 
@@ -310,10 +320,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.22.20":
-  version: 7.22.20
-  resolution: "@babel/helper-validator-identifier@npm:7.22.20"
-  checksum: 10/df882d2675101df2d507b95b195ca2f86a3ef28cb711c84f37e79ca23178e13b9f0d8b522774211f51e40168bf5142be4c1c9776a150cddb61a0d5bf3e95750b
+"@babel/helper-validator-identifier@npm:^7.22.20, @babel/helper-validator-identifier@npm:^7.24.7":
+  version: 7.24.7
+  resolution: "@babel/helper-validator-identifier@npm:7.24.7"
+  checksum: 10/86875063f57361471b531dbc2ea10bbf5406e12b06d249b03827d361db4cad2388c6f00936bcd9dc86479f7e2c69ea21412c2228d4b3672588b754b70a449d4b
   languageName: node
   linkType: hard
 
@@ -346,7 +356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/highlight@npm:7.23.4, @babel/highlight@npm:^7.23.4":
+"@babel/highlight@npm:7.23.4":
   version: 7.23.4
   resolution: "@babel/highlight@npm:7.23.4"
   dependencies:
@@ -354,6 +364,18 @@ __metadata:
     chalk: "npm:^2.4.2"
     js-tokens: "npm:^4.0.0"
   checksum: 10/62fef9b5bcea7131df4626d009029b1ae85332042f4648a4ce6e740c3fd23112603c740c45575caec62f260c96b11054d3be5987f4981a5479793579c3aac71f
+  languageName: node
+  linkType: hard
+
+"@babel/highlight@npm:^7.23.4, @babel/highlight@npm:^7.24.7":
+  version: 7.24.7
+  resolution: "@babel/highlight@npm:7.24.7"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.24.7"
+    chalk: "npm:^2.4.2"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.0.0"
+  checksum: 10/69b73f38cdd4f881b09b939a711e76646da34f4834f4ce141d7a49a6bb1926eab1c594148970a8aa9360398dff800f63aade4e81fafdd7c8d8a8489ea93bfec1
   languageName: node
   linkType: hard
 
@@ -5647,6 +5669,7 @@ __metadata:
     eslint-plugin-promise: "npm:^6.1.1"
     events: "npm:^3.3.0"
     execa: "npm:^5.1.1"
+    fork-ts-checker-webpack-plugin: "npm:^9.0.2"
     https-browserify: "npm:^1.0.0"
     jest: "npm:^29.0.2"
     jest-it-up: "npm:^2.0.0"
@@ -11148,6 +11171,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cosmiconfig@npm:^8.2.0":
+  version: 8.3.6
+  resolution: "cosmiconfig@npm:8.3.6"
+  dependencies:
+    import-fresh: "npm:^3.3.0"
+    js-yaml: "npm:^4.1.0"
+    parse-json: "npm:^5.2.0"
+    path-type: "npm:^4.0.0"
+  peerDependencies:
+    typescript: ">=4.9.5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/91d082baca0f33b1c085bf010f9ded4af43cbedacba8821da0fb5667184d0a848addc52c31fadd080007f904a555319c238cf5f4c03e6d58ece2e4876b2e73d6
+  languageName: node
+  linkType: hard
+
 "crc-32@npm:^1.2.0":
   version: 1.2.2
   resolution: "crc-32@npm:1.2.2"
@@ -13840,6 +13880,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fork-ts-checker-webpack-plugin@npm:^9.0.2":
+  version: 9.0.2
+  resolution: "fork-ts-checker-webpack-plugin@npm:9.0.2"
+  dependencies:
+    "@babel/code-frame": "npm:^7.16.7"
+    chalk: "npm:^4.1.2"
+    chokidar: "npm:^3.5.3"
+    cosmiconfig: "npm:^8.2.0"
+    deepmerge: "npm:^4.2.2"
+    fs-extra: "npm:^10.0.0"
+    memfs: "npm:^3.4.1"
+    minimatch: "npm:^3.0.4"
+    node-abort-controller: "npm:^3.0.1"
+    schema-utils: "npm:^3.1.1"
+    semver: "npm:^7.3.5"
+    tapable: "npm:^2.2.1"
+  peerDependencies:
+    typescript: ">3.6.0"
+    webpack: ^5.11.0
+  checksum: 10/3399ea114d9397da5e51baaa1cf2ca704f4616c8255df672889cafc2a823f77e8bf9913133852d29d676657b1d40e4a2fba8eb9fafee09e00faeda924289220e
+  languageName: node
+  linkType: hard
+
 "form-data-encoder@npm:^2.1.2":
   version: 2.1.4
   resolution: "form-data-encoder@npm:2.1.4"
@@ -13955,6 +14018,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-extra@npm:^10.0.0":
+  version: 10.1.0
+  resolution: "fs-extra@npm:10.1.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10/05ce2c3b59049bcb7b52001acd000e44b3c4af4ec1f8839f383ef41ec0048e3cfa7fd8a637b1bddfefad319145db89be91f4b7c1db2908205d38bf91e7d1d3b7
+  languageName: node
+  linkType: hard
+
 "fs-extra@npm:^11.1.0, fs-extra@npm:^11.1.1":
   version: 11.1.1
   resolution: "fs-extra@npm:11.1.1"
@@ -13995,10 +14069,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-monkey@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "fs-monkey@npm:1.0.3"
-  checksum: 10/af1abe305863956f5471fe41a4026da7607e866ee5f6c9a9ad6666b51eed102cbba08043eec708e15a1c78ced56bc33c72ee1ddf79720704791c77ed8f274a47
+"fs-monkey@npm:^1.0.4":
+  version: 1.0.6
+  resolution: "fs-monkey@npm:1.0.6"
+  checksum: 10/a0502a23aa0b467f671cd5c7f989ff48611cce1f23deb8f6924862b49234ff37de6828f739a4f2c1acf8f20e80cb426bf6a9d135c401f3df1e7089b7de04c815
   languageName: node
   linkType: hard
 
@@ -14957,7 +15031,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-fresh@npm:^3.0.0, import-fresh@npm:^3.2.1":
+"import-fresh@npm:^3.0.0, import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
   dependencies:
@@ -17296,12 +17370,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"memfs@npm:^3.4.13, memfs@npm:^3.4.3":
-  version: 3.5.1
-  resolution: "memfs@npm:3.5.1"
+"memfs@npm:^3.4.1, memfs@npm:^3.4.13, memfs@npm:^3.4.3":
+  version: 3.5.3
+  resolution: "memfs@npm:3.5.3"
   dependencies:
-    fs-monkey: "npm:^1.0.3"
-  checksum: 10/47a112689adcc282a0b80fc296d9145564c398c567ffa27f8e7c2d0ed0059e1604109dc1d0469bf3d810af3e9d3a4fea02b18adfc556155b5def1ccf1ae13836
+    fs-monkey: "npm:^1.0.4"
+  checksum: 10/7c9cdb453a6b06e87f11e2dbe6c518fd3c1c1581b370ffa24f42f3fd5b1db8c2203f596e43321a0032963f3e9b66400f2c3cf043904ac496d6ae33eafd0878fe
   languageName: node
   linkType: hard
 
@@ -17935,6 +18009,13 @@ __metadata:
   dependencies:
     semver: "npm:^7.3.5"
   checksum: 10/e9f137f9e2eefb4d508514fd00f292d01cb77f695f1511e6f51f272a91c161ad15676ae9590ba53da09845b852b6c14a829e2f033c5488e03127ea502213be93
+  languageName: node
+  linkType: hard
+
+"node-abort-controller@npm:^3.0.1":
+  version: 3.1.1
+  resolution: "node-abort-controller@npm:3.1.1"
+  checksum: 10/0a2cdb7ec0aeaf3cb31e1ca0e192f5add48f1c5c9c9ed822129f9dddbd9432f69b7425982f94ce803c56a2104884530aa67cd57696e5774b2e5b8ec2f58de042
   languageName: node
   linkType: hard
 
@@ -21618,7 +21699,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tapable@npm:^2.0.0, tapable@npm:^2.1.1, tapable@npm:^2.2.0":
+"tapable@npm:^2.0.0, tapable@npm:^2.1.1, tapable@npm:^2.2.0, tapable@npm:^2.2.1":
   version: 2.2.1
   resolution: "tapable@npm:2.2.1"
   checksum: 10/1769336dd21481ae6347611ca5fca47add0962fd8e80466515032125eca0084a4f0ede11e65341b9c0018ef4e1cf1ad820adbb0fba7cc99865c6005734000b0a


### PR DESCRIPTION
This PR adds support for Typescript checking in snaps-cli. It does so by using `fork-ts-checker-webpack-plugin` webpack plugin which runs TSC in a separate thread during webpack compilation.

fixes #2785