### PR TITLE
fix: Add line beginning to origin regex

### DIFF
--- a/packages/snaps-utils/src/json-rpc.test.ts
+++ b/packages/snaps-utils/src/json-rpc.test.ts
@@ -161,6 +161,15 @@ describe('isOriginAllowed', () => {
     expect(isOriginAllowed(origins, SubjectType.Website, 'bar')).toBe(false);
   });
 
+  it('matches full string', () => {
+    const origins: RpcOrigins = {
+      allowedOrigins: ['https://metamask.io'],
+    };
+    expect(
+      isOriginAllowed(origins, SubjectType.Website, 'https://notmetamask.io'),
+    ).toBe(false);
+  });
+
   it('supports wildcards', () => {
     const origins: RpcOrigins = {
       allowedOrigins: ['*'],
@@ -195,7 +204,7 @@ describe('isOriginAllowed', () => {
 
   it('supports partial strings with wildcards', () => {
     const origins: RpcOrigins = {
-      allowedOrigins: ['*.metamask.io'],
+      allowedOrigins: ['https://*.metamask.io'],
     };
 
     expect(
@@ -219,7 +228,7 @@ describe('isOriginAllowed', () => {
 
   it('supports multiple wildcards', () => {
     const origins: RpcOrigins = {
-      allowedOrigins: ['*.metamask.*'],
+      allowedOrigins: ['https://*.metamask.*'],
     };
 
     expect(

--- a/packages/snaps-utils/src/json-rpc.ts
+++ b/packages/snaps-utils/src/json-rpc.ts
@@ -115,7 +115,7 @@ function createOriginRegExp(matcher: string) {
   const escaped = matcher.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
   // Support wildcards
   const regex = escaped.replace(/\\\*/gu, '.*');
-  return RegExp(`${regex}$`, 'u');
+  return RegExp(`^${regex}$`, 'u');
 }
 
 /**


### PR DESCRIPTION
Add line beginning to regex to prevent incorrect matches with certain types of origins.