### PR TITLE
feat: Add `hideBalances` to `snap_getPreferences`

### DIFF
--- a/packages/snaps-rpc-methods/src/restricted/getPreferences.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getPreferences.test.ts
@@ -26,9 +26,11 @@ describe('snap_getPreferences', () => {
   describe('getImplementation', () => {
     it('returns the preferences', async () => {
       const methodHooks = {
-        getPreferences: jest
-          .fn()
-          .mockReturnValue({ locale: 'en', currency: 'usd' }),
+        getPreferences: jest.fn().mockReturnValue({
+          locale: 'en',
+          currency: 'usd',
+          hideBalances: false,
+        }),
       };
 
       const implementation = getImplementation(methodHooks);
@@ -40,7 +42,7 @@ describe('snap_getPreferences', () => {
           },
           method: 'snap_getPreferences',
         }),
-      ).toStrictEqual({ locale: 'en', currency: 'usd' });
+      ).toStrictEqual({ locale: 'en', currency: 'usd', hideBalances: false });
     });
   });
 });

--- a/packages/snaps-sdk/src/types/methods/get-preferences.ts
+++ b/packages/snaps-sdk/src/types/methods/get-preferences.ts
@@ -10,4 +10,8 @@ export type GetPreferencesParams = never;
  *
  * It is the user selected preferences from the MetaMask extension.
  */
-export type GetPreferencesResult = { locale: string; currency: string };
+export type GetPreferencesResult = {
+  locale: string;
+  currency: string;
+  hideBalances: boolean;
+};

--- a/packages/snaps-sdk/src/types/methods/get-preferences.ts
+++ b/packages/snaps-sdk/src/types/methods/get-preferences.ts
@@ -9,6 +9,10 @@ export type GetPreferencesParams = never;
  * The result returned by the `snap_getPreferences` method.
  *
  * It is the user selected preferences from the MetaMask extension.
+ *
+ * @property locale - The user's selected locale.
+ * @property currency - The user's selected currency.
+ * @property hideBalances - Whether the user has chosen to hide balances.
  */
 export type GetPreferencesResult = {
   locale: string;

--- a/packages/snaps-sdk/src/types/methods/get-preferences.ts
+++ b/packages/snaps-sdk/src/types/methods/get-preferences.ts
@@ -8,7 +8,7 @@ export type GetPreferencesParams = never;
 /**
  * The result returned by the `snap_getPreferences` method.
  *
- * It is the user selected preferences from the MetaMask extension.
+ * It is the user selected preferences from the MetaMask client.
  *
  * @property locale - The user's selected locale.
  * @property currency - The user's selected currency.

--- a/packages/snaps-simulation/src/methods/hooks/get-preferences.test.ts
+++ b/packages/snaps-simulation/src/methods/hooks/get-preferences.test.ts
@@ -9,7 +9,11 @@ describe('getGetPreferencesMethodImplementation', () => {
       }),
     );
 
-    expect(fn()).toStrictEqual({ currency: 'usd', locale: 'en' });
+    expect(fn()).toStrictEqual({
+      currency: 'usd',
+      locale: 'en',
+      hideBalances: false,
+    });
   });
 
   it('returns the implementation of the `getPreferences` hook for a different locale', async () => {
@@ -19,7 +23,11 @@ describe('getGetPreferencesMethodImplementation', () => {
       }),
     );
 
-    expect(fn()).toStrictEqual({ currency: 'usd', locale: 'nl' });
+    expect(fn()).toStrictEqual({
+      currency: 'usd',
+      locale: 'nl',
+      hideBalances: false,
+    });
   });
 
   it('returns the implementation of the `getPreferences` hook for a different currency', async () => {
@@ -29,6 +37,24 @@ describe('getGetPreferencesMethodImplementation', () => {
       }),
     );
 
-    expect(fn()).toStrictEqual({ currency: 'dkk', locale: 'en' });
+    expect(fn()).toStrictEqual({
+      currency: 'dkk',
+      locale: 'en',
+      hideBalances: false,
+    });
+  });
+
+  it('returns the implementation of the `getPreferences` hook for hidden balances', async () => {
+    const fn = getGetPreferencesMethodImplementation(
+      getMockOptions({
+        hideBalances: true,
+      }),
+    );
+
+    expect(fn()).toStrictEqual({
+      currency: 'usd',
+      locale: 'en',
+      hideBalances: true,
+    });
   });
 });

--- a/packages/snaps-simulation/src/methods/hooks/get-preferences.ts
+++ b/packages/snaps-simulation/src/methods/hooks/get-preferences.ts
@@ -6,13 +6,15 @@ import type { SimulationOptions } from '../../options';
  * @param options - The simulation options.
  * @param options.currency - The currency to use.
  * @param options.locale - The locale to use.
+ * @param options.hideBalances - Whether to hide balances.
  * @returns The implementation of the `getPreferences` hook.
  */
 export function getGetPreferencesMethodImplementation({
   currency,
   locale,
+  hideBalances,
 }: SimulationOptions) {
   return () => {
-    return { currency, locale };
+    return { currency, locale, hideBalances };
   };
 }

--- a/packages/snaps-simulation/src/options.test.ts
+++ b/packages/snaps-simulation/src/options.test.ts
@@ -7,6 +7,7 @@ describe('getOptions', () => {
     expect(options).toMatchInlineSnapshot(`
       {
         "currency": "usd",
+        "hideBalances": false,
         "locale": "en",
         "secretRecoveryPhrase": "test test test test test test test test test test test ball",
         "state": null,
@@ -24,6 +25,7 @@ describe('getOptions', () => {
     expect(options).toMatchInlineSnapshot(`
       {
         "currency": "eur",
+        "hideBalances": false,
         "locale": "nl",
         "secretRecoveryPhrase": "test test test test test test test test test test test ball",
         "state": null,

--- a/packages/snaps-simulation/src/options.ts
+++ b/packages/snaps-simulation/src/options.ts
@@ -1,5 +1,6 @@
 import type { Infer } from '@metamask/superstruct';
 import {
+  boolean,
   create,
   defaulted,
   nullable,
@@ -21,6 +22,7 @@ const SimulationOptionsStruct = object({
     optional(nullable(record(string(), JsonStruct))),
     null,
   ),
+  hideBalances: defaulted(optional(boolean()), false),
 });
 
 /**

--- a/packages/snaps-simulation/src/test-utils/options.ts
+++ b/packages/snaps-simulation/src/test-utils/options.ts
@@ -10,11 +10,13 @@ import type { SimulationOptions } from '../options';
  * @param options.secretRecoveryPhrase - The secret recovery phrase to use.
  * @param options.state - The state to use.
  * @param options.unencryptedState - The unencrypted state to use.
+ * @param options.hideBalances - Whether to hide balances.
  * @returns The options for the simulation.
  */
 export function getMockOptions({
   currency = 'usd',
   locale = 'en',
+  hideBalances = false,
   secretRecoveryPhrase = DEFAULT_SRP,
   state = null,
   unencryptedState = null,
@@ -25,5 +27,6 @@ export function getMockOptions({
     secretRecoveryPhrase,
     state,
     unencryptedState,
+    hideBalances,
   };
 }

--- a/packages/snaps-simulator/src/features/simulation/sagas.ts
+++ b/packages/snaps-simulator/src/features/simulation/sagas.ts
@@ -130,7 +130,11 @@ export function* initSaga({ payload }: PayloadAction<string>) {
       ...sharedHooks,
       // TODO: Add all the hooks required
       // TODO: Allow changing this?
-      getPreferences: () => ({ locale: 'en', currency: 'usd' }),
+      getPreferences: () => ({
+        locale: 'en',
+        currency: 'usd',
+        hideBalances: false,
+      }),
       getUnlockPromise: async () => Promise.resolve(true),
       showDialog: async (...args: Parameters<typeof showDialog>) =>
         await runSaga(showDialog, ...args).toPromise(),


### PR DESCRIPTION
This adds a new property to the `snap_getPreferences` return value called `hideBalances` which binds to the property existing in the preference controller called `privacyMode`.

Fixes: #2977 