### PR TITLE
Add `sol` to supported currency in `snap_getCurrencyRate`

### DIFF
--- a/packages/snaps-rpc-methods/src/permitted/getCurrencyRate.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getCurrencyRate.test.ts
@@ -148,7 +148,7 @@ describe('snap_getCurrencyRate', () => {
         error: {
           code: -32602,
           message:
-            'Invalid params: At path: currency -- Expected the value to satisfy a union of `literal`, but received: "eth".',
+            'Invalid params: At path: currency -- Expected the value to satisfy a union of `literal | literal`, but received: "eth".',
           stack: expect.any(String),
         },
         id: 1,

--- a/packages/snaps-rpc-methods/src/permitted/getCurrencyRate.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getCurrencyRate.ts
@@ -21,7 +21,7 @@ const hookNames: MethodHooksObject<GetCurrencyRateMethodHooks> = {
 export type GetCurrencyRateMethodHooks = {
   /**
    * @param currency - The currency symbol.
-   * Currently only 'btc' is supported.
+   * Currently only 'btc' and 'sol' are supported.
    * @returns The {@link CurrencyRate} object.
    */
   getCurrencyRate: (currency: AvailableCurrency) => CurrencyRate | undefined;
@@ -38,7 +38,7 @@ export const getCurrencyRateHandler: PermittedHandlerExport<
 };
 
 const GetCurrencyRateParametersStruct = object({
-  currency: union([currency('btc')]),
+  currency: union([currency('btc'), currency('sol')]),
 });
 
 export type GetCurrencyRateParameters = InferMatching<

--- a/packages/snaps-sdk/src/types/methods/get-currency-rate.ts
+++ b/packages/snaps-sdk/src/types/methods/get-currency-rate.ts
@@ -2,7 +2,7 @@ export type Currency<Value extends string> =
   | Lowercase<Value>
   | Uppercase<Value>;
 
-export type AvailableCurrency = Currency<'btc'>;
+export type AvailableCurrency = Currency<'btc'> | Currency<'sol'>;
 
 /**
  * The currency rate object.


### PR DESCRIPTION
This PR adds the `sol` to the supported currency union in `snap_getCurrencyRate` params