### PR TITLE
feat: Add `waitForUpdate` interface action

### DIFF
--- a/packages/snaps-jest/src/helpers.test.tsx
+++ b/packages/snaps-jest/src/helpers.test.tsx
@@ -411,6 +411,7 @@ describe('installSnap', () => {
         selectFromRadioGroup: expect.any(Function),
         selectFromSelector: expect.any(Function),
         uploadFile: expect.any(Function),
+        waitForUpdate: expect.any(Function),
         ok: expect.any(Function),
         cancel: expect.any(Function),
       });
@@ -473,6 +474,7 @@ describe('installSnap', () => {
         selectFromRadioGroup: expect.any(Function),
         selectFromSelector: expect.any(Function),
         uploadFile: expect.any(Function),
+        waitForUpdate: expect.any(Function),
         ok: expect.any(Function),
         cancel: expect.any(Function),
       });
@@ -535,6 +537,7 @@ describe('installSnap', () => {
         selectFromRadioGroup: expect.any(Function),
         selectFromSelector: expect.any(Function),
         uploadFile: expect.any(Function),
+        waitForUpdate: expect.any(Function),
         ok: expect.any(Function),
       });
 

--- a/packages/snaps-simulation/package.json
+++ b/packages/snaps-simulation/package.json
@@ -70,6 +70,7 @@
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^10.0.0",
     "@reduxjs/toolkit": "^1.9.5",
+    "fast-deep-equal": "^3.1.3",
     "mime": "^3.0.0",
     "readable-stream": "^3.6.2",
     "redux-saga": "^1.2.3"

