### PR TITLE
fix(controllers): Properly pass down execution service constructor args

### DIFF
--- a/packages/snaps-controllers/src/services/AbstractExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.test.ts
@@ -8,8 +8,9 @@ import type { ExecutionServiceArgs } from './AbstractExecutionService';
 import { NodeThreadExecutionService } from './node';
 
 class MockExecutionService extends NodeThreadExecutionService {
-  constructor({ messenger, setupSnapProvider }: ExecutionServiceArgs) {
+  constructor({ messenger, setupSnapProvider, ...args }: ExecutionServiceArgs) {
     super({
+      ...args,
       messenger,
       setupSnapProvider,
       initTimeout: inMilliseconds(5, Duration.Second),

--- a/packages/snaps-controllers/src/services/iframe/IframeExecutionService.ts
+++ b/packages/snaps-controllers/src/services/iframe/IframeExecutionService.ts
@@ -19,8 +19,10 @@ export class IframeExecutionService extends AbstractExecutionService<Window> {
     iframeUrl,
     messenger,
     setupSnapProvider,
+    ...args
   }: IframeExecutionEnvironmentServiceArgs) {
     super({
+      ...args,
       messenger,
       setupSnapProvider,
     });

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
@@ -25,8 +25,10 @@ export class OffscreenExecutionService extends ProxyExecutionService {
     messenger,
     setupSnapProvider,
     offscreenPromise,
+    ...args
   }: OffscreenExecutionEnvironmentServiceArgs) {
     super({
+      ...args,
       messenger,
       setupSnapProvider,
       stream: new BrowserRuntimePostMessageStream({

--- a/packages/snaps-controllers/src/services/proxy/ProxyExecutionService.ts
+++ b/packages/snaps-controllers/src/services/proxy/ProxyExecutionService.ts
@@ -30,8 +30,10 @@ export class ProxyExecutionService extends AbstractExecutionService<string> {
     stream,
     messenger,
     setupSnapProvider,
+    ...args
   }: ProxyExecutionEnvironmentServiceArgs) {
     super({
+      ...args,
       messenger,
       setupSnapProvider,
       usePing: false,

--- a/packages/snaps-controllers/src/services/webview/WebViewExecutionService.ts
+++ b/packages/snaps-controllers/src/services/webview/WebViewExecutionService.ts
@@ -14,8 +14,10 @@ export class WebViewExecutionService extends ProxyExecutionService {
     messenger,
     setupSnapProvider,
     getWebView,
+    ...args
   }: WebViewExecutionServiceArgs) {
     super({
+      ...args,
       messenger,
       setupSnapProvider,
       stream: new WebViewMessageStream({

--- a/packages/snaps-controllers/src/services/webworker/WebWorkerExecutionService.ts
+++ b/packages/snaps-controllers/src/services/webworker/WebWorkerExecutionService.ts
@@ -37,8 +37,10 @@ export class WebWorkerExecutionService extends AbstractExecutionService<string> 
     documentUrl,
     messenger,
     setupSnapProvider,
+    ...args
   }: WebWorkerExecutionEnvironmentServiceArgs) {
     super({
+      ...args,
       messenger,
       setupSnapProvider,
     });


### PR DESCRIPTION
Properly pass down constructor arguments passed into execution services. This allows proper overriding of the `initTimeout` for instance.