### PR TITLE
feat: Automatically add `platformVersion` to manifest

### DIFF
--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "dWCQ3BjoAmv1KlzbrNPRa4QlB3qSHQKL6ONaV0mo7b0=",
+    "shasum": "BXI9661L/fYaiBpXRSdqkP8BMOngNdoo9FwYTbrY7+s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -43,5 +43,6 @@
       }
     ]
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "dqWYaxXKggEChwefUCTvipvNzQ+0KbaT6x8vRDW0miw=",
+    "shasum": "k9draXonmeZgsn647IkJLhYHrc75/Krpn7tA4F+8wGM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -31,5 +31,6 @@
       }
     ]
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "DYLBW3jdovQYu6jwACo/3xlujGXb0YxJ19UEpUKX1qE=",
+    "shasum": "SquG9JvLanG/gJwBw5H1AZBlsthmv21Ci4Vn+sMemjM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -21,5 +21,6 @@
       "dapps": true
     }
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "dFTqb94KtIZ44IaoMYhGunl9c9Of9j67TNYobl+CwYg=",
+    "shasum": "pCp96i558WHqHIUZyZGUFcxAfOQ0afBHJ59nJB5ma78=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -21,5 +21,6 @@
       "dapps": true
     }
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2apoRqY/ywA9P7gcTYwLsbxYFp8Tb7aNmT2bADL/13o=",
+    "shasum": "+KdGrdkNoCdZlzq7KulSaWDD1OU4Vu+LpHiCgmYXnHg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -22,5 +22,6 @@
       "snaps": false
     }
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8bB9qcVDzKQyefr78Cm03aTbojKKg5jQ4nkzZUccKhs=",
+    "shasum": "z06MC0KYtySDOdGTKH+afyyu3GWBu4LnKc4FVvfq1Oo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -29,5 +29,6 @@
     },
     "snap_dialog": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "uZhYG9+3b1yA/94e0QhCJycqrPA96cBQyP+2plF0SEg=",
+    "shasum": "YsyK0ottmZX+MXbSvusMiJ44lQoHoP7y0sq+GrPlRK0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -22,5 +22,6 @@
     },
     "snap_dialog": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/errors/snap.manifest.json
+++ b/packages/examples/packages/errors/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "nBAHoKcN5GNzCeKU2UdH+/8auyBBq6z3NxRbcTSuKj4=",
+    "shasum": "YKH6iL1qdRaQSvIDIf2jnhVb30U7z6LoZp3sJ3vgBBg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -21,5 +21,6 @@
       "dapps": true
     }
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cFhK3nsekRxmXeas/P58bEzMVeLhbtp+ZeCDQ5LTtSs=",
+    "shasum": "HYGsbZCa1cbaJLBU9dcQziEhKS1KD/sesQgTxZVI9lc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -22,5 +22,6 @@
     },
     "endowment:ethereum-provider": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "uVLwzYliwDATW6CiqATb1FyPgyagNs+3ini7QA+0okc=",
+    "shasum": "H18HO5WDT/09sJKQ+JxTuqYi5Krx3LkE2G+JlQMeBVY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -23,5 +23,6 @@
     "snap_dialog": {},
     "snap_getEntropy": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "14D89bvKXu2AM/k7XG9b7LhSxbf4mJq+8xdfpAAFXE8=",
+    "shasum": "xk2qj65HFB618cIUh/sYWfLrviSfgu8C+7Fnv6qsDWE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -24,5 +24,6 @@
     "snap_dialog": {},
     "snap_manageState": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1jPm8koZvt+Tme7DCtogqKfS+fR4SJnPU7N8r85ku1Y=",
+    "shasum": "s/mu+Z/V/G7XwdIVMyuXvZ4ORhLTOQHSFdlwRlgfwuw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -23,5 +23,6 @@
     "snap_dialog": {},
     "snap_getEntropy": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "xJ6zVUIFqDUR04wPM54X1H64TBQnJ5TWD1wol4ggBz0=",
