### PR TITLE
Add url export

### DIFF
--- a/packages/snaps-utils/src/index.ts
+++ b/packages/snaps-utils/src/index.ts
@@ -27,6 +27,7 @@ export * from './strings';
 export * from './structs';
 export * from './types';
 export * from './ui';
+export * from './url';
 export * from './validation';
 export * from './versions';
 export * from './virtual-file';


### PR DESCRIPTION
The `url.ts` file was not being exported in `snaps-utils`. 