### PR TITLE
Add `sm` size variant to `Heading`

### DIFF
--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4Waitn0bnIxi/w96Dqni+0tHJkuPURlZznHkrdp2cPc=",
+    "shasum": "cpGbAa5I7Y1mBlhvQlq5Sj8KkB/UcsD5MEgaeFeyMmM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "27AQQByAFXL3KIpdFzj+ke9/98WSR8o8Fan72A4LuXg=",
+    "shasum": "v1nVnxArJyII7qfswvNyO/rW2hG89ZQgyttgPAUp1r8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-sdk/src/jsx/components/Heading.ts
+++ b/packages/snaps-sdk/src/jsx/components/Heading.ts
@@ -5,11 +5,11 @@ import { createSnapComponent } from '../component';
  * The props of the {@link Heading} component.
  *
  * @property children - The text to display in the heading.
- * @property size - The size of the heading.
+ * @property size - The size of the heading. Defaults to `sm`.
  */
 type HeadingProps = {
   children: StringElement;
-  size?: 'md' | 'lg' | undefined;
+  size?: 'sm' | 'md' | 'lg' | undefined;
 };
 
 const TYPE = 'Heading';
@@ -19,7 +19,7 @@ const TYPE = 'Heading';
  *
  * @param props - The props of the component.
  * @param props.children - The text to display in the heading.
- * @param props.size - The size of the heading.
+ * @param props.size - The size of the heading. Defaults to `sm`.
  * @returns A heading element.
  * @example
  * <Heading>Hello world!</Heading>

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -685,7 +685,7 @@ export const ValueStruct: Describe<ValueElement> = element('Value', {
  */
 export const HeadingStruct: Describe<HeadingElement> = element('Heading', {
   children: StringElementStruct,
-  size: optional(nullUnion([literal('md'), literal('lg')])),
+  size: optional(nullUnion([literal('sm'), literal('md'), literal('lg')])),
 });
 
 /**


### PR DESCRIPTION
This adds a new `size` variant to the `Heading` component `sm`. It is the default size of the heading