+    "shasum": "QMdO7yoFhhvlyuMe4KAP1mKwBDvd7AWPqw51JOLiL+4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -22,5 +22,6 @@
       "dapps": true
     }
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "NyUuomb1PK2tdiQmOZyT0C+vugl6CamwZ6iS86tREHE=",
+    "shasum": "tcaY0oALNFbvXqOUzovxeXU3lzbkbi6o/K3lfTsvs04=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -19,5 +19,6 @@
   "initialPermissions": {
     "endowment:page-home": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "PWtPR8sJIxj/6B8eLRvGjndi5udmdlWu6eKP4QWFOXg=",
+    "shasum": "w2YY6L6V4CLq+WEwkrgTmB55B+/z4ceD2/zZIn9NNMY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -23,5 +23,6 @@
     },
     "snap_dialog": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "il7JIqsKAL7HdA9TDvZ3uaZ2DmhrvG3/06VlWLZqY3I=",
+    "shasum": "ProfhCT750VS73AYlE9ypKu95ZsGLLoHXmoEX8zKUt0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -25,5 +25,6 @@
     "endowment:transaction-insight": {},
     "endowment:page-home": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "McFa4RUs1FqKkxa/srAwgV/6zph9wvinW1vfD8u/OA8=",
+    "shasum": "J9qfjo4ls7KSmOMVlDXxYNO055eANDjIwEV1uxCxXI8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -21,5 +21,6 @@
       "dapps": true
     }
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "QPxHqRPygXB1Z6M4XreZtw/im8wCEBJgEtLdkOtwob8=",
+    "shasum": "rZzEML+px4RJ15ADWtQRvVMEVd1ShKd8JtZfAn0sHU8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -23,5 +23,6 @@
     "snap_dialog": {},
     "snap_manageState": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "mZmPwOndC6aSHcjT6+N6qNxtwBpXA88fE2+T7jg3/GA=",
+    "shasum": "+t2ZHLZx3lvm7ImrZe6jicCH7xTG5xTMdAPEt1onuC4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -26,5 +26,6 @@
       }
     }
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "s8bOADHqPUfTvQpQHBYauAnOLB9OUEVADsYyTUWJFMo=",
+    "shasum": "bDD/Av6Wb3HYIx4dd3fBiDwxVb4BL0SzZNsIY2XjZZg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -23,5 +23,6 @@
     "snap_dialog": {},
     "snap_manageState": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "lFAmVlA2xtorYkfuEClJwiSdLKvEvVx8bWDb3FaKdi4=",
+    "shasum": "I3HrKMbzbQslQrfoJZ6CPbPwUOJtl5GBudiJNV3xzJo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -20,5 +20,6 @@
     "snap_dialog": {},
     "endowment:lifecycle-hooks": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Z1wvLAfqLXOmsioIaOk0nUIvWydYKYL99EICJOMY1Cg=",
+    "shasum": "/G+GFTl+PxKobMfdOVdbzdGNjSkclJr7W79GBE3L3cA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -23,5 +23,6 @@
     },
     "snap_getPreferences": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4F+GzRueJNZ90SaB6GnKyBFD2C3rGD3ZtEiHg+sEgcI=",
+    "shasum": "rFRplL4VuGBRqiNooRMJTf7dGzVZGMMO7eiEHU3DzrA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -22,5 +22,6 @@
     },
     "snap_manageState": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/name-lookup/snap.manifest.json
