### PR TITLE
fix: Make `jobs` property fully optional in the cronjob endowment

### DIFF
--- a/packages/snaps-sdk/src/types/permissions.ts
+++ b/packages/snaps-sdk/src/types/permissions.ts
@@ -37,7 +37,7 @@ export type RequestedSnap = {
 
 export type InitialPermissions = Partial<{
   'endowment:cronjob': {
-    jobs: Cronjob[];
+    jobs?: Cronjob[];
     maxRequestTime?: number;
   };
   'endowment:ethereum-provider': EmptyObject;

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -191,7 +191,7 @@ export const PermissionsStruct: Describe<InitialPermissions> = type({
   'endowment:cronjob': optional(
     mergeStructs(
       HandlerCaveatsStruct,
-      object({ jobs: CronjobSpecificationArrayStruct }),
+      object({ jobs: optional(CronjobSpecificationArrayStruct) }),
     ),
   ),
   'endowment:ethereum-provider': optional(EmptyObjectStruct),


### PR DESCRIPTION
Make the `jobs` property fully optional in the cronjob endowment since it is also allowed to be empty.

We accounted for and discussed this in #2941, but must have forgotten to allow `endowment:cronjob: {}`.