### PR TITLE
Bump Chromedriver to `^131.0.5`

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^6.21.0",
     "@yarnpkg/types": "^4.0.0",
-    "chromedriver": "^129.0.2",
+    "chromedriver": "^131.0.5",
     "depcheck": "^1.4.7",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",

--- a/scripts/install-chrome.sh
+++ b/scripts/install-chrome.sh
@@ -5,12 +5,12 @@ set -u
 set -o pipefail
 
 # To get the latest version, see <https://www.ubuntuupdates.org/ppa/google_chrome?dist=stable>
-CHROME_VERSION='129.0.6668.89-1'
+CHROME_VERSION='131.0.6778.264-1'
 CHROME_BINARY="google-chrome-stable_${CHROME_VERSION}_amd64.deb"
 CHROME_BINARY_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/${CHROME_BINARY}"
 
 # To retrieve this checksum, run the `wget` and `shasum` commands below
-CHROME_BINARY_SHA512SUM='b764b14ea7958ee2ca7ab7985c479bb2c281a29d6e0570eaf87978591c4a98c837082ce16b290c2f465ab72804f49ad4e8c8c31945fea6eb9d1cda158fb9be8a'
+CHROME_BINARY_SHA512SUM='95123e9d86b2e84be8b4964d4e5d16ab987f2e2854ca90d192f3c88e4b5bbb2f6a1aae46adb408b3538d6277a0083bb1da4d35d3b9806ef7788f3bdac40020f8'
 
 wget -O "${CHROME_BINARY}" -t 5 "${CHROME_BINARY_URL}"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10624,9 +10624,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromedriver@npm:^129.0.2":
-  version: 129.0.2
-  resolution: "chromedriver@npm:129.0.2"
+"chromedriver@npm:^131.0.5":
+  version: 131.0.5
+  resolution: "chromedriver@npm:131.0.5"
   dependencies:
     "@testim/chrome-version": "npm:^1.1.4"
     axios: "npm:^1.7.4"
@@ -10637,7 +10637,7 @@ __metadata:
     tcp-port-used: "npm:^1.0.2"
   bin:
     chromedriver: bin/chromedriver
-  checksum: 10/223854665dce25a5d4b1073cb6732df70172a3cbcba23e91f2e81f07437b0b4be0d1712e90aa2b069e45aacf0eea4f99ba4d76cbda96def9ea8194ce73ee813f
+  checksum: 10/f2bf39f8a658825313a8f977de561932f4b9798c6e46a997c74cab2cd9dc8bc0a1302cfbb7d5127d87238cdb6a7f3d44207112c2e4f9c59d4e2a62fadf815a2c
   languageName: node
   linkType: hard
 
@@ -20498,7 +20498,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^5.42.1"
     "@typescript-eslint/parser": "npm:^6.21.0"
     "@yarnpkg/types": "npm:^4.0.0"
-    chromedriver: "npm:^129.0.2"
+    chromedriver: "npm:^131.0.5"
     depcheck: "npm:^1.4.7"
     eslint: "npm:^8.27.0"
     eslint-config-prettier: "npm:^8.5.0"


### PR DESCRIPTION
This bumps `chromedriver` to `^131.0.5` and updates CI to use the latest version of Chrome.