### PR TITLE
Update `lint-staged` config

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "update-readme-content": "tsx ./scripts/update-readme-content.mts"
   },
   "simple-git-hooks": {
-    "pre-commit": "yarn lint-staged && yarn dedupe --check && yarn update-readme-content"
+    "pre-commit": "yarn lint-staged && yarn update-readme-content"
   },
   "lint-staged": {
     "*.{js,ts,tsx,jsx}": [
@@ -49,6 +49,9 @@
     ],
     "!(CHANGELOG).{json,yml,md}": [
       "prettier --write"
+    ],
+    "yarn.lock": [
+      "yarn dedupe"
     ]
   },
   "resolutions": {


### PR DESCRIPTION
Rather than running `yarn dedupe --check` in the pre-commit hook we now run `yarn dedupe` whenever `yarn.lock` has changed. This means we no longer need to run `yarn dedupe` manually after adding or updating dependencies, and also fixes an issue in Dependabot.