### PR TITLE
fix: Make `ResponseWrapper` an instance of `Response`

### DIFF
--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 80,
-  "functions": 90.06,
+  "branches": 80.27,
+  "functions": 90.13,
   "lines": 90.77,
   "statements": 90.15
 }

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 80,
   "functions": 90.06,
-  "lines": 90.75,
-  "statements": 90.12
+  "lines": 90.77,
+  "statements": 90.15
 }

--- a/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
@@ -227,10 +227,8 @@ describe('endowments', () => {
           new ResponseWrapper(
             new Response(),
             { lastTeardown: 0 },
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            async () => {},
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            async () => {},
+            async () => undefined,
+            async () => undefined,
           ),
       },
     };

--- a/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
@@ -12,7 +12,7 @@ import CryptoEndowment from './crypto';
 import date from './date';
 import interval from './interval';
 import math from './math';
-import network from './network';
+import network, { ResponseWrapper } from './network';
 import timeout from './timeout';
 
 // @ts-expect-error - `globalThis.process` is not optional.
@@ -217,6 +217,21 @@ describe('endowments', () => {
       fetchAttenuated: {
         endowments: { fetchAttenuated },
         factory: () => undefined,
+      },
+      ResponseWrapper: {
+        endowments: {
+          Response: ResponseHardened,
+          ResponseWrapper: harden(ResponseWrapper),
+        },
+        factory: () =>
+          new ResponseWrapper(
+            new Response(),
+            { lastTeardown: 0 },
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            async () => {},
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            async () => {},
+          ),
       },
     };
 

--- a/packages/snaps-execution-environments/src/common/endowments/network.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/network.test.ts
@@ -1,6 +1,6 @@
 import fetchMock from 'jest-fetch-mock';
 
-import network from './network';
+import network, { ResponseWrapper } from './network';
 
 describe('Network endowments', () => {
   beforeAll(() => {
@@ -187,7 +187,7 @@ describe('Network endowments', () => {
       const clonedResult = result.clone();
       expect(clonedResult).toBeDefined();
       expect(await clonedResult.text()).toBe(RESULT);
-      expect(clonedResult).not.toBeInstanceOf(Response);
+      expect(clonedResult).toBeInstanceOf(ResponseWrapper);
     });
 
     it('should return when json is called', async () => {

--- a/packages/snaps-execution-environments/src/common/endowments/network.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/network.test.ts
@@ -180,13 +180,14 @@ describe('Network endowments', () => {
       const RESULT = 'OK';
       fetchMock.mockOnce(async () => Promise.resolve(RESULT));
 
-      const { fetch } = network.factory(factoryOptions);
+      const { fetch, Response } = network.factory(factoryOptions);
       const result = await fetch('foo.com');
 
       expect(result.bodyUsed).toBe(false);
       const clonedResult = result.clone();
       expect(clonedResult).toBeDefined();
       expect(await clonedResult.text()).toBe(RESULT);
+      expect(clonedResult).toBeInstanceOf(Response);
       expect(clonedResult).toBeInstanceOf(ResponseWrapper);
     });
 

--- a/packages/snaps-execution-environments/src/common/endowments/network.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/network.ts
@@ -7,7 +7,7 @@ import type { EndowmentFactoryOptions } from './commonEndowmentFactory';
  * This class wraps a Response object.
  * That way, a teardown process can stop any processes left.
  */
-export class ResponseWrapper {
+export class ResponseWrapper implements Response {
   readonly #teardownRef: { lastTeardown: number };
 
   #ogResponse: Response;

--- a/packages/snaps-execution-environments/src/common/endowments/network.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/network.ts
@@ -145,8 +145,11 @@ export class ResponseWrapper implements Response {
   }
 }
 
+// We redefine the global Response class to overwrite [Symbol.hasInstance].
+// This fixes problems where the response from `fetch` would not pass
+// instance of checks, leading to failures in WASM bindgen.
 class AlteredResponse extends Response {
-  static [Symbol.hasInstance](instance: any) {
+  static [Symbol.hasInstance](instance: unknown) {
     return instance instanceof Response || instance instanceof ResponseWrapper;
   }
 }

--- a/packages/snaps-execution-environments/src/common/endowments/network.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/network.ts
@@ -7,7 +7,7 @@ import type { EndowmentFactoryOptions } from './commonEndowmentFactory';
  * This class wraps a Response object.
  * That way, a teardown process can stop any processes left.
  */
-class ResponseWrapper implements Response {
+export class ResponseWrapper extends Response {
   readonly #teardownRef: { lastTeardown: number };
 
   #ogResponse: Response;
@@ -22,6 +22,7 @@ class ResponseWrapper implements Response {
     onStart: () => Promise<void>,
     onFinish: () => Promise<void>,
   ) {
+    super();
     this.#ogResponse = ogResponse;
     this.#teardownRef = teardownRef;
     this.#onStart = onStart;

--- a/packages/snaps-execution-environments/src/common/endowments/network.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/network.ts
@@ -7,7 +7,7 @@ import type { EndowmentFactoryOptions } from './commonEndowmentFactory';
  * This class wraps a Response object.
  * That way, a teardown process can stop any processes left.
  */
-export class ResponseWrapper extends Response {
+export class ResponseWrapper {
   readonly #teardownRef: { lastTeardown: number };
 
   #ogResponse: Response;
@@ -22,7 +22,6 @@ export class ResponseWrapper extends Response {
     onStart: () => Promise<void>,
     onFinish: () => Promise<void>,
   ) {
-    super();
     this.#ogResponse = ogResponse;
     this.#teardownRef = teardownRef;
     this.#onStart = onStart;
@@ -143,6 +142,12 @@ export class ResponseWrapper extends Response {
       })(),
       this.#teardownRef,
     );
+  }
+}
+
+class AlteredResponse extends Response {
+  static [Symbol.hasInstance](instance: any) {
+    return instance instanceof Response || instance instanceof ResponseWrapper;
   }
 }
 
@@ -298,7 +303,7 @@ const createNetwork = ({ notify }: EndowmentFactoryOptions = {}) => {
     // These endowments are not (and should never be) available by default.
     Request: harden(Request),
     Headers: harden(Headers),
-    Response: harden(Response),
+    Response: harden(AlteredResponse),
     teardownFunction,
   };
 };


### PR DESCRIPTION
Overwrite `[Symbol.hasInstance]` on the exposed `Response` class slightly to make `ResponseWrapper` pass `instanceof` checks. This prevents `fetch` responses from failing when using WASM bindgen for instance.

Fixes https://github.com/MetaMask/snaps/issues/2891