+++ b/packages/examples/packages/name-lookup/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "pC2NRrOhYv4sUS7Vkx5As0A5F1rqcQwCWwnijZqCqSc=",
+    "shasum": "eaW1e0+YR+RJFQ8hE2CGSLOERHVOPVJcvOBCE90K/bk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -21,5 +21,6 @@
       "chains": ["eip155:1"]
     }
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "nRsZQCtNSsaFiu3rzF/ymnflq7ZQQwwm/KnQTBzwav4=",
+    "shasum": "568PERukIcZVLcToP+a+moHyPJErIpXA2iTmreY92zQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -23,5 +23,6 @@
     },
     "endowment:network-access": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "uh0g/qoSTv4n3PQrESflSZbajX7GaGUZQkr4DxSSWsw=",
+    "shasum": "M4hanawafBYKNQW9wA4Cefir4vyqGOEo8Y4dQznfyJg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -22,5 +22,6 @@
     },
     "snap_notify": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/preinstalled/snap.manifest.json
+++ b/packages/examples/packages/preinstalled/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "adwoj6L+hZGsdmCh0Y/obHY00nAXHBoduUo9Gwtm+HE=",
+    "shasum": "WF9+BfnWRznf3otVkb8p0M38ULIIPywefZdHiAAk7jM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -22,5 +22,6 @@
     },
     "snap_dialog": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "rPQS5d+6fj93/L4Y7L1oNp5v+8IobP+t6JAUW31ZSQA=",
+    "shasum": "P/mNUgdJyP6AHtNFl4/cj2Qkw2heVmn1u4LF0TWfSdQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -21,5 +21,6 @@
       "dapps": true
     }
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/send-flow/snap.manifest.json
+++ b/packages/examples/packages/send-flow/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "eiwEi6JZTZnPkriRaoiuFQX37mSHsdJEzO5MDZJGqOg=",
+    "shasum": "0zmrLyYqp4N2ZJNYnCPW9H0lXGNq23XMupxpJBVKWLU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -23,5 +23,6 @@
     "snap_dialog": {},
     "endowment:page-home": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "W7760+wNYB7ikWVHQeEx5IRAt+Q07Cq4zaYwmfCEqr8=",
+    "shasum": "hBbOcBi+PekNhLgd8NtXH7iLdEyBXljq/0+bpSuCIqc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -19,5 +19,6 @@
   "initialPermissions": {
     "endowment:signature-insight": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FxEMWKtdMuijdmu4neAmXosp1zIiuvwzngv7U6t9eC4=",
+    "shasum": "B1+y/ga3yTLQxAXV3UuVGqnH9VjtIvdW+6q+84yjBKQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -19,5 +19,6 @@
   "initialPermissions": {
     "endowment:transaction-insight": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "YtnZetn37cq3RA2PdwjDBPOjvxDSAQ5vSzOqC2zjBNw=",
+    "shasum": "dtlSHKSUvPxdcyM84056BdRyrZoSdMWFQFQBVN76rx0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -22,5 +22,6 @@
     },
     "endowment:webassembly": {}
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7PgzAThtBB7Ay2cfYsGz8xhHXjzEfJWyW9d+Uh3gTX0=",
+    "shasum": "1tYoOe+sHrXpkzyRoNO5IJhxTRnGbLHcNY7+zG7hDOc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -21,5 +21,6 @@
       "dapps": true
     }
   },
+  "platformVersion": "6.13.0",
   "manifestVersion": "0.1"
 }

