### PR TITLE
chore: Bump ts-bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/utils": "^10.0.0",
     "@swc/core": "1.3.78",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^27.5.1",
     "@types/lodash": "^4",
     "@types/node": "18.14.2",

--- a/packages/create-snap/package.json
+++ b/packages/create-snap/package.json
@@ -73,7 +73,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^27.5.1",
     "@types/node": "18.14.2",
     "@types/yargs": "^17.0.24",

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -70,7 +70,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/browserify": "^12.0.37",
     "@types/convert-source-map": "^1.5.2",
     "@types/jest": "^27.5.1",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -123,7 +123,7 @@
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/browserify": "^12.0.37",
     "@types/jest": "^27.5.1",
     "@types/node": "18.14.2",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -119,7 +119,7 @@
     "@metamask/template-snap": "^0.7.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/chrome": "^0.0.237",
     "@types/concat-stream": "^2.0.0",
     "@types/gunzip-maybe": "^1.4.0",

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -92,7 +92,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/express": "^4.17.17",
     "@types/jest": "^27.5.1",
     "@types/node": "18.14.2",

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -81,7 +81,7 @@
     "@metamask/snaps-utils": "workspace:^",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^27.5.1",
     "@types/semver": "^7.5.0",
     "@typescript-eslint/eslint-plugin": "^5.42.1",

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -69,7 +69,7 @@
     "@rollup/plugin-virtual": "^2.1.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^27.5.1",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^6.21.0",

--- a/packages/snaps-rpc-methods/package.json
+++ b/packages/snaps-rpc-methods/package.json
@@ -74,7 +74,7 @@
     "@metamask/json-rpc-engine": "^10.0.1",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/node": "18.14.2",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^6.21.0",

--- a/packages/snaps-sdk/package.json
+++ b/packages/snaps-sdk/package.json
@@ -104,7 +104,7 @@
     "@metamask/eslint-config-jest": "^12.1.0",
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^27.5.1",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^6.21.0",

--- a/packages/snaps-simulation/package.json
+++ b/packages/snaps-simulation/package.json
@@ -81,7 +81,7 @@
     "@metamask/eslint-config-jest": "^12.1.0",
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/express": "^4.17.17",
     "@types/jest": "^27.5.1",
     "@types/mime": "^3.0.0",

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -113,7 +113,7 @@
     "@metamask/post-message-stream": "^8.1.1",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^27.5.1",
     "@types/mocha": "^10.0.1",
     "@types/node": "18.14.2",

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -72,7 +72,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@swc/core": "1.3.78",
     "@swc/jest": "^0.2.26",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^27.5.1",
     "@types/webpack-sources": "^3.2.0",
     "@typescript-eslint/eslint-plugin": "^5.42.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4257,7 +4257,7 @@ __metadata:
     "@metamask/snaps-utils": "workspace:^"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^27.5.1"
     "@types/node": "npm:18.14.2"
     "@types/yargs": "npm:^17.0.24"
@@ -5574,7 +5574,7 @@ __metadata:
     "@metamask/snaps-utils": "workspace:^"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/browserify": "npm:^12.0.37"
     "@types/convert-source-map": "npm:^1.5.2"
     "@types/jest": "npm:^27.5.1"
@@ -5629,7 +5629,7 @@ __metadata:
     "@metamask/utils": "npm:^10.0.0"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/browserify": "npm:^12.0.37"
     "@types/jest": "npm:^27.5.1"
     "@types/node": "npm:18.14.2"
@@ -5730,7 +5730,7 @@ __metadata:
     "@metamask/utils": "npm:^10.0.0"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/chrome": "npm:^0.0.237"
     "@types/concat-stream": "npm:^2.0.0"
     "@types/gunzip-maybe": "npm:^1.4.0"
@@ -5824,7 +5824,7 @@ __metadata:
     "@metamask/utils": "npm:^10.0.0"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/express": "npm:^4.17.17"
     "@types/jest": "npm:^27.5.1"
     "@types/node": "npm:18.14.2"
@@ -5901,7 +5901,7 @@ __metadata:
     "@metamask/utils": "npm:^10.0.0"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^27.5.1"
     "@types/semver": "npm:^7.5.0"
     "@typescript-eslint/eslint-plugin": "npm:^5.42.1"
@@ -5955,7 +5955,7 @@ __metadata:
     "@rollup/plugin-virtual": "npm:^2.1.0"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^27.5.1"
     "@typescript-eslint/eslint-plugin": "npm:^5.42.1"
     "@typescript-eslint/parser": "npm:^6.21.0"
@@ -6001,7 +6001,7 @@ __metadata:
     "@noble/hashes": "npm:^1.3.1"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/node": "npm:18.14.2"
     "@typescript-eslint/eslint-plugin": "npm:^5.42.1"
     "@typescript-eslint/parser": "npm:^6.21.0"
@@ -6039,7 +6039,7 @@ __metadata:
     "@metamask/rpc-errors": "npm:^7.0.1"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^10.0.0"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^27.5.1"
     "@typescript-eslint/eslint-plugin": "npm:^5.42.1"
     "@typescript-eslint/parser": "npm:^6.21.0"
@@ -6090,7 +6090,7 @@ __metadata:
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^10.0.0"
     "@reduxjs/toolkit": "npm:^1.9.5"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/express": "npm:^4.17.17"
     "@types/jest": "npm:^27.5.1"
     "@types/mime": "npm:^3.0.0"
@@ -6259,7 +6259,7 @@ __metadata:
     "@scure/base": "npm:^1.1.1"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^27.5.1"
     "@types/mocha": "npm:^10.0.1"
     "@types/node": "npm:18.14.2"
@@ -6330,7 +6330,7 @@ __metadata:
     "@metamask/utils": "npm:^10.0.0"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^27.5.1"
     "@types/webpack-sources": "npm:^3.2.0"
     "@typescript-eslint/eslint-plugin": "npm:^5.42.1"
@@ -7469,9 +7469,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ts-bridge/cli@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@ts-bridge/cli@npm:0.6.0"
+"@ts-bridge/cli@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@ts-bridge/cli@npm:0.6.1"
   dependencies:
     "@ts-bridge/resolver": "npm:^0.2.0"
     chalk: "npm:^5.3.0"
@@ -7482,7 +7482,7 @@ __metadata:
   bin:
     ts-bridge: ./dist/index.js
     tsbridge: ./dist/index.js
-  checksum: 10/a23da563b99c56124538fbaf77a2d7a0ad01c898c86ab3be527e3dbe0b22f380daa9207bfeffd8591508ed878959ba168daf6197e06822ba8a3b62dfd7396dab
+  checksum: 10/1cbb8fbfc7f58b804553ab9bc06b689b409d4cdd0f1e960a0ea87971ec7885b5ee2a86cb192d955c7d3611afcadb960e7dfee66aeca60f798a70e7f97aa969c3
   languageName: node
   linkType: hard
 
@@ -20471,7 +20471,7 @@ __metadata:
     "@metamask/eslint-config-typescript": "npm:^12.1.0"
     "@metamask/utils": "npm:^10.0.0"
     "@swc/core": "npm:1.3.78"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^27.5.1"
     "@types/lodash": "npm:^4"
     "@types/node": "npm:18.14.2"


### PR DESCRIPTION
Bumps `ts-bridge` to the latest version, fixing some issues with processing CJS exports: https://github.com/ts-bridge/ts-bridge/commit/ce3394692cc7236d3baacbbb8b334a3ee20dc500