### PR TITLE
Add `snap_getCurrencyRate` to `SnapMethods`

### DIFF
--- a/packages/snaps-sdk/src/types/methods/methods.ts
+++ b/packages/snaps-sdk/src/types/methods/methods.ts
@@ -68,8 +68,8 @@ export type SnapMethods = {
   snap_getBip32PublicKey: [GetBip32PublicKeyParams, GetBip32PublicKeyResult];
   snap_getBip44Entropy: [GetBip44EntropyParams, GetBip44EntropyResult];
   snap_getClientStatus: [GetClientStatusParams, GetClientStatusResult];
-  snap_getEntropy: [GetEntropyParams, GetEntropyResult];
   snap_getCurrencyRate: [GetCurrencyRateParams, GetCurrencyRateResult];
+  snap_getEntropy: [GetEntropyParams, GetEntropyResult];
   snap_getFile: [GetFileParams, GetFileResult];
   snap_getLocale: [GetLocaleParams, GetLocaleResult];
   snap_getPreferences: [GetPreferencesParams, GetPreferencesResult];

--- a/packages/snaps-sdk/src/types/methods/methods.ts
+++ b/packages/snaps-sdk/src/types/methods/methods.ts
@@ -20,6 +20,10 @@ import type {
   GetClientStatusParams,
   GetClientStatusResult,
 } from './get-client-status';
+import type {
+  GetCurrencyRateParams,
+  GetCurrencyRateResult,
+} from './get-currency-rate';
 import type { GetEntropyParams, GetEntropyResult } from './get-entropy';
 import type { GetFileParams, GetFileResult } from './get-file';
 import type {
@@ -65,6 +69,7 @@ export type SnapMethods = {
   snap_getBip44Entropy: [GetBip44EntropyParams, GetBip44EntropyResult];
   snap_getClientStatus: [GetClientStatusParams, GetClientStatusResult];
   snap_getEntropy: [GetEntropyParams, GetEntropyResult];
+  snap_getCurrencyRate: [GetCurrencyRateParams, GetCurrencyRateResult];
   snap_getFile: [GetFileParams, GetFileResult];
   snap_getLocale: [GetLocaleParams, GetLocaleResult];
   snap_getPreferences: [GetPreferencesParams, GetPreferencesResult];


### PR DESCRIPTION
This adds the types for the `snap_getCurrencyRate` method in `snaps-sdk`. It was forgotten in #2763 