### PR TITLE
feat: Emit `snapInstalled` and `snapUpdated` for preinstalled Snaps

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 92.85,
+  "branches": 92.89,
   "functions": 96.71,
   "lines": 98,
-  "statements": 97.7
+  "statements": 97.71
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -966,6 +966,7 @@ describe('SnapController', () => {
       'SnapController:snapInstalled',
       getTruncatedSnap(),
       MOCK_ORIGIN,
+      false,
     );
 
     snapController.destroy();
@@ -4665,6 +4666,7 @@ describe('SnapController', () => {
     it('supports preinstalled snaps', async () => {
       const rootMessenger = getControllerMessenger();
       jest.spyOn(rootMessenger, 'call');
+      jest.spyOn(rootMessenger, 'publish');
 
       // The snap should not have permission initially
       rootMessenger.registerActionHandler(
@@ -4709,6 +4711,13 @@ describe('SnapController', () => {
           },
           subject: { origin: MOCK_SNAP_ID },
         },
+      );
+
+      expect(rootMessenger.publish).toHaveBeenCalledWith(
+        'SnapController:snapInstalled',
+        getTruncatedSnap(),
+        'metamask',
+        true,
       );
 
       // After install the snap should have permissions
@@ -4880,6 +4889,7 @@ describe('SnapController', () => {
     it('supports updating preinstalled snaps', async () => {
       const rootMessenger = getControllerMessenger();
       jest.spyOn(rootMessenger, 'call');
+      jest.spyOn(rootMessenger, 'publish');
 
       const preinstalledSnaps = [
         {
@@ -4932,6 +4942,21 @@ describe('SnapController', () => {
           },
           subject: { origin: MOCK_SNAP_ID },
         },
+      );
+
+      expect(rootMessenger.publish).toHaveBeenCalledWith(
+        'SnapController:snapUpdated',
+        getTruncatedSnap({
+          version: '1.2.3',
+          initialPermissions: {
+            'endowment:rpc': { dapps: false, snaps: true },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            snap_getEntropy: {},
+          },
+        }),
+        '1.0.0',
+        'metamask',
+        true,
       );
 
       // After install the snap should have permissions
@@ -5088,6 +5113,66 @@ describe('SnapController', () => {
           shasum: manifest.result.source.shasum,
         }),
       );
+
+      snapController.destroy();
+    });
+
+    it('disallows manual updates of preinstalled snaps', async () => {
+      const rootMessenger = getControllerMessenger();
+      jest.spyOn(rootMessenger, 'call');
+
+      // The snap should not have permissions initially
+      rootMessenger.registerActionHandler(
+        'PermissionController:getPermissions',
+        () => ({}),
+      );
+
+      const preinstalledSnaps = [
+        {
+          snapId: MOCK_SNAP_ID,
+          manifest: getSnapManifest(),
+          files: [
+            {
+              path: DEFAULT_SOURCE_PATH,
+              value: stringToBytes(DEFAULT_SNAP_BUNDLE),
+            },
+            {
+              path: DEFAULT_ICON_PATH,
+              value: stringToBytes(DEFAULT_SNAP_ICON),
+            },
+          ],
+        },
+      ];
+
+      const snapControllerOptions = getSnapControllerWithEESOptions({
+        preinstalledSnaps,
+        rootMessenger,
+      });
+      const [snapController] = getSnapControllerWithEES(snapControllerOptions);
+
+      // After install the snap should have permissions
+      rootMessenger.registerActionHandler(
+        'PermissionController:getPermissions',
+        () => MOCK_SNAP_PERMISSIONS,
+      );
+
+      const { manifest } = await getMockSnapFilesWithUpdatedChecksum({
+        manifest: getSnapManifest({
+          version: '1.1.0' as SemVerVersion,
+        }),
+      });
+
+      const detectSnapLocation = loopbackDetect({
+        manifest: manifest.result,
+      });
+
+      await expect(
+        snapController.updateSnap(
+          MOCK_ORIGIN,
+          MOCK_SNAP_ID,
+          detectSnapLocation(),
+        ),
+      ).rejects.toThrow('Preinstalled Snaps cannot be manually updated.');
 
       snapController.destroy();
     });
@@ -6772,6 +6857,7 @@ describe('SnapController', () => {
         newSnapTruncated,
         '1.0.0',
         MOCK_ORIGIN,
+        false,
       );
 
       controller.destroy();


### PR DESCRIPTION
Fixes an oversight where preinstalled Snaps would not emit `snapInstalled` and `snapUpdated`. This would cause lifecycle hooks among other things to not work. This PR also adds a `preinstalled` flag to the events, this will be necessary to not collect metrics for installation/update of preinstalled Snaps.

Additionally, this PR fixes an oversight where preinstalled Snaps could have the manual update flow triggered. For now, we disallow this behaviour.

Progresses https://github.com/MetaMask/snaps/issues/2899