--- a/packages/snaps-simulation/src/controllers.ts
+++ b/packages/snaps-simulation/src/controllers.ts
@@ -15,6 +15,7 @@ import type {
   ExecutionServiceActions,
   SnapInterfaceControllerActions,
   SnapInterfaceControllerAllowedActions,
+  SnapInterfaceControllerStateChangeEvent,
 } from '@metamask/snaps-controllers';
 import {
   caveatSpecifications as snapsCaveatsSpecifications,
@@ -38,9 +39,12 @@ export type RootControllerAllowedActions =
   | ExecutionServiceActions
   | SubjectMetadataControllerActions;
 
+export type RootControllerAllowedEvents =
+  SnapInterfaceControllerStateChangeEvent;
+
 export type RootControllerMessenger = ControllerMessenger<
   RootControllerAllowedActions,
-  any
+  RootControllerAllowedEvents
 >;
 
 export type GetControllersOptions = {

--- a/packages/snaps-simulation/src/helpers.test.tsx
+++ b/packages/snaps-simulation/src/helpers.test.tsx
@@ -145,6 +145,7 @@ describe('helpers', () => {
         selectFromRadioGroup: expect.any(Function),
         selectFromSelector: expect.any(Function),
         uploadFile: expect.any(Function),
+        waitForUpdate: expect.any(Function),
         ok: expect.any(Function),
         cancel: expect.any(Function),
       });
@@ -207,6 +208,7 @@ describe('helpers', () => {
         selectFromRadioGroup: expect.any(Function),
         selectFromSelector: expect.any(Function),
         uploadFile: expect.any(Function),
+        waitForUpdate: expect.any(Function),
         ok: expect.any(Function),
         cancel: expect.any(Function),
       });
@@ -269,6 +271,7 @@ describe('helpers', () => {
         selectFromRadioGroup: expect.any(Function),
         selectFromSelector: expect.any(Function),
         uploadFile: expect.any(Function),
+        waitForUpdate: expect.any(Function),
         ok: expect.any(Function),
       });
 

--- a/packages/snaps-simulation/src/interface.ts
+++ b/packages/snaps-simulation/src/interface.ts
@@ -780,18 +780,20 @@ export async function waitForUpdate(
       const newContent = currentInterface?.content;
 
       if (!deepEqual(originalContent, newContent)) {
-        // Unsubscribe
         controllerMessenger.unsubscribe(
           'SnapInterfaceController:stateChange',
           listener,
         );
+
         const actions = getInterfaceActions(snapId, controllerMessenger, {
           content: newContent,
           id,
         });
+
         resolve({ ...actions, content: newContent });
       }
     };
+
     controllerMessenger.subscribe(
       'SnapInterfaceController:stateChange',
       listener,

--- a/packages/snaps-simulation/src/interface.ts
+++ b/packages/snaps-simulation/src/interface.ts
@@ -1,3 +1,4 @@
+import type { SnapInterfaceControllerState } from '@metamask/snaps-controllers';
 import type { DialogApprovalTypes } from '@metamask/snaps-rpc-methods';
 import { DIALOG_APPROVAL_TYPES } from '@metamask/snaps-rpc-methods';
 import type {
@@ -19,6 +20,7 @@ import {
 } from '@metamask/snaps-utils';
 import { assertExhaustive, hasProperty } from '@metamask/utils';
 import type { PayloadAction } from '@reduxjs/toolkit';
+import deepEqual from 'fast-deep-equal';
 import { type SagaIterator } from 'redux-saga';
 import { call, put, select, take } from 'redux-saga/effects';
 
@@ -26,7 +28,12 @@ import type { RootControllerMessenger } from './controllers';
 import { getFileSize, getFileToUpload } from './files';
 import type { Interface, RunSagaFunction } from './store';
 import { getCurrentInterface, resolveInterface, setInterface } from './store';
-import type { FileOptions, SnapInterface, SnapInterfaceActions } from './types';
+import type {
+  FileOptions,
+  SnapHandlerInterface,
+  SnapInterface,
+  SnapInterfaceActions,
+} from './types';
 
 /**
  * The maximum file size that can be uploaded.
@@ -753,6 +760,46 @@ export async function selectFromSelector(
 }
 
 /**
+ * Wait for an interface to be updated.
+ *
+ * @param controllerMessenger - The controller messenger used to call actions.
+ * @param snapId - The Snap ID.
+ * @param id - The interface ID.
+ * @param originalContent - The original interface content.
+ * @returns A promise that resolves to the updated interface.
+ */
+export async function waitForUpdate(
+  controllerMessenger: RootControllerMessenger,
+  snapId: SnapId,
+  id: string,
+  originalContent: JSXElement,
+) {
+  return new Promise<SnapHandlerInterface>((resolve) => {
+    const listener = (state: SnapInterfaceControllerState) => {
+      const currentInterface = state.interfaces[id];
+      const newContent = currentInterface?.content;
+
+      if (!deepEqual(originalContent, newContent)) {
+        // Unsubscribe
+        controllerMessenger.unsubscribe(
+          'SnapInterfaceController:stateChange',
+          listener,
+        );
+        const actions = getInterfaceActions(snapId, controllerMessenger, {
+          content: newContent,
+          id,
+        });
+        resolve({ ...actions, content: newContent });
+      }
+    };
+    controllerMessenger.subscribe(
+      'SnapInterfaceController:stateChange',
+      listener,
+    );
+  });
+}
+
+/**
  * Get a formatted file size.
  *
  * @param size - The file size in bytes.
@@ -923,6 +970,9 @@ export function getInterfaceActions(
         options,
       );
     },
+
+    waitForUpdate: async () =>
+      waitForUpdate(controllerMessenger, snapId, id, content),
   };
 }
 

--- a/packages/snaps-simulation/src/request.test.tsx
+++ b/packages/snaps-simulation/src/request.test.tsx
@@ -115,6 +115,7 @@ describe('handleRequest', () => {
       selectInDropdown: expect.any(Function),
       typeInField: expect.any(Function),
       uploadFile: expect.any(Function),
+      waitForUpdate: expect.any(Function),
     });
 
     await closeServer();
@@ -346,6 +347,7 @@ describe('getInterfaceApi', () => {
       selectFromRadioGroup: expect.any(Function),
       selectFromSelector: expect.any(Function),
       uploadFile: expect.any(Function),
+      waitForUpdate: expect.any(Function),
     });
   });
 
@@ -379,6 +381,7 @@ describe('getInterfaceApi', () => {
       selectFromRadioGroup: expect.any(Function),
       selectFromSelector: expect.any(Function),
       uploadFile: expect.any(Function),
+      waitForUpdate: expect.any(Function),
     });
   });
 

--- a/packages/snaps-simulation/src/types.ts
+++ b/packages/snaps-simulation/src/types.ts
@@ -173,6 +173,11 @@ export type SnapInterfaceActions = {
     file: string | Uint8Array,
     options?: FileOptions,
   ): Promise<void>;
+
+  /**
+   * Wait for the interface to be updated.
+   */
+  waitForUpdate: () => Promise<SnapHandlerInterface>;
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -6145,6 +6145,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-promise: "npm:^6.1.1"
     express: "npm:^4.18.2"
+    fast-deep-equal: "npm:^3.1.3"
     jest: "npm:^29.0.2"
     jest-it-up: "npm:^2.0.0"
     jest-silent-reporter: "npm:^0.6.0"


### PR DESCRIPTION
Adds `waitForUpdate` as an interface action, which lets developers wait for the Snap content to be updated by the Snap. This is useful when waiting for the Snap to populate the UI with information gathered asynchronously.

Fixes https://github.com/MetaMask/snaps/issues/2958