### PR TITLE
Allow `Field` in `Box`

### DIFF
--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5Jms4CVyGrXp46D7/zaU+Dst9AGCZk7mHLOSB2UlmnQ=",
+    "shasum": "d1js9Y4zJwk7n/e47V5fdMreo1FBtVKl4GtPhfckZrs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4yLB19XYAdGgHBPFlVOzCkb/JUZCjSajPRSQWs+a3uE=",
+    "shasum": "5Jms4CVyGrXp46D7/zaU+Dst9AGCZk7mHLOSB2UlmnQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+0hxp1uhfCqe9KR+4RPDSPGHFTgRyGULKLn9XWwCmsY=",
+    "shasum": "KgWNba9gUKLZQ/XNfFXPuWzjP3VKi5Wb2jnzN8FJWzc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "KgWNba9gUKLZQ/XNfFXPuWzjP3VKi5Wb2jnzN8FJWzc=",
+    "shasum": "VvMm+Zet1+q467UNweIuLLtYVoHoJdTeNjZn0xnEwO8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-controllers/src/interface/utils.test.tsx
+++ b/packages/snaps-controllers/src/interface/utils.test.tsx
@@ -242,6 +242,21 @@ describe('constructState', () => {
     });
   });
 
+  it('handles root level Field', () => {
+    const element = (
+      <Box>
+        <Field label="foo">
+          <Input name="foo" type="text" value="bar" />
+        </Field>
+      </Box>
+    );
+
+    const result = constructState({}, element);
+    expect(result).toStrictEqual({
+      foo: 'bar',
+    });
+  });
+
   it('handles root level inputs with value', () => {
     const element = (
       <Box>

--- a/packages/snaps-rpc-methods/src/permitted/createInterface.test.tsx
+++ b/packages/snaps-rpc-methods/src/permitted/createInterface.test.tsx
@@ -9,6 +9,7 @@ import {
   Form,
   Container,
   Footer,
+  Copyable,
 } from '@metamask/snaps-sdk/jsx';
 import type { JsonRpcRequest, PendingJsonRpcResponse } from '@metamask/utils';
 
@@ -140,7 +141,7 @@ describe('snap_createInterface', () => {
       error: {
         code: -32602,
         message:
-          'Invalid params: At path: ui -- Expected type to be one of: "Address", "Bold", "Box", "Button", "Copyable", "Divider", "Dropdown", "RadioGroup", "FileInput", "Form", "Heading", "Input", "Image", "Italic", "Link", "Row", "Spinner", "Text", "Tooltip", "Checkbox", "Card", "Icon", "Selector", "Section", "Avatar", "Container", but received: undefined.',
+          'Invalid params: At path: ui -- Expected type to be one of: "Address", "Bold", "Box", "Button", "Copyable", "Divider", "Dropdown", "RadioGroup", "Field", "FileInput", "Form", "Heading", "Input", "Image", "Italic", "Link", "Row", "Spinner", "Text", "Tooltip", "Checkbox", "Card", "Icon", "Selector", "Section", "Avatar", "Container", but received: undefined.',
         stack: expect.any(String),
       },
       id: 1,
@@ -179,7 +180,7 @@ describe('snap_createInterface', () => {
         ui: (
           <Box>
             <Field label="Input">
-              <Input name="input" />
+              <Copyable value="foo" />
             </Field>
           </Box>
         ) as JSXElement,
@@ -190,7 +191,7 @@ describe('snap_createInterface', () => {
       error: {
         code: -32602,
         message:
-          'Invalid params: At path: ui.props.children -- Expected type to be one of: "Address", "Bold", "Box", "Button", "Copyable", "Divider", "Dropdown", "RadioGroup", "FileInput", "Form", "Heading", "Input", "Image", "Italic", "Link", "Row", "Spinner", "Text", "Tooltip", "Checkbox", "Card", "Icon", "Selector", "Section", "Avatar", but received: "Field".',
+          'Invalid params: At path: ui.props.children.props.children -- Expected the value to satisfy a union of `tuple | tuple | tuple | object | object | object | object | object | object`, but received: [object Object].',
         stack: expect.any(String),
       },
       id: 1,

--- a/packages/snaps-sdk/src/jsx/components/form/Field.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Field.ts
@@ -32,8 +32,7 @@ export type FieldProps = {
 const TYPE = 'Field';
 
 /**
- * A field component, which is used to create a form field. This component can
- * only be used as a child of the {@link Form} component.
+ * A field component, which is used to create a form field.
  *
  * @param props - The props of the component.
  * @param props.label - The label of the field.

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -568,6 +568,11 @@ describe('BoxStruct', () => {
       <Text>bar</Text>
     </Box>,
     <Box>
+      <Field label="foo">
+        <Input name="foo" />
+      </Field>
+    </Box>,
+    <Box>
       <Text>foo</Text>
       <Row label="label">
         <Image src="<svg />" alt="alt" />
@@ -619,11 +624,6 @@ describe('BoxStruct', () => {
       <Row label="label">
         <Image src="<svg />" alt="alt" />
       </Row>
-    </Box>,
-    <Box>
-      <Field label="foo">
-        <Input name="foo" />
-      </Field>
     </Box>,
     <Box>
       <Value extra="foo" value="bar" />

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -512,7 +512,7 @@ export const FieldStruct: Describe<FieldElement> = element('Field', {
  */
 export const FormChildStruct = children(
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  [FieldStruct, lazy(() => BoxChildStruct)],
+  [lazy(() => BoxChildStruct)],
 ) as unknown as Struct<SnapsChildren<GenericSnapElement>, null>;
 
 /**
@@ -796,6 +796,7 @@ export const BoxChildStruct = typedUnion([
   DividerStruct,
   DropdownStruct,
   RadioGroupStruct,
+  FieldStruct,
   FileInputStruct,
   FormStruct,
   HeadingStruct,

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -507,20 +507,6 @@ export const FieldStruct: Describe<FieldElement> = element('Field', {
   children: FieldChildStruct,
 });
 
-export const BoxChildrenStruct = children(
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  [lazy(() => BoxChildStruct)],
-) as unknown as Struct<SnapsChildren<GenericSnapElement>, null>;
-
-/**
- * A struct for the {@link FormElement} type.
- */
-export const FormStruct: Describe<FormElement> = element('Form', {
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  children: BoxChildrenStruct,
-  name: string(),
-});
-
 /**
  * A struct for the {@link BoldElement} type.
  */
@@ -559,6 +545,11 @@ export const AvatarStruct = element('Avatar', {
   size: optional(nullUnion([literal('sm'), literal('md'), literal('lg')])),
 }) as unknown as Struct<AvatarElement, null>;
 
+export const BoxChildrenStruct = children(
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  [lazy(() => BoxChildStruct)],
+) as unknown as Struct<SnapsChildren<GenericSnapElement>, null>;
+
 /**
  * A struct for the {@link BoxElement} type.
  */
@@ -575,6 +566,19 @@ export const BoxStruct: Describe<BoxElement> = element('Box', {
     ]),
   ),
   center: optional(boolean()),
+});
+
+/**
+ * A subset of JSX elements that are allowed as children of the Form component.
+ */
+export const FormChildStruct = BoxChildrenStruct;
+
+/**
+ * A struct for the {@link FormElement} type.
+ */
+export const FormStruct: Describe<FormElement> = element('Form', {
+  children: FormChildStruct,
+  name: string(),
 });
 
 const FooterButtonStruct = refine(ButtonStruct, 'FooterButton', (value) => {

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -507,10 +507,7 @@ export const FieldStruct: Describe<FieldElement> = element('Field', {
   children: FieldChildStruct,
 });
 
-/**
- * A subset of JSX elements that are allowed as children of the Form component.
- */
-export const FormChildStruct = children(
+export const BoxChildrenStruct = children(
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   [lazy(() => BoxChildStruct)],
 ) as unknown as Struct<SnapsChildren<GenericSnapElement>, null>;
@@ -519,7 +516,8 @@ export const FormChildStruct = children(
  * A struct for the {@link FormElement} type.
  */
 export const FormStruct: Describe<FormElement> = element('Form', {
-  children: FormChildStruct,
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  children: BoxChildrenStruct,
   name: string(),
 });
 
@@ -560,11 +558,6 @@ export const AvatarStruct = element('Avatar', {
   address: CaipAccountIdStruct,
   size: optional(nullUnion([literal('sm'), literal('md'), literal('lg')])),
 }) as unknown as Struct<AvatarElement, null>;
-
-export const BoxChildrenStruct = children(
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  [lazy(() => BoxChildStruct)],
-) as unknown as Struct<SnapsChildren<GenericSnapElement>, null>;
 
 /**
  * A struct for the {@link BoxElement} type.

--- a/packages/snaps-simulator/src/features/builder/utils.test.ts
+++ b/packages/snaps-simulator/src/features/builder/utils.test.ts
@@ -9,6 +9,7 @@ import {
   Copyable,
   Heading,
   Option,
+  Container,
 } from '@metamask/snaps-sdk/jsx';
 import type { NodeModel } from '@minoru/react-dnd-treeview';
 
@@ -30,7 +31,7 @@ describe('isValidBoxChild', () => {
   });
 
   it('returns false for invalid box children', () => {
-    const child = Field({ children: Input({ name: 'input' }) });
+    const child = Container({ children: Input({ name: 'input' }) });
     expect(isValidBoxChild(child)).toBe(false);
   });
 });
@@ -80,7 +81,7 @@ describe('setElementChildren', () => {
     const element = Box({
       children: [Text({ children: 'foo' }), Heading({ children: 'baz' })],
     });
-    const children = Field({ children: Input({ name: 'input' }) });
+    const children = Container({ children: Input({ name: 'input' }) });
 
     const result = setElementChildren(element, children, isValidBoxChild);
     expect(result).toStrictEqual(element.props.children);


### PR DESCRIPTION
This PR allows the usage of `Field` in `Box` to be able to put two field in a row.