### PR TITLE
Fix minor issue with Dependabot update workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
   update-pull-request:
     name: Update pull request
     needs: check-workflows
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && github.actor != 'metamaskbot' }}
     uses: ./.github/workflows/update-pull-request.yml
     with:
       dependabot: true

--- a/.github/workflows/update-pull-request.yml
+++ b/.github/workflows/update-pull-request.yml
@@ -220,7 +220,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Set commit prefix
         if: ${{ inputs.dependabot == true }}
-        run: echo "COMMIT_PREFIX='[dependabot skip] '" >> "$GITHUB_ENV"
+        run: echo "COMMIT_PREFIX=[dependabot skip] " >> "$GITHUB_ENV"
       - name: Commit yarn.lock
         run: |
           git add yarn.lock


### PR DESCRIPTION
This fixes a couple minor issues with the Dependabot update workflow:

- The update won't be retriggered anymore after MetaMask bot pushes the new commits.
- I've updated the commit message so it doesn't include the quotes. Turns out those were unnecessary.