### PR TITLE
perf: Remove unnecessary proxy for provider globals

### DIFF
--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 80.27,
-  "functions": 90.13,
-  "lines": 90.77,
-  "statements": 90.15
+  "branches": 80.55,
+  "functions": 89.26,
+  "lines": 90.66,
+  "statements": 90.05
 }

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -4,7 +4,7 @@ import { createIdRemapMiddleware } from '@metamask/json-rpc-engine';
 import type { RequestArguments } from '@metamask/providers';
 import { StreamProvider } from '@metamask/providers/stream-provider';
 import { errorCodes, rpcErrors, serializeError } from '@metamask/rpc-errors';
-import type { SnapsProvider } from '@metamask/snaps-sdk';
+import type { SnapsEthereumProvider, SnapsProvider } from '@metamask/snaps-sdk';
 import { getErrorData } from '@metamask/snaps-sdk';
 import type {
   SnapExports,
@@ -45,7 +45,6 @@ import {
   assertEthereumOutboundRequest,
   assertSnapOutboundRequest,
   sanitizeRequestArguments,
-  proxyStreamProvider,
   withTeardown,
   isValidResponse,
 } from './utils';
@@ -500,9 +499,9 @@ export class BaseSnapExecutor {
       );
     };
 
-    const snapGlobalProxy = proxyStreamProvider(request) as SnapsProvider;
+    const snapsProvider = { request } as SnapsProvider;
 
-    return harden(snapGlobalProxy);
+    return harden(snapsProvider);
   }
 
   /**
@@ -511,7 +510,9 @@ export class BaseSnapExecutor {
    * @param provider - A StreamProvider connected to MetaMask.
    * @returns The EIP-1193 Ethereum provider object.
    */
-  private createEIP1193Provider(provider: StreamProvider): StreamProvider {
+  private createEIP1193Provider(
+    provider: StreamProvider,
+  ): SnapsEthereumProvider {
     const originalRequest = provider.request.bind(provider);
 
     const request = async (args: RequestArguments) => {
@@ -537,9 +538,9 @@ export class BaseSnapExecutor {
       );
     };
 
-    const streamProviderProxy = proxyStreamProvider(request);
+    const ethereumProvider = { request };
 
-    return harden(streamProviderProxy);
+    return harden(ethereumProvider);
   }
 
   /**

--- a/packages/snaps-execution-environments/src/common/endowments/index.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.ts
@@ -1,6 +1,5 @@
-import type { StreamProvider } from '@metamask/providers';
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { SnapsProvider } from '@metamask/snaps-sdk';
+import type { SnapsEthereumProvider, SnapsProvider } from '@metamask/snaps-sdk';
 import { logWarning } from '@metamask/snaps-utils';
 import { hasProperty } from '@metamask/utils';
 
@@ -62,7 +61,7 @@ export function createEndowments({
   notify,
 }: {
   snap: SnapsProvider;
-  ethereum: StreamProvider;
+  ethereum: SnapsEthereumProvider;
   snapId: string;
   endowments: string[];
   notify: NotifyFunction;

--- a/packages/snaps-execution-environments/src/common/test-utils/endowments.ts
+++ b/packages/snaps-execution-environments/src/common/test-utils/endowments.ts
@@ -4,13 +4,10 @@ import { createIdRemapMiddleware } from '@metamask/json-rpc-engine';
 import ObjectMultiplex from '@metamask/object-multiplex';
 import type { RequestArguments } from '@metamask/providers';
 import { StreamProvider } from '@metamask/providers/stream-provider';
+import type { SnapsEthereumProvider } from '@metamask/snaps-sdk';
 import { SNAP_STREAM_NAMES } from '@metamask/snaps-utils';
 
-import {
-  assertEthereumOutboundRequest,
-  proxyStreamProvider,
-  withTeardown,
-} from '../utils';
+import { assertEthereumOutboundRequest, withTeardown } from '../utils';
 import { SILENT_LOGGER } from './logger';
 
 /**
@@ -42,7 +39,7 @@ export function walkAndSearch(subject: unknown, target: unknown) {
  *
  * @returns Proxy to StreamProvider instance.
  */
-export function getMockedStreamProvider() {
+export function getMockedStreamProvider(): SnapsEthereumProvider {
   const mux = new ObjectMultiplex();
   const rpcStream = mux.createStream(SNAP_STREAM_NAMES.JSON_RPC);
 
@@ -59,5 +56,5 @@ export function getMockedStreamProvider() {
     return await withTeardown(originalRequest(args), { lastTeardown: 0 });
   };
 
-  return proxyStreamProvider(request);
+  return { request };
 }

--- a/packages/snaps-execution-environments/src/common/utils.ts
+++ b/packages/snaps-execution-environments/src/common/utils.ts
@@ -1,4 +1,4 @@
-import type { StreamProvider, RequestArguments } from '@metamask/providers';
+import type { RequestArguments } from '@metamask/providers';
 import { rpcErrors } from '@metamask/rpc-errors';
 import { assert, getJsonSize, getSafeJson, isObject } from '@metamask/utils';
 
@@ -44,35 +44,6 @@ export async function withTeardown<Type>(
         }
       });
   });
-}
-
-/**
- * Returns a Proxy that only allows access to a `request` function.
- * This is useful for replacing StreamProvider with an attenuated version.
- *
- * @param request - Custom attenuated request function.
- * @returns Proxy that mimics a StreamProvider instance.
- */
-export function proxyStreamProvider(request: unknown): StreamProvider {
-  // Proxy target is intentionally set to be an empty object, to ensure
-  // that access to the prototype chain is not possible.
-  const proxy = new Proxy(
-    {},
-    {
-      has(_target: object, prop: string | symbol) {
-        return typeof prop === 'string' && ['request'].includes(prop);
-      },
-      get(_target, prop: keyof StreamProvider) {
-        if (prop === 'request') {
-          return request;
-        }
-
-        return undefined;
-      },
-    },
-  );
-
-  return proxy as StreamProvider;
 }
 
 // We're blocking these RPC methods for v1, will revisit later.


### PR DESCRIPTION
Removes unnecessary proxy wrapping of provider globals to reduce complexity and overhead.