### PR TITLE
chore: Add link to notification example

### DIFF
--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FxFEoTtrqrgcIixfoilv0YsEofcugLh1ZNLpz1tz/us=",
+    "shasum": "SELpk82JtBQolxOnwrXlAG8OCIfDSP8tc1j7FZzA5ps=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/src/index.test.ts
+++ b/packages/examples/packages/notifications/src/index.test.ts
@@ -32,7 +32,7 @@ describe('onRpcRequest', () => {
 
       expect(response).toRespondWith(null);
       expect(response).toSendNotification(
-        'Hello from within MetaMask!',
+        'Hello from within MetaMask! [This](https://snaps.metamask.io/) is a what a link looks like.',
         NotificationType.InApp,
       );
     });

--- a/packages/examples/packages/notifications/src/index.ts
+++ b/packages/examples/packages/notifications/src/index.ts
@@ -24,7 +24,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
           // We're using the `NotificationType` enum here, but you can also use
           // the string values directly, e.g. `type: 'inApp'`.
           type: NotificationType.InApp,
-          message: `Hello from within MetaMask!`,
+          message: `Hello from within MetaMask! [This](https://snaps.metamask.io/) is a what a link looks like.`,
         },
       });
 


### PR DESCRIPTION
Adds an inline link to the notification example, this is helpful for testing purposes.

Progresses https://github.com/MetaMask/snaps/issues/2914