--- a/packages/snaps-cli/src/commands/manifest/implementation.test.ts
+++ b/packages/snaps-cli/src/commands/manifest/implementation.test.ts
@@ -36,7 +36,8 @@ jest.mock('../../webpack', () => ({
 jest.mock('module', () => ({
   createRequire: jest.fn().mockImplementation(() => {
     const fn = jest.fn().mockReturnValue({ version: '1.0.0' }) as any;
-    jest.spyOn(fn, 'resolve').mockImplementation();
+    // eslint-disable-next-line jest/prefer-spy-on
+    fn.resolve = jest.fn();
     return fn;
   }),
 }));

--- a/packages/snaps-cli/src/commands/manifest/implementation.test.ts
+++ b/packages/snaps-cli/src/commands/manifest/implementation.test.ts
@@ -164,7 +164,7 @@ describe('manifest', () => {
           "url": "https://github.com/MetaMask/example-snap.git"
         },
         "source": {
-          "shasum": "itjh0enng42nO6BxNCEhDH8wm3yl4xlVclfd5LsZ2wA=",
+          "shasum": "xYFUdpKz+yNGb1LwDGRHmqsH1PXknt2tE9ZJr1P0kb4=",
           "location": {
             "npm": {
               "filePath": "dist/bundle.js",
@@ -179,7 +179,7 @@ describe('manifest', () => {
             "chains": ["eip155:1", "eip155:2", "eip155:3"]
           }
         },
-        "platformVersion": "1.0.0",
+        "platformVersion": "6.13.0",
         "manifestVersion": "0.1"
       }
       "

--- a/packages/snaps-cli/src/commands/manifest/implementation.test.ts
+++ b/packages/snaps-cli/src/commands/manifest/implementation.test.ts
@@ -1,4 +1,3 @@
-import { getPlatformVersion } from '@metamask/snaps-utils';
 import {
   DEFAULT_SNAP_BUNDLE,
   DEFAULT_SNAP_ICON,
@@ -6,6 +5,7 @@ import {
   getPackageJson,
   getSnapManifest,
 } from '@metamask/snaps-utils/test-utils';
+import type { SemVerVersion } from '@metamask/utils';
 import normalFs from 'fs';
 import ora from 'ora';
 
@@ -33,12 +33,20 @@ jest.mock('../../webpack', () => ({
   }),
 }));
 
+jest.mock('module', () => ({
+  createRequire: jest.fn().mockImplementation(() => {
+    const fn = jest.fn().mockReturnValue({ version: '1.0.0' }) as any;
+    jest.spyOn(fn, 'resolve').mockImplementation();
+    return fn;
+  }),
+}));
+
 describe('manifest', () => {
   beforeEach(async () => {
     const { manifest: newManifest } = await getMockSnapFilesWithUpdatedChecksum(
       {
         manifest: getSnapManifest({
-          platformVersion: getPlatformVersion(),
+          platformVersion: '1.0.0' as SemVerVersion,
         }),
       },
     );
@@ -164,7 +172,7 @@ describe('manifest', () => {
           "url": "https://github.com/MetaMask/example-snap.git"
         },
         "source": {
-          "shasum": "xYFUdpKz+yNGb1LwDGRHmqsH1PXknt2tE9ZJr1P0kb4=",
+          "shasum": "itjh0enng42nO6BxNCEhDH8wm3yl4xlVclfd5LsZ2wA=",
           "location": {
             "npm": {
               "filePath": "dist/bundle.js",
@@ -179,7 +187,7 @@ describe('manifest', () => {
             "chains": ["eip155:1", "eip155:2", "eip155:3"]
           }
         },
-        "platformVersion": "6.13.0",
+        "platformVersion": "1.0.0",
         "manifestVersion": "0.1"
       }
       "

--- a/packages/snaps-utils/src/manifest/validators/index.ts
+++ b/packages/snaps-utils/src/manifest/validators/index.ts
@@ -8,8 +8,7 @@ export * from './is-snap-manifest';
 export * from './manifest-localization';
 export * from './package-json-recommended-fields';
 export * from './package-name-match';
-// TODO: Uncomment the following line after the next release.
-// export * from './platform-version';
+export * from './platform-version';
 export * from './repository-match';
 export * from './version-match';
 export * from './icon-declared';


### PR DESCRIPTION
In https://github.com/MetaMask/snaps/pull/2803 we added support for `platformVersion` in the manifest to indicate what version of the platform the Snap was implemented for. We chose to not automatically add this version to the manifest before releasing the initial changes. Since those changes have now been released we can enable automatically adding the field to the manifest.

Closes https://github.com/MetaMask/snaps/issues/2854
