### PR TITLE
fix: Skip unnecesary provider initialization

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -1652,14 +1652,7 @@ describe('SnapController', () => {
         const stream = mux.createStream('metamask-provider');
         const engine = new JsonRpcEngine();
         const middleware = createAsyncMiddleware(async (req, res, _next) => {
-          if (req.method === 'metamask_getProviderState') {
-            res.result = {
-              isUnlocked: false,
-              accounts: [],
-              chainId: '0x1',
-              networkVersion: '1',
-            };
-          } else if (req.method === 'eth_blockNumber') {
+          if (req.method === 'eth_blockNumber') {
             await sleep(100);
             res.result = MOCK_BLOCK_NUMBER;
           }
@@ -1737,14 +1730,7 @@ describe('SnapController', () => {
         const stream = mux.createStream('metamask-provider');
         const engine = new JsonRpcEngine();
         const middleware = createAsyncMiddleware(async (req, res, _next) => {
-          if (req.method === 'metamask_getProviderState') {
-            res.result = {
-              isUnlocked: false,
-              accounts: [],
-              chainId: '0x1',
-              networkVersion: '1',
-            };
-          } else if (req.method === 'eth_blockNumber') {
+          if (req.method === 'eth_blockNumber') {
             await sleep(100);
             res.result = MOCK_BLOCK_NUMBER;
           }

--- a/packages/snaps-controllers/src/test-utils/execution-environment.ts
+++ b/packages/snaps-controllers/src/test-utils/execution-environment.ts
@@ -43,15 +43,7 @@ export const getNodeEES = (messenger: ReturnType<typeof getNodeEESMessenger>) =>
       const stream = mux.createStream('metamask-provider');
       const engine = new JsonRpcEngine();
       engine.push((req, res, next, end) => {
-        if (req.method === 'metamask_getProviderState') {
-          res.result = {
-            isUnlocked: false,
-            accounts: [],
-            chainId: '0x1',
-            networkVersion: '1',
-          };
-          return end();
-        } else if (req.method === 'eth_blockNumber') {
+        if (req.method === 'eth_blockNumber') {
           res.result = MOCK_BLOCK_NUMBER;
           return end();
         }

--- a/packages/snaps-controllers/src/test-utils/service.ts
+++ b/packages/snaps-controllers/src/test-utils/service.ts
@@ -39,16 +39,6 @@ export const createService = <
       const stream = mux.createStream('metamask-provider');
       const engine = new JsonRpcEngine();
       engine.push((req, res, next, end) => {
-        if (req.method === 'metamask_getProviderState') {
-          res.result = {
-            isUnlocked: false,
-            accounts: [],
-            chainId: '0x1',
-            networkVersion: '1',
-          };
-          return end();
-        }
-
         if (req.method === 'eth_blockNumber') {
           res.result = MOCK_BLOCK_NUMBER;
           return end();

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 80.68,
-  "functions": 89.26,
-  "lines": 90.67,
-  "statements": 90.06
+  "functions": 89.33,
+  "lines": 90.68,
+  "statements": 90.08
 }

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -1,8 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference path="../../../../node_modules/ses/types.d.ts" />
 import { createIdRemapMiddleware } from '@metamask/json-rpc-engine';
-import type { RequestArguments } from '@metamask/providers';
-import { StreamProvider } from '@metamask/providers/stream-provider';
+import type { RequestArguments, StreamProvider } from '@metamask/providers';
 import { errorCodes, rpcErrors, serializeError } from '@metamask/rpc-errors';
 import type { SnapsEthereumProvider, SnapsProvider } from '@metamask/snaps-sdk';
 import { getErrorData } from '@metamask/snaps-sdk';
@@ -40,6 +39,7 @@ import type { CommandMethodsMapping } from './commands';
 import { getCommandMethodImplementations } from './commands';
 import { createEndowments } from './endowments';
 import { addEventListener, removeEventListener } from './globalEvents';
+import { SnapProvider } from './SnapProvider';
 import { sortParamKeys } from './sortParams';
 import {
   assertEthereumOutboundRequest,
@@ -369,12 +369,12 @@ export class BaseSnapExecutor {
       });
     };
 
-    const provider = new StreamProvider(this.rpcStream, {
+    const provider = new SnapProvider(this.rpcStream, {
       jsonRpcStreamName: 'metamask-provider',
       rpcMiddleware: [createIdRemapMiddleware()],
     });
 
-    await provider.initialize();
+    provider.initializeSync();
 
     const snap = this.createSnapGlobal(provider);
     const ethereum = this.createEIP1193Provider(provider);

--- a/packages/snaps-execution-environments/src/common/SnapProvider.ts
+++ b/packages/snaps-execution-environments/src/common/SnapProvider.ts
@@ -1,0 +1,10 @@
+import { StreamProvider } from '@metamask/providers/stream-provider';
+
+export class SnapProvider extends StreamProvider {
+  // Since only the request function is exposed to the Snap, we can initialize the provider
+  // without making the metamask_getProviderState request, saving us a
+  // potential network request before boot.
+  initializeSync() {
+    this._initializeState();
+  }
+}

--- a/packages/snaps-execution-environments/src/common/test-utils/executor.ts
+++ b/packages/snaps-execution-environments/src/common/test-utils/executor.ts
@@ -111,7 +111,6 @@ export class TestSnapExecutor extends BaseSnapExecutor {
     code: string,
     endowments: string[],
   ) {
-    const providerRequestPromise = this.readRpc();
     await this.writeCommand({
       jsonrpc: '2.0',
       id,
@@ -121,26 +120,6 @@ export class TestSnapExecutor extends BaseSnapExecutor {
 
     // In case we are running fake timers, execute a tiny step that forces
     // `setTimeout` to execute, is required for stream communication.
-    if ('clock' in setTimeout) {
-      jest.advanceTimersByTime(1);
-    }
-
-    const providerRequest = await providerRequestPromise;
-    await this.writeRpc({
-      name: 'metamask-provider',
-      data: {
-        jsonrpc: '2.0',
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        id: providerRequest.data.id!,
-        result: {
-          isUnlocked: false,
-          accounts: [],
-          chainId: '0x1',
-          networkVersion: '1',
-        },
-      },
-    });
-
     if ('clock' in setTimeout) {
       jest.advanceTimersByTime(1);
     }

--- a/packages/snaps-execution-environments/src/iframe/IFrameSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/iframe/IFrameSnapExecutor.test.browser.ts
@@ -6,7 +6,6 @@ import {
   MOCK_SNAP_ID,
   MockWindowPostMessageStream,
 } from '@metamask/snaps-utils/test-utils';
-import type { JsonRpcRequest } from '@metamask/utils';
 
 import { IFrameSnapExecutor } from './IFrameSnapExecutor';
 
@@ -35,22 +34,6 @@ async function getResponse(
   return new Promise((resolve) => {
     stream.once('response', (data) => {
       resolve(data);
-    });
-  });
-}
-
-/**
- * Wait for a outbound request from the stream.
- *
- * @param stream - The stream to wait for a response on.
- * @returns The raw JSON-RPC response object.
- */
-async function getOutboundRequest(
-  stream: MockWindowPostMessageStream,
-): Promise<JsonRpcRequest> {
-  return new Promise((resolve) => {
-    stream.once('outbound', (data) => {
-      resolve(data.data);
     });
   });
 }
@@ -101,26 +84,6 @@ describe('IFrameSnapExecutor', () => {
         id: 2,
         method: 'executeSnap',
         params: [MOCK_SNAP_ID, CODE, []],
-      },
-    });
-
-    const outboundRequest = await getOutboundRequest(mockStream);
-    expect(outboundRequest.method).toBe('metamask_getProviderState');
-
-    writeMessage(mockStream, {
-      name: 'jsonRpc',
-      data: {
-        name: 'metamask-provider',
-        data: {
-          jsonrpc: '2.0',
-          id: outboundRequest.id,
-          result: {
-            isUnlocked: false,
-            accounts: [],
-            chainId: '0x1',
-            networkVersion: '1',
-          },
-        },
       },
     });
 

--- a/packages/snaps-execution-environments/src/node-process/ChildProcessSnapExecutor.test.ts
+++ b/packages/snaps-execution-environments/src/node-process/ChildProcessSnapExecutor.test.ts
@@ -2,7 +2,7 @@
 import 'ses';
 import { HandlerType, SNAP_STREAM_NAMES } from '@metamask/snaps-utils';
 import { MOCK_ORIGIN, MOCK_SNAP_ID } from '@metamask/snaps-utils/test-utils';
-import type { Json, JsonRpcRequest, JsonRpcSuccess } from '@metamask/utils';
+import type { Json, JsonRpcSuccess } from '@metamask/utils';
 import { EventEmitter } from 'stream';
 
 import { ChildProcessSnapExecutor } from './ChildProcessSnapExecutor';
@@ -34,18 +34,6 @@ describe('ChildProcessSnapExecutor', () => {
     // Utility functions
     const emit = (data: Json) => parentEmitter.emit('message', { data });
     const emitChunk = (name: string, data: Json) => emit({ name, data });
-    const waitForOutbound = (request: Partial<JsonRpcRequest<any>>): any =>
-      new Promise((resolve) => {
-        childEmitter.on('message', ({ data: { name, data } }) => {
-          if (
-            name === SNAP_STREAM_NAMES.JSON_RPC &&
-            data.name === 'metamask-provider' &&
-            data.data.method === request.method
-          ) {
-            resolve(data.data);
-          }
-        });
-      });
 
     const waitForResponse = async (response: JsonRpcSuccess<string>) =>
       new Promise((resolve) => {
@@ -70,24 +58,6 @@ describe('ChildProcessSnapExecutor', () => {
       id: 1,
       method: 'executeSnap',
       params: [MOCK_SNAP_ID, CODE, []],
-    });
-
-    const providerRequest = await waitForOutbound({
-      method: 'metamask_getProviderState',
-    });
-
-    emitChunk(SNAP_STREAM_NAMES.JSON_RPC, {
-      name: 'metamask-provider',
-      data: {
-        jsonrpc: '2.0',
-        id: providerRequest.id,
-        result: {
-          isUnlocked: false,
-          accounts: [],
-          chainId: '0x1',
-          networkVersion: '1',
-        },
-      },
     });
 
     expect(

--- a/packages/snaps-execution-environments/src/node-thread/ThreadSnapExecutor.test.ts
+++ b/packages/snaps-execution-environments/src/node-thread/ThreadSnapExecutor.test.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-unassigned-import
 import 'ses';
 import { SNAP_STREAM_NAMES, HandlerType } from '@metamask/snaps-utils';
-import type { Json, JsonRpcRequest, JsonRpcSuccess } from '@metamask/utils';
+import type { Json, JsonRpcSuccess } from '@metamask/utils';
 import { EventEmitter } from 'stream';
 import { parentPort } from 'worker_threads';
 
@@ -48,18 +48,6 @@ describe('ThreadSnapExecutor', () => {
     // Utility functions
     const emit = (data: Json) => parentEmitter.emit('message', { data });
     const emitChunk = (name: string, data: Json) => emit({ name, data });
-    const waitForOutbound = (request: Partial<JsonRpcRequest<any>>): any =>
-      new Promise((resolve) => {
-        childEmitter.on('message', ({ data: { name, data } }) => {
-          if (
-            name === SNAP_STREAM_NAMES.JSON_RPC &&
-            data.name === 'metamask-provider' &&
-            data.data.method === request.method
-          ) {
-            resolve(data.data);
-          }
-        });
-      });
 
     const waitForResponse = async (response: JsonRpcSuccess<string>) =>
       new Promise((resolve) => {
@@ -84,24 +72,6 @@ describe('ThreadSnapExecutor', () => {
       id: 1,
       method: 'executeSnap',
       params: [FAKE_SNAP_NAME, CODE, []],
-    });
-
-    const providerRequest = await waitForOutbound({
-      method: 'metamask_getProviderState',
-    });
-
-    emitChunk(SNAP_STREAM_NAMES.JSON_RPC, {
-      name: 'metamask-provider',
-      data: {
-        jsonrpc: '2.0',
-        id: providerRequest.id,
-        result: {
-          isUnlocked: false,
-          accounts: [],
-          chainId: '0x1',
-          networkVersion: '1',
-        },
-      },
     });
 
     expect(

--- a/packages/snaps-execution-environments/src/webworker/executor/WebWorkerSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/webworker/executor/WebWorkerSnapExecutor.test.browser.ts
@@ -8,7 +8,6 @@ import {
   MockWindowPostMessageStream,
   spy,
 } from '@metamask/snaps-utils/test-utils';
-import type { JsonRpcRequest } from '@metamask/utils';
 
 import { WebWorkerSnapExecutor } from './WebWorkerSnapExecutor';
 
@@ -37,22 +36,6 @@ async function getResponse(
   return new Promise((resolve) => {
     stream.once('response', (data) => {
       resolve(data);
-    });
-  });
-}
-
-/**
- * Wait for a outbound request from the stream.
- *
- * @param stream - The stream to wait for a response on.
- * @returns The raw JSON-RPC response object.
- */
-async function getOutboundRequest(
-  stream: MockWindowPostMessageStream,
-): Promise<JsonRpcRequest> {
-  return new Promise((resolve) => {
-    stream.once('outbound', (data) => {
-      resolve(data.data);
     });
   });
 }
@@ -113,26 +96,6 @@ describe('WebWorkerSnapExecutor', () => {
         id: 2,
         method: 'executeSnap',
         params: [MOCK_SNAP_ID, CODE, []],
-      },
-    });
-
-    const outboundRequest = await getOutboundRequest(mockStream);
-    expect(outboundRequest.method).toBe('metamask_getProviderState');
-
-    writeMessage(mockStream, {
-      name: 'jsonRpc',
-      data: {
-        name: 'metamask-provider',
-        data: {
-          jsonrpc: '2.0',
-          id: outboundRequest.id,
-          result: {
-            isUnlocked: false,
-            accounts: [],
-            chainId: '0x1',
-            networkVersion: '1',
-          },
-        },
       },
     });
 


### PR DESCRIPTION
Since we only expose the `request` function from the provider and don't allow listening to events or using `provider.chainId` etc we can initialize the provider without making the `metamask_getProviderState` request. This saves us a potential network request that may add overhead to booting the Snap. Specifically the clients call `net_version` since this property is required in the `MetaMaskInpageProvider`.

Closes https://github.com/MetaMask/snaps/issues/2968