### PR TITLE
feat: Mock chain ID and network version calls in simulation

### DIFF
--- a/packages/examples/packages/ethereum-provider/src/index.test.ts
+++ b/packages/examples/packages/ethereum-provider/src/index.test.ts
@@ -45,14 +45,7 @@ describe('onRpcRequest', () => {
     const MOCK_VERSION = '1'; // Ethereum Mainnet
 
     it('returns the current network version', async () => {
-      const { request, mockJsonRpc } = await installSnap();
-
-      // To avoid relying on the network, we mock the response from the Ethereum
-      // provider.
-      mockJsonRpc({
-        method: 'net_version',
-        result: MOCK_VERSION,
-      });
+      const { request } = await installSnap();
 
       const response = await request({
         method: 'getVersion',

--- a/packages/snaps-simulation/src/middleware/internal-methods/chain-id.test.ts
+++ b/packages/snaps-simulation/src/middleware/internal-methods/chain-id.test.ts
@@ -1,0 +1,28 @@
+import type { Json, PendingJsonRpcResponse } from '@metamask/utils';
+
+import { getChainIdHandler } from './chain-id';
+
+describe('getChainIdHandler', () => {
+  it('returns the chain id', async () => {
+    const end = jest.fn();
+    const result: PendingJsonRpcResponse<Json> = {
+      jsonrpc: '2.0' as const,
+      id: 1,
+    };
+
+    await getChainIdHandler(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_chainId',
+        params: [],
+      },
+      result,
+      jest.fn(),
+      end,
+    );
+
+    expect(end).toHaveBeenCalled();
+    expect(result.result).toBe('0x01');
+  });
+});

--- a/packages/snaps-simulation/src/middleware/internal-methods/chain-id.ts
+++ b/packages/snaps-simulation/src/middleware/internal-methods/chain-id.ts
@@ -1,0 +1,34 @@
+import type {
+  JsonRpcEngineEndCallback,
+  JsonRpcEngineNextCallback,
+} from '@metamask/json-rpc-engine';
+import type {
+  Json,
+  JsonRpcRequest,
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
+
+/**
+ * A mock handler for eth_chainId that always returns a specific
+ * hardcoded result.
+ *
+ * @param _request - Incoming JSON-RPC request. Ignored for this specific
+ * handler.
+ * @param response - The outgoing JSON-RPC response, modified to return the
+ * result.
+ * @param _next - The `json-rpc-engine` middleware next handler.
+ * @param end - The `json-rpc-engine` middleware end handler.
+ * @returns The JSON-RPC response.
+ */
+export async function getChainIdHandler(
+  _request: JsonRpcRequest,
+  response: PendingJsonRpcResponse<Json>,
+  _next: JsonRpcEngineNextCallback,
+  end: JsonRpcEngineEndCallback,
+) {
+  // For now this will return a mocked result, this should probably match
+  // whatever network the simulation is using.
+  response.result = '0x01';
+
+  return end();
+}

--- a/packages/snaps-simulation/src/middleware/internal-methods/middleware.ts
+++ b/packages/snaps-simulation/src/middleware/internal-methods/middleware.ts
@@ -3,6 +3,8 @@ import { logError } from '@metamask/snaps-utils';
 import type { Json, JsonRpcParams } from '@metamask/utils';
 
 import { getAccountsHandler } from './accounts';
+import { getChainIdHandler } from './chain-id';
+import { getNetworkVersionHandler } from './net-version';
 import { getProviderStateHandler } from './provider-state';
 
 export type InternalMethodsMiddlewareHooks = {
@@ -19,6 +21,8 @@ const methodHandlers = {
   metamask_getProviderState: getProviderStateHandler,
   eth_requestAccounts: getAccountsHandler,
   eth_accounts: getAccountsHandler,
+  eth_chainId: getChainIdHandler,
+  net_version: getNetworkVersionHandler,
   /* eslint-enable @typescript-eslint/naming-convention */
 };
 

--- a/packages/snaps-simulation/src/middleware/internal-methods/net-version.test.ts
+++ b/packages/snaps-simulation/src/middleware/internal-methods/net-version.test.ts
@@ -1,0 +1,28 @@
+import type { Json, PendingJsonRpcResponse } from '@metamask/utils';
+
+import { getNetworkVersionHandler } from './net-version';
+
+describe('getNetworkVersionHandler', () => {
+  it('returns the network version', async () => {
+    const end = jest.fn();
+    const result: PendingJsonRpcResponse<Json> = {
+      jsonrpc: '2.0' as const,
+      id: 1,
+    };
+
+    await getNetworkVersionHandler(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'net_version',
+        params: [],
+      },
+      result,
+      jest.fn(),
+      end,
+    );
+
+    expect(end).toHaveBeenCalled();
+    expect(result.result).toBe('0x01');
+  });
+});

--- a/packages/snaps-simulation/src/middleware/internal-methods/net-version.test.ts
+++ b/packages/snaps-simulation/src/middleware/internal-methods/net-version.test.ts
@@ -23,6 +23,6 @@ describe('getNetworkVersionHandler', () => {
     );
 
     expect(end).toHaveBeenCalled();
-    expect(result.result).toBe('0x01');
+    expect(result.result).toBe('1');
   });
 });

--- a/packages/snaps-simulation/src/middleware/internal-methods/net-version.ts
+++ b/packages/snaps-simulation/src/middleware/internal-methods/net-version.ts
@@ -28,7 +28,7 @@ export async function getNetworkVersionHandler(
 ) {
   // For now this will return a mocked result, this should probably match
   // whatever network the simulation is using.
-  response.result = '0x01';
+  response.result = '1';
 
   return end();
 }

--- a/packages/snaps-simulation/src/middleware/internal-methods/net-version.ts
+++ b/packages/snaps-simulation/src/middleware/internal-methods/net-version.ts
@@ -1,0 +1,34 @@
+import type {
+  JsonRpcEngineEndCallback,
+  JsonRpcEngineNextCallback,
+} from '@metamask/json-rpc-engine';
+import type {
+  Json,
+  JsonRpcRequest,
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
+
+/**
+ * A mock handler for net_version that always returns a specific
+ * hardcoded result.
+ *
+ * @param _request - Incoming JSON-RPC request. Ignored for this specific
+ * handler.
+ * @param response - The outgoing JSON-RPC response, modified to return the
+ * result.
+ * @param _next - The `json-rpc-engine` middleware next handler.
+ * @param end - The `json-rpc-engine` middleware end handler.
+ * @returns The JSON-RPC response.
+ */
+export async function getNetworkVersionHandler(
+  _request: JsonRpcRequest,
+  response: PendingJsonRpcResponse<Json>,
+  _next: JsonRpcEngineNextCallback,
+  end: JsonRpcEngineEndCallback,
+) {
+  // For now this will return a mocked result, this should probably match
+  // whatever network the simulation is using.
+  response.result = '0x01';
+
+  return end();
+}


### PR DESCRIPTION
Mock calls to `eth_chainId` and `net_version` in the simulation framework, so users don't have to mock them manually.

This should also prevent some flakiness in our tests.