### PR TITLE
Add `min`, `max` and `step` props to `Input`

### DIFF
--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "HEAbfXBUqw5fNP+sJVyvUpXucZy6CwiCFXJi36CEfUw=",
+    "shasum": "4Waitn0bnIxi/w96Dqni+0tHJkuPURlZznHkrdp2cPc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "mCoDlMSdhDJAXd9zT74ST7jHysifHdQ8r0++b8uPbOs=",
+    "shasum": "27AQQByAFXL3KIpdFzj+ke9/98WSR8o8Fan72A4LuXg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-sdk/src/jsx/components/form/Input.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/Input.test.tsx
@@ -28,13 +28,16 @@ describe('Input', () => {
   });
 
   it('renders a number input', () => {
-    const result = <Input name="foo" type="number" />;
+    const result = <Input name="foo" type="number" min="0" max="10" step="1" />;
 
     expect(result).toStrictEqual({
       type: 'Input',
       props: {
         name: 'foo',
         type: 'number',
+        min: '0',
+        max: '10',
+        step: '1',
       },
       key: null,
     });

--- a/packages/snaps-sdk/src/jsx/components/form/Input.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/Input.test.tsx
@@ -28,16 +28,16 @@ describe('Input', () => {
   });
 
   it('renders a number input', () => {
-    const result = <Input name="foo" type="number" min="0" max="10" step="1" />;
+    const result = <Input name="foo" type="number" min={0} max={10} step={1} />;
 
     expect(result).toStrictEqual({
       type: 'Input',
       props: {
         name: 'foo',
         type: 'number',
-        min: '0',
-        max: '10',
-        step: '1',
+        min: 0,
+        max: 10,
+        step: 1,
       },
       key: null,
     });

--- a/packages/snaps-sdk/src/jsx/components/form/Input.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Input.ts
@@ -9,7 +9,9 @@ export type GenericInputProps = {
 };
 
 export type TextInputProps = { type: 'text' } & GenericInputProps;
+
 export type PasswordInputProps = { type: 'password' } & GenericInputProps;
+
 export type NumberInputProps = {
   type: 'number';
   min?: number;

--- a/packages/snaps-sdk/src/jsx/components/form/Input.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Input.ts
@@ -22,9 +22,9 @@ export type InputProps = {
   type?: 'text' | 'password' | 'number' | undefined;
   value?: string | undefined;
   placeholder?: string | undefined;
-  min?: string | undefined;
-  max?: string | undefined;
-  step?: string | undefined;
+  min?: number | undefined;
+  max?: number | undefined;
+  step?: number | undefined;
 };
 
 const TYPE = 'Input';

--- a/packages/snaps-sdk/src/jsx/components/form/Input.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Input.ts
@@ -2,6 +2,21 @@ import { createSnapComponent } from '../../component';
 
 // TODO: Add the `onChange` prop to the `InputProps` type.
 
+export type GenericInputProps = {
+  name: string;
+  value?: string | undefined;
+  placeholder?: string | undefined;
+};
+
+export type TextInputProps = { type: 'text' } & GenericInputProps;
+export type PasswordInputProps = { type: 'password' } & GenericInputProps;
+export type NumberInputProps = {
+  type: 'number';
+  min?: number;
+  max?: number;
+  step?: number;
+} & GenericInputProps;
+
 /**
  * The props of the {@link Input} component.
  *
@@ -17,15 +32,11 @@ import { createSnapComponent } from '../../component';
  * @property step - The step value of the input field.
  * Only applicable to the type `number` input.
  */
-export type InputProps = {
-  name: string;
-  type?: 'text' | 'password' | 'number' | undefined;
-  value?: string | undefined;
-  placeholder?: string | undefined;
-  min?: number | undefined;
-  max?: number | undefined;
-  step?: number | undefined;
-};
+export type InputProps =
+  | GenericInputProps
+  | TextInputProps
+  | PasswordInputProps
+  | NumberInputProps;
 
 const TYPE = 'Input';
 
@@ -38,9 +49,17 @@ const TYPE = 'Input';
  * @param props.type - The type of the input field.
  * @param props.value - The value of the input field.
  * @param props.placeholder - The placeholder text of the input field.
+ * @param props.min - The minimum value of the input field.
+ * Only applicable to the type `number` input.
+ * @param props.max - The maximum value of the input field.
+ * Only applicable to the type `number` input.
+ * @param props.step - The step value of the input field.
+ * Only applicable to the type `number` input.
  * @returns An input element.
  * @example
  * <Input name="username" type="text" />
+ * @example
+ * <Input name="numeric" type="number" min={1} max={100} step={1} />
  */
 export const Input = createSnapComponent<InputProps, typeof TYPE>(TYPE);
 

--- a/packages/snaps-sdk/src/jsx/components/form/Input.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Input.ts
@@ -10,12 +10,21 @@ import { createSnapComponent } from '../../component';
  * @property type - The type of the input field. Defaults to `text`.
  * @property value - The value of the input field.
  * @property placeholder - The placeholder text of the input field.
+ * @property min - The minimum value of the input field.
+ * Only applicable to the type `number` input.
+ * @property max - The maximum value of the input field.
+ * Only applicable to the type `number` input.
+ * @property step - The step value of the input field.
+ * Only applicable to the type `number` input.
  */
 export type InputProps = {
   name: string;
   type?: 'text' | 'password' | 'number' | undefined;
   value?: string | undefined;
   placeholder?: string | undefined;
+  min?: string | undefined;
+  max?: string | undefined;
+  step?: string | undefined;
 };
 
 const TYPE = 'Input';

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -207,7 +207,7 @@ describe('InputStruct', () => {
     <Input name="foo" type="number" />,
     <Input name="foo" type="text" value="bar" />,
     <Input name="foo" type="text" placeholder="bar" />,
-    <Input name="foo" type="number" min="0" max="10" step="1" />,
+    <Input name="foo" type="number" min={0} max={10} step={1} />,
   ])('validates an input element', (value) => {
     expect(is(value, InputStruct)).toBe(true);
   });
@@ -223,6 +223,9 @@ describe('InputStruct', () => {
     <Input />,
     // @ts-expect-error - Invalid props.
     <Input name="foo" type="foo" />,
+    // @ts-expect-error - Invalid props.
+    <Input name="foo" min="foo" />,
+    <Input name="foo" type="text" min={42} />,
     <Text>foo</Text>,
     <Box>
       <Text>foo</Text>
@@ -230,7 +233,6 @@ describe('InputStruct', () => {
     <Row label="label">
       <Image src="<svg />" alt="alt" />
     </Row>,
-    <Input name="foo" min="foo" />,
   ])('does not validate "%p"', (value) => {
     expect(is(value, InputStruct)).toBe(false);
   });

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -225,6 +225,7 @@ describe('InputStruct', () => {
     <Input name="foo" type="foo" />,
     // @ts-expect-error - Invalid props.
     <Input name="foo" min="foo" />,
+    // @ts-expect-error - Invalid props.
     <Input name="foo" type="text" min={42} />,
     <Text>foo</Text>,
     <Box>

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -207,6 +207,7 @@ describe('InputStruct', () => {
     <Input name="foo" type="number" />,
     <Input name="foo" type="text" value="bar" />,
     <Input name="foo" type="text" placeholder="bar" />,
+    <Input name="foo" type="number" min="0" max="10" step="1" />,
   ])('validates an input element', (value) => {
     expect(is(value, InputStruct)).toBe(true);
   });
@@ -229,6 +230,7 @@ describe('InputStruct', () => {
     <Row label="label">
       <Image src="<svg />" alt="alt" />
     </Row>,
+    <Input name="foo" min="foo" />,
   ])('does not validate "%p"', (value) => {
     expect(is(value, InputStruct)).toBe(false);
   });

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -250,9 +250,9 @@ export const InputStruct: Describe<InputElement> = refine(
     ),
     value: optional(string()),
     placeholder: optional(string()),
-    min: optional(string()),
-    max: optional(string()),
-    step: optional(string()),
+    min: optional(number()),
+    max: optional(number()),
+    step: optional(number()),
   }),
   'Input',
   (value) => {

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -242,14 +242,33 @@ export const CheckboxStruct: Describe<CheckboxElement> = element('Checkbox', {
 /**
  * A struct for the {@link InputElement} type.
  */
-export const InputStruct: Describe<InputElement> = element('Input', {
-  name: string(),
-  type: optional(
-    nullUnion([literal('text'), literal('password'), literal('number')]),
-  ),
-  value: optional(string()),
-  placeholder: optional(string()),
-});
+export const InputStruct: Describe<InputElement> = refine(
+  element('Input', {
+    name: string(),
+    type: optional(
+      nullUnion([literal('text'), literal('password'), literal('number')]),
+    ),
+    value: optional(string()),
+    placeholder: optional(string()),
+    min: optional(string()),
+    max: optional(string()),
+    step: optional(string()),
+  }),
+  'Input',
+  (value) => {
+    if (value.props.type !== 'number') {
+      if (
+        hasProperty(value.props, 'min') ||
+        hasProperty(value.props, 'max') ||
+        hasProperty(value.props, 'step')
+      ) {
+        return 'The `min`, `max`, and `step` props are only applicable to number inputs.';
+      }
+    }
+
+    return true;
+  },
+);
 
 /**
  * A struct for the {@link OptionElement} type.

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -256,14 +256,13 @@ export const InputStruct: Describe<InputElement> = refine(
   }),
   'Input',
   (value) => {
-    if (value.props.type !== 'number') {
-      if (
-        hasProperty(value.props, 'min') ||
+    if (
+      value.props.type !== 'number' &&
+      (hasProperty(value.props, 'min') ||
         hasProperty(value.props, 'max') ||
-        hasProperty(value.props, 'step')
-      ) {
-        return 'The `min`, `max`, and `step` props are only applicable to number inputs.';
-      }
+        hasProperty(value.props, 'step'))
+    ) {
+      return 'The `min`, `max`, and `step` props are only applicable to number inputs.';
     }
 
     return true;

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -300,6 +300,9 @@ export const NumberInputPropsStruct = assign(
   }),
 );
 
+/**
+ * A struct for the {@link InputElement} type.
+ */
 export const InputStruct: Describe<InputElement> = elementWithSelectiveProps(
   'Input',
   (value) => {

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -18,6 +18,7 @@ import {
   string,
   tuple,
   refine,
+  assign,
 } from '@metamask/superstruct';
 import {
   CaipAccountIdStruct,
@@ -195,6 +196,24 @@ function element<Name extends string, Props extends ObjectSchema = EmptyObject>(
 }
 
 /**
+ * A helper function for creating a struct for a JSX element with selective props.
+ *
+ * @param name - The name of the element.
+ * @param selector - The selector function choosing the struct to validate with.
+ * @returns The struct for the element.
+ */
+function elementWithSelectiveProps<
+  Name extends string,
+  Selector extends (value: any) => AnyStruct,
+>(name: Name, selector: Selector) {
+  return object({
+    type: literal(name) as unknown as Struct<Name, Name>,
+    props: selectiveUnion(selector),
+    key: nullable(KeyStruct),
+  });
+}
+
+/**
  * A struct for the {@link ImageElement} type.
  */
 export const ImageStruct: Describe<ImageElement> = element('Image', {
@@ -240,32 +259,63 @@ export const CheckboxStruct: Describe<CheckboxElement> = element('Checkbox', {
 });
 
 /**
- * A struct for the {@link InputElement} type.
+ * A struct for the generic input element props.
  */
-export const InputStruct: Describe<InputElement> = refine(
-  element('Input', {
-    name: string(),
-    type: optional(
-      nullUnion([literal('text'), literal('password'), literal('number')]),
-    ),
-    value: optional(string()),
-    placeholder: optional(string()),
+export const GenericInputPropsStruct = object({
+  name: string(),
+  value: optional(string()),
+  placeholder: optional(string()),
+});
+
+/**
+ * A struct for the text type input props.
+ */
+export const TextInputPropsStruct = assign(
+  GenericInputPropsStruct,
+  object({
+    type: literal('text'),
+  }),
+);
+
+/**
+ * A struct for the password type input props.
+ */
+export const PasswordInputPropsStruct = assign(
+  GenericInputPropsStruct,
+  object({
+    type: literal('password'),
+  }),
+);
+
+/**
+ * A struct for the number type input props.
+ */
+export const NumberInputPropsStruct = assign(
+  GenericInputPropsStruct,
+  object({
+    type: literal('number'),
     min: optional(number()),
     max: optional(number()),
     step: optional(number()),
   }),
+);
+
+export const InputStruct: Describe<InputElement> = elementWithSelectiveProps(
   'Input',
   (value) => {
-    if (
-      value.props.type !== 'number' &&
-      (hasProperty(value.props, 'min') ||
-        hasProperty(value.props, 'max') ||
-        hasProperty(value.props, 'step'))
-    ) {
-      return 'The `min`, `max`, and `step` props are only applicable to number inputs.';
+    if (isPlainObject(value) && hasProperty(value, 'type')) {
+      switch (value.type) {
+        case 'text':
+          return TextInputPropsStruct;
+        case 'password':
+          return PasswordInputPropsStruct;
+        case 'number':
+          return NumberInputPropsStruct;
+        default:
+          return GenericInputPropsStruct;
+      }
     }
-
-    return true;
+    return GenericInputPropsStruct;
   },
 );
 


### PR DESCRIPTION
This PR adds the `min`, `max` and `step` props to the `Input` component of type `number`.