### PR TITLE
Automatically re-run failed jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,3 +92,15 @@ jobs:
           if [[ $passed != "true" ]]; then
             exit 1
           fi
+
+  re-run:
+    name: Re-run failed jobs
+    needs: lint-build-test
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
+        run: gh workflow run re-run.yml -F run-id=${{ github.run_id }}

--- a/.github/workflows/re-run.yml
+++ b/.github/workflows/re-run.yml
@@ -1,0 +1,18 @@
+on:
+  workflow_dispatch:
+    inputs:
+      run-id:
+        required: true
+
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    steps:
+      - name: rerun ${{ inputs.run-id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
+        run: |
+          gh run watch ${{ inputs.run-id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.run-id }} --failed


### PR DESCRIPTION
Some CI jobs are a bit flaky, without an obvious way for us to fix them. Instead, I've added a new job that checks if any job failed, and re-runs them automatically.