### PR TITLE
Fix Linux support for `update-chrome` script

### DIFF
--- a/scripts/update-chrome.sh
+++ b/scripts/update-chrome.sh
@@ -4,10 +4,6 @@ set -e
 set -u
 set -o pipefail
 
-#!/bin/bash
-
-yarn add -D chromedriver
-
 CHROME_VERSION=$(curl -s https://dl.google.com/linux/chrome/deb/dists/stable/main/binary-amd64/Packages.gz | \
     gunzip -c | \
     grep -A 1 "Package: google-chrome-stable" | grep "Version:" | awk '{print $2}')
@@ -24,7 +20,7 @@ SCRIPT_PATH="./scripts/install-chrome.sh"
 wget -O "${CHROME_BINARY}" -t 5 "${CHROME_BINARY_URL}"
 CHROME_BINARY_SHA512SUM=$(shasum -a 512 "${CHROME_BINARY}" | awk '{print $1}')
 
-sed -i '' "s/^CHROME_VERSION='.*'/CHROME_VERSION='${CHROME_VERSION}'/" "${SCRIPT_PATH}"
-sed -i '' "s/^CHROME_BINARY_SHA512SUM='.*'/CHROME_BINARY_SHA512SUM='${CHROME_BINARY_SHA512SUM}'/" "${SCRIPT_PATH}"
+sed -i "s/^CHROME_VERSION='.*'/CHROME_VERSION='${CHROME_VERSION}'/" "${SCRIPT_PATH}"
+sed -i "s/^CHROME_BINARY_SHA512SUM='.*'/CHROME_BINARY_SHA512SUM='${CHROME_BINARY_SHA512SUM}'/" "${SCRIPT_PATH}"
 
 rm -rf "${CHROME_BINARY}"


### PR DESCRIPTION
The `update-chrome` script was only compatible with macOS. Since we now run it as part of Dependabot, I've updated it to be compatible with Linux.