### PR TITLE
feat: Allow async initialization logic

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hRuh420QB8uksiS3rFwrvqNoQD5XTH/QyWkhFkmNBD8=",
+    "shasum": "dWCQ3BjoAmv1KlzbrNPRa4QlB3qSHQKL6ONaV0mo7b0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "kztNgPuBct9iJIGhWZs2i/yluGPJSQi0xl5+00opVGs=",
+    "shasum": "dqWYaxXKggEChwefUCTvipvNzQ+0KbaT6x8vRDW0miw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VvMm+Zet1+q467UNweIuLLtYVoHoJdTeNjZn0xnEwO8=",
+    "shasum": "2OhDjaajEbvT1LdHB1G/Jl9NpfRtJxYl87w1c+1eJck=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "U1D6XbPDJ3m50P5jpjrEKh18nmCtNsAu0Th4sgqMqPk=",
+    "shasum": "2apoRqY/ywA9P7gcTYwLsbxYFp8Tb7aNmT2bADL/13o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZjF3VIQyyZMjs7bCHZHcBqkkM4mxQjAHhxURv3bNdIg=",
+    "shasum": "8bB9qcVDzKQyefr78Cm03aTbojKKg5jQ4nkzZUccKhs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Mo4tLj3FLGjTrODhiznPVbTmqLdghRqKWaAEhPUmBmg=",
+    "shasum": "uZhYG9+3b1yA/94e0QhCJycqrPA96cBQyP+2plF0SEg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/errors/snap.manifest.json
+++ b/packages/examples/packages/errors/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "yBkP0yx/0fYCe3r3hglrIJJAXuxTgMpCsR0HMJ/KV7o=",
+    "shasum": "nBAHoKcN5GNzCeKU2UdH+/8auyBBq6z3NxRbcTSuKj4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "jb8yEH2CbYso7JvLwI2hxARfkiq1IXhGMJcD6xpGPrs=",
+    "shasum": "cFhK3nsekRxmXeas/P58bEzMVeLhbtp+ZeCDQ5LTtSs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "kgnGTfsOQs26Kb8oopMnEvXPmbOeDqy0BllLa9z5GCM=",
+    "shasum": "uVLwzYliwDATW6CiqATb1FyPgyagNs+3ini7QA+0okc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OeWGq3s0Anzwjj9wjWBtQQ+M2ArnYyo7iiJVb5I4NWg=",
+    "shasum": "14D89bvKXu2AM/k7XG9b7LhSxbf4mJq+8xdfpAAFXE8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "i70snr3mPw7knx20YaN64bYsJjEgaqNNDl01oFi4Bo4=",
+    "shasum": "1jPm8koZvt+Tme7DCtogqKfS+fR4SJnPU7N8r85ku1Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "IHFTR7r/ZFrWGriDCjtG4cIh1TnQ/DOJ9/7XvzBnaXA=",
+    "shasum": "xJ6zVUIFqDUR04wPM54X1H64TBQnJ5TWD1wol4ggBz0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "emnlXHvrhsGBMi/y1IPhiQPX9ogHmjmOU/iujBu5GB8=",
+    "shasum": "NyUuomb1PK2tdiQmOZyT0C+vugl6CamwZ6iS86tREHE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "KJTZWGggYaU8C3LnOd9CodSJoIMtvzkNKC5bzfMPg4M=",
+    "shasum": "PWtPR8sJIxj/6B8eLRvGjndi5udmdlWu6eKP4QWFOXg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "tjpxfy8rDCt+Qfl9RH+E+58FgwnkyN6WNHac2BzGH8A=",
+    "shasum": "il7JIqsKAL7HdA9TDvZ3uaZ2DmhrvG3/06VlWLZqY3I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "HICk/M3ngw+6Vc+5PD1z97BZ0+hIIb0OhZMB1gNlA3g=",
+    "shasum": "McFa4RUs1FqKkxa/srAwgV/6zph9wvinW1vfD8u/OA8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "g0lygIry0x1ULrACMgFTncUXfstO2l+7iM7/D65BXqY=",
+    "shasum": "QPxHqRPygXB1Z6M4XreZtw/im8wCEBJgEtLdkOtwob8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "fnBcv6jDxgrg7eGcfSt877oYlchyk3LOvWHXUarlMmM=",
+    "shasum": "mZmPwOndC6aSHcjT6+N6qNxtwBpXA88fE2+T7jg3/GA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "pwOggutOjvi9JIOQUsz3PtcWuIVeq88V8sM4H2Be+QE=",
+    "shasum": "s8bOADHqPUfTvQpQHBYauAnOLB9OUEVADsYyTUWJFMo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "U+ry3tQOBH2gb+WQYNBYTqKst27YLCCNPNrL3mzwxY8=",
+    "shasum": "lFAmVlA2xtorYkfuEClJwiSdLKvEvVx8bWDb3FaKdi4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Riel+Ad0p0CyhwwLM52UgkSx6BORsIoK3N6g5f/3Epw=",
+    "shasum": "Z1wvLAfqLXOmsioIaOk0nUIvWydYKYL99EICJOMY1Cg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "qPBUmh7sDOnakV5nawQSF5g4Z3Oq9SA0S7md02dV4NE=",
+    "shasum": "4F+GzRueJNZ90SaB6GnKyBFD2C3rGD3ZtEiHg+sEgcI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/name-lookup/snap.manifest.json
+++ b/packages/examples/packages/name-lookup/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xk7O5itVsuV3Dfldq3rI3WgggHa3z7HX7e17jzheE8w=",
+    "shasum": "pC2NRrOhYv4sUS7Vkx5As0A5F1rqcQwCWwnijZqCqSc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TTxdWj886/layHpYcL7oQMNqjur7dKuCGwQqoCwIZ+E=",
+    "shasum": "nRsZQCtNSsaFiu3rzF/ymnflq7ZQQwwm/KnQTBzwav4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZXgMRkK/FtEZlwVSdOC+dmP99tuBTqHx/2Mj/FNhzAg=",
+    "shasum": "uh0g/qoSTv4n3PQrESflSZbajX7GaGUZQkr4DxSSWsw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/preinstalled/snap.manifest.json
+++ b/packages/examples/packages/preinstalled/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "KbOfXRukEkbyCkPhl4rONcCB3Ih1YXLJK+2QV/WoKHE=",
+    "shasum": "adwoj6L+hZGsdmCh0Y/obHY00nAXHBoduUo9Gwtm+HE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/send-flow/snap.manifest.json
+++ b/packages/examples/packages/send-flow/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0oqDk8ELSuPUKhZ1e9kqw42QXW+hNMUtYIgThYsN0hk=",
+    "shasum": "eiwEi6JZTZnPkriRaoiuFQX37mSHsdJEzO5MDZJGqOg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hlMIB9kls/72D0A77vdvIkZEbJNUDj3Py9PIxm7aWOM=",
+    "shasum": "W7760+wNYB7ikWVHQeEx5IRAt+Q07Cq4zaYwmfCEqr8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "oKKYF+AERJAyRBABHRf4nsfQ6IrhKele+Fei+JXxGzA=",
+    "shasum": "FxEMWKtdMuijdmu4neAmXosp1zIiuvwzngv7U6t9eC4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "n/JVqBQfO2/1ojbBN1WFNddejGlTvGduO9VgxYGYQQg=",
+    "shasum": "YtnZetn37cq3RA2PdwjDBPOjvxDSAQ5vSzOqC2zjBNw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "t4uK/pnTJODpftadTGKumNIEqmSCTP0zb87aMLMqFt8=",
+    "shasum": "n/JVqBQfO2/1ojbBN1WFNddejGlTvGduO9VgxYGYQQg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-cli/src/commands/build/implementation.test.ts
+++ b/packages/snaps-cli/src/commands/build/implementation.test.ts
@@ -223,10 +223,13 @@ describe('build', () => {
     // deterministic.
     const deterministicOutput = output
       .replace(/var r=\{(\d+):/u, 'var r={1:')
-      .replace(/u.exports\}\(\d+\),t/u, 'u.exports}(1),t');
+      .replace(
+        /u.exports\}\(\d+\);module.exports/u,
+        'u.exports}(1);module.exports',
+      );
 
     expect(deterministicOutput).toMatchInlineSnapshot(
-      `"(()=>{var r={1:r=>{r.exports=function(){function r(o,t,e){function n(s,i){if(!t[s]){if(!o[s]){if(u)return u(s,!0);var c=new Error("Cannot find module '"+s+"'");throw c.code="MODULE_NOT_FOUND",c}var f=t[s]={exports:{}};o[s][0].call(f.exports,(function(r){return n(o[s][1][r]||r)}),f,f.exports,r,o,t,e)}return t[s].exports}for(var u=void 0,s=0;s<e.length;s++)n(e[s]);return n}return r}()({1:[function(r,o,t){"use strict";o.exports.onRpcRequest=({request:r})=>{console.log("Hello, world!");const{method:o,id:t}=r;return o+t}},{}]},{},[1])(1)}},o={};var t=function t(e){var n=o[e];if(void 0!==n)return n.exports;var u=o[e]={exports:{}};return r[e](u,u.exports,t),u.exports}(360);module.exports=t})();"`,
+      `"(()=>{var r={1:r=>{r.exports=function(){function r(o,t,e){function n(s,i){if(!t[s]){if(!o[s]){if(u)return u(s,!0);var c=new Error("Cannot find module '"+s+"'");throw c.code="MODULE_NOT_FOUND",c}var f=t[s]={exports:{}};o[s][0].call(f.exports,(function(r){return n(o[s][1][r]||r)}),f,f.exports,r,o,t,e)}return t[s].exports}for(var u=void 0,s=0;s<e.length;s++)n(e[s]);return n}return r}()({1:[function(r,o,t){"use strict";o.exports.onRpcRequest=({request:r})=>{console.log("Hello, world!");const{method:o,id:t}=r;return o+t}},{}]},{},[1])(1)}},o={};var t=function t(e){var n=o[e];if(void 0!==n)return n.exports;var u=o[e]={exports:{}};return r[e](u,u.exports,t),u.exports}(1);module.exports=t})();"`,
     );
   });
 

