### PR TITLE
Add `actions` permission for re-run workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,8 @@ jobs:
     needs: lint-build-test
     if: failure() && fromJSON(github.run_attempt) < 3
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - env:
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/re-run.yml
+++ b/.github/workflows/re-run.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   rerun:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: rerun ${{ inputs.run-id }}
         env:


### PR DESCRIPTION
We have the default permissions for `GITHUB_TOKEN` set to read-only, meaning we need to explicitly grant write permission to any workflows.