### PR TITLE
Fix typo in `test-snaps`

### DIFF
--- a/packages/examples/packages/notifications/src/index.tsx
+++ b/packages/examples/packages/notifications/src/index.tsx
@@ -4,10 +4,12 @@ import { Box, Row, Address } from '@metamask/snaps-sdk/jsx';
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the
- * `wallet_invokeSnap` method. This handler handles two methods:
+ * `wallet_invokeSnap` method. This handler handles three methods:
  *
  * - `inApp`: Show an in-app notification to the user.
  * - `native`: Show a desktop notification to the user.
+ * - `inApp-expanded`: Show an expanded view in-app notification to the user.
+ *
  *
  * @param params - The request parameters.
  * @param params.request - The JSON-RPC request object.

--- a/packages/examples/packages/notifications/src/index.tsx
+++ b/packages/examples/packages/notifications/src/index.tsx
@@ -10,7 +10,6 @@ import { Box, Row, Address } from '@metamask/snaps-sdk/jsx';
  * - `native`: Show a desktop notification to the user.
  * - `inApp-expanded`: Show an expanded view in-app notification to the user.
  *
- *
  * @param params - The request parameters.
  * @param params.request - The JSON-RPC request object.
  * @returns The JSON-RPC response.

--- a/packages/test-snaps/src/features/snaps/notifications/Notifications.tsx
+++ b/packages/test-snaps/src/features/snaps/notifications/Notifications.tsx
@@ -40,7 +40,7 @@ export const Notifications: FunctionComponent = () => {
         <Button
           id="sendExpandedViewNotification"
           disabled={isLoading}
-          onClick={handleClick('inApp-extended')}
+          onClick={handleClick('inApp-expanded')}
         >
           Send In-App Notification With Expanded View
         </Button>


### PR DESCRIPTION
The wrong method was being triggered in `test-snaps`. Fixed the typo.