### PR TITLE
Update state section on `test-snaps`

### DIFF
--- a/packages/test-snaps/src/features/snaps/state/State.tsx
+++ b/packages/test-snaps/src/features/snaps/state/State.tsx
@@ -49,6 +49,7 @@ export const State: FunctionComponent = () => {
         </pre>
       </Result>
 
+      <GetState encrypted={false} />
       <SetState encrypted={false} />
       <ClearState encrypted={false} />
     </Snap>

--- a/packages/test-snaps/src/features/snaps/state/components/SetState.tsx
+++ b/packages/test-snaps/src/features/snaps/state/components/SetState.tsx
@@ -59,14 +59,14 @@ export const SetState: FunctionComponent<{ encrypted: boolean }> = ({
             placeholder="Value"
             value={value}
             onChange={handleChangeValue}
-            id={encrypted ? 'dataManageState' : 'dataUnencryptedManageState'}
+            id={encrypted ? 'dataState' : 'dataUnencryptedState'}
             className="mb-3"
           />
         </Form.Group>
 
         <Button
           type="submit"
-          id={encrypted ? 'sendManageState' : 'sendUnencryptedManageState'}
+          id={encrypted ? 'sendState' : 'sendUnencryptedState'}
           disabled={isLoading}
         >
           Set State
@@ -74,13 +74,7 @@ export const SetState: FunctionComponent<{ encrypted: boolean }> = ({
       </Form>
 
       <Result className="mb-3">
-        <span
-          id={
-            encrypted
-              ? 'sendManageStateResult'
-              : 'sendUnencryptedManageStateResult'
-          }
-        >
+        <span id={encrypted ? 'sendStateResult' : 'sendUnencryptedStateResult'}>
           {JSON.stringify(data, null, 2)}
           {JSON.stringify(error, null, 2)}
         </span>


### PR DESCRIPTION
Some HTML IDs were duplicated between the state and manage state sections on `test-snaps`, and there was a missing button as well. I've fixed both issues in this PR.