### PR TITLE
Handle Webpack and Prettier breaking changes

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -121,6 +121,10 @@ module.exports = {
   // A preset that is used as a base for Jest's configuration
   // preset: '',
 
+  // The path to the Prettier executable used to format snapshots
+  // Jest doesn't support Prettier 3 yet, so we use Prettier 2
+  prettierPath: require.resolve('prettier-2'),
+
   // Run tests from one or more projects
   // projects: undefined,
 

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "lodash": "^4.17.21",
     "minimatch": "^7.4.1",
     "prettier": "^3.3.3",
+    "prettier-2": "npm:prettier@^2.8.8",
     "prettier-plugin-packagejson": "^2.5.8",
     "rimraf": "^4.1.2",
     "semver": "^7.5.4",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hKyk+E4FxoOrxVUot4h92CctQ35L8Zwo6y5x4DpdkZw=",
+    "shasum": "IPmfU5Yfr8CtU8hqE+sKtIvrtoKWeNZbjDWxck0Q1c8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "KQiLG98qS86ThxbVvJW6DLpRtkSq238/rh2tHEZiJmA=",
+    "shasum": "Fe+hvYArPSD1N+RvmsAhRM2makxXA9xPJzMsT/xYDLU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "t/mItLdi/miIU7FWJjijmmaFT/5svN1dK4Ik+1LMbqw=",
+    "shasum": "AAbLURsZMLxSRC5F69z6Un2W2wZ0v9UJfuPoYutZoH8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3kC/z0z6RjjarArtxcs+iltJRQgvZNIPBueMP0cLQJw=",
+    "shasum": "DpjsNMTfivqHjOV/NMrhSZR4o3dHAQOFIPkV0gzPeFU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Gk6JUIChMAQRJbHFCWyMtmMGmqknidjdE8nLnHyaM2Q=",
+    "shasum": "tiOQUmZUUEjlVRuK7Sb1t8Lmcy5TQXsdj8uJ8Ecfd4k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "b/ZsZh0z0ieSBHzlazYSkpkLMUSV4c442IFQ8Zgepq0=",
+    "shasum": "Gw/JAlj3moUPfdWya3XTZV+mkROKZpUQ7spUAHsu8zE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "asBcwQ0fIXFCZ6skpbENtZiyskGDEdEIrAbWkOvEQ0s=",
+    "shasum": "nsXCGehK5VQDG0DBaUuQKx9tfOQsWcgyyJptTEE+Glw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Vm44DmG3HizDFI1VHohwXafP+dnv3evvlhgFmB8DX98=",
+    "shasum": "E5FILDC9eOuFG+3qvKiAFRTzTitjBDzFPcTicdFqB9k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Aq+JN0IumEWkpEV1WAMMcj8tFCjJc2JIgz6ngW1ghCI=",
+    "shasum": "Rc5OrsLKdb7+9YsGjgbNGEH2XmU+RMcpphb7IHPqC2s=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cVHHqNAq33UzS3K9AQEFn/P/qA9IF/v2Ru4Wp4Prolw=",
+    "shasum": "2hqQJlHUZ3ilXiDVHuKHL5SZK2MrdlC09b/a939g3X0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "jHLW/TPnr+5WCVVKton++heY7ANqnmdXYIos57bJMFg=",
+    "shasum": "+qBVdCwt/nJF4ufkvmWG9CSGhko6Ygybd8TE2bSmNnk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "EjJkL2kQyJLWRx+MVHrfMyrxnQCidkDIg4j9VW/4e+0=",
+    "shasum": "2l842tQwt+3opl3b1GAgibYz9L23WfLAK3y7Xy4jc1k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "jsrLxUR5DtPf/77zAm3jiCCPqOg8YZRF7vsYgEim+vg=",
+    "shasum": "G7eD8MRIlkvYr4vjurbcLuLGIvUGxnLcLxP89QaHqQk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0ltirRoW8OBkrJUSnIAql4rdR9k00Gp30Pp8anO8SyQ=",
+    "shasum": "gK5w9WgWgbAA8nzQLRJEl6Vm3GZ4tQG/Mckp4gyOb64=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2XAIve/Nn/RGKdyrooukRjz+ixn0c9n10gqme9HGJxY=",
+    "shasum": "Od2jws/OlpvhBImWFXQ3QQ3jpYMKc34HWAzz3CxMDIc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Ybacx795qo9tN0TCqRc2PhpqSag8K56p6aomjpPJl+o=",
+    "shasum": "0QMZsmHgfBj0XikEblYpf4Ylwmx+UrJFMDsCJCm1Yis=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "mOeSPVTlrbYhU4ueYFtxYX2jdgautNZJqatqcl8xHcY=",
+    "shasum": "uXGZpRIKkYANInV1jD2+aW5haQbrtt/9AwVmSJpV+9I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "An0r5dIP8lHzsMGaYcJqJIq1ynF0MZADyjoAo4trirs=",
+    "shasum": "A5COdI8IhqSN9zwvjqbms2my1m1PfmiSrkkZKkgaXC8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "slB8CHO9cqeUog9kw6E0ODJf6Dkcm05/GQ+vDLxvAas=",
+    "shasum": "AyIHrzAYbEJVr+/QGqXeE8Hw2OrWdnPB6UsF4hon4RA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "anygDtewBP8eXfF4VfpT5S2He80rvy5Hb/RdXUpOmOA=",
+    "shasum": "neXtE4zGwyszoQ111WzsK1SAqvzReg8Ulf2eeRO/w30=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "uNotSODL7gl8JK/sSWL/jR87bsxsuBkaO6F414X3qwQ=",
+    "shasum": "Vvd5VIY75Ny8vY47iZ3GSELOYLLgRz71RhIvKJpS1Ag=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "yhTtMDHnm4sYAHiV7TQ0OXi1WlkV8gAPXj+OCbJdmKw=",
+    "shasum": "2qzcNy1Reotfc2mDLOx/aE6/UTcZ5HV6CehG3PNTe8Q=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AqdUpB8Q3S80ndYGDMIiSXAhNIA2y+QBdZL09x5MN/k=",
+    "shasum": "UDZMY2SiJ1Wbk5H/+mgZie+Xbt40YuLvJ55aqYplK8I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/preinstalled/snap.manifest.json
+++ b/packages/examples/packages/preinstalled/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "nMtsXN1K9BkY6zSrF8nii2pxbKBpWaAq7eUOOZ04ajs=",
+    "shasum": "v8FsOM57C+tH3MQOinkpVbg90L3iytd+8JeLk+ecWkA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/protocol/snap.manifest.json
+++ b/packages/examples/packages/protocol/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "XCSzJbcyYNaEve/S9QSQiUzs5IPqWPoF3sEKJpg5KTQ=",
+    "shasum": "GZWLGz4J9wN1TiZDI+BkDvS7+Kluvro2rWVFRUczAt0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "91lc41gLDh3TQY+Wv6aP/szcbaT0Z9aeVfoBY+lmlcc=",
+    "shasum": "C8GH13QQb3N3OceJKkvKQG0Iz0o2KOUHPPWP/uTa6U4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/send-flow/snap.manifest.json
+++ b/packages/examples/packages/send-flow/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "KZtEm+Gz8nWwCiyEtiQRmnVvp0J5F91e/bUWY1rJUNI=",
+    "shasum": "GaRBzrcpkF3Jc1W+VFfpd11RH7cvHgbsosxM2DFwJKI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/signature-insights/snap.manifest.json
+++ b/packages/examples/packages/signature-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "JtztKgU1DtgTq/mvEpzZ3mllvHm07Wo8PmUd19dBApU=",
+    "shasum": "L5YsHe35++DnUuKt5YTWdztehVDU3m80jSZ65i4Bc1M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/transaction-insights/snap.manifest.json
+++ b/packages/examples/packages/transaction-insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "KXDRKn0g31gllneOBkzJXNedjFKklSZh7DW2We2+Pm0=",
+    "shasum": "qBiJMFzBD+/X07YrtirrFuq4Qfs0wRSl5/MaYAutpAM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cM4+w95k5SocDfGu9CStTDP1YYAUkjCOvIBNBf7aJHc=",
+    "shasum": "mscQHxQMt0q+EZPpoSR+5Y/EHmIJR7opSBX3usAln0k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Az6qvsHGwGKNwWgEZI34jzkwXoHbaadbLgygwwfLHwI=",
+    "shasum": "mYG34iCWxtAQRxIUr+Ge2n+N8b9RcVjMv4/SSBxuGeM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-cli/src/commands/build/implementation.test.ts
+++ b/packages/snaps-cli/src/commands/build/implementation.test.ts
@@ -16,6 +16,7 @@ import type * as webpack from '../../webpack';
 import type * as utils from '../../webpack/utils';
 import { BROWSERSLIST_FILE } from '../../webpack/utils';
 import { build } from './implementation';
+import { SemVerVersion } from '@metamask/utils';
 
 const { promises: fs } = normalFs;
 
@@ -36,7 +37,10 @@ jest.mock('../../webpack', () => ({
       .requireActual<typeof webpack>('../../webpack')
       .getCompiler(...args);
 
+    // @ts-expect-error: Type mismatch.
     compiler.inputFileSystem = normalFs;
+
+    // @ts-expect-error: Type mismatch.
     compiler.outputFileSystem = normalFs;
 
     return compiler;
@@ -48,6 +52,7 @@ jest.mock('../../webpack/utils', () => ({
   getDefaultLoader: jest.fn<
     ReturnType<typeof utils.getDefaultLoader>,
     Parameters<typeof utils.getDefaultLoader>
+    // @ts-expect-error: Type mismatch.
   >(async (config) => {
     if (config.legacy) {
       return {
@@ -66,7 +71,7 @@ describe('build', () => {
   beforeEach(async () => {
     const { manifest } = await getMockSnapFilesWithUpdatedChecksum({
       manifest: getSnapManifest({
-        platformVersion: getPlatformVersion(),
+        platformVersion: getPlatformVersion() as SemVerVersion,
       }),
     });
 
@@ -129,7 +134,7 @@ describe('build', () => {
 
     const output = await fs.readFile('/snap/output.js', 'utf8');
     expect(output).toMatchInlineSnapshot(
-      `"(()=>{var r={67:r=>{r.exports.onRpcRequest=({request:r})=>{console.log("Hello, world!");const{method:e,id:o}=r;return e+o}}},e={};var o=function o(t){var s=e[t];if(void 0!==s)return s.exports;var n=e[t]={exports:{}};return r[t](n,n.exports,o),n.exports}(67);module.exports=o})();"`,
+      `"(()=>{var r={157:r=>{r.exports.onRpcRequest=({request:r})=>{console.log("Hello, world!");const{method:e,id:o}=r;return e+o}}},e={};var o=function o(t){var s=e[t];if(void 0!==s)return s.exports;var n=e[t]={exports:{}};return r[t](n,n.exports,o),n.exports}(157);module.exports=o})();"`,
     );
   });
 
@@ -165,7 +170,7 @@ describe('build', () => {
     expect(output).toMatchInlineSnapshot(`
       "(() => {
         var __webpack_modules__ = {
-          67: module => {
+          157: module => {
             module.exports.onRpcRequest = ({
               request
             }) => {
@@ -190,7 +195,7 @@ describe('build', () => {
           __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
           return module.exports;
         }
-        var __webpack_exports__ = __webpack_require__(67);
+        var __webpack_exports__ = __webpack_require__(157);
         module.exports = __webpack_exports__;
       })();"
     `);

--- a/packages/snaps-cli/src/commands/watch/implementation.test.ts
+++ b/packages/snaps-cli/src/commands/watch/implementation.test.ts
@@ -24,7 +24,10 @@ jest.mock('../../webpack', () => ({
       .requireActual<typeof webpack>('../../webpack')
       .getCompiler(...args);
 
+    // @ts-expect-error: Type mismatch.
     compiler.inputFileSystem = normalFs;
+
+    // @ts-expect-error: Type mismatch.
     compiler.outputFileSystem = normalFs;
 
     return compiler;
@@ -57,6 +60,7 @@ describe('watch', () => {
     // @ts-expect-error - Partial mock.
     mock.mockImplementationOnce(() => ({
       watch: watchMock,
+      watching: {},
     }));
 
     await watch(
@@ -78,6 +82,7 @@ describe('watch', () => {
     // @ts-expect-error - Partial mock.
     mock.mockImplementationOnce(() => ({
       watch: watchMock,
+      watching: {},
     }));
 
     await expect(

--- a/packages/snaps-cli/src/commands/watch/implementation.ts
+++ b/packages/snaps-cli/src/commands/watch/implementation.ts
@@ -4,6 +4,7 @@ import type { Watching } from 'webpack';
 import type { ProcessedWebpackConfig } from '../../config';
 import type { WebpackOptions } from '../../webpack';
 import { getCompiler } from '../../webpack';
+import { assert } from '@metamask/utils';
 
 /**
  * Build the snap bundle and watch for changes. This uses Webpack to build the
@@ -39,6 +40,7 @@ export async function watch(
           return;
         }
 
+        assert(compiler.watching, 'Expected `compiler.watching` to be set.');
         resolve(compiler.watching);
       },
     );

--- a/packages/snaps-cli/src/webpack/plugins.ts
+++ b/packages/snaps-cli/src/webpack/plugins.ts
@@ -5,7 +5,6 @@ import type { Ora } from 'ora';
 import type {
   Compiler,
   ProvidePlugin,
-  ResolvePluginInstance,
   Resolver,
   StatsError,
   WebpackPluginInstance,
@@ -242,12 +241,22 @@ export type SnapsBuiltInResolverOptions = {
 };
 
 /**
+ * A Webpack resolve plugin.
+ *
+ * Copied from Webpack's own types, because the `ResolvePluginInstance` type is
+ * a union, and can't be used as a type for a class.
+ */
+type ResolvePlugin = {
+  apply: (resolver: Resolver) => void;
+}
+
+/**
  * A plugin that logs a message when a built-in module is not resolved. The
  * MetaMask Snaps CLI does not support built-in modules by default, and this
  * plugin is used to warn the user when they try to import a built-in module,
  * when no fallback is configured.
  */
-export class SnapsBuiltInResolver implements ResolvePluginInstance {
+export class SnapsBuiltInResolver implements ResolvePlugin {
   /**
    * The built-in modules that have been imported, but not resolved.
    */

--- a/packages/snaps-webpack-plugin/src/__snapshots__/plugin.test.ts.snap
+++ b/packages/snaps-webpack-plugin/src/__snapshots__/plugin.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`SnapsWebpackPlugin applies a transform 1`] = `
 "(() => {
-  var __webpack_exports__ = {};
   const foo = 'bar';
 })();"
 `;
@@ -10,7 +9,6 @@ exports[`SnapsWebpackPlugin applies a transform 1`] = `
 exports[`SnapsWebpackPlugin forwards the options 1`] = `
 "/******/(() => {
   // webpackBootstrap
-  var __webpack_exports__ = {};
 
   // foo bar
   /* baz qux */

--- a/packages/snaps-webpack-plugin/src/manifest.test.ts
+++ b/packages/snaps-webpack-plugin/src/manifest.test.ts
@@ -47,44 +47,6 @@ describe('writeManifest', () => {
     `);
   });
 
-  it('uses a custom Prettier config if found', async () => {
-    const manifest = JSON.stringify(getSnapManifest());
-    await writeManifest(
-      resolve(__dirname, '__fixtures__', 'foo.json'),
-      manifest,
-    );
-
-    expect(jest.mocked(fs.writeFile).mock.calls[0][1]).toMatchInlineSnapshot(`
-      "{
-          "version": "1.0.0",
-          "description": "The test example snap!",
-          "proposedName": "@metamask/example-snap",
-          "repository": {
-              "type": "git",
-              "url": "https://github.com/MetaMask/example-snap.git"
-          },
-          "source": {
-              "shasum": "/17SwI03+Cn9sk45Z6Czp+Sktru1oLzOmkJW+YbP9WE=",
-              "location": {
-                  "npm": {
-                      "filePath": "dist/bundle.js",
-                      "packageName": "@metamask/example-snap",
-                      "registry": "https://registry.npmjs.org",
-                      "iconPath": "images/icon.svg"
-                  }
-              }
-          },
-          "initialPermissions": {
-              "snap_dialog": {},
-              "endowment:rpc": { "snaps": true, "dapps": false }
-          },
-          "platformVersion": "1.0.0",
-          "manifestVersion": "0.1"
-      }
-      "
-    `);
-  });
-
   it('accepts a custom write function', async () => {
     const fn = jest.fn();
     const manifest = JSON.stringify(getSnapManifest());

--- a/packages/snaps-webpack-plugin/src/manifest.ts
+++ b/packages/snaps-webpack-plugin/src/manifest.ts
@@ -1,12 +1,11 @@
 import type { WriteFileFunction } from '@metamask/snaps-utils/node';
 import { promises as fs } from 'fs';
-import { format, resolveConfig } from 'prettier';
+import { format } from 'prettier/standalone';
+import * as babel from 'prettier/plugins/babel';
+import * as estree from 'prettier/plugins/estree';
 
 /**
  * Format the manifest data with Prettier and write it to disk.
- *
- * It uses the Prettier configuration found in the project directory (if any),
- * or the default Prettier configuration if none is found.
  *
  * @param path - The path to write the manifest to.
  * @param data - The manifest data.
@@ -18,14 +17,11 @@ export async function writeManifest(
   data: string,
   writeFileFn: WriteFileFunction = fs.writeFile,
 ) {
-  const config = await resolveConfig(path, {
-    editorconfig: true,
-  });
-
-  const formattedManifest = format(data, {
-    ...config,
+  const formattedManifest = await format(data, {
+    tabWidth: 2,
     parser: 'json',
     filepath: path,
+    plugins: [babel, estree],
   });
 
   await writeFileFn(path, formattedManifest);

--- a/packages/snaps-webpack-plugin/src/plugin.ts
+++ b/packages/snaps-webpack-plugin/src/plugin.ts
@@ -128,6 +128,7 @@ export default class SnapsWebpackPlugin {
 
       const filePath = pathUtils.join(outputPath, file.name);
 
+      assert(compiler.outputFileSystem, 'Expected compiler to have an output file system.');
       const bundleFile = await promisify(
         compiler.outputFileSystem.readFile.bind(compiler.outputFileSystem),
       )(filePath);
@@ -148,6 +149,7 @@ export default class SnapsWebpackPlugin {
             updateAndWriteManifest: this.options.writeManifest,
             sourceCode: bundleContent,
             writeFileFn: async (path, data) => {
+              assert(compiler.outputFileSystem, 'Expected compiler to have an output file system.');
               return writeManifest(
                 path,
                 data,

--- a/yarn.lock
+++ b/yarn.lock
@@ -19326,6 +19326,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier-2@npm:prettier@^2.8.8":
+  version: 2.8.8
+  resolution: "prettier@npm:2.8.8"
+  bin:
+    prettier: bin-prettier.js
+  checksum: 10/00cdb6ab0281f98306cd1847425c24cbaaa48a5ff03633945ab4c701901b8e96ad558eb0777364ffc312f437af9b5a07d0f45346266e8245beaf6247b9c62b24
+  languageName: node
+  linkType: hard
+
 "prettier-linter-helpers@npm:^1.0.0":
   version: 1.0.0
   resolution: "prettier-linter-helpers@npm:1.0.0"
@@ -20708,6 +20717,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     minimatch: "npm:^7.4.1"
     prettier: "npm:^3.3.3"
+    prettier-2: "npm:prettier@^2.8.8"
     prettier-plugin-packagejson: "npm:^2.5.8"
     rimraf: "npm:^4.1.2"
     semver: "npm:^7.5.4"


### PR DESCRIPTION
This updates the CLI and Webpack plugin to handle breaking changes following the bump required for ESLint 9.

Unfortunately Prettier 3 makes it very complicated to load configuration files with CJS, since it loads the ESM bundle using a top-level await, which is not supported by Node.js without additional experimental parameters. For now I've removed the functionality for custom Prettier configs, but we can reconsider this in the future (i.e., through specifying a Prettier path in the CLI config, or allowing to provide the options directly).