### PR TITLE
feat: Unblock `eth_signTypedData`

### DIFF
--- a/packages/examples/packages/ethereum-provider/README.md
+++ b/packages/examples/packages/ethereum-provider/README.md
@@ -33,6 +33,8 @@ JSON-RPC methods:
 - `getVersion`: Get the Ethereum network version from an Ethereum provider.
 - `getAccounts`: Get the Ethereum accounts made available to the snap from an
   Ethereum provider.
+- `personalSign`: Sign a message using an Ethereum account made available to the Snap.
+- `signTypedData`: Sign a struct using an Ethereum account made available to the Snap.
 
 For more information, you can refer to
 [the end-to-end tests](./src/index.test.ts).

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wGmGlT7y9asBxBtugpaU+ZkK1bzawwMx3upjmMDhygs=",
+    "shasum": "I23+R0H/oTfb5PUA99hAW8ILCCn0kFAk2apS+Q0blPA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/src/index.test.ts
+++ b/packages/examples/packages/ethereum-provider/src/index.test.ts
@@ -76,4 +76,48 @@ describe('onRpcRequest', () => {
       ]);
     });
   });
+
+  describe('personalSign', () => {
+    const MOCK_SIGNATURE =
+      '0x16f672a12220dc4d9e27671ef580cfc1397a9a4d5ee19eadea46c0f350b2f72a4922be7c1f16ed9b03ef1d3351eac469e33accf5a36194b1d88923701c2b163f1b';
+
+    it('returns a signature', async () => {
+      const { request, mockJsonRpc } = await installSnap();
+
+      // We can mock the signature request with the response we want.
+      mockJsonRpc({
+        method: 'personal_sign',
+        result: MOCK_SIGNATURE,
+      });
+
+      const response = await request({
+        method: 'personalSign',
+        params: { message: 'foo' },
+      });
+
+      expect(response).toRespondWith(MOCK_SIGNATURE);
+    });
+  });
+
+  describe('signTypedData', () => {
+    const MOCK_SIGNATURE =
+      '0x01b37713300d99fecf0274bcb0dfb586a23d56c4bf2ed700c5ecf4ada7a2a14825e7b1212b1cc49c9440c375337561f2b7a6e639ba25be6a6f5a16f60e6931d31c';
+
+    it('returns a signature', async () => {
+      const { request, mockJsonRpc } = await installSnap();
+
+      // We can mock the signature request with the response we want.
+      mockJsonRpc({
+        method: 'eth_signTypedData_v4',
+        result: MOCK_SIGNATURE,
+      });
+
+      const response = await request({
+        method: 'signTypedData',
+        params: { message: 'foo' },
+      });
+
+      expect(response).toRespondWith(MOCK_SIGNATURE);
+    });
+  });
 });

--- a/packages/examples/packages/ethereum-provider/src/types.ts
+++ b/packages/examples/packages/ethereum-provider/src/types.ts
@@ -1,3 +1,7 @@
 export type PersonalSignParams = {
   message: string;
 };
+
+export type SignTypedDataParams = {
+  message: string;
+};

--- a/packages/snaps-execution-environments/src/common/utils.ts
+++ b/packages/snaps-execution-environments/src/common/utils.ts
@@ -52,10 +52,6 @@ export const BLOCKED_RPC_METHODS = Object.freeze([
   'wallet_revokePermissions',
   // We disallow all of these confirmations for now, since the screens are not ready for Snaps.
   'eth_sendTransaction',
-  'eth_signTypedData',
-  'eth_signTypedData_v1',
-  'eth_signTypedData_v3',
-  'eth_signTypedData_v4',
   'eth_decrypt',
   'eth_getEncryptionPublicKey',
   'wallet_addEthereumChain',

--- a/packages/test-snaps/src/features/snaps/ethereum-provider/EthereumProvider.tsx
+++ b/packages/test-snaps/src/features/snaps/ethereum-provider/EthereumProvider.tsx
@@ -5,7 +5,7 @@ import { Button, ButtonGroup } from 'react-bootstrap';
 import { useInvokeMutation } from '../../../api';
 import { Result, Snap } from '../../../components';
 import { getSnapId } from '../../../utils';
-import { SignMessage } from './components/SignMessage';
+import { SignMessage, SignTypedData } from './components';
 import {
   ETHEREUM_PROVIDER_SNAP_ID,
   ETHEREUM_PROVIDER_SNAP_PORT,
@@ -60,6 +60,7 @@ export const EthereumProvider: FunctionComponent = () => {
         </span>
       </Result>
       <SignMessage />
+      <SignTypedData />
     </Snap>
   );
 };

--- a/packages/test-snaps/src/features/snaps/ethereum-provider/components/SignTypedData.tsx
+++ b/packages/test-snaps/src/features/snaps/ethereum-provider/components/SignTypedData.tsx
@@ -11,7 +11,7 @@ import {
   ETHEREUM_PROVIDER_SNAP_PORT,
 } from '../constants';
 
-export const SignMessage: FunctionComponent = () => {
+export const SignTypedData: FunctionComponent = () => {
   const [message, setMessage] = useState('');
   const [invokeSnap, { isLoading, data, error }] = useInvokeMutation();
 
@@ -24,7 +24,7 @@ export const SignMessage: FunctionComponent = () => {
 
     invokeSnap({
       snapId: getSnapId(ETHEREUM_PROVIDER_SNAP_ID, ETHEREUM_PROVIDER_SNAP_PORT),
-      method: 'personalSign',
+      method: 'signTypedData',
       params: {
         message,
       },
@@ -33,7 +33,7 @@ export const SignMessage: FunctionComponent = () => {
 
   return (
     <>
-      <h3 className="h5">Personal Sign</h3>
+      <h3 className="h5">Sign Typed Data</h3>
       <Form onSubmit={handleSubmit} className="mb-3">
         <Form.Label>Message</Form.Label>
         <Form.Control
@@ -41,16 +41,16 @@ export const SignMessage: FunctionComponent = () => {
           placeholder="Message"
           value={message}
           onChange={handleChange}
-          id="personalSignMessage"
+          id="signTypedData"
           className="mb-3"
         />
 
-        <Button type="submit" id="signPersonalSignMessage" disabled={isLoading}>
-          Sign Message
+        <Button type="submit" id="signTypedDataButton" disabled={isLoading}>
+          Sign Typed Data
         </Button>
       </Form>
-      <Result className="mb-3">
-        <span id="personalSignResult">
+      <Result>
+        <span id="signTypedDataResult">
           {JSON.stringify(data, null, 2)}
           {JSON.stringify(error, null, 2)}
         </span>

--- a/packages/test-snaps/src/features/snaps/ethereum-provider/components/index.ts
+++ b/packages/test-snaps/src/features/snaps/ethereum-provider/components/index.ts
@@ -1,0 +1,2 @@
+export * from './SignMessage';
+export * from './SignTypedData';


### PR DESCRIPTION
Unblock all variants of `eth_signTypedData` as they are deemed lower risk following UI changes on the clients.

Also adds logic to use it in the Ethereum provider example Snap.