### PR TITLE
fix: Disable `nodeEnv` optimization in Webpack

### DIFF
--- a/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
+++ b/packages/snaps-cli/src/webpack/__snapshots__/config.test.ts.snap
@@ -84,6 +84,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -255,6 +256,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -426,6 +428,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -597,6 +600,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -767,6 +771,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -938,6 +943,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -1109,6 +1115,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -1280,6 +1287,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -1459,6 +1467,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -1623,6 +1632,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -1794,6 +1804,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -1973,6 +1984,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -2152,6 +2164,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -2332,6 +2345,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -2503,6 +2517,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -2674,6 +2689,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -2854,6 +2870,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -3030,6 +3047,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -3187,6 +3205,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",
@@ -3344,6 +3363,7 @@ exports[`getDefaultConfiguration returns the default Webpack configuration for t
         },
       },
     ],
+    "nodeEnv": false,
   },
   "output": {
     "chunkFormat": "commonjs",

--- a/packages/snaps-cli/src/webpack/config.ts
+++ b/packages/snaps-cli/src/webpack/config.ts
@@ -374,6 +374,12 @@ export async function getDefaultConfiguration(
       minimize: config.output.minimize,
 
       /**
+       * We disable the nodeEnv optimization as we already add process.NODE_ENV
+       * via the DefinePlugin in the section above this.
+       */
+      nodeEnv: false,
+
+      /**
        * The minimizer to use. We set it to use the `TerserPlugin`.
        */
       minimizer: [


### PR DESCRIPTION
Disable the `nodeEnv` optimization in the default Webpack config, this optimization would simply add the `NODE_ENV` environment variable set to `production`, but that is unnecessary since we are already defining `NODE_ENV` ourselves.

This prevents an issue where devs would run into warnings when attempting to set `NODE_ENV` themselves.