### PR TITLE
Improve state size validation

### DIFF
--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -10,10 +10,10 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 93.97,
+      branches: 94.89,
       functions: 98.05,
       lines: 98.67,
-      statements: 98.25,
+      statements: 98.34,
     },
   },
 });

--- a/packages/snaps-rpc-methods/src/restricted/manageState.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/manageState.test.ts
@@ -333,7 +333,7 @@ describe('snap_manageState', () => {
           },
         }),
       ).rejects.toThrow(
-        'Invalid snap_manageState "updateState" parameter: The new state must be a plain object.',
+        'Invalid snap_manageState "newState" parameter: The new state must be a plain object.',
       );
 
       expect(updateSnapState).not.toHaveBeenCalledWith(
@@ -375,7 +375,7 @@ describe('snap_manageState', () => {
           },
         }),
       ).rejects.toThrow(
-        'Invalid snap_manageState "updateState" parameter: The new state must be JSON serializable.',
+        'Invalid snap_manageState "newState" parameter: The new state must be JSON serializable.',
       );
 
       expect(updateSnapState).not.toHaveBeenCalledWith(
@@ -459,7 +459,7 @@ describe('snap_manageState', () => {
           'snap_manageState',
         ),
       ).toThrow(
-        'Invalid snap_manageState "updateState" parameter: The new state must be a plain object.',
+        'Invalid snap_manageState "newState" parameter: The new state must be a plain object.',
       );
     });
 
@@ -478,7 +478,7 @@ describe('snap_manageState', () => {
           'snap_manageState',
         ),
       ).toThrow(
-        'Invalid snap_manageState "updateState" parameter: The new state must be JSON serializable.',
+        'Invalid snap_manageState "newState" parameter: The new state must be JSON serializable.',
       );
     });
 
@@ -498,7 +498,7 @@ describe('snap_manageState', () => {
           MOCK_SMALLER_STORAGE_SIZE_LIMIT,
         ),
       ).toThrow(
-        `Invalid snap_manageState "updateState" parameter: The new state must not exceed ${
+        `Invalid snap_manageState "newState" parameter: The new state must not exceed ${
           MOCK_SMALLER_STORAGE_SIZE_LIMIT / 1_000_000
         } MB in size.`,
       );

--- a/packages/snaps-rpc-methods/src/restricted/manageState.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/manageState.test.ts
@@ -498,7 +498,9 @@ describe('snap_manageState', () => {
           MOCK_SMALLER_STORAGE_SIZE_LIMIT,
         ),
       ).toThrow(
-        `Invalid snap_manageState "updateState" parameter: The new state must not exceed ${MOCK_SMALLER_STORAGE_SIZE_LIMIT} bytes in size.`,
+        `Invalid snap_manageState "updateState" parameter: The new state must not exceed ${
+          MOCK_SMALLER_STORAGE_SIZE_LIMIT / 1_000_000
+        } MB in size.`,
       );
     });
   });

--- a/packages/snaps-rpc-methods/src/restricted/manageState.ts
+++ b/packages/snaps-rpc-methods/src/restricted/manageState.ts
@@ -107,7 +107,7 @@ export const manageStateBuilder = Object.freeze({
   methodHooks,
 } as const);
 
-export const STORAGE_SIZE_LIMIT = 104857600; // In bytes (100MB)
+export const STORAGE_SIZE_LIMIT = 64_000_000; // In bytes (64 MB)
 
 type GetEncryptionKeyArgs = {
   snapId: string;
@@ -257,10 +257,6 @@ export function getValidatedParams(
     if (!isObject(newState)) {
       throw rpcErrors.invalidParams({
         message: `Invalid ${method} "updateState" parameter: The new state must be a plain object.`,
-        data: {
-          receivedNewState:
-            typeof newState === 'undefined' ? 'undefined' : newState,
-        },
       });
     }
 
@@ -271,20 +267,14 @@ export function getValidatedParams(
     } catch {
       throw rpcErrors.invalidParams({
         message: `Invalid ${method} "updateState" parameter: The new state must be JSON serializable.`,
-        data: {
-          receivedNewState:
-            typeof newState === 'undefined' ? 'undefined' : newState,
-        },
       });
     }
 
     if (size > storageSizeLimit) {
       throw rpcErrors.invalidParams({
-        message: `Invalid ${method} "updateState" parameter: The new state must not exceed ${storageSizeLimit} bytes in size.`,
-        data: {
-          receivedNewState:
-            typeof newState === 'undefined' ? 'undefined' : newState,
-        },
+        message: `Invalid ${method} "updateState" parameter: The new state must not exceed ${
+          storageSizeLimit / 1_000_000
+        } MB in size.`,
       });
     }
   }

--- a/packages/snaps-rpc-methods/src/restricted/manageState.ts
+++ b/packages/snaps-rpc-methods/src/restricted/manageState.ts
@@ -256,7 +256,7 @@ export function getValidatedParams(
   if (operation === ManageStateOperation.UpdateState) {
     if (!isObject(newState)) {
       throw rpcErrors.invalidParams({
-        message: `Invalid ${method} "updateState" parameter: The new state must be a plain object.`,
+        message: `Invalid ${method} "newState" parameter: The new state must be a plain object.`,
       });
     }
 
@@ -266,13 +266,13 @@ export function getValidatedParams(
       size = getJsonSize(newState);
     } catch {
       throw rpcErrors.invalidParams({
-        message: `Invalid ${method} "updateState" parameter: The new state must be JSON serializable.`,
+        message: `Invalid ${method} "newState" parameter: The new state must be JSON serializable.`,
       });
     }
 
     if (size > storageSizeLimit) {
       throw rpcErrors.invalidParams({
-        message: `Invalid ${method} "updateState" parameter: The new state must not exceed ${
+        message: `Invalid ${method} "newState" parameter: The new state must not exceed ${
           storageSizeLimit / 1_000_000
         } MB in size.`,
       });


### PR DESCRIPTION
This PR contains a couple changes related to JSON size validation in the `snap_manageState` and `snap_setState` methods:

- The maximum size was reduced from 100 MB to 64 MB. This is to because `window.postMessage` breaks when sending payloads that are too large. This is technically a breaking change, but I'm not sure if it should be considered as one, given that the execution environment would throw regardless, if the new state is too big?
- `snap_setState` now properly validates the size of the new state, like `snap_manageState` does.