### PR TITLE
fix: Use regular import to reference package.json

### DIFF
--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -2,5 +2,5 @@
   "branches": 99.74,
   "functions": 98.93,
   "lines": 99.46,
-  "statements": 96.36
+  "statements": 96.37
 }

--- a/packages/snaps-utils/src/platform-version.ts
+++ b/packages/snaps-utils/src/platform-version.ts
@@ -1,3 +1,5 @@
+import packageJson from '@metamask/snaps-sdk/package.json';
+
 /**
  * Get the current supported platform version.
  *
@@ -8,6 +10,5 @@
  * @returns The platform version.
  */
 export function getPlatformVersion() {
-  // eslint-disable-next-line import/no-dynamic-require, @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-  return require('@metamask/snaps-sdk/package.json').version;
+  return packageJson.version;
 }


### PR DESCRIPTION
Use regular import to reference the package.json of the SDK. This makes referencing the JSON work in the browser as well when using ESM.