### PR TITLE
chore: Add Kadena derivation path

### DIFF
--- a/packages/snaps-utils/src/derivation-paths.ts
+++ b/packages/snaps-utils/src/derivation-paths.ts
@@ -175,6 +175,11 @@ export const SNAPS_DERIVATION_PATHS: SnapsDerivationPath[] = [
     curve: 'secp256k1',
     name: 'Avail',
   },
+  {
+    path: ['m', `44'`, `626'`],
+    curve: 'ed25519',
+    name: 'Kadena',
+  },
 ];
 
 /**


### PR DESCRIPTION
Add Kadena to list of known derivation paths.

Fixes https://github.com/MetaMask/MetaMask-planning/issues/3527