### PR TITLE
fix: Ignore query strings when parsing URLs

### DIFF
--- a/packages/snaps-cli/src/webpack/server.test.ts
+++ b/packages/snaps-cli/src/webpack/server.test.ts
@@ -227,6 +227,34 @@ describe('getServer', () => {
     await close();
   });
 
+  it('ignores query strings', async () => {
+    const config = getMockConfig('webpack', {
+      input: 'src/index.js',
+      server: {
+        root: '/foo',
+        port: 0,
+      },
+    });
+
+    const server = getServer(config);
+    const { port, close } = await server.listen();
+
+    const response = await fetch(
+      `http://localhost:${port}/snap.manifest.json?_=1731493314736`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('');
+
+    expect(serveMiddleware).toHaveBeenCalledWith(
+      expect.any(IncomingMessage),
+      expect.any(ServerResponse),
+      expect.objectContaining({ public: expect.stringContaining('foo') }),
+    );
+
+    await close();
+  });
+
   it('responds with 404 for non-allowed files', async () => {
     const config = getMockConfig('webpack', {
       input: 'src/index.js',

--- a/packages/snaps-cli/src/webpack/server.ts
+++ b/packages/snaps-cli/src/webpack/server.ts
@@ -113,7 +113,11 @@ export function getServer(config: ProcessedConfig) {
     const { result } = await readJsonFile<SnapManifest>(manifestPath);
     const allowedPaths = getAllowedPaths(config, result);
 
-    const path = request.url?.slice(1);
+    const pathname =
+      request.url &&
+      request.headers.host &&
+      new URL(request.url, `http://${request.headers.host}`).pathname;
+    const path = pathname?.slice(1);
     const allowed = allowedPaths.some((allowedPath) => path === allowedPath);
 
     if (!allowed) {


### PR DESCRIPTION
Mobile uses a polyfill for fetch that adds certain query strings to fetch URLs, this breaks our CLI server implementation as it doesn't expect query strings. This PR changes the server implementation to ignore query strings and only look at `pathname`.