### PR TITLE
fix: Ignore Snap insight response if transaction/signature has already been signed

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 92.62,
+  "branches": 92.63,
   "functions": 96.65,
   "lines": 97.97,
   "statements": 97.67

--- a/packages/snaps-controllers/src/insights/SnapInsightsController.ts
+++ b/packages/snaps-controllers/src/insights/SnapInsightsController.ts
@@ -390,6 +390,12 @@ export class SnapInsightsController extends BaseController<
     response?: Record<string, Json>;
     error?: Error;
   }) {
+    // If the insight has been cleaned up already, we can skip setting the state.
+    // This may happen if a user accepts/rejects a transaction/signature faster than the Snap responds.
+    if (!this.#hasInsight(id)) {
+      return;
+    }
+
     this.update((state) => {
       state.insights[id][snapId].loading = false;
       state.insights[id][snapId].interfaceId = response?.id as string;


### PR DESCRIPTION
Ignore Snap insight responses when a transaction/signature has already been signed/rejected. Otherwise, we are trying to set state that no longer exists.

Fixes https://github.com/MetaMask/metamask-extension/issues/27738