--- a/packages/snaps-cli/src/commands/build/implementation.test.ts
+++ b/packages/snaps-cli/src/commands/build/implementation.test.ts
@@ -129,7 +129,7 @@ describe('build', () => {
 
     const output = await fs.readFile('/snap/output.js', 'utf8');
     expect(output).toMatchInlineSnapshot(
-      `"(()=>{var e={67:e=>{e.exports.onRpcRequest=({request:e})=>{console.log("Hello, world!");const{method:r,id:o}=e;return r+o}}},r={};var o=function o(t){var s=r[t];if(void 0!==s)return s.exports;var n=r[t]={exports:{}};return e[t](n,n.exports,o),n.exports}(67),t=exports;for(var s in o)t[s]=o[s];o.__esModule&&Object.defineProperty(t,"__esModule",{value:!0})})();"`,
+      `"(()=>{var r={67:r=>{r.exports.onRpcRequest=({request:r})=>{console.log("Hello, world!");const{method:e,id:o}=r;return e+o}}},e={};var o=function o(t){var s=e[t];if(void 0!==s)return s.exports;var n=e[t]={exports:{}};return r[t](n,n.exports,o),n.exports}(67);module.exports=o})();"`,
     );
   });
 
@@ -191,11 +191,7 @@ describe('build', () => {
           return module.exports;
         }
         var __webpack_exports__ = __webpack_require__(67);
-        var __webpack_export_target__ = exports;
-        for (var i in __webpack_exports__) __webpack_export_target__[i] = __webpack_exports__[i];
-        if (__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, "__esModule", {
-          value: true
-        });
+        module.exports = __webpack_exports__;
       })();"
     `);
   });
@@ -230,7 +226,7 @@ describe('build', () => {
       .replace(/u.exports\}\(\d+\),t/u, 'u.exports}(1),t');
 
     expect(deterministicOutput).toMatchInlineSnapshot(
-      `"(()=>{var r={1:r=>{r.exports=function(){function r(e,o,t){function n(s,i){if(!o[s]){if(!e[s]){if(u)return u(s,!0);var f=new Error("Cannot find module '"+s+"'");throw f.code="MODULE_NOT_FOUND",f}var c=o[s]={exports:{}};e[s][0].call(c.exports,(function(r){return n(e[s][1][r]||r)}),c,c.exports,r,e,o,t)}return o[s].exports}for(var u=void 0,s=0;s<t.length;s++)n(t[s]);return n}return r}()({1:[function(r,e,o){"use strict";e.exports.onRpcRequest=({request:r})=>{console.log("Hello, world!");const{method:e,id:o}=r;return e+o}},{}]},{},[1])(1)}},e={};var o=function o(t){var n=e[t];if(void 0!==n)return n.exports;var u=e[t]={exports:{}};return r[t](u,u.exports,o),u.exports}(1),t=exports;for(var n in o)t[n]=o[n];o.__esModule&&Object.defineProperty(t,"__esModule",{value:!0})})();"`,
+      `"(()=>{var r={1:r=>{r.exports=function(){function r(o,t,e){function n(s,i){if(!t[s]){if(!o[s]){if(u)return u(s,!0);var c=new Error("Cannot find module '"+s+"'");throw c.code="MODULE_NOT_FOUND",c}var f=t[s]={exports:{}};o[s][0].call(f.exports,(function(r){return n(o[s][1][r]||r)}),f,f.exports,r,o,t,e)}return t[s].exports}for(var u=void 0,s=0;s<e.length;s++)n(e[s]);return n}return r}()({1:[function(r,o,t){"use strict";o.exports.onRpcRequest=({request:r})=>{console.log("Hello, world!");const{method:o,id:t}=r;return o+t}},{}]},{},[1])(1)}},o={};var t=function t(e){var n=o[e];if(void 0!==n)return n.exports;var u=o[e]={exports:{}};return r[e](u,u.exports,t),u.exports}(360);module.exports=t})();"`,
     );
   });
 
@@ -336,11 +332,7 @@ describe('build', () => {
           return module.exports;
         }
         var __webpack_exports__ = __webpack_require__(1);
-        var __webpack_export_target__ = exports;
-        for (var i in __webpack_exports__) __webpack_export_target__[i] = __webpack_exports__[i];
-        if (__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, "__esModule", {
-          value: true
-        });
+        module.exports = __webpack_exports__;
       })();"
     `);
   });

