### PR TITLE
Replace nested workspace configuration with top-level configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   },
   "files": [],
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "packages/examples/packages/*",
+    "packages/examples/packages/invoke-snap/packages/*"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -19,9 +19,6 @@
   "license": "(MIT-0 OR Apache-2.0)",
   "sideEffects": false,
   "files": [],
-  "workspaces": [
-    "packages/*"
-  ],
   "scripts": {
     "build": "yarn workspaces foreach --worktree --parallel --verbose --no-private run build",
     "build:clean": "yarn clean && yarn build",

--- a/packages/examples/packages/invoke-snap/package.json
+++ b/packages/examples/packages/invoke-snap/package.json
@@ -19,9 +19,6 @@
   "license": "(MIT-0 OR Apache-2.0)",
   "sideEffects": false,
   "files": [],
-  "workspaces": [
-    "packages/*"
-  ],
   "scripts": {
     "build": "yarn workspaces foreach --worktree --parallel --verbose run build",
     "build:clean": "yarn clean && yarn build",


### PR DESCRIPTION
This replaces the nested workspace configuration we use for examples with a top-level configuration. It seems that Dependabot doesn't support nested workspaces, resulting in lint errors that need to be manually fixed. Hopefully this change addresses that issue.