### PR TITLE
Set name for `SnapController`

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -825,7 +825,7 @@ const name = 'SnapController';
  */
 
 export class SnapController extends BaseController<
-  string,
+  typeof name,
   SnapControllerState,
   SnapControllerMessenger
 > {


### PR DESCRIPTION
`SnapController`'s name was set to `string` rather than `"SnapController"`, which causes some problems with type inference in MetaMask/metamask-extension#30034.