--- a/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
+++ b/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
@@ -4,9 +4,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -93,7 +90,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/foo/bar/dist",
     "publicPath": "/",
@@ -177,9 +175,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.ts",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -266,7 +261,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/foo/bar/dist",
     "publicPath": "/",
@@ -350,9 +346,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": "inline-source-map",
   "entry": "/foo/bar/src/index.ts",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -439,7 +432,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/foo/bar/dist",
     "publicPath": "/",
@@ -523,9 +517,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": "source-map",
   "entry": "/foo/bar/src/index.ts",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -612,7 +603,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/foo/bar/dist",
     "publicPath": "/",
@@ -687,9 +679,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -784,7 +773,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/foo/bar/dist",
     "publicPath": "/",
@@ -868,9 +858,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -957,7 +944,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/foo/bar/dist",
     "publicPath": "/",
@@ -1041,9 +1029,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -1130,7 +1115,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/foo/bar/dist",
     "publicPath": "/",
@@ -1214,9 +1200,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -1303,7 +1286,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/foo/bar/dist",
     "publicPath": "/",
@@ -1395,9 +1379,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -1484,7 +1465,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/foo/bar/dist",
     "publicPath": "/",
@@ -1576,9 +1558,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -1650,7 +1629,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/foo/bar/dist",
     "publicPath": "/",
@@ -1734,9 +1714,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -1823,7 +1800,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/foo/bar/dist",
     "publicPath": "/",
@@ -1915,9 +1893,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -2004,7 +1979,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/foo/bar/dist",
     "publicPath": "/",
@@ -2096,9 +2072,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.ts",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -2185,7 +2158,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/bar/baz",
     "publicPath": "/",
@@ -2278,9 +2252,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.ts",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -2367,7 +2338,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/bar/baz",
     "publicPath": "/",
@@ -2451,9 +2423,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.ts",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -2540,7 +2509,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/bar/baz",
     "publicPath": "/",
@@ -2624,9 +2594,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.ts",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -2713,7 +2680,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/bar/baz",
     "publicPath": "/",
@@ -2806,9 +2774,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.ts",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -2895,7 +2860,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/bar/baz",
     "publicPath": "/",
@@ -2988,9 +2954,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.js",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -3073,7 +3036,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/foo/bar/dist",
     "publicPath": "/",
@@ -3147,9 +3111,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.ts",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -3232,7 +3193,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/foo/bar/dist",
     "publicPath": "/",
@@ -3306,9 +3268,6 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
 {
   "devtool": false,
   "entry": "/foo/bar/src/index.ts",
-  "experiments": {
-    "topLevelAwait": false,
-  },
   "infrastructureLogging": {
     "level": "none",
   },
@@ -3391,7 +3350,8 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
     "clean": false,
     "filename": "bundle.js",
     "library": {
-      "type": "commonjs",
+      "name": "module.exports",
+      "type": "assign",
     },
     "path": "/foo/bar/dist",
     "publicPath": "/",

--- a/packages/snaps-cli/src/webpack/config.ts
+++ b/packages/snaps-cli/src/webpack/config.ts
@@ -161,8 +161,11 @@ export async function getDefaultConfiguration(
        */
       library: {
         /**
-         * This tells Webpack to export the bundle as a CommonJS module. This
-         * is necessary for MetaMask Snaps.
+         * This tells Webpack to export the bundle via assignment to module.exports.
+         * We do this to mimic CommonJS, but still allow for usage of async initialization logic
+         * via top level await.
+         *
+         * CommonJS is currently the only supported format for MetaMask Snaps.
          *
          * @see https://webpack.js.org/configuration/output/#outputlibrarytarget
          */

--- a/packages/snaps-cli/src/webpack/config.ts
+++ b/packages/snaps-cli/src/webpack/config.ts
@@ -166,7 +166,8 @@ export async function getDefaultConfiguration(
          *
          * @see https://webpack.js.org/configuration/output/#outputlibrarytarget
          */
-        type: 'commonjs',
+        type: 'global',
+        name: 'exports',
       },
 
       /**
@@ -177,7 +178,7 @@ export async function getDefaultConfiguration(
        *
        * @see https://webpack.js.org/configuration/output/#outputchunkformat
        */
-      chunkFormat: 'commonjs',
+      chunkFormat: 'module',
     },
 
     /**
@@ -386,14 +387,7 @@ export async function getDefaultConfiguration(
      * @see https://webpack.js.org/configuration/experiments
      */
     experiments: {
-      /**
-       * Experimental support for top level await.
-       *
-       * This is unsupported in Snaps and therefore disabled.
-       *
-       * @see https://webpack.js.org/configuration/experiments/#experimentstoplevelawait
-       */
-      topLevelAwait: false,
+      outputModule: true,
     },
 
     /**

--- a/packages/snaps-cli/src/webpack/config.ts
+++ b/packages/snaps-cli/src/webpack/config.ts
@@ -166,8 +166,8 @@ export async function getDefaultConfiguration(
          *
          * @see https://webpack.js.org/configuration/output/#outputlibrarytarget
          */
-        type: 'global',
-        name: 'exports',
+        type: 'assign',
+        name: 'module.exports',
       },
 
       /**
@@ -178,7 +178,7 @@ export async function getDefaultConfiguration(
        *
        * @see https://webpack.js.org/configuration/output/#outputchunkformat
        */
-      chunkFormat: 'module',
+      chunkFormat: 'commonjs',
     },
 
     /**
@@ -378,16 +378,6 @@ export async function getDefaultConfiguration(
           parallel: true,
         }),
       ],
-    },
-
-    /**
-     * The experiments configuration. This configures which Webpack
-     * experiments to enable/disable.
-     *
-     * @see https://webpack.js.org/configuration/experiments
-     */
-    experiments: {
-      outputModule: true,
     },
 
     /**

--- a/packages/snaps-cli/src/webpack/loaders/wasm.test.ts
+++ b/packages/snaps-cli/src/webpack/loaders/wasm.test.ts
@@ -85,8 +85,7 @@ describe('loader', () => {
           }
 
           const bytes = decode(b64);
-          const module = new WebAssembly.Module(bytes);
-          const instance = new WebAssembly.Instance(module, {
+          const { instance } = await WebAssembly.instantiate(bytes, {
             "../src/bindings.ts": { add },
           });
 

--- a/packages/snaps-cli/src/webpack/loaders/wasm.ts
+++ b/packages/snaps-cli/src/webpack/loaders/wasm.ts
@@ -115,8 +115,7 @@ const loader: LoaderDefinitionFunction = async function loader(
     }
 
     const bytes = decode(b64);
-    const module = await WebAssembly.compile(bytes);
-    const instance = new WebAssembly.Instance(module, {
+    const { instance } = await WebAssembly.instantiate(bytes, {
       ${getModuleImports(imports)}
     });
 

--- a/packages/snaps-cli/src/webpack/loaders/wasm.ts
+++ b/packages/snaps-cli/src/webpack/loaders/wasm.ts
@@ -115,7 +115,7 @@ const loader: LoaderDefinitionFunction = async function loader(
     }
 
     const bytes = decode(b64);
-    const module = new WebAssembly.Module(bytes);
+    const module = await WebAssembly.compile(bytes);
     const instance = new WebAssembly.Instance(module, {
       ${getModuleImports(imports)}
     });

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 80.55,
   "functions": 89.26,
-  "lines": 90.66,
-  "statements": 90.05
+  "lines": 90.67,
+  "statements": 90.06
 }

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -416,8 +416,9 @@ export class BaseSnapExecutor {
       compartment.globalThis.global = compartment.globalThis;
       compartment.globalThis.window = compartment.globalThis;
 
-      await this.executeInSnapContext(snapId, () => {
+      await this.executeInSnapContext(snapId, async () => {
         compartment.evaluate(sourceCode);
+        await snapModule.exports;
         this.registerSnapExports(snapId, snapModule);
       });
     } catch (error) {

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -418,8 +418,7 @@ export class BaseSnapExecutor {
 
       await this.executeInSnapContext(snapId, async () => {
         compartment.evaluate(sourceCode);
-        await snapModule.exports;
-        this.registerSnapExports(snapId, snapModule);
+        await this.registerSnapExports(snapId, snapModule);
       });
     } catch (error) {
       this.removeSnap(snapId);
@@ -448,15 +447,17 @@ export class BaseSnapExecutor {
     this.snapData.clear();
   }
 
-  private registerSnapExports(snapId: string, snapModule: any) {
+  private async registerSnapExports(snapId: string, snapModule: any) {
     const data = this.snapData.get(snapId);
     // Somebody deleted the snap before we could register.
     if (!data) {
       return;
     }
 
+    // If the module is async, we must await the exports.
+    const snapExports = await snapModule.exports;
     data.exports = SNAP_EXPORT_NAMES.reduce((acc, exportName) => {
-      const snapExport = snapModule.exports[exportName];
+      const snapExport = snapExports[exportName];
       const { validator } = SNAP_EXPORTS[exportName];
       if (validator(snapExport)) {
         return { ...acc, [exportName]: snapExport };


### PR DESCRIPTION
Allow async initialization logic for Snaps by altering the CLI config to do direct assignment of the exports to `module.exports`. This lets Snap developers use async initialization logic such as top-level await (which has been re-enabled) and asynchronous instantiation of WASM modules (which has been introduced in favor of sync). A minor change was also made to the execution environment to await the exposed module after evaluating it. 

Snaps are still subject to a 60 second initialization timeout, so the asynchronous logic must finish before that timer runs out.

Closes https://github.com/MetaMask/snaps/issues/2919
Closes https://github.com/MetaMask/snaps/issues/2359