### PR TITLE
feat: Add `Intl` as a default endowment

### DIFF
--- a/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
@@ -39,6 +39,7 @@ const commonEndowments: CommonEndowmentSpecification[] = [
   { endowment: DataView, name: 'DataView' },
   { endowment: Float32Array, name: 'Float32Array' },
   { endowment: Float64Array, name: 'Float64Array' },
+  { endowment: Intl, name: 'Intl' },
   { endowment: Int8Array, name: 'Int8Array' },
   { endowment: Int16Array, name: 'Int16Array' },
   { endowment: Int32Array, name: 'Int32Array' },

--- a/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
@@ -168,6 +168,10 @@ describe('endowments', () => {
         endowments: { crypto },
         factory: () => crypto,
       },
+      Intl: {
+        endowments: { Intl },
+        factory: () => Intl,
+      },
       mathAttenuated: {
         endowments: { mathAttenuated },
         factory: () => mathAttenuated,
@@ -351,6 +355,10 @@ describe('endowments', () => {
         {
           factory: expect.any(Function),
           names: ['Float64Array'],
+        },
+        {
+          factory: expect.any(Function),
+          names: ['Intl'],
         },
         {
           factory: expect.any(Function),

--- a/packages/snaps-simulation/src/methods/specifications.test.ts
+++ b/packages/snaps-simulation/src/methods/specifications.test.ts
@@ -356,6 +356,7 @@ describe('getEndowments', () => {
         "Uint16Array",
         "Int32Array",
         "isSecureContext",
+        "Intl",
         "Uint32Array",
         "Float32Array",
         "Float64Array",

--- a/packages/snaps-utils/src/default-endowments.ts
+++ b/packages/snaps-utils/src/default-endowments.ts
@@ -24,6 +24,7 @@ export const DEFAULT_ENDOWMENTS: readonly string[] = Object.freeze([
   'Uint16Array',
   'Int32Array',
   'isSecureContext',
+  'Intl',
   'Uint32Array',
   'Float32Array',
   'Float64Array',


### PR DESCRIPTION
Add `Intl` as a default endowment to allow Snaps to use the browser native functionality for formatting text and numbers in the UI.

Closes #3034 