### PR TITLE
Add `requireCompleteView` prop to `Footer` component

### DIFF
--- a/packages/snaps-sdk/src/jsx/components/Footer.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/Footer.test.tsx
@@ -27,7 +27,7 @@ describe('Footer', () => {
 
   it('renders a footer element with multiple buttons', () => {
     const result = (
-      <Footer>
+      <Footer requireCompleteView>
         <Button name="cancel">Cancel</Button>
         <Button name="confirm">Confirm</Button>
       </Footer>
@@ -37,6 +37,7 @@ describe('Footer', () => {
       type: 'Footer',
       key: null,
       props: {
+        requireCompleteView: true,
         children: [
           {
             type: 'Button',

--- a/packages/snaps-sdk/src/jsx/components/Footer.ts
+++ b/packages/snaps-sdk/src/jsx/components/Footer.ts
@@ -5,9 +5,11 @@ import type { ButtonElement } from './form';
  * The props of the {@link Footer} component.
  *
  * @property children - The single or multiple buttons in the footer.
+ * @property requireCompleteView - Controls whether footer buttons require all content to be viewed before becoming active.
  */
 export type FooterProps = {
   children: ButtonElement | [ButtonElement, ButtonElement];
+  requireCompleteView?: boolean;
 };
 
 const TYPE = 'Footer';
@@ -15,13 +17,20 @@ const TYPE = 'Footer';
 /**
  * A footer component, which is used to create a footer with buttons.
  *
+ * Note: The `requireCompleteView` prop also activates an arrow that allows you to scroll to bottom.
+ *
  * @param props - The props of the component.
+ * @param props.requireCompleteView - Controls whether footer buttons require all content to be viewed before becoming active.
  * @param props.children - The single or multiple buttons in the footer.
  * @returns A footer element.
  * @example
  * <Footer>
  *   <Button name="cancel">Cancel</Button>
  *   <Button name="confirm">Confirm</Button>
+ * </Footer>
+ * @example
+ * <Footer requireCompleteView>
+ *   <Button name="accept">Accept</Button>
  * </Footer>
  */
 export const Footer = createSnapComponent<FooterProps, typeof TYPE>(TYPE);

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -662,6 +662,7 @@ export const FooterChildStruct = selectiveUnion((value) => {
  */
 export const FooterStruct: Describe<FooterElement> = element('Footer', {
   children: FooterChildStruct,
+  requireCompleteView: optional(boolean()),
 });
 
 /**


### PR DESCRIPTION
Adds a new prop to require that snap ui content be viewed entirely before enabling the footer button(s).

Note: This is the snaps side code for https://github.com/MetaMask/snaps/issues/3021, a follow up PR to integrate in the extension will be opened.