### PR TITLE
Add `isSnapId` utility function

### DIFF
--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 99.74,
-  "functions": 98.91,
+  "functions": 98.92,
   "lines": 99.45,
-  "statements": 96.3
+  "statements": 96.31
 }

--- a/packages/snaps-utils/src/snaps.test.ts
+++ b/packages/snaps-utils/src/snaps.test.ts
@@ -22,8 +22,8 @@ import { uri, WALLET_SNAP_PERMISSION_KEY } from './types';
 describe('isSnapId', () => {
   it.each(['npm:@metamask/test-snap-bip44', 'local:http://localhost:8000'])(
     'returns `true` for "%s"',
-    () => {
-      expect(isSnapId('npm:@metamask/test-snap-bip44')).toBe(true);
+    (value) => {
+      expect(isSnapId(value)).toBe(true);
     },
   );
 

--- a/packages/snaps-utils/src/snaps.test.ts
+++ b/packages/snaps-utils/src/snaps.test.ts
@@ -2,6 +2,7 @@ import type {
   SubjectPermissions,
   PermissionConstraint,
 } from '@metamask/permission-controller';
+import { MOCK_SNAP_ID } from '@metamask/snaps-utils/test-utils';
 import { is } from '@metamask/superstruct';
 
 import { SnapCaveatType } from './caveats';
@@ -14,8 +15,35 @@ import {
   assertIsValidSnapId,
   verifyRequestedSnapPermissions,
   stripSnapPrefix,
+  isSnapId,
 } from './snaps';
 import { uri, WALLET_SNAP_PERMISSION_KEY } from './types';
+
+describe('isSnapId', () => {
+  it.each(['npm:@metamask/test-snap-bip44', 'local:http://localhost:8000'])(
+    'returns `true` for "%s"',
+    () => {
+      expect(isSnapId('npm:@metamask/test-snap-bip44')).toBe(true);
+    },
+  );
+
+  it.each([
+    undefined,
+    {},
+    null,
+    true,
+    2,
+    'foo:bar',
+    ' local:http://localhost:8000',
+    'local:http://localhost:8000 ',
+    'local:http://localhost:8000\n',
+    'local:http://localhost:8000\r',
+    'local:😎',
+    'local:␡',
+  ])('returns `false` for "%s"', (value) => {
+    expect(isSnapId(value)).toBe(false);
+  });
+});
 
 describe('assertIsValidSnapId', () => {
   it.each([undefined, {}, null, true, 2])(
@@ -239,7 +267,7 @@ describe('isSnapPermitted', () => {
           {
             type: 'snapIds',
             value: {
-              foo: {},
+              [MOCK_SNAP_ID]: {},
             },
           },
         ],
@@ -273,9 +301,9 @@ describe('isSnapPermitted', () => {
       },
     };
 
-    expect(isSnapPermitted(validPermissions, 'foo')).toBe(true);
-    expect(isSnapPermitted(invalidPermissions1, 'foo')).toBe(false);
-    expect(isSnapPermitted(invalidPermissions2, 'foo')).toBe(false);
+    expect(isSnapPermitted(validPermissions, MOCK_SNAP_ID)).toBe(true);
+    expect(isSnapPermitted(invalidPermissions1, MOCK_SNAP_ID)).toBe(false);
+    expect(isSnapPermitted(invalidPermissions2, MOCK_SNAP_ID)).toBe(false);
   });
 
   describe('verifyRequestedSnapPermissions', () => {

--- a/packages/snaps-utils/src/snaps.test.ts
+++ b/packages/snaps-utils/src/snaps.test.ts
@@ -2,7 +2,6 @@ import type {
   SubjectPermissions,
   PermissionConstraint,
 } from '@metamask/permission-controller';
-import { MOCK_SNAP_ID } from '@metamask/snaps-utils/test-utils';
 import { is } from '@metamask/superstruct';
 
 import { SnapCaveatType } from './caveats';
@@ -17,6 +16,7 @@ import {
   stripSnapPrefix,
   isSnapId,
 } from './snaps';
+import { MOCK_SNAP_ID } from './test-utils';
 import { uri, WALLET_SNAP_PERMISSION_KEY } from './types';
 
 describe('isSnapId', () => {

--- a/packages/snaps-utils/src/snaps.ts
+++ b/packages/snaps-utils/src/snaps.ts
@@ -7,6 +7,7 @@ import type { BlockReason } from '@metamask/snaps-registry';
 import type { SnapId, Snap as TruncatedSnap } from '@metamask/snaps-sdk';
 import type { Struct } from '@metamask/superstruct';
 import {
+  is,
   empty,
   enums,
   intersection,
@@ -309,6 +310,17 @@ export function getSnapPrefix(snapId: string): SnapIdPrefixes {
  */
 export function stripSnapPrefix(snapId: string): string {
   return snapId.replace(getSnapPrefix(snapId), '');
+}
+
+/**
+ * Check if the given value is a valid snap ID. This function is a type guard,
+ * and will narrow the type of the value to `SnapId` if it returns `true`.
+ *
+ * @param value - The value to check.
+ * @returns `true` if the value is a valid snap ID, and `false` otherwise.
+ */
+export function isSnapId(value: unknown): value is SnapId {
+  return is(value, SnapIdStruct);
 }
 
 /**


### PR DESCRIPTION
This adds a `isSnapId` function which accepts any value, and returns a boolean if the input is a valid Snap ID or not.

This is extracted from #2634.