### PR TITLE
BREAKING: Restrict proposed name in manifest

### DIFF
--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -2,5 +2,5 @@
   "branches": 99.74,
   "functions": 98.91,
   "lines": 99.45,
-  "statements": 96.3
+  "statements": 96.31
 }

--- a/packages/snaps-utils/src/manifest/validation.test.ts
+++ b/packages/snaps-utils/src/manifest/validation.test.ts
@@ -206,6 +206,7 @@ describe('isSnapManifest', () => {
     { name: 'foo' },
     { version: '1.0.0' },
     getSnapManifest({ version: 'foo bar' }),
+    getSnapManifest({ proposedName: '😄' }),
   ])('returns false for an invalid snap manifest', (value) => {
     expect(isSnapManifest(value)).toBe(false);
   });

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -36,7 +36,12 @@ import { KeyringOriginsStruct, RpcOriginsStruct } from '../json-rpc';
 import { ChainIdStruct } from '../namespace';
 import { SnapIdStruct } from '../snaps';
 import { mergeStructs, type InferMatching } from '../structs';
-import { NameStruct, NpmSnapFileNames, uri } from '../types';
+import {
+  NameStruct,
+  NpmSnapFileNames,
+  ProposedNameStruct,
+  uri,
+} from '../types';
 
 // BIP-43 purposes that cannot be used for entropy derivation. These are in the
 // string form, ending with `'`.
@@ -266,7 +271,7 @@ export type InitialConnections = Infer<typeof InitialConnectionsStruct>;
 export const SnapManifestStruct = object({
   version: VersionStruct,
   description: size(string(), 1, 280),
-  proposedName: size(string(), 1, 214),
+  proposedName: ProposedNameStruct,
   repository: optional(
     type({
       type: size(string(), 1, Infinity),

--- a/packages/snaps-utils/src/types.test.ts
+++ b/packages/snaps-utils/src/types.test.ts
@@ -1,6 +1,19 @@
 import { enums, is, literal } from '@metamask/superstruct';
 
-import { isValidUrl, uri } from './types';
+import { ProposedNameStruct, isValidUrl, uri } from './types';
+
+describe('ProposedNameStruct', () => {
+  it.each(['foo', 'bar baz', 'foo-bar', '@foo/bar', '@^_-()[]'])(
+    'accepts %p',
+    (value) => {
+      expect(is(value, ProposedNameStruct)).toBe(true);
+    },
+  );
+
+  it.each([1, '', '😄', String.fromCharCode(8206)])('rejects %p', (value) => {
+    expect(is(value, ProposedNameStruct)).toBe(false);
+  });
+});
 
 describe.each([
   isValidUrl,

--- a/packages/snaps-utils/src/types.ts
+++ b/packages/snaps-utils/src/types.ts
@@ -34,6 +34,12 @@ export const NameStruct = size(
   214,
 );
 
+/**
+ * A struct that matches anything from ASCII index 32 (space) to 126 (~), i.e.,
+ * all printable ASCII characters, between 1 and 214 characters long.
+ */
+export const ProposedNameStruct = size(pattern(string(), /^[ -~]+$/u), 1, 214);
+
 // Note we use `type` instead of `object` here, because the latter does not
 // allow unknown keys.
 export const NpmSnapPackageJsonStruct = type({


### PR DESCRIPTION
This changes manifest validation to restrict the `proposedName` field to printable ASCII characters. This is a breaking change because previously any string (within a certain length) was allowed.