### PR TITLE
fix: Recreate JSON-RPC request in MultichainRouter

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 93.28,
+  "branches": 93.31,
   "functions": 96.8,
   "lines": 98.15,
   "statements": 97.88

--- a/packages/snaps-controllers/src/multichain/MultichainRouter.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRouter.ts
@@ -18,6 +18,7 @@ import {
   KnownCaipNamespace,
   parseCaipAccountId,
 } from '@metamask/utils';
+import { nanoid } from 'nanoid';
 
 import { getRunnableSnaps } from '../snaps';
 import type { GetAllSnaps, HandleSnapRequest } from '../snaps';
@@ -291,7 +292,7 @@ export class MultichainRouter {
     connectedAddresses,
     origin,
     scope,
-    request,
+    request: rawRequest,
   }: {
     connectedAddresses: CaipAccountId[];
     origin: string;
@@ -303,6 +304,14 @@ export class MultichainRouter {
       !scope.startsWith(KnownCaipNamespace.Eip155) &&
         !scope.startsWith('wallet:eip155'),
     );
+
+    // Re-create the request to simplify and remove additional properties that may be present in MM middleware.
+    const request = {
+      jsonrpc: '2.0' as const,
+      id: rawRequest.id ?? nanoid(),
+      method: rawRequest.method,
+      params: rawRequest.params,
+    };
 
     const { method, params } = request;
 


### PR DESCRIPTION
Recreate the JSON-RPC request in MultichainRouter to remove any unnecesary properties passed in from the middlewares in the client. This ensures that we don't leak unnecessary details to Snaps and also makes sure the requests are formatted as expected downstream.