### PR TITLE
fix: Use proper chain ID for `signTypedData` example

### DIFF
--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "T/7hin+Vhg0SdK8RxXvonPhkTRe/luTzGwqfWrH/8MQ=",
+    "shasum": "1QLc9RhVgpwxBu8FjPo5kZY61mpNoNAfkiAatq99Nc4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/src/index.ts
+++ b/packages/examples/packages/ethereum-provider/src/index.ts
@@ -3,7 +3,12 @@ import {
   type OnRpcRequestHandler,
 } from '@metamask/snaps-sdk';
 import type { Hex } from '@metamask/utils';
-import { assert, stringToBytes, bytesToHex } from '@metamask/utils';
+import {
+  assert,
+  stringToBytes,
+  bytesToHex,
+  hexToNumber,
+} from '@metamask/utils';
 
 import type { PersonalSignParams, SignTypedDataParams } from './types';
 
@@ -107,6 +112,9 @@ async function personalSign(message: string, from: string) {
  * @see https://docs.metamask.io/wallet/concepts/signing-methods/#eth_signtypeddata_v4
  */
 async function signTypedData(message: string, from: string) {
+  const chainId = (await ethereum.request<string>({
+    method: 'eth_chainId',
+  })) as string;
   const signature = await ethereum.request<Hex>({
     method: 'eth_signTypedData_v4',
     params: [
@@ -160,7 +168,7 @@ async function signTypedData(message: string, from: string) {
         domain: {
           name: 'Ether Mail',
           version: '1',
-          chainId: 1,
+          chainId: hexToNumber(chainId),
           verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
         },
         message: {


### PR DESCRIPTION
When writing the signTypedData example I had based the code on some example code that hardcoded the chain ID. Instead we should use the current chain ID, so we can test the Snap on any chain.