### PR TITLE
feat: Add `URLSearchParams` as a default endowment

### DIFF
--- a/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
@@ -49,6 +49,7 @@ const commonEndowments: CommonEndowmentSpecification[] = [
   { endowment: Uint16Array, name: 'Uint16Array' },
   { endowment: Uint32Array, name: 'Uint32Array' },
   { endowment: URL, name: 'URL' },
+  { endowment: URLSearchParams, name: 'URLSearchParams' },
   { endowment: WebAssembly, name: 'WebAssembly' },
 ];
 

--- a/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
@@ -92,6 +92,10 @@ describe('endowments', () => {
         endowments: { URL },
         factory: () => new URL('https://metamask.io/snaps/'),
       },
+      URLSearchParams: {
+        endowments: { URLSearchParams },
+        factory: () => new URLSearchParams('https://metamask.io/snaps?foo=bar'),
+      },
       Int8Array: {
         endowments: { Int8Array },
         factory: () => new Int8Array(),
@@ -384,6 +388,7 @@ describe('endowments', () => {
         { factory: expect.any(Function), names: ['Uint16Array'] },
         { factory: expect.any(Function), names: ['Uint32Array'] },
         { factory: expect.any(Function), names: ['URL'] },
+        { factory: expect.any(Function), names: ['URLSearchParams'] },
         { factory: expect.any(Function), names: ['WebAssembly'] },
       ]);
     });

--- a/packages/snaps-simulation/src/methods/specifications.test.ts
+++ b/packages/snaps-simulation/src/methods/specifications.test.ts
@@ -347,6 +347,7 @@ describe('getEndowments', () => {
         "TextDecoder",
         "TextEncoder",
         "URL",
+        "URLSearchParams",
         "setInterval",
         "clearInterval",
         "Int8Array",

--- a/packages/snaps-utils/src/default-endowments.ts
+++ b/packages/snaps-utils/src/default-endowments.ts
@@ -15,6 +15,7 @@ export const DEFAULT_ENDOWMENTS: readonly string[] = Object.freeze([
   'TextDecoder',
   'TextEncoder',
   'URL',
+  'URLSearchParams',
   'setInterval',
   'clearInterval',
   'Int8Array',


### PR DESCRIPTION
Add `URLSearchParams` as a default global to allow for easy modification of query strings for API calls. This was already somewhat available through `URL.searchParams`.

Closes https://github.com/MetaMask/snaps/issues/3044