### PR TITLE
feat: Allow updating interface context

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 92.6,
+  "branches": 92.63,
   "functions": 96.65,
   "lines": 97.97,
   "statements": 97.67

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 92.63,
+  "branches": 92.62,
   "functions": 96.65,
   "lines": 97.97,
   "statements": 97.67

--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.test.tsx
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.test.tsx
@@ -599,6 +599,57 @@ describe('SnapInterfaceController', () => {
       expect(interfaceContext).toStrictEqual(newContext);
     });
 
+    it('does not replace context if none is provided', async () => {
+      const rootMessenger = getRootSnapInterfaceControllerMessenger();
+      const controllerMessenger =
+        getRestrictedSnapInterfaceControllerMessenger(rootMessenger);
+
+      /* eslint-disable-next-line no-new */
+      new SnapInterfaceController({
+        messenger: controllerMessenger,
+      });
+
+      const components = form({
+        name: 'foo',
+        children: [input({ name: 'bar' })],
+      });
+
+      const newContent = form({
+        name: 'foo',
+        children: [input({ name: 'baz' })],
+      });
+
+      const context = { foo: 'bar' };
+
+      const id = await rootMessenger.call(
+        'SnapInterfaceController:createInterface',
+        MOCK_SNAP_ID,
+        components,
+        context,
+      );
+
+      await rootMessenger.call(
+        'SnapInterfaceController:updateInterface',
+        MOCK_SNAP_ID,
+        id,
+        newContent,
+      );
+
+      const {
+        content,
+        state,
+        context: interfaceContext,
+      } = rootMessenger.call(
+        'SnapInterfaceController:getInterface',
+        MOCK_SNAP_ID,
+        id,
+      );
+
+      expect(content).toStrictEqual(getJsxElementFromComponent(newContent));
+      expect(state).toStrictEqual({ foo: { baz: null } });
+      expect(interfaceContext).toStrictEqual(context);
+    });
+
     it('throws if a link is on the phishing list', async () => {
       const rootMessenger = getRootSnapInterfaceControllerMessenger();
       const controllerMessenger = getRestrictedSnapInterfaceControllerMessenger(

--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.test.tsx
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.test.tsx
@@ -545,6 +545,60 @@ describe('SnapInterfaceController', () => {
       expect(state).toStrictEqual({ foo: { baz: null } });
     });
 
+    it('can update an interface and context', async () => {
+      const rootMessenger = getRootSnapInterfaceControllerMessenger();
+      const controllerMessenger =
+        getRestrictedSnapInterfaceControllerMessenger(rootMessenger);
+
+      /* eslint-disable-next-line no-new */
+      new SnapInterfaceController({
+        messenger: controllerMessenger,
+      });
+
+      const components = form({
+        name: 'foo',
+        children: [input({ name: 'bar' })],
+      });
+
+      const newContent = form({
+        name: 'foo',
+        children: [input({ name: 'baz' })],
+      });
+
+      const context = { foo: 'bar' };
+
+      const id = await rootMessenger.call(
+        'SnapInterfaceController:createInterface',
+        MOCK_SNAP_ID,
+        components,
+        context,
+      );
+
+      const newContext = { foo: 'baz' };
+
+      await rootMessenger.call(
+        'SnapInterfaceController:updateInterface',
+        MOCK_SNAP_ID,
+        id,
+        newContent,
+        newContext,
+      );
+
+      const {
+        content,
+        state,
+        context: interfaceContext,
+      } = rootMessenger.call(
+        'SnapInterfaceController:getInterface',
+        MOCK_SNAP_ID,
+        id,
+      );
+
+      expect(content).toStrictEqual(getJsxElementFromComponent(newContent));
+      expect(state).toStrictEqual({ foo: { baz: null } });
+      expect(interfaceContext).toStrictEqual(newContext);
+    });
+
     it('throws if a link is on the phishing list', async () => {
       const rootMessenger = getRootSnapInterfaceControllerMessenger();
       const controllerMessenger = getRestrictedSnapInterfaceControllerMessenger(

--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
@@ -249,7 +249,9 @@ export class SnapInterfaceController extends BaseController<
     this.update((draftState) => {
       draftState.interfaces[id].state = newState;
       draftState.interfaces[id].content = castDraft(element);
-      draftState.interfaces[id].context = context ?? null;
+      if (context) {
+        draftState.interfaces[id].context = context;
+      }
     });
   }
 

--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
@@ -230,15 +230,18 @@ export class SnapInterfaceController extends BaseController<
    * @param snapId - The snap id requesting the update.
    * @param id - The interface id.
    * @param content - The new content.
+   * @param context - An optional interface context object.
    */
   async updateInterface(
     snapId: SnapId,
     id: string,
     content: ComponentOrElement,
+    context?: InterfaceContext,
   ) {
     this.#validateArgs(snapId, id);
     const element = getJsxInterface(content);
     await this.#validateContent(element);
+    validateInterfaceContext(context);
 
     const oldState = this.state.interfaces[id].state;
     const newState = constructState(oldState, element);
@@ -246,6 +249,7 @@ export class SnapInterfaceController extends BaseController<
     this.update((draftState) => {
       draftState.interfaces[id].state = newState;
       draftState.interfaces[id].content = castDraft(element);
+      draftState.interfaces[id].context = context ?? null;
     });
   }
 

--- a/packages/snaps-rpc-methods/src/permitted/updateInterface.test.tsx
+++ b/packages/snaps-rpc-methods/src/permitted/updateInterface.test.tsx
@@ -98,8 +98,56 @@ describe('snap_updateInterface', () => {
         <Box>
           <Text>Hello, world!</Text>
         </Box>,
+        undefined,
       );
     });
+  });
+
+  it('updates the interface context', async () => {
+    const { implementation } = updateInterfaceHandler;
+
+    const updateInterface = jest.fn();
+
+    const hooks = {
+      updateInterface,
+    };
+
+    const engine = new JsonRpcEngine();
+
+    engine.push((request, response, next, end) => {
+      const result = implementation(
+        request as JsonRpcRequest<UpdateInterfaceParams>,
+        response as PendingJsonRpcResponse<UpdateInterfaceResult>,
+        next,
+        end,
+        hooks,
+      );
+
+      result?.catch(end);
+    });
+
+    await engine.handle({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'snap_updateInterface',
+      params: {
+        id: 'foo',
+        ui: (
+          <Box>
+            <Text>Hello, world!</Text>
+          </Box>
+        ) as JSXElement,
+        context: { foo: 'bar' },
+      },
+    });
+
+    expect(updateInterface).toHaveBeenCalledWith(
+      'foo',
+      <Box>
+        <Text>Hello, world!</Text>
+      </Box>,
+      { foo: 'bar' },
+    );
   });
 
   it('throws on invalid params', async () => {

--- a/packages/snaps-rpc-methods/src/permitted/updateInterface.ts
+++ b/packages/snaps-rpc-methods/src/permitted/updateInterface.ts
@@ -6,10 +6,20 @@ import type {
   UpdateInterfaceResult,
   JsonRpcRequest,
   ComponentOrElement,
+  InterfaceContext,
 } from '@metamask/snaps-sdk';
-import { ComponentOrElementStruct } from '@metamask/snaps-sdk';
+import {
+  ComponentOrElementStruct,
+  InterfaceContextStruct,
+} from '@metamask/snaps-sdk';
 import { type InferMatching } from '@metamask/snaps-utils';
-import { StructError, create, object, string } from '@metamask/superstruct';
+import {
+  StructError,
+  create,
+  object,
+  optional,
+  string,
+} from '@metamask/superstruct';
 import type { PendingJsonRpcResponse } from '@metamask/utils';
 
 import type { MethodHooksObject } from '../utils';
@@ -22,8 +32,13 @@ export type UpdateInterfaceMethodHooks = {
   /**
    * @param id - The interface ID.
    * @param ui - The UI components.
+   * @param context - The optional interface context object.
    */
-  updateInterface: (id: string, ui: ComponentOrElement) => Promise<void>;
+  updateInterface: (
+    id: string,
+    ui: ComponentOrElement,
+    context?: InterfaceContext,
+  ) => Promise<void>;
 };
 
 export const updateInterfaceHandler: PermittedHandlerExport<
@@ -39,6 +54,7 @@ export const updateInterfaceHandler: PermittedHandlerExport<
 const UpdateInterfaceParametersStruct = object({
   id: string(),
   ui: ComponentOrElementStruct,
+  context: optional(InterfaceContextStruct),
 });
 
 export type UpdateInterfaceParameters = InferMatching<
@@ -70,9 +86,9 @@ async function getUpdateInterfaceImplementation(
   try {
     const validatedParams = getValidatedParams(params);
 
-    const { id, ui } = validatedParams;
+    const { id, ui, context } = validatedParams;
 
-    await updateInterface(id, ui);
+    await updateInterface(id, ui, context);
     res.result = null;
   } catch (error) {
     return end(error);

--- a/packages/snaps-sdk/src/types/methods/update-interface.ts
+++ b/packages/snaps-sdk/src/types/methods/update-interface.ts
@@ -1,4 +1,4 @@
-import type { ComponentOrElement } from '..';
+import type { ComponentOrElement, InterfaceContext } from '..';
 
 /**
  * The request parameters for the `snap_createInterface` method.
@@ -9,6 +9,7 @@ import type { ComponentOrElement } from '..';
 export type UpdateInterfaceParams = {
   id: string;
   ui: ComponentOrElement;
+  context?: InterfaceContext;
 };
 
 /**


### PR DESCRIPTION
Allows updating the `context` object in the `SnapInterfaceController` via `snap_updateInterface`. This is a non-breaking change as `context` is optional.

Closes https://github.com/MetaMask/snaps/issues/2804