### PR TITLE
Add script to update Chrome version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:clean": "yarn workspaces foreach --all --parallel --verbose run test:clean",
     "test:verbose": "yarn workspaces foreach --all --parallel --verbose run test:verbose",
     "test:watch": "yarn workspaces foreach --all --parallel --verbose run test:watch",
+    "update-chrome": "./scripts/update-chrome.sh",
     "update-readme-content": "tsx ./scripts/update-readme-content.mts"
   },
   "simple-git-hooks": {

--- a/scripts/install-chrome.sh
+++ b/scripts/install-chrome.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-# To get the latest version, see <https://www.ubuntuupdates.org/ppa/google_chrome?dist=stable>
+# To get the latest version, run `yarn update-chrome`
 CHROME_VERSION='131.0.6778.264-1'
 CHROME_BINARY="google-chrome-stable_${CHROME_VERSION}_amd64.deb"
 CHROME_BINARY_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/${CHROME_BINARY}"

--- a/scripts/update-chrome.sh
+++ b/scripts/update-chrome.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+#!/bin/bash
+
+yarn add -D chromedriver
+
+CHROME_VERSION=$(curl -s https://dl.google.com/linux/chrome/deb/dists/stable/main/binary-amd64/Packages.gz | \
+    gunzip -c | \
+    grep -A 1 "Package: google-chrome-stable" | grep "Version:" | awk '{print $2}')
+
+if [ -z "$CHROME_VERSION" ]; then
+    echo "Failed to fetch the version of google-chrome-stable."
+    exit 1
+fi
+
+CHROME_BINARY="google-chrome-stable_${CHROME_VERSION}_amd64.deb"
+CHROME_BINARY_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/${CHROME_BINARY}"
+SCRIPT_PATH="./scripts/install-chrome.sh"
+
+wget -O "${CHROME_BINARY}" -t 5 "${CHROME_BINARY_URL}"
+CHROME_BINARY_SHA512SUM=$(shasum -a 512 "${CHROME_BINARY}" | awk '{print $1}')
+
+sed -i '' "s/^CHROME_VERSION='.*'/CHROME_VERSION='${CHROME_VERSION}'/" "${SCRIPT_PATH}"
+sed -i '' "s/^CHROME_BINARY_SHA512SUM='.*'/CHROME_BINARY_SHA512SUM='${CHROME_BINARY_SHA512SUM}'/" "${SCRIPT_PATH}"
+
+rm -rf "${CHROME_BINARY}"


### PR DESCRIPTION
I've created a script to simplify bumping Chrome and `chromedriver` a little bit. With the script you can just run `yarn update-chrome`, which fetches the latest version of `chromedriver`, and updates the version and shasum in the `install-chrome` script.

Ideally we can run this automatically on Dependabot PRs, but Dependabot seems to be broken right now.