### PR TITLE
feat: Add `size` prop to Button

### DIFF
--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "SquG9JvLanG/gJwBw5H1AZBlsthmv21Ci4Vn+sMemjM=",
+    "shasum": "eug1Oxfxo/X97epSDNuF3elpxJUBNGgPgfvvmVxShxo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "pCp96i558WHqHIUZyZGUFcxAfOQ0afBHJ59nJB5ma78=",
+    "shasum": "Jh7Kcnzc5flRZM4SL8yQnMBj99YrmU91iLLaIxH2o/k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-sdk/src/jsx/components/form/Button.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/Button.test.tsx
@@ -82,4 +82,17 @@ describe('Button', () => {
       key: null,
     });
   });
+
+  it('returns a button element with a size', () => {
+    const result = <Button size="sm">bar</Button>;
+
+    expect(result).toStrictEqual({
+      type: 'Button',
+      props: {
+        children: 'bar',
+        size: 'sm',
+      },
+      key: null,
+    });
+  });
 });

--- a/packages/snaps-sdk/src/jsx/components/form/Button.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Button.ts
@@ -24,6 +24,7 @@ export type ButtonProps = {
   name?: string | undefined;
   type?: 'button' | 'submit' | undefined;
   variant?: 'primary' | 'destructive' | undefined;
+  size?: 'sm' | 'md' | undefined;
   disabled?: boolean | undefined;
   loading?: boolean | undefined;
   form?: string | undefined;

--- a/packages/snaps-sdk/src/jsx/components/form/Button.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Button.ts
@@ -15,6 +15,7 @@ import type { ImageElement } from '../Image';
  * Defaults to `'button'`.
  * @property variant - The variant of the button, i.e., `'primary'` or
  * `'destructive'`. Defaults to `'primary'`.
+ * @property size - The size of the button. Defaults to `md`.
  * @property disabled - Whether the button is disabled. Defaults to `false`.
  * @property loading - Whether the button is loading. Defaults to `false`.
  * @property form - The name of the form component to associate the button with.

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -175,6 +175,7 @@ describe('ButtonStruct', () => {
       <Image src="<svg></svg>" />
     </Button>,
     <Button form="foo">bar</Button>,
+    <Button size="sm">bar</Button>,
   ])('validates a button element', (value) => {
     expect(is(value, ButtonStruct)).toBe(true);
   });

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -244,6 +244,7 @@ export const ButtonStruct: Describe<ButtonElement> = element('Button', {
   name: optional(string()),
   type: optional(nullUnion([literal('button'), literal('submit')])),
   variant: optional(nullUnion([literal('primary'), literal('destructive')])),
+  size: optional(nullUnion([literal('sm'), literal('md')])),
   disabled: optional(boolean()),
   loading: optional(boolean()),
   form: optional(string()),


### PR DESCRIPTION
Add `size` prop to buttons, letting devs size them similarly to `Text`. 

Progresses https://github.com/MetaMask/snaps/issues/2947