### PR TITLE
feat: Allow passing btoa for mobile execution service

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 92.89,
+  "branches": 92.91,
   "functions": 96.71,
-  "lines": 98,
+  "lines": 98.01,
   "statements": 97.71
 }

--- a/packages/snaps-controllers/src/services/webview/WebViewExecutionService.ts
+++ b/packages/snaps-controllers/src/services/webview/WebViewExecutionService.ts
@@ -5,6 +5,7 @@ import { WebViewMessageStream } from './WebViewMessageStream';
 
 export type WebViewExecutionServiceArgs = ExecutionServiceArgs & {
   getWebView: () => Promise<WebViewInterface>;
+  btoa?: (data: string) => string;
 };
 
 export class WebViewExecutionService extends ProxyExecutionService {
@@ -14,6 +15,7 @@ export class WebViewExecutionService extends ProxyExecutionService {
     messenger,
     setupSnapProvider,
     getWebView,
+    btoa,
   }: WebViewExecutionServiceArgs) {
     super({
       messenger,
@@ -22,6 +24,7 @@ export class WebViewExecutionService extends ProxyExecutionService {
         name: 'parent',
         target: 'child',
         getWebView,
+        btoa,
       }),
     });
     this.#getWebView = getWebView;

--- a/packages/snaps-controllers/src/test-utils/webview.ts
+++ b/packages/snaps-controllers/src/test-utils/webview.ts
@@ -1,4 +1,9 @@
-import { base64ToBytes, bytesToString } from '@metamask/utils';
+import {
+  base64ToBytes,
+  bytesToBase64,
+  bytesToString,
+  stringToBytes,
+} from '@metamask/utils';
 
 import { WebViewMessageStream } from '../services/webview/WebViewMessageStream';
 
@@ -52,6 +57,11 @@ export function createWebViewObjects() {
     name: 'a',
     target: 'b',
     getWebView: mockGetWebViewA,
+    // For one of the streams, we test that a custom btoa function is used.
+    btoa: (data: string) => {
+      const bytes = stringToBytes(data);
+      return bytesToBase64(bytes);
+    },
   });
 
   const streamB = new WebViewMessageStream({


### PR DESCRIPTION
Allow passing in a `btoa` (base64 encoding) function to the mobile execution service. This lets us use native code for the encoding on mobile. We use base64 encoding to prevent XSS due to the weird nature of how React Native WebView `postMessage` works, but currently do not use a native implementation for base64. This is mostly problematic for larger messages, such as the `executeSnap` payload, that end up taking over half a second for some example Snaps. This problem would only grow for larger Snaps. We already use `react-native-quick-base64` for other purposes in mobile, so dropping it into Snaps will be quite simple.

```
Old approach:
Base64 encoding took 523 ms

New approach
Base64 encoding took 1 ms
```

Progresses https://github.com/MetaMask/snaps/issues/2910