### PR TITLE
BREAKING: Add support for new state methods to `snaps-simulation`

### DIFF
--- a/packages/examples/packages/manage-state/src/index.test.ts
+++ b/packages/examples/packages/manage-state/src/index.test.ts
@@ -20,6 +20,244 @@ describe('onRpcRequest', () => {
     });
   });
 
+  describe('setState', () => {
+    it('sets the state to the params', async () => {
+      const { request } = await installSnap();
+
+      expect(
+        await request({
+          method: 'setState',
+          params: {
+            value: {
+              items: ['foo'],
+            },
+          },
+        }),
+      ).toRespondWith(null);
+
+      expect(
+        await request({
+          method: 'getState',
+        }),
+      ).toRespondWith({
+        items: ['foo'],
+      });
+    });
+
+    it('sets the state at a specific key', async () => {
+      const { request } = await installSnap();
+
+      expect(
+        await request({
+          method: 'setState',
+          params: {
+            value: 'foo',
+            key: 'nested.key',
+          },
+        }),
+      ).toRespondWith(null);
+
+      expect(
+        await request({
+          method: 'getState',
+        }),
+      ).toRespondWith({
+        nested: {
+          key: 'foo',
+        },
+      });
+    });
+
+    it('sets the unencrypted state to the params', async () => {
+      const { request } = await installSnap();
+
+      expect(
+        await request({
+          method: 'setState',
+          params: {
+            value: {
+              items: ['foo'],
+            },
+            encrypted: false,
+          },
+        }),
+      ).toRespondWith(null);
+
+      expect(
+        await request({
+          method: 'getState',
+        }),
+      ).toRespondWith(null);
+
+      expect(
+        await request({
+          method: 'getState',
+          params: {
+            encrypted: false,
+          },
+        }),
+      ).toRespondWith({
+        items: ['foo'],
+      });
+    });
+
+    it('throws if the state is not an object and no key is specified', async () => {
+      const { request } = await installSnap();
+
+      const response = await request({
+        method: 'setState',
+        params: {
+          value: 'foo',
+        },
+      });
+
+      expect(response).toRespondWithError(
+        expect.objectContaining({
+          code: -32602,
+          message:
+            'Invalid params: Value must be an object if key is not provided.',
+        }),
+      );
+    });
+  });
+
+  describe('getState', () => {
+    it('returns `null` if no state has been set', async () => {
+      const { request } = await installSnap();
+
+      const response = await request({
+        method: 'getState',
+      });
+
+      expect(response).toRespondWith(null);
+    });
+
+    it('returns the state', async () => {
+      const { request } = await installSnap();
+
+      await request({
+        method: 'setState',
+        params: {
+          value: {
+            items: ['foo'],
+          },
+        },
+      });
+
+      const response = await request({
+        method: 'getState',
+      });
+
+      expect(response).toRespondWith({
+        items: ['foo'],
+      });
+    });
+
+    it('returns the state at a specific key', async () => {
+      const { request } = await installSnap();
+
+      await request({
+        method: 'setState',
+        params: {
+          value: {
+            nested: {
+              key: 'foo',
+            },
+          },
+        },
+      });
+
+      const response = await request({
+        method: 'getState',
+        params: {
+          key: 'nested.key',
+        },
+      });
+
+      expect(response).toRespondWith('foo');
+    });
+
+    it('returns the unencrypted state', async () => {
+      const { request } = await installSnap();
+
+      await request({
+        method: 'setState',
+        params: {
+          value: {
+            items: ['foo'],
+          },
+          encrypted: false,
+        },
+      });
+
+      const response = await request({
+        method: 'getState',
+        params: {
+          encrypted: false,
+        },
+      });
+
+      expect(response).toRespondWith({
+        items: ['foo'],
+      });
+    });
+  });
+
+  describe('clearState', () => {
+    it('clears the state', async () => {
+      const { request } = await installSnap();
+
+      await request({
+        method: 'setState',
+        params: {
+          value: {
+            items: ['foo'],
+          },
+        },
+      });
+
+      await request({
+        method: 'clearState',
+      });
+
+      const response = await request({
+        method: 'getState',
+      });
+
+      expect(response).toRespondWith(null);
+    });
+
+    it('clears the unencrypted state', async () => {
+      const { request } = await installSnap();
+
+      await request({
+        method: 'setState',
+        params: {
+          value: {
+            items: ['foo'],
+          },
+          encrypted: false,
+        },
+      });
+
+      await request({
+        method: 'clearState',
+        params: {
+          encrypted: false,
+        },
+      });
+
+      const response = await request({
+        method: 'getState',
+        params: {
+          encrypted: false,
+        },
+      });
+
+      expect(response).toRespondWith(null);
+    });
+  });
+
   describe('legacy_setState', () => {
     it('sets the state to the params', async () => {
       const { request } = await installSnap();

--- a/packages/snaps-simulation/src/controllers.test.ts
+++ b/packages/snaps-simulation/src/controllers.test.ts
@@ -5,10 +5,10 @@ import {
 } from '@metamask/permission-controller';
 
 import { getControllers } from './controllers';
-import type { MiddlewareHooks } from './simulation';
+import type { RestrictedMiddlewareHooks } from './simulation';
 import { getMockOptions } from './test-utils';
 
-const MOCK_HOOKS: MiddlewareHooks = {
+const MOCK_HOOKS: RestrictedMiddlewareHooks = {
   getIsLocked: jest.fn(),
   getMnemonic: jest.fn(),
   getSnapFile: jest.fn(),

--- a/packages/snaps-simulation/src/controllers.ts
+++ b/packages/snaps-simulation/src/controllers.ts
@@ -29,7 +29,7 @@ import { getSafeJson } from '@metamask/utils';
 import { getPermissionSpecifications } from './methods';
 import { UNRESTRICTED_METHODS } from './methods/constants';
 import type { SimulationOptions } from './options';
-import type { MiddlewareHooks } from './simulation';
+import type { RestrictedMiddlewareHooks } from './simulation';
 import type { RunSagaFunction } from './store';
 
 export type RootControllerAllowedActions =
@@ -49,7 +49,7 @@ export type RootControllerMessenger = ControllerMessenger<
 
 export type GetControllersOptions = {
   controllerMessenger: ControllerMessenger<any, any>;
-  hooks: MiddlewareHooks;
+  hooks: RestrictedMiddlewareHooks;
   runSaga: RunSagaFunction;
   options: SimulationOptions;
 };

--- a/packages/snaps-simulation/src/methods/hooks/index.ts
+++ b/packages/snaps-simulation/src/methods/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './get-preferences';
+export * from './interface';
 export * from './notifications';
+export * from './permitted';
 export * from './request-user-approval';
 export * from './state';
-export * from './interface';

--- a/packages/snaps-simulation/src/methods/hooks/permitted/index.ts
+++ b/packages/snaps-simulation/src/methods/hooks/permitted/index.ts
@@ -1,0 +1,1 @@
+export * from './state';

--- a/packages/snaps-simulation/src/methods/hooks/permitted/state.test.ts
+++ b/packages/snaps-simulation/src/methods/hooks/permitted/state.test.ts
@@ -1,0 +1,119 @@
+import { createStore, getState, setState } from '../../../store';
+import { getMockOptions } from '../../../test-utils';
+import {
+  getPermittedClearSnapStateMethodImplementation,
+  getPermittedGetSnapStateMethodImplementation,
+  getPermittedUpdateSnapStateMethodImplementation,
+} from './state';
+
+describe('getPermittedGetSnapStateMethodImplementation', () => {
+  it('returns the implementation of the `getSnapState` hook', async () => {
+    const { store, runSaga } = createStore(getMockOptions());
+    const fn = getPermittedGetSnapStateMethodImplementation(runSaga);
+
+    expect(await fn(true)).toBeNull();
+
+    store.dispatch(
+      setState({
+        state: JSON.stringify({
+          foo: 'bar',
+        }),
+        encrypted: true,
+      }),
+    );
+
+    expect(await fn(true)).toStrictEqual({
+      foo: 'bar',
+    });
+  });
+
+  it('returns the implementation of the `getSnapState` hook for unencrypted state', async () => {
+    const { store, runSaga } = createStore(getMockOptions());
+    const fn = getPermittedGetSnapStateMethodImplementation(runSaga);
+
+    expect(await fn(false)).toBeNull();
+
+    store.dispatch(
+      setState({
+        state: JSON.stringify({
+          foo: 'bar',
+        }),
+        encrypted: false,
+      }),
+    );
+
+    expect(await fn(false)).toStrictEqual({
+      foo: 'bar',
+    });
+  });
+});
+
+describe('getPermittedUpdateSnapStateMethodImplementation', () => {
+  it('returns the implementation of the `updateSnapState` hook', async () => {
+    const { store, runSaga } = createStore(getMockOptions());
+    const fn = getPermittedUpdateSnapStateMethodImplementation(runSaga);
+
+    expect(getState(true)(store.getState())).toBeNull();
+
+    await fn({ foo: 'bar' }, true);
+
+    expect(getState(true)(store.getState())).toStrictEqual(
+      JSON.stringify({
+        foo: 'bar',
+      }),
+    );
+  });
+
+  it('returns the implementation of the `updateSnapState` hook for unencrypted state', async () => {
+    const { store, runSaga } = createStore(getMockOptions());
+    const fn = getPermittedUpdateSnapStateMethodImplementation(runSaga);
+
+    expect(getState(false)(store.getState())).toBeNull();
+
+    await fn({ foo: 'bar' }, false);
+
+    expect(getState(false)(store.getState())).toStrictEqual(
+      JSON.stringify({
+        foo: 'bar',
+      }),
+    );
+  });
+});
+
+describe('getPermittedClearSnapStateMethodImplementation', () => {
+  it('returns the implementation of the `clearSnapState` hook', async () => {
+    const { store, runSaga } = createStore(getMockOptions());
+    const fn = getPermittedClearSnapStateMethodImplementation(runSaga);
+
+    store.dispatch(
+      setState({
+        state: JSON.stringify({
+          foo: 'bar',
+        }),
+        encrypted: true,
+      }),
+    );
+
+    await fn(true);
+
+    expect(getState(true)(store.getState())).toBeNull();
+  });
+
+  it('returns the implementation of the `clearSnapState` hook for unencrypted state', async () => {
+    const { store, runSaga } = createStore(getMockOptions());
+    const fn = getPermittedClearSnapStateMethodImplementation(runSaga);
+
+    store.dispatch(
+      setState({
+        state: JSON.stringify({
+          foo: 'bar',
+        }),
+        encrypted: false,
+      }),
+    );
+
+    await fn(false);
+
+    expect(getState(false)(store.getState())).toBeNull();
+  });
+});

--- a/packages/snaps-simulation/src/methods/hooks/permitted/state.ts
+++ b/packages/snaps-simulation/src/methods/hooks/permitted/state.ts
@@ -1,0 +1,90 @@
+import { parseJson } from '@metamask/snaps-utils';
+import type { Json } from '@metamask/utils';
+import type { SagaIterator } from 'redux-saga';
+import { put, select } from 'redux-saga/effects';
+
+import type { RunSagaFunction } from '../../../store';
+import { clearState, getState, setState } from '../../../store';
+
+/**
+ * Get the Snap state from the store.
+ *
+ * @param encrypted - Whether to get the encrypted or unencrypted state.
+ * Defaults to encrypted state.
+ * @returns The state of the Snap.
+ * @yields Selects the state from the store.
+ */
+function* getSnapStateImplementation(encrypted: boolean): SagaIterator<string> {
+  const state = yield select(getState(encrypted));
+  // TODO: Use actual decryption implementation
+  return parseJson(state);
+}
+
+/**
+ * Get the implementation of the `getSnapState` hook.
+ *
+ * @param runSaga - The function to run a saga outside the usual Redux flow.
+ * @returns The implementation of the `getSnapState` hook.
+ */
+export function getPermittedGetSnapStateMethodImplementation(
+  runSaga: RunSagaFunction,
+) {
+  return async (...args: Parameters<typeof getSnapStateImplementation>) => {
+    return await runSaga(getSnapStateImplementation, ...args).toPromise();
+  };
+}
+
+/**
+ * Update the Snap state in the store.
+ *
+ * @param newState - The new state.
+ * @param encrypted - Whether to update the encrypted or unencrypted state.
+ * Defaults to encrypted state.
+ * @yields Puts the new state in the store.
+ */
+function* updateSnapStateImplementation(
+  newState: Record<string, Json>,
+  encrypted: boolean,
+): SagaIterator<void> {
+  // TODO: Use actual encryption implementation
+  yield put(setState({ state: JSON.stringify(newState), encrypted }));
+}
+
+/**
+ * Get the implementation of the `updateSnapState` hook.
+ *
+ * @param runSaga - The function to run a saga outside the usual Redux flow.
+ * @returns The implementation of the `updateSnapState` hook.
+ */
+export function getPermittedUpdateSnapStateMethodImplementation(
+  runSaga: RunSagaFunction,
+) {
+  return async (...args: Parameters<typeof updateSnapStateImplementation>) => {
+    return await runSaga(updateSnapStateImplementation, ...args).toPromise();
+  };
+}
+
+/**
+ * Clear the Snap state in the store.
+ *
+ * @param encrypted - Whether to clear the encrypted or unencrypted state.
+ * Defaults to encrypted state.
+ * @yields Puts the new state in the store.
+ */
+function* clearSnapStateImplementation(encrypted: boolean): SagaIterator<void> {
+  yield put(clearState({ encrypted }));
+}
+
+/**
+ * Get the implementation of the `clearSnapState` hook.
+ *
+ * @param runSaga - The function to run a saga outside the usual Redux flow.
+ * @returns The implementation of the `clearSnapState` hook.
+ */
+export function getPermittedClearSnapStateMethodImplementation(
+  runSaga: RunSagaFunction,
+) {
+  return async (...args: Parameters<typeof clearSnapStateImplementation>) => {
+    runSaga(clearSnapStateImplementation, ...args).result();
+  };
+}

--- a/packages/snaps-simulation/src/methods/specifications.test.ts
+++ b/packages/snaps-simulation/src/methods/specifications.test.ts
@@ -5,7 +5,7 @@ import {
 } from '@metamask/snaps-utils/test-utils';
 
 import { getControllers, registerSnap } from '../controllers';
-import type { MiddlewareHooks } from '../simulation';
+import type { RestrictedMiddlewareHooks } from '../simulation';
 import { getMockOptions } from '../test-utils/options';
 import {
   asyncResolve,
@@ -14,7 +14,7 @@ import {
   resolve,
 } from './specifications';
 
-const MOCK_HOOKS: MiddlewareHooks = {
+const MOCK_HOOKS: RestrictedMiddlewareHooks = {
   getMnemonic: jest.fn(),
   getSnapFile: jest.fn(),
   createInterface: jest.fn(),

--- a/packages/snaps-simulation/src/methods/specifications.ts
+++ b/packages/snaps-simulation/src/methods/specifications.ts
@@ -59,7 +59,7 @@ export function resolve(result: unknown) {
  * resolve with `undefined`.
  * @returns The function implementation.
  */
-export function asyncResolve(result?: unknown) {
+export function asyncResolve<Type>(result?: Type) {
   return async () => result;
 }
 

--- a/packages/snaps-simulation/src/middleware/engine.test.ts
+++ b/packages/snaps-simulation/src/middleware/engine.test.ts
@@ -7,11 +7,18 @@ describe('createJsonRpcEngine', () => {
     const { store } = createStore(getMockOptions());
     const engine = createJsonRpcEngine({
       store,
-      hooks: {
+      restrictedHooks: {
         getMnemonic: jest.fn(),
-        getSnapFile: jest.fn().mockResolvedValue('foo'),
         getIsLocked: jest.fn(),
+        getClientCryptography: jest.fn(),
+      },
+      permittedHooks: {
+        getSnapFile: jest.fn().mockResolvedValue('foo'),
+        getSnapState: jest.fn(),
+        updateSnapState: jest.fn(),
+        clearSnapState: jest.fn(),
         getInterfaceState: jest.fn(),
+        getInterfaceContext: jest.fn(),
         createInterface: jest.fn(),
         updateInterface: jest.fn(),
         resolveInterface: jest.fn(),

--- a/packages/snaps-simulation/src/middleware/engine.ts
+++ b/packages/snaps-simulation/src/middleware/engine.ts
@@ -45,8 +45,12 @@ export function createJsonRpcEngine({
 }: CreateJsonRpcEngineOptions) {
   const engine = new JsonRpcEngine();
   engine.push(createMockMiddleware(store));
+
+  // The hooks here do not match the hooks used by the clients, so this
+  // middleware should not be used outside of the simulation environment.
   engine.push(createInternalMethodsMiddleware(restrictedHooks));
   engine.push(createSnapsMethodMiddleware(true, permittedHooks));
+
   engine.push(permissionMiddleware);
   engine.push(
     createFetchMiddleware({

--- a/packages/snaps-simulation/src/middleware/engine.ts
+++ b/packages/snaps-simulation/src/middleware/engine.ts
@@ -6,14 +6,18 @@ import { createSnapsMethodMiddleware } from '@metamask/snaps-rpc-methods';
 import type { Json } from '@metamask/utils';
 
 import { DEFAULT_JSON_RPC_ENDPOINT } from '../constants';
-import type { MiddlewareHooks } from '../simulation';
+import type {
+  PermittedMiddlewareHooks,
+  RestrictedMiddlewareHooks,
+} from '../simulation';
 import type { Store } from '../store';
 import { createInternalMethodsMiddleware } from './internal-methods';
 import { createMockMiddleware } from './mock';
 
 export type CreateJsonRpcEngineOptions = {
   store: Store;
-  hooks: MiddlewareHooks;
+  restrictedHooks: RestrictedMiddlewareHooks;
+  permittedHooks: PermittedMiddlewareHooks;
   permissionMiddleware: JsonRpcMiddleware<RestrictedMethodParameters, Json>;
   endpoint?: string;
 };
@@ -26,21 +30,23 @@ export type CreateJsonRpcEngineOptions = {
  *
  * @param options - The options to use when creating the engine.
  * @param options.store - The Redux store to use.
- * @param options.hooks - Any hooks used by the middleware handlers.
+ * @param options.restrictedHooks - Any hooks used by the middleware handlers.
+ * @param options.permittedHooks - Any hooks used by the middleware handlers.
  * @param options.permissionMiddleware - The permission middleware to use.
  * @param options.endpoint - The JSON-RPC endpoint to use for Ethereum requests.
  * @returns A JSON-RPC engine.
  */
 export function createJsonRpcEngine({
   store,
-  hooks,
+  restrictedHooks,
+  permittedHooks,
   permissionMiddleware,
   endpoint = DEFAULT_JSON_RPC_ENDPOINT,
 }: CreateJsonRpcEngineOptions) {
   const engine = new JsonRpcEngine();
   engine.push(createMockMiddleware(store));
-  engine.push(createInternalMethodsMiddleware(hooks));
-  engine.push(createSnapsMethodMiddleware(true, hooks));
+  engine.push(createInternalMethodsMiddleware(restrictedHooks));
+  engine.push(createSnapsMethodMiddleware(true, permittedHooks));
   engine.push(permissionMiddleware);
   engine.push(
     createFetchMiddleware({

--- a/packages/snaps-simulation/src/simulation.test.ts
+++ b/packages/snaps-simulation/src/simulation.test.ts
@@ -233,6 +233,75 @@ describe('getPermittedHooks', () => {
   const { runSaga, store } = createStore(getMockOptions());
   const controllerMessenger = getRootControllerMessenger();
 
+  it('returns the `hasPermission` hook', async () => {
+    const { snapId, close } = await getMockServer({
+      manifest: getSnapManifest(),
+    });
+
+    const location = detectSnapLocation(snapId, {
+      allowLocal: true,
+    });
+
+    const snapFiles = await fetchSnap(snapId, location);
+
+    const { hasPermission } = getPermittedHooks(
+      snapId,
+      snapFiles,
+      controllerMessenger,
+      runSaga,
+    );
+
+    expect(hasPermission('snap_manageState')).toBe(true);
+
+    await close();
+  });
+
+  it('returns the `getUnlockPromise` hook', async () => {
+    const { snapId, close } = await getMockServer({
+      manifest: getSnapManifest(),
+    });
+
+    const location = detectSnapLocation(snapId, {
+      allowLocal: true,
+    });
+
+    const snapFiles = await fetchSnap(snapId, location);
+
+    const { getUnlockPromise } = getPermittedHooks(
+      snapId,
+      snapFiles,
+      controllerMessenger,
+      runSaga,
+    );
+
+    expect(await getUnlockPromise(true)).toBeUndefined();
+
+    await close();
+  });
+
+  it('returns the `getIsLocked` hook', async () => {
+    const { snapId, close } = await getMockServer({
+      manifest: getSnapManifest(),
+    });
+
+    const location = detectSnapLocation(snapId, {
+      allowLocal: true,
+    });
+
+    const snapFiles = await fetchSnap(snapId, location);
+
+    const { getIsLocked } = getPermittedHooks(
+      snapId,
+      snapFiles,
+      controllerMessenger,
+      runSaga,
+    );
+
+    expect(getIsLocked()).toBe(false);
+
+    await close();
+  });
+
   it('returns the `getSnapFile` hook', async () => {
     const value = JSON.stringify({ bar: 'baz' });
     const { snapId, close } = await getMockServer({

--- a/packages/snaps-simulation/src/simulation.ts
+++ b/packages/snaps-simulation/src/simulation.ts
@@ -38,7 +38,7 @@ import { getSnapFile } from './files';
 import type { SnapHelpers } from './helpers';
 import { getHelpers } from './helpers';
 import { resolveWithSaga } from './interface';
-import { getEndowments } from './methods';
+import { asyncResolve, getEndowments } from './methods';
 import {
   getPermittedClearSnapStateMethodImplementation,
   getPermittedGetSnapStateMethodImplementation,
@@ -123,6 +123,22 @@ export type RestrictedMiddlewareHooks = {
 };
 
 export type PermittedMiddlewareHooks = {
+  /**
+   * A hook that gets whether the requesting origin has a given permission.
+   *
+   * @param permissionName - The name of the permission to check.
+   * @returns Whether the origin has the permission.
+   */
+  hasPermission: (permissionName: string) => boolean;
+
+  /**
+   * A hook that returns a promise that resolves once the extension is unlocked.
+   *
+   * @param shouldShowUnlockRequest - Whether to show the unlock request.
+   * @returns A promise that resolves once the extension is unlocked.
+   */
+  getUnlockPromise: (shouldShowUnlockRequest: boolean) => Promise<void>;
+
   /**
    * A hook that returns the Snap's auxiliary file for the given path. This hook
    * is bound to the Snap ID.
@@ -372,6 +388,9 @@ export function getPermittedHooks(
   runSaga: RunSagaFunction,
 ): PermittedMiddlewareHooks {
   return {
+    hasPermission: () => true,
+    getUnlockPromise: asyncResolve(),
+
     getSnapFile: async (path: string, encoding: AuxiliaryFileEncoding) =>
       await getSnapFile(snapFiles.auxiliaryFiles, path, encoding),
 

--- a/packages/snaps-simulation/src/simulation.ts
+++ b/packages/snaps-simulation/src/simulation.ts
@@ -140,6 +140,13 @@ export type PermittedMiddlewareHooks = {
   getUnlockPromise: (shouldShowUnlockRequest: boolean) => Promise<void>;
 
   /**
+   * A hook that returns whether the client is locked or not.
+   *
+   * @returns A boolean flag signaling whether the client is locked.
+   */
+  getIsLocked: () => boolean;
+
+  /**
    * A hook that returns the Snap's auxiliary file for the given path. This hook
    * is bound to the Snap ID.
    *
@@ -390,6 +397,7 @@ export function getPermittedHooks(
   return {
     hasPermission: () => true,
     getUnlockPromise: asyncResolve(),
+    getIsLocked: () => false,
 
     getSnapFile: async (path: string, encoding: AuxiliaryFileEncoding) =>
       await getSnapFile(snapFiles.auxiliaryFiles, path, encoding),


### PR DESCRIPTION
This adds support for the state methods introduced in #2916 to `snaps-simulation` (and `snaps-jest`), and updates the example to test these methods as well.

## Breaking changes

- The middleware hooks in `snaps-simulation` were separated into two separate types, `PermittedMiddlewareHooks` and `RestrictedMiddlewareHooks`.
- The `MiddlewareHooks` type was removed.