### PR TITLE
feat: Support `fontWeight` prop on `Text`

### DIFF
--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vr/JCeU5DXN3CeJIeLbZmr44rFnq+BGqQPng7kVxZGY=",
+    "shasum": "zWAvAKOxzUuZWjb75gYJw+izGqyBRcXoy2ocUCKMyGk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4diRqHxV2Sr2wHuyoP1dL/WcSbS6HSVzxkDL+Iv0JNM=",
+    "shasum": "i5/9SEgHydVQotkWZ7ErpPhOI2N7Cg3U+lbR5/ApQI4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-sdk/src/jsx/components/Text.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/Text.test.tsx
@@ -53,7 +53,11 @@ describe('Text', () => {
   });
 
   it('renders text with props', () => {
-    const result = <Text size="sm">Hello world!</Text>;
+    const result = (
+      <Text size="sm" fontWeight="medium">
+        Hello world!
+      </Text>
+    );
 
     expect(result).toStrictEqual({
       type: 'Text',
@@ -61,6 +65,7 @@ describe('Text', () => {
       props: {
         children: 'Hello world!',
         size: 'sm',
+        fontWeight: 'medium',
       },
     });
   });

--- a/packages/snaps-sdk/src/jsx/components/Text.ts
+++ b/packages/snaps-sdk/src/jsx/components/Text.ts
@@ -29,6 +29,7 @@ export type TextColors =
  * @property alignment - The alignment of the text.
  * @property color - The color of the text.
  * @property size - The size of the text. Defaults to `md`.
+ * @property fontWeight - The font weight of the text. Defaults to `regular`.
  */
 export type TextProps = {
   children: TextChildren;
@@ -48,6 +49,7 @@ const TYPE = 'Text';
  * @param props.color - The color of the text.
  * @param props.children - The text to display.
  * @param props.size - The size of the text. Defaults to `md`.
+ * @param props.fontWeight - The font weight of the text. Defaults to `regular`.
  * @returns A text element.
  * @example
  * <Text>
@@ -59,6 +61,10 @@ const TYPE = 'Text';
  * </Text>
  * @example
  * <Text size="sm">
+ *   Hello <Bold>world</Bold>!
+ * </Text>
+ * @example
+ * <Text fontWeight="medium">
  *   Hello <Bold>world</Bold>!
  * </Text>
  */

--- a/packages/snaps-sdk/src/jsx/components/Text.ts
+++ b/packages/snaps-sdk/src/jsx/components/Text.ts
@@ -35,6 +35,7 @@ export type TextProps = {
   alignment?: 'start' | 'center' | 'end' | undefined;
   color?: TextColors | undefined;
   size?: 'sm' | 'md' | undefined;
+  fontWeight?: 'regular' | 'medium' | 'bold' | undefined;
 };
 
 const TYPE = 'Text';

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -1182,6 +1182,7 @@ describe('TextStruct', () => {
       Hello, <Bold>world</Bold>
     </Text>,
     <Text size="sm">foo</Text>,
+    <Text fontWeight="medium">foo</Text>,
   ])('validates a text element', (value) => {
     expect(is(value, TextStruct)).toBe(true);
   });
@@ -1197,6 +1198,8 @@ describe('TextStruct', () => {
     <Text />,
     // @ts-expect-error - Invalid props.
     <Text foo="bar">foo</Text>,
+    // @ts-expect-error - Invalid props.
+    <Text fontWeight="bar">foo</Text>,
     <Box>
       <Text>foo</Text>
     </Box>,

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -721,6 +721,9 @@ export const TextStruct: Describe<TextElement> = element('Text', {
     ]),
   ),
   size: optional(nullUnion([literal('sm'), literal('md')])),
+  fontWeight: optional(
+    nullUnion([literal('regular'), literal('medium'), literal('bold')]),
+  ),
 });
 
 /**


### PR DESCRIPTION
Add support for specifying the `fontWeight` prop on the `Text` component.