### PR TITLE
Add `name` and `state` to `ExecutionService` type

### DIFF
--- a/packages/snaps-controllers/src/services/AbstractExecutionService.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.ts
@@ -64,6 +64,10 @@ export type TerminateJobArgs<WorkerType> = Partial<Job<WorkerType>> &
 export abstract class AbstractExecutionService<WorkerType>
   implements ExecutionService
 {
+  name = 'ExecutionService' as const;
+
+  state = null;
+
   #snapRpcHooks: Map<string, SnapRpcHook>;
 
   // Cannot be hash private yet because of tests.

--- a/packages/snaps-controllers/src/services/ExecutionService.ts
+++ b/packages/snaps-controllers/src/services/ExecutionService.ts
@@ -12,6 +12,11 @@ type HandleRpcRequest = (
 ) => Promise<unknown>;
 
 export interface ExecutionService {
+  // These fields are required for modular initialisation of the execution
+  // service in the MetaMask extension.
+  name: 'ExecutionService';
+  state: null;
+
   terminateSnap: TerminateSnap;
   terminateAllSnaps: TerminateAll;
   executeSnap: ExecuteSnap;


### PR DESCRIPTION
This adds a `name` and `state` field to the `ExecutionService` type, which is required for it to work with modular initialisation in the MetaMask extension.