### PR TITLE
Add missing checkout step to `update-chrome` workflow

### DIFF
--- a/.github/workflows/update-pull-request.yml
+++ b/.github/workflows/update-pull-request.yml
@@ -197,6 +197,8 @@ jobs:
       - prepare
       - dedupe-yarn-lock
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Restore yarn.lock
         uses: actions/cache/restore@v4
         with:


### PR DESCRIPTION
`update-chrome` was missing `actions/checkout`, causing the workflow to fail.