### PR TITLE
fix: Make `parseMetaMaskUrl` platform agnostic

### DIFF
--- a/packages/snaps-utils/src/url.ts
+++ b/packages/snaps-utils/src/url.ts
@@ -25,14 +25,17 @@ export function parseMetaMaskUrl(str: string): {
   path: string;
 } {
   const url = new URL(str);
-  const { pathname: path, protocol } = url;
+  const { protocol } = url;
   if (protocol !== 'metamask:') {
     throw new Error(
       `Unable to parse URL. Expected the protocol to be "metamask:", but received "${protocol}".`,
     );
   }
 
-  const [authority] = url.href.replace('metamask://', '').split('/');
+  const [authority, ...pathElements] = url.href
+    .replace('metamask://', '')
+    .split('/');
+  const path = pathElements.join('/');
 
   switch (authority) {
     case 'client':

--- a/packages/snaps-utils/src/url.ts
+++ b/packages/snaps-utils/src/url.ts
@@ -32,6 +32,8 @@ export function parseMetaMaskUrl(str: string): {
     );
   }
 
+  // The browser version of URL differs from the Node version so we rely on the href
+  // property to grab the relevant parts of the url instead of hostname and pathname
   const [authority, ...pathElements] = url.href
     .replace('metamask://', '')
     .split('/');

--- a/packages/snaps-utils/src/url.ts
+++ b/packages/snaps-utils/src/url.ts
@@ -25,12 +25,15 @@ export function parseMetaMaskUrl(str: string): {
   path: string;
 } {
   const url = new URL(str);
-  const { hostname: authority, pathname: path, protocol } = url;
+  const { pathname: path, protocol } = url;
   if (protocol !== 'metamask:') {
     throw new Error(
       `Unable to parse URL. Expected the protocol to be "metamask:", but received "${protocol}".`,
     );
   }
+
+  const [authority] = url.href.replace('metamask://', '').split('/');
+
   switch (authority) {
     case 'client':
       assert(

--- a/packages/snaps-utils/src/url.ts
+++ b/packages/snaps-utils/src/url.ts
@@ -35,7 +35,7 @@ export function parseMetaMaskUrl(str: string): {
   const [authority, ...pathElements] = url.href
     .replace('metamask://', '')
     .split('/');
-  const path = pathElements.join('/');
+  const path = `/${pathElements.join('/')}`;
 
   switch (authority) {
     case 'client':


### PR DESCRIPTION
`URL` in the browser does not populate the `hostname` property, additional logic is added to handle this.