### PR TITLE
Bump `chromedriver` to `^129.0.2`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       time: '06:00'
     allow:
       - dependency-name: '@metamask/*'
+      - dependency-name: 'chromedriver'
     target-branch: 'main'
     versioning-strategy: 'increase'
     open-pull-requests-limit: 10

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^6.21.0",
     "@yarnpkg/types": "^4.0.0",
-    "chromedriver": "^127.0.0",
+    "chromedriver": "^129.0.2",
     "depcheck": "^1.4.7",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",

--- a/scripts/install-chrome.sh
+++ b/scripts/install-chrome.sh
@@ -5,12 +5,12 @@ set -u
 set -o pipefail
 
 # To get the latest version, see <https://www.ubuntuupdates.org/ppa/google_chrome?dist=stable>
-CHROME_VERSION='127.0.6533.72-1'
+CHROME_VERSION='129.0.6668.89-1'
 CHROME_BINARY="google-chrome-stable_${CHROME_VERSION}_amd64.deb"
 CHROME_BINARY_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/${CHROME_BINARY}"
 
 # To retrieve this checksum, run the `wget` and `shasum` commands below
-CHROME_BINARY_SHA512SUM='54097b33fbe8bf485273f25446b5da36fdae1b4a3d1722f3b245b63f7337f5acdae1788000ca7b6817e8197c675785f2c94e487426126c734e7ca725affb7f2a'
+CHROME_BINARY_SHA512SUM='b764b14ea7958ee2ca7ab7985c479bb2c281a29d6e0570eaf87978591c4a98c837082ce16b290c2f465ab72804f49ad4e8c8c31945fea6eb9d1cda158fb9be8a'
 
 wget -O "${CHROME_BINARY}" -t 5 "${CHROME_BINARY_URL}"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9617,14 +9617,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.6.7":
-  version: 1.7.4
-  resolution: "axios@npm:1.7.4"
+"axios@npm:^1.7.4":
+  version: 1.7.7
+  resolution: "axios@npm:1.7.7"
   dependencies:
     follow-redirects: "npm:^1.15.6"
     form-data: "npm:^4.0.0"
     proxy-from-env: "npm:^1.1.0"
-  checksum: 10/7a1429be1e3d0c2e1b96d4bba4d113efbfabc7c724bed107beb535c782c7bea447ff634886b0c7c43395a264d085450d009eb1154b5f38a8bae49d469fdcbc61
+  checksum: 10/7f875ea13b9298cd7b40fd09985209f7a38d38321f1118c701520939de2f113c4ba137832fe8e3f811f99a38e12c8225481011023209a77b0c0641270e20cde1
   languageName: node
   linkType: hard
 
@@ -10569,12 +10569,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromedriver@npm:^127.0.0":
-  version: 127.0.0
-  resolution: "chromedriver@npm:127.0.0"
+"chromedriver@npm:^129.0.2":
+  version: 129.0.2
+  resolution: "chromedriver@npm:129.0.2"
   dependencies:
     "@testim/chrome-version": "npm:^1.1.4"
-    axios: "npm:^1.6.7"
+    axios: "npm:^1.7.4"
     compare-versions: "npm:^6.1.0"
     extract-zip: "npm:^2.0.1"
     proxy-agent: "npm:^6.4.0"
@@ -10582,7 +10582,7 @@ __metadata:
     tcp-port-used: "npm:^1.0.2"
   bin:
     chromedriver: bin/chromedriver
-  checksum: 10/8b56f51b79a12c28b7d417b24ca59123026345e4debf417b67c15b64c194a1b3abe81e970255bcb3820877544a48ed20865f96caf796941eaaac616bb7b52fd2
+  checksum: 10/223854665dce25a5d4b1073cb6732df70172a3cbcba23e91f2e81f07437b0b4be0d1712e90aa2b069e45aacf0eea4f99ba4d76cbda96def9ea8194ce73ee813f
   languageName: node
   linkType: hard
 
@@ -20387,7 +20387,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^5.42.1"
     "@typescript-eslint/parser": "npm:^6.21.0"
     "@yarnpkg/types": "npm:^4.0.0"
-    chromedriver: "npm:^127.0.0"
+    chromedriver: "npm:^129.0.2"
     depcheck: "npm:^1.4.7"
     eslint: "npm:^8.27.0"
     eslint-config-prettier: "npm:^8.5.0"


### PR DESCRIPTION
This bumps `chromedriver` to `^129.0.2` to fix compatibility with Chrome 129.