### PR TITLE
chore: Add Massa derivation path

### DIFF
--- a/packages/snaps-utils/src/derivation-paths.ts
+++ b/packages/snaps-utils/src/derivation-paths.ts
@@ -180,6 +180,11 @@ export const SNAPS_DERIVATION_PATHS: SnapsDerivationPath[] = [
     curve: 'ed25519',
     name: 'Kadena',
   },
+  {
+    path: ['m', `44'`, `632'`],
+    curve: 'ed25519',
+    name: 'Massa',
+  },
 ];
 
 /**


### PR DESCRIPTION
Add Massa derivation path as per SLIP44, but using the `ed25519` curve.