### PR TITLE
perf: Stop validating JSON for stored state

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 92.67,
+  "branches": 92.73,
   "functions": 96.65,
-  "lines": 97.98,
-  "statements": 97.68
+  "lines": 97.99,
+  "statements": 97.69
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1759,7 +1759,9 @@ export class SnapController extends BaseController<
    */
   async #decryptSnapState(snapId: SnapId, state: string) {
     try {
-      const parsed = parseJson<EncryptionResult>(state);
+      // We assume that the state string here is valid JSON since we control serialization.
+      // This lets us skip JSON validation.
+      const parsed = JSON.parse(state) as EncryptionResult;
       const { salt, keyMetadata } = parsed;
       const useCache = this.#encryptor.isVaultUpdated(state);
       const { key } = await this.#getSnapEncryptionKey({

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -87,7 +87,6 @@ import {
   NpmSnapFileNames,
   OnNameLookupResponseStruct,
   getLocalizedSnapManifest,
-  parseJson,
   MAX_FILE_SIZE,
 } from '@metamask/snaps-utils';
 import type { Json, NonEmptyArray, SemVerRange } from '@metamask/utils';
@@ -101,7 +100,6 @@ import {
   hasProperty,
   inMilliseconds,
   isNonEmptyArray,
-  isValidJson,
   isValidSemVerRange,
   satisfiesVersionRange,
   timeSince,
@@ -1774,8 +1772,7 @@ export class SnapController extends BaseController<
       });
       const decryptedState = await this.#encryptor.decryptWithKey(key, parsed);
 
-      assert(isValidJson(decryptedState));
-
+      // We assume this to be valid JSON, since all RPC requests from a Snap are validated and sanitized.
       return decryptedState as Record<string, Json>;
     } catch {
       throw rpcErrors.internal({
@@ -1866,7 +1863,8 @@ export class SnapController extends BaseController<
     }
 
     if (!encrypted) {
-      return parseJson(state);
+      // For performance reasons, we do not validate that the state is JSON, since we control serialization.
+      return JSON.parse(state);
     }
 
     const decrypted = await this.#decryptSnapState(snapId, state);


### PR DESCRIPTION
Removes some validation checks when storing and retrieving state from `snap_manageState`. Since we have input sanitization on the Snap side, we can improve performance significantly when retrieving state by parsing it without additional validation.

Also improves performance slightly by not using `isVaultUpdated` as the sole check for caching (as that function can be somewhat expensive to call).