### PR TITLE
fix: Add `isSecureContext` endowment

### DIFF
--- a/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
@@ -42,6 +42,7 @@ const commonEndowments: CommonEndowmentSpecification[] = [
   { endowment: Int8Array, name: 'Int8Array' },
   { endowment: Int16Array, name: 'Int16Array' },
   { endowment: Int32Array, name: 'Int32Array' },
+  { endowment: globalThis.isSecureContext, name: 'isSecureContext' },
   { endowment: Uint8Array, name: 'Uint8Array' },
   { endowment: Uint8ClampedArray, name: 'Uint8ClampedArray' },
   { endowment: Uint16Array, name: 'Uint16Array' },

--- a/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
@@ -177,6 +177,12 @@ describe('endowments', () => {
         factory: () => WebAssembly,
       },
 
+      // Properties
+      isSecureContext: {
+        endowments: { isSecureContext: globalThis.isSecureContext },
+        factory: () => globalThis.isSecureContext,
+      },
+
       // Functions.
       atob: {
         endowments: { atob },
@@ -357,6 +363,10 @@ describe('endowments', () => {
         {
           factory: expect.any(Function),
           names: ['Int32Array'],
+        },
+        {
+          factory: expect.any(Function),
+          names: ['isSecureContext'],
         },
         {
           factory: expect.any(Function),

--- a/packages/snaps-simulation/src/methods/specifications.test.ts
+++ b/packages/snaps-simulation/src/methods/specifications.test.ts
@@ -333,6 +333,7 @@ describe('getEndowments', () => {
         "Int16Array",
         "Uint16Array",
         "Int32Array",
+        "isSecureContext",
         "Uint32Array",
         "Float32Array",
         "Float64Array",

--- a/packages/snaps-utils/src/default-endowments.ts
+++ b/packages/snaps-utils/src/default-endowments.ts
@@ -23,6 +23,7 @@ export const DEFAULT_ENDOWMENTS: readonly string[] = Object.freeze([
   'Int16Array',
   'Uint16Array',
   'Int32Array',
+  'isSecureContext',
   'Uint32Array',
   'Float32Array',
   'Float64Array',


### PR DESCRIPTION
Adds `isSecureContext` for the browser environments, this will continue to be undefined in the Node.js environment.

Fixes https://github.com/MetaMask/snaps/issues/2890