### PR TITLE
Add support for button `form` property in `snaps-simulation`

### DIFF
--- a/packages/snaps-simulation/src/interface.test.tsx
+++ b/packages/snaps-simulation/src/interface.test.tsx
@@ -27,6 +27,7 @@ import {
   SelectorOption,
   Card,
   Selector,
+  Field,
 } from '@metamask/snaps-sdk/jsx';
 import {
   getJsxElementFromComponent,
@@ -446,6 +447,31 @@ describe('getElement', () => {
       form: 'form-2',
     });
   });
+
+  it('gets a button with a form property', () => {
+    const content = (
+      <Box>
+        <Form name="referenced-form">
+          <Field>
+            <Input name="input" />
+          </Field>
+        </Form>
+        <Button name="button" type="submit" form="referenced-form">
+          foo
+        </Button>
+      </Box>
+    );
+    const result = getElement(content, 'button');
+
+    expect(result).toStrictEqual({
+      element: (
+        <Button name="button" type="submit" form="referenced-form">
+          foo
+        </Button>
+      ),
+      form: 'referenced-form',
+    });
+  });
 });
 
 describe('clickElement', () => {
@@ -546,6 +572,71 @@ describe('clickElement', () => {
             name: 'bar',
             value: {
               foo: 'foo',
+            },
+          },
+          id: interfaceId,
+          context: null,
+        },
+      },
+    });
+  });
+
+  it('sends a `FormSubmitEvent` to the Snap for a button with a form property', async () => {
+    const content = (
+      <Box>
+        <Form name="referenced-form">
+          <Field>
+            <Input name="input" />
+          </Field>
+        </Form>
+        <Button name="button" type="submit" form="referenced-form">
+          foo
+        </Button>
+      </Box>
+    );
+
+    const interfaceId = await interfaceController.createInterface(
+      MOCK_SNAP_ID,
+      content,
+    );
+
+    await clickElement(
+      rootControllerMessenger,
+      interfaceId,
+      content,
+      MOCK_SNAP_ID,
+      'button',
+    );
+
+    expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
+      origin: '',
+      handler: HandlerType.OnUserInput,
+      request: {
+        jsonrpc: '2.0',
+        method: ' ',
+        params: {
+          event: {
+            type: UserInputEventType.ButtonClickEvent,
+            name: 'button',
+          },
+          id: interfaceId,
+          context: null,
+        },
+      },
+    });
+
+    expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
+      origin: '',
+      handler: HandlerType.OnUserInput,
+      request: {
+        jsonrpc: '2.0',
+        method: ' ',
+        params: {
+          event: {
+            type: UserInputEventType.FormSubmitEvent,
+            name: 'referenced-form',
+            value: {
+              input: null,
             },
           },
           id: interfaceId,

--- a/packages/snaps-simulation/src/interface.ts
+++ b/packages/snaps-simulation/src/interface.ts
@@ -229,6 +229,26 @@ function getFormElement(form: FormElement, name: string) {
 }
 
 /**
+ * Get an object containing the element, and optional form that's associated
+ * with the element if any.
+ *
+ * @param element - The JSX element.
+ * @returns An object containing the element and optional form.
+ */
+function getElementWithOptionalForm(element: NamedJSXElement):
+  | {
+      element: NamedJSXElement;
+      form?: string;
+    }
+  | undefined {
+  if (element.type !== 'Button' || !element.props.form) {
+    return { element };
+  }
+
+  return { element, form: element.props.form };
+}
+
+/**
  * Get an element from a JSX tree with the given name.
  *
  * @param content - The interface content.
@@ -246,7 +266,7 @@ export function getElement(
     }
   | undefined {
   if (isJSXElementWithName(content, name)) {
-    return { element: content };
+    return getElementWithOptionalForm(content);
   }
 
   return walkJsx(content, (element) => {
@@ -255,7 +275,7 @@ export function getElement(
     }
 
     if (isJSXElementWithName(element, name)) {
-      return { element };
+      return getElementWithOptionalForm(element);
     }
 
     return undefined;

--- a/packages/snaps-simulation/src/interface.ts
+++ b/packages/snaps-simulation/src/interface.ts
@@ -235,12 +235,10 @@ function getFormElement(form: FormElement, name: string) {
  * @param element - The JSX element.
  * @returns An object containing the element and optional form.
  */
-function getElementWithOptionalForm(element: NamedJSXElement):
-  | {
-      element: NamedJSXElement;
-      form?: string;
-    }
-  | undefined {
+function getElementWithOptionalForm(element: NamedJSXElement): {
+  element: NamedJSXElement;
+  form?: string;
+} {
   if (element.type !== 'Button' || !element.props.form) {
     return { element };
   }


### PR DESCRIPTION
In #2712 we added a `form` property to the button component, but we didn't add support to `snaps-simulation`/`snaps-jest`. In this PR I've added some logic to `snaps-simulation` to support this prop, so that forms are submitted when a button is placed outside a form with this prop.