### PR TITLE
feat!: Run a WebView per Snap on mobile

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 93.31,
-  "functions": 96.79,
-  "lines": 98.15,
-  "statements": 97.88
+  "functions": 97.05,
+  "lines": 98.2,
+  "statements": 97.93
 }

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 93.31,
-  "functions": 96.8,
+  "functions": 96.79,
   "lines": 98.15,
   "statements": 97.88
 }

--- a/packages/snaps-controllers/src/services/webview/WebViewExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/webview/WebViewExecutionService.test.ts
@@ -49,6 +49,7 @@ describe('WebViewExecutionService', () => {
     });
 
     expect(service).toBeDefined();
+    await service.terminateAllSnaps();
   });
 
   it('can execute snaps', async () => {
@@ -117,5 +118,7 @@ describe('WebViewExecutionService', () => {
         endowments: [],
       }),
     ).toBe('OK');
+
+    await service.terminateAllSnaps();
   });
 });

--- a/packages/snaps-controllers/src/services/webview/WebViewExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/webview/WebViewExecutionService.test.ts
@@ -43,9 +43,7 @@ describe('WebViewExecutionService', () => {
     const { service } = createService(WebViewExecutionService, {
       createWebView: async (_id: string) =>
         mockedWebView as unknown as WebViewInterface,
-      removeWebView: () => {
-        // no-op
-      },
+      removeWebView: jest.fn(),
     });
 
     expect(service).toBeDefined();
@@ -106,9 +104,7 @@ describe('WebViewExecutionService', () => {
         unregisterMessageListener: jest.fn(),
         injectJavaScript,
       }),
-      removeWebView: () => {
-        // no-op
-      },
+      removeWebView: jest.fn(),
     });
 
     expect(

--- a/packages/snaps-controllers/src/services/webview/WebViewExecutionService.ts
+++ b/packages/snaps-controllers/src/services/webview/WebViewExecutionService.ts
@@ -11,10 +11,10 @@ export type WebViewExecutionServiceArgs = ExecutionServiceArgs & {
   removeWebView: (jobId: string) => void;
 };
 
-export class WebViewExecutionService extends AbstractExecutionService<string> {
-  #createWebView;
+export class WebViewExecutionService extends AbstractExecutionService<WebViewInterface> {
+  readonly #createWebView;
 
-  #removeWebView;
+  readonly #removeWebView;
 
   constructor({
     messenger,
@@ -48,10 +48,10 @@ export class WebViewExecutionService extends AbstractExecutionService<string> {
       webView,
     });
 
-    return { worker: jobId, stream };
+    return { worker: webView, stream };
   }
 
-  protected terminateJob(jobWrapper: TerminateJobArgs<string>): void {
+  protected terminateJob(jobWrapper: TerminateJobArgs<WebViewInterface>): void {
     this.#removeWebView(jobWrapper.id);
   }
 }

--- a/packages/snaps-controllers/src/services/webview/WebViewExecutionService.ts
+++ b/packages/snaps-controllers/src/services/webview/WebViewExecutionService.ts
@@ -45,7 +45,7 @@ export class WebViewExecutionService extends AbstractExecutionService<string> {
     const stream = new WebViewMessageStream({
       name: 'parent',
       target: 'child',
-      getWebView: async () => webView,
+      webView,
     });
 
     return { worker: jobId, stream };

--- a/packages/snaps-controllers/src/test-utils/webview.ts
+++ b/packages/snaps-controllers/src/test-utils/webview.ts
@@ -17,7 +17,7 @@ export function parseInjectedJS(js: string) {
 /**
  * Takes no param and return mocks necessary for testing WebViewMessageStream.
  *
- * @returns The mockWebView, mockGetWebView, and mockStream.
+ * @returns The mockWebView, and mockStream.
  */
 export function createWebViewObjects() {
   const registerMessageListenerA = jest.fn();
@@ -45,26 +45,21 @@ export function createWebViewObjects() {
     }),
   };
 
-  const mockGetWebViewA = jest.fn().mockResolvedValue(mockWebViewA);
-  const mockGetWebViewB = jest.fn().mockResolvedValue(mockWebViewB);
-
   const streamA = new WebViewMessageStream({
     name: 'a',
     target: 'b',
-    getWebView: mockGetWebViewA,
+    webView: mockWebViewA,
   });
 
   const streamB = new WebViewMessageStream({
     name: 'b',
     target: 'a',
-    getWebView: mockGetWebViewB,
+    webView: mockWebViewB,
   });
 
   return {
     mockWebViewA,
     mockWebViewB,
-    mockGetWebViewA,
-    mockGetWebViewB,
     streamA,
     streamB,
   };

--- a/packages/snaps-execution-environments/lavamoat/browserify/webview/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/browserify/webview/policy.json
@@ -1,5 +1,26 @@
 {
   "resources": {
+    "@metamask/json-rpc-engine": {
+      "packages": {
+        "@metamask/providers>@metamask/safe-event-emitter": true,
+        "@metamask/rpc-errors": true,
+        "@metamask/utils": true
+      }
+    },
+    "@metamask/object-multiplex": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@metamask/object-multiplex>once": true,
+        "readable-stream": true
+      }
+    },
+    "@metamask/object-multiplex>once": {
+      "packages": {
+        "@metamask/object-multiplex>once>wrappy": true
+      }
+    },
     "@metamask/post-message-stream": {
       "globals": {
         "MessageEvent.prototype": true,
@@ -14,6 +35,39 @@
       "packages": {
         "@metamask/utils": true,
         "readable-stream": true
+      }
+    },
+    "@metamask/providers": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "@metamask/json-rpc-engine": true,
+        "@metamask/providers>@metamask/json-rpc-middleware-stream": true,
+        "@metamask/providers>@metamask/safe-event-emitter": true,
+        "@metamask/providers>is-stream": true,
+        "@metamask/rpc-errors": true,
+        "eslint>fast-deep-equal": true,
+        "readable-stream": true
+      }
+    },
+    "@metamask/providers>@metamask/json-rpc-middleware-stream": {
+      "globals": {
+        "console.warn": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/providers>@metamask/safe-event-emitter": true,
+        "@metamask/utils": true,
+        "readable-stream": true
+      }
+    },
+    "@metamask/providers>@metamask/safe-event-emitter": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>events": true
       }
     },
     "@metamask/rpc-errors": {

--- a/packages/snaps-execution-environments/src/webview/index.ts
+++ b/packages/snaps-execution-environments/src/webview/index.ts
@@ -1,6 +1,6 @@
 import { executeLockdownEvents } from '../common/lockdown/lockdown-events';
 import { executeLockdownMore } from '../common/lockdown/lockdown-more';
-import { ProxySnapExecutor } from '../proxy/ProxySnapExecutor';
+import { IFrameSnapExecutor } from '../iframe/IFrameSnapExecutor';
 import { WebViewExecutorStream } from './WebViewExecutorStream';
 
 // Lockdown is already applied in LavaMoat
@@ -13,4 +13,4 @@ const parentStream = new WebViewExecutorStream({
   targetWindow: window.ReactNativeWebView,
 });
 
-ProxySnapExecutor.initialize(parentStream);
+IFrameSnapExecutor.initialize(parentStream);


### PR DESCRIPTION
Allows us to run Snaps locally on mobile by instantiating a WebView per Snap. This PR changes the `WebViewExecutionService` to let it instantiate and remove webviews (this will need support on the mobile implementation side). Additionally alters the WebView bundle so it no longer functions as a "proxy executor", but instead inherits from the iframe executor implementation. 

**Breaking changes**
- `WebViewExecutionService` now requires `createWebView` and `removeWebView` constructor arguments, `getWebView` is no longer supported.
- The WebView bundle in `snaps-execution-environments` no longer supports proxy executor calls and functions as a single executor.