### PR TITLE
fix: Add missing dependency on execution environments to `snaps-simulation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ linkStyle default opacity:0.5
   snaps_rpc_methods --> snaps_sdk;
   snaps_rpc_methods --> snaps_utils;
   snaps_simulation --> snaps_controllers;
+  snaps_simulation --> snaps_execution_environments;
   snaps_simulation --> snaps_rpc_methods;
   snaps_simulation --> snaps_sdk;
   snaps_simulation --> snaps_utils;

--- a/packages/snaps-simulation/package.json
+++ b/packages/snaps-simulation/package.json
@@ -63,6 +63,7 @@
     "@metamask/permission-controller": "^11.0.0",
     "@metamask/phishing-controller": "^12.0.2",
     "@metamask/snaps-controllers": "workspace:^",
+    "@metamask/snaps-execution-environments": "workspace:^",
     "@metamask/snaps-rpc-methods": "workspace:^",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6066,6 +6066,7 @@ __metadata:
     "@metamask/permission-controller": "npm:^11.0.0"
     "@metamask/phishing-controller": "npm:^12.0.2"
     "@metamask/snaps-controllers": "workspace:^"
+    "@metamask/snaps-execution-environments": "workspace:^"
     "@metamask/snaps-rpc-methods": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"


### PR DESCRIPTION
When moving the simulation logic to `snaps-simulation`, we forgot to add `snaps-execution-environments` as a direct dependency. This causes errors at runtime when trying to install the latest version of `snaps-jest`.

`snaps-execution-environments` is an optional peer dependency of `snaps-controllers` . But is not optional for `snaps-simulation` as it leverages the Node execution environments.