### PR TITLE
chore: Update comments referencing extension main branch

### DIFF
--- a/packages/snaps-sdk/src/jsx/components/Icon.ts
+++ b/packages/snaps-sdk/src/jsx/components/Icon.ts
@@ -1,6 +1,6 @@
 import { createSnapComponent } from '../component';
 
-// Copied from https://github.com/MetaMask/metamask-extension/blob/develop/ui/components/component-library/icon/icon.types.ts
+// Copied from https://github.com/MetaMask/metamask-extension/blob/main/ui/components/component-library/icon/icon.types.ts
 // Currently requires manual syncing when new icon is added.
 export enum IconName {
   AddSquare = 'add-square',

--- a/packages/snaps-sdk/src/ui/components/input.ts
+++ b/packages/snaps-sdk/src/ui/components/input.ts
@@ -14,7 +14,7 @@ import { LiteralStruct, NodeType } from '../nodes';
 
 /**
  * This replicates the available input types from the metamask extension.
- * https://github.com/MetaMask/metamask-extension/develop/ui/components/component-library/input/input.constants.js
+ * https://github.com/MetaMask/metamask-extension/main/ui/components/component-library/input/input.constants.js
  */
 export enum InputType {
   /* eslint-disable @typescript-eslint/no-shadow */


### PR DESCRIPTION
Rename the main `metamask-extension` branch in comments where it is referenced. It was recently renamed from `develop` to `main`.