### PR TITLE
chore: Rename `ControllerMessenger` to `Messenger`

### DIFF
--- a/docs/internals/permissions.md
+++ b/docs/internals/permissions.md
@@ -197,7 +197,7 @@ const permissionSpecifications = {
 
 const permissionController = new PermissionController({
   caveatSpecifications,
-  messenger: controllerMessenger, // assume this was given
+  messenger: permissionControllerMessenger, // assume this was given
   permissionSpecifications,
   unrestrictedMethods: ['wallet_unrestrictedMethod'],
 });

--- a/packages/snaps-controllers/src/cronjob/CronjobController.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.ts
@@ -1,5 +1,5 @@
 import type {
-  RestrictedControllerMessenger,
+  RestrictedMessenger,
   ControllerGetStateAction,
   ControllerStateChangeEvent,
 } from '@metamask/base-controller';
@@ -78,7 +78,7 @@ export type CronjobControllerEvents =
   | SnapDisabled
   | CronjobControllerStateChangeEvent;
 
-export type CronjobControllerMessenger = RestrictedControllerMessenger<
+export type CronjobControllerMessenger = RestrictedMessenger<
   typeof controllerName,
   CronjobControllerActions,
   CronjobControllerEvents,

--- a/packages/snaps-controllers/src/insights/SnapInsightsController.ts
+++ b/packages/snaps-controllers/src/insights/SnapInsightsController.ts
@@ -1,5 +1,5 @@
 import type {
-  RestrictedControllerMessenger,
+  RestrictedMessenger,
   ControllerGetStateAction,
   ControllerStateChangeEvent,
 } from '@metamask/base-controller';
@@ -58,7 +58,7 @@ export type SnapInsightsControllerAllowedEvents =
   | TransactionControllerTransactionStatusUpdatedEvent
   | SignatureStateChange;
 
-export type SnapInsightsControllerMessenger = RestrictedControllerMessenger<
+export type SnapInsightsControllerMessenger = RestrictedMessenger<
   typeof controllerName,
   SnapInsightsControllerActions | SnapInsightsControllerAllowedActions,
   SnapInsightControllerEvents | SnapInsightsControllerAllowedEvents,

--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
@@ -3,7 +3,7 @@ import type {
   HasApprovalRequest,
 } from '@metamask/approval-controller';
 import type {
-  RestrictedControllerMessenger,
+  RestrictedMessenger,
   ControllerGetStateAction,
   ControllerStateChangeEvent,
 } from '@metamask/base-controller';
@@ -127,7 +127,7 @@ export type SnapInterfaceControllerEvents =
   | SnapInterfaceControllerStateChangeEvent
   | NotificationListUpdatedEvent;
 
-export type SnapInterfaceControllerMessenger = RestrictedControllerMessenger<
+export type SnapInterfaceControllerMessenger = RestrictedMessenger<
   typeof controllerName,
   SnapInterfaceControllerActions | SnapInterfaceControllerAllowedActions,
   SnapInterfaceControllerEvents,

--- a/packages/snaps-controllers/src/multichain/MultichainRouter.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRouter.ts
@@ -1,4 +1,4 @@
-import type { RestrictedControllerMessenger } from '@metamask/base-controller';
+import type { RestrictedMessenger } from '@metamask/base-controller';
 import type { GetPermissions } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
 import {
@@ -93,7 +93,7 @@ export type MultichainRouterAllowedActions =
 
 export type MultichainRouterEvents = never;
 
-export type MultichainRouterMessenger = RestrictedControllerMessenger<
+export type MultichainRouterMessenger = RestrictedMessenger<
   typeof name,
   MultichainRouterActions | MultichainRouterAllowedActions,
   never,

--- a/packages/snaps-controllers/src/services/ExecutionService.ts
+++ b/packages/snaps-controllers/src/services/ExecutionService.ts
@@ -1,4 +1,4 @@
-import type { RestrictedControllerMessenger } from '@metamask/base-controller';
+import type { RestrictedMessenger } from '@metamask/base-controller';
 import type { SnapRpcHookArgs } from '@metamask/snaps-utils';
 import type { Json } from '@metamask/utils';
 
@@ -90,7 +90,7 @@ export type ExecutionServiceActions =
   | TerminateSnapAction
   | TerminateAllSnapsAction;
 
-export type ExecutionServiceMessenger = RestrictedControllerMessenger<
+export type ExecutionServiceMessenger = RestrictedMessenger<
   'ExecutionService',
   ExecutionServiceActions,
   ExecutionServiceEvents,

--- a/packages/snaps-controllers/src/services/node-js/NodeProcessExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/node-js/NodeProcessExecutionService.test.ts
@@ -93,9 +93,7 @@ describe('NodeProcessExecutionService', () => {
 
   it('can handle errors out of band', async () => {
     expect.assertions(2);
-    const { service, controllerMessenger } = createService(
-      NodeProcessExecutionService,
-    );
+    const { service, messenger } = createService(NodeProcessExecutionService);
     const snapId = 'TestSnap';
     await service.executeSnap({
       snapId,
@@ -118,7 +116,7 @@ describe('NodeProcessExecutionService', () => {
     });
 
     const unhandledErrorPromise = new Promise((resolve) => {
-      controllerMessenger.subscribe(
+      messenger.subscribe(
         'ExecutionService:unhandledError',
         (_snapId: string, error: SnapErrorJson) => {
           resolve(error);

--- a/packages/snaps-controllers/src/services/node-js/NodeThreadExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/node-js/NodeThreadExecutionService.test.ts
@@ -93,9 +93,7 @@ describe('NodeThreadExecutionService', () => {
 
   it('can handle errors out of band', async () => {
     expect.assertions(2);
-    const { service, controllerMessenger } = createService(
-      NodeThreadExecutionService,
-    );
+    const { service, messenger } = createService(NodeThreadExecutionService);
     const snapId = 'TestSnap';
     await service.executeSnap({
       snapId,
@@ -118,7 +116,7 @@ describe('NodeThreadExecutionService', () => {
     });
 
     const unhandledErrorPromise = new Promise((resolve) => {
-      controllerMessenger.subscribe(
+      messenger.subscribe(
         'ExecutionService:unhandledError',
         (_snapId: string, error: SnapErrorJson) => {
           resolve(error);

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -3,7 +3,7 @@ import type {
   UpdateRequestState,
 } from '@metamask/approval-controller';
 import type {
-  RestrictedControllerMessenger,
+  RestrictedMessenger,
   ControllerGetStateAction,
   ControllerStateChangeEvent,
 } from '@metamask/base-controller';
@@ -644,7 +644,7 @@ export type AllowedEvents =
   | SnapUpdated
   | KeyringControllerLock;
 
-type SnapControllerMessenger = RestrictedControllerMessenger<
+type SnapControllerMessenger = RestrictedMessenger<
   typeof controllerName,
   SnapControllerActions | AllowedActions,
   SnapControllerEvents | AllowedEvents,

--- a/packages/snaps-controllers/src/snaps/registry/json.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.ts
@@ -1,7 +1,7 @@
 import type {
   ControllerGetStateAction,
   ControllerStateChangeEvent,
-  RestrictedControllerMessenger,
+  RestrictedMessenger,
 } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
 import type { SnapsRegistryDatabase } from '@metamask/snaps-registry';
@@ -88,7 +88,7 @@ export type SnapsRegistryStateChangeEvent = ControllerStateChangeEvent<
 
 export type SnapsRegistryEvents = SnapsRegistryStateChangeEvent;
 
-export type SnapsRegistryMessenger = RestrictedControllerMessenger<
+export type SnapsRegistryMessenger = RestrictedMessenger<
   'SnapsRegistry',
   SnapsRegistryActions,
   SnapsRegistryEvents,

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -1,8 +1,5 @@
 import type { ApprovalRequest } from '@metamask/approval-controller';
-import type {
-  ControllerMessenger,
-  RestrictedControllerMessenger,
-} from '@metamask/base-controller';
+import type { Messenger, RestrictedMessenger } from '@metamask/base-controller';
 import {
   encryptWithKey,
   decryptWithKey,
@@ -851,8 +848,8 @@ export const getRestrictedSnapInsightsControllerMessenger = (
  */
 export async function waitForStateChange(
   messenger:
-    | ControllerMessenger<any, SnapControllerStateChangeEvent>
-    | RestrictedControllerMessenger<
+    | Messenger<any, SnapControllerStateChangeEvent>
+    | RestrictedMessenger<
         'SnapController',
         any,
         SnapControllerStateChangeEvent,

--- a/packages/snaps-controllers/src/test-utils/service.ts
+++ b/packages/snaps-controllers/src/test-utils/service.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 import { createEngineStream } from '@metamask/json-rpc-middleware-stream';
 import { logError } from '@metamask/snaps-utils';
@@ -19,12 +19,9 @@ export const createService = <
     'messenger' | 'setupSnapProvider'
   >,
 ) => {
-  const controllerMessenger = new ControllerMessenger<
-    never,
-    ErrorMessageEvent
-  >();
+  const messenger = new Messenger<never, ErrorMessageEvent>();
 
-  const messenger = controllerMessenger.getRestricted<
+  const restrictedMessenger = messenger.getRestricted<
     'ExecutionService',
     never,
     ErrorMessageEvent['type']
@@ -33,7 +30,7 @@ export const createService = <
   });
 
   const service = new ServiceClass({
-    messenger,
+    messenger: restrictedMessenger,
     setupSnapProvider: (_snapId: string, rpcStream: Duplex) => {
       const mux = setupMultiplex(rpcStream, 'foo');
       const stream = mux.createStream('metamask-provider');
@@ -56,5 +53,8 @@ export const createService = <
     ...options,
   });
 
-  return { service, messenger, controllerMessenger };
+  return {
+    service,
+    messenger: restrictedMessenger,
+  };
 };

--- a/packages/snaps-simulation/src/controllers.test.ts
+++ b/packages/snaps-simulation/src/controllers.test.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import {
   PermissionController,
   SubjectMetadataController,
@@ -21,7 +21,7 @@ const MOCK_HOOKS: RestrictedMiddlewareHooks = {
 describe('getControllers', () => {
   it('returns the controllers', () => {
     const { permissionController, subjectMetadataController } = getControllers({
-      controllerMessenger: new ControllerMessenger(),
+      controllerMessenger: new Messenger(),
       hooks: MOCK_HOOKS,
       runSaga: jest.fn(),
       options: getMockOptions(),

--- a/packages/snaps-simulation/src/controllers.ts
+++ b/packages/snaps-simulation/src/controllers.ts
@@ -1,4 +1,4 @@
-import type { ControllerMessenger } from '@metamask/base-controller';
+import type { Messenger } from '@metamask/base-controller';
 import type {
   CaveatSpecificationConstraint,
   PermissionSpecificationConstraint,
@@ -42,13 +42,13 @@ export type RootControllerAllowedActions =
 export type RootControllerAllowedEvents =
   SnapInterfaceControllerStateChangeEvent;
 
-export type RootControllerMessenger = ControllerMessenger<
+export type RootControllerMessenger = Messenger<
   RootControllerAllowedActions,
   RootControllerAllowedEvents
 >;
 
 export type GetControllersOptions = {
-  controllerMessenger: ControllerMessenger<any, any>;
+  controllerMessenger: Messenger<any, any>;
   hooks: RestrictedMiddlewareHooks;
   runSaga: RunSagaFunction;
   options: SimulationOptions;

--- a/packages/snaps-simulation/src/methods/specifications.test.ts
+++ b/packages/snaps-simulation/src/methods/specifications.test.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import {
   getSnapManifest,
   MOCK_SNAP_ID,
@@ -45,7 +45,7 @@ describe('getPermissionSpecifications', () => {
         hooks: MOCK_HOOKS,
         runSaga: jest.fn(),
         options: getMockOptions(),
-        controllerMessenger: new ControllerMessenger(),
+        controllerMessenger: new Messenger(),
       }),
     ).toMatchInlineSnapshot(`
       {
@@ -324,7 +324,7 @@ describe('getPermissionSpecifications', () => {
 describe('getEndowments', () => {
   it('returns the endowments', async () => {
     const controllers = getControllers({
-      controllerMessenger: new ControllerMessenger(),
+      controllerMessenger: new Messenger(),
       hooks: MOCK_HOOKS,
       runSaga: jest.fn(),
       options: getMockOptions(),

--- a/packages/snaps-simulation/src/simulation.ts
+++ b/packages/snaps-simulation/src/simulation.ts
@@ -2,7 +2,7 @@ import type {
   ActionConstraint,
   EventConstraint,
 } from '@metamask/base-controller';
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import { createEngineStream } from '@metamask/json-rpc-middleware-stream';
 import {
   type CryptographicFunctions,
@@ -94,7 +94,7 @@ export type InstalledSnap = {
   snapId: SnapId;
   store: Store;
   executionService: InstanceType<typeof AbstractExecutionService>;
-  controllerMessenger: ControllerMessenger<ActionConstraint, EventConstraint>;
+  controllerMessenger: Messenger<ActionConstraint, EventConstraint>;
   runSaga: RunSagaFunction;
 };
 
@@ -276,7 +276,7 @@ export async function installSnap<
   // Create Redux store.
   const { store, runSaga } = createStore(options);
 
-  const controllerMessenger = new ControllerMessenger<any, any>();
+  const controllerMessenger = new Messenger<any, any>();
 
   registerActions(controllerMessenger, runSaga);
 

--- a/packages/snaps-simulator/jest.config.js
+++ b/packages/snaps-simulator/jest.config.js
@@ -9,7 +9,7 @@ module.exports = deepmerge(baseConfig, {
     global: {
       branches: 54.33,
       functions: 60.59,
-      lines: 80.49,
+      lines: 80.54,
       statements: 80.83,
     },
   },

--- a/packages/snaps-simulator/src/features/simulation/sagas.ts
+++ b/packages/snaps-simulator/src/features/simulation/sagas.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import { createFetchMiddleware } from '@metamask/eth-json-rpc-middleware';
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 import { createEngineStream } from '@metamask/json-rpc-middleware-stream';
@@ -89,17 +89,14 @@ const DEFAULT_ENVIRONMENT_URL = `https://execution.metamask.io/iframe/${packageJ
 /**
  * Register the misc controller actions.
  *
- * @param controllerMessenger - The controller messenger.
+ * @param messenger - The messenger.
  */
-export function registerActions(
-  controllerMessenger: ControllerMessenger<any, any>,
-) {
-  controllerMessenger.registerActionHandler(
-    'PhishingController:testOrigin',
-    () => ({ result: false }),
-  );
+export function registerActions(messenger: Messenger<any, any>) {
+  messenger.registerActionHandler('PhishingController:testOrigin', () => ({
+    result: false,
+  }));
 
-  controllerMessenger.registerActionHandler(
+  messenger.registerActionHandler(
     'PhishingController:maybeUpdateState',
     async () => Promise.resolve(),
   );
@@ -114,9 +111,9 @@ export function registerActions(
  * @yields Puts the execution environment after creation.
  */
 export function* initSaga({ payload }: PayloadAction<string>) {
-  const controllerMessenger = new ControllerMessenger<any, any>();
+  const messenger = new Messenger<any, any>();
 
-  registerActions(controllerMessenger);
+  registerActions(messenger);
 
   const srp: string = yield select(getSrp);
 
@@ -161,7 +158,7 @@ export function* initSaga({ payload }: PayloadAction<string>) {
   };
 
   const subjectMetadataController = new SubjectMetadataController({
-    messenger: controllerMessenger.getRestricted({
+    messenger: messenger.getRestricted({
       name: 'SubjectMetadataController',
       allowedActions: [],
       allowedEvents: [],
@@ -170,7 +167,7 @@ export function* initSaga({ payload }: PayloadAction<string>) {
   });
 
   const permissionController = new PermissionController({
-    messenger: controllerMessenger.getRestricted({
+    messenger: messenger.getRestricted({
       name: 'PermissionController',
       allowedActions: [
         `ApprovalController:addRequest`,
@@ -192,7 +189,7 @@ export function* initSaga({ payload }: PayloadAction<string>) {
   });
 
   const snapInterfaceController = new SnapInterfaceController({
-    messenger: controllerMessenger.getRestricted({
+    messenger: messenger.getRestricted({
       name: 'SnapInterfaceController',
       allowedActions: [
         `PhishingController:testOrigin`,
@@ -244,7 +241,7 @@ export function* initSaga({ payload }: PayloadAction<string>) {
 
   const executionService = new IframeExecutionService({
     iframeUrl: new URL(environmentUrl),
-    messenger: controllerMessenger.getRestricted({
+    messenger: messenger.getRestricted({
       name: 'ExecutionService',
       allowedActions: [],
       allowedEvents: [],

--- a/packages/snaps-simulator/src/features/simulation/test/controllers.ts
+++ b/packages/snaps-simulator/src/features/simulation/test/controllers.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import { SnapInterfaceController } from '@metamask/snaps-controllers';
 
 import { registerActions } from '../sagas';
@@ -9,7 +9,7 @@ import { registerActions } from '../sagas';
  * @returns The {@link SnapInterfaceController}.
  */
 export function getSnapInterfaceController() {
-  const messenger = new ControllerMessenger<any, any>();
+  const messenger = new Messenger<any, any>();
 
   registerActions(messenger);
 

--- a/packages/snaps-utils/src/test-utils/controller.ts
+++ b/packages/snaps-utils/src/test-utils/controller.ts
@@ -3,12 +3,12 @@ import type {
   ActionHandler,
   EventConstraint,
 } from '@metamask/base-controller';
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 
 export class MockControllerMessenger<
   Action extends ActionConstraint,
   Event extends EventConstraint,
-> extends ControllerMessenger<Action, Event> {
+> extends Messenger<Action, Event> {
   /**
    * Registers an action handler for the given action type. If an action handler
    * already exists for the given action type, it will be overwritten.


### PR DESCRIPTION
## Explanation

Rename `RestrictedControllerMessenger` to `RestrictedMessenger` and `ControllerMessenger` to `Messenger`.

## References

Relates to [#4538](https://github.com/MetaMask/core/issues/4538)

## Changelog

No functional changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
