### PR TITLE
Fix remaining Node.js, browser, globals errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import typescript from '@metamask/eslint-config-typescript';
 
 const config = createConfig([
   {
-    ignores: ['**/coverage', '**/dist/', '**/docs/', '**/public/', '.yarn/'],
+    ignores: ['**/coverage', '**/dist', '**/docs', '**/public', '.yarn'],
   },
 
   // Base configuration
@@ -267,6 +267,7 @@ const config = createConfig([
       'packages/snaps-utils/src/**/*',
       'packages/snaps-webpack-plugin/src/**/*',
       'packages/test-snaps/src/**/*',
+      '**/scripts/**/*.ts',
       '**/test-utils/**/*.ts',
       '**/webpack.config.ts',
       '**/snap.config.ts',
@@ -274,7 +275,14 @@ const config = createConfig([
     extends: nodejs,
 
     rules: {
+      // These rules are too strict for some cases.
+      // TODO: Re-investigate these rules.
+      'n/callback-return': 'off',
       'n/hashbang': 'off',
+      'n/no-unsupported-features/node-builtins': 'off',
+      'n/no-process-env': 'off',
+      'n/no-process-exit': 'off',
+      'n/no-sync': 'off',
       'no-restricted-globals': 'off',
     },
   },
@@ -282,8 +290,11 @@ const config = createConfig([
   // Files that contain browser functionality
   {
     files: [
+      'packages/snaps-controllers/src/services/iframe/**/*',
+      'packages/snaps-controllers/src/services/webworker/**/*',
       'packages/snaps-execution-environments/src/**/*',
       'packages/snaps-simulator/src/**/*',
+      'packages/snaps-simulator/jest.setup.js',
       'packages/test-snaps/src/**/*',
       '**/*.test.browser.ts',
     ],

--- a/packages/examples/packages/invoke-snap/packages/core-signer/src/utils.ts
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/src/utils.ts
@@ -37,6 +37,7 @@ export async function getEntropy(): Promise<SLIP10Node> {
     }
 
     // Otherwise, generate some entropy and store it in state.
+    // eslint-disable-next-line no-restricted-globals
     const entropy = crypto.getRandomValues(new Uint8Array(32));
     await snap.request({
       method: 'snap_manageState',

--- a/packages/snaps-browserify-plugin/src/plugin.ts
+++ b/packages/snaps-browserify-plugin/src/plugin.ts
@@ -29,7 +29,9 @@ export type Options = PluginOptions &
  */
 async function postBundle(options: Partial<Options>, code: string) {
   if (options.eval) {
-    await useTemporaryFile('snaps-bundle.js', code, async (path) => evalBundle(path));
+    await useTemporaryFile('snaps-bundle.js', code, async (path) =>
+      evalBundle(path),
+    );
   }
 
   if (options.manifestPath) {

--- a/packages/snaps-cli/jest.setup.ts
+++ b/packages/snaps-cli/jest.setup.ts
@@ -3,9 +3,11 @@
 // reset the exit code before and after each test.
 // eslint-disable-next-line import-x/unambiguous
 beforeEach(() => {
+  // eslint-disable-next-line no-restricted-globals
   process.exitCode = 0;
 });
 
 afterEach(() => {
+  // eslint-disable-next-line no-restricted-globals
   process.exitCode = 0;
 });

--- a/packages/snaps-cli/src/__mocks__/fs.ts
+++ b/packages/snaps-cli/src/__mocks__/fs.ts
@@ -15,10 +15,8 @@ const BROWSERIFY_FILES = [
 ];
 
 for (const file of BROWSERIFY_FILES) {
-  /* eslint-disable n/no-sync */
   volume.mkdirSync(dirname(file), { recursive: true });
   volume.writeFileSync(file, jest.requireActual('fs').readFileSync(file));
-  /* eslint-enable n/no-sync */
 }
 
 export = createFsFromVolume(volume);

--- a/packages/snaps-cli/src/cli.ts
+++ b/packages/snaps-cli/src/cli.ts
@@ -24,7 +24,6 @@ export function checkNodeVersion(
     error(
       `Node version ${nodeVersion} is not supported. Please use Node ${minimumVersion} or later.`,
     );
-    // eslint-disable-next-line n/no-process-exit
     process.exit(1);
   }
 }
@@ -76,7 +75,6 @@ export async function cli(argv: string[], commands: any) {
 
     .fail((message, failure) => {
       error(getYargsErrorMessage(message, failure));
-      // eslint-disable-next-line n/no-process-exit
       process.exit(1);
     })
 

--- a/packages/snaps-cli/src/main.ts
+++ b/packages/snaps-cli/src/main.ts
@@ -13,7 +13,6 @@ import commands from './commands';
  *  npx update-browserslist-db@latest
  *  Why you should do it regularly: https://github.com/browserslist/update-db#readme
  */
-// eslint-disable-next-line n/no-process-env
 process.env.BROWSERSLIST_IGNORE_OLD_DATA = '1';
 
 cli(process.argv, commands).catch((error) => {

--- a/packages/snaps-cli/src/utils/steps.ts
+++ b/packages/snaps-cli/src/utils/steps.ts
@@ -11,7 +11,8 @@ export type Step<Context extends Record<string, unknown>> = {
   task: (context: Context & { spinner: Ora }) => Promise<Context | void>;
 };
 
-export type Steps<Context extends Record<string, unknown>> = readonly Step<Context>[];
+export type Steps<Context extends Record<string, unknown>> =
+  readonly Step<Context>[];
 
 /**
  * Execute a list of steps in series. Each step receives the context object and

--- a/packages/snaps-cli/src/webpack/loaders/function.ts
+++ b/packages/snaps-cli/src/webpack/loaders/function.ts
@@ -55,7 +55,6 @@ export function getFunctionLoader<Options>(
 // When running as CJS, we need to export the loader as a default export, since
 // `tsup` exports it as `loader_default`.
 // istanbul ignore next 3
-// eslint-disable-next-line n/no-process-env
 if (typeof module !== 'undefined' && process?.env?.NODE_ENV !== 'test') {
   module.exports = loader;
   module.exports.getFunctionLoader = getFunctionLoader;

--- a/packages/snaps-controllers/src/snaps/location/local.ts
+++ b/packages/snaps-controllers/src/snaps/location/local.ts
@@ -48,10 +48,6 @@ function convertCanonical<Result>(
   vfile: VirtualFile<Result>,
 ): VirtualFile<Result> {
   assert(vfile.data.canonicalPath !== undefined);
-
-  // TODO: Either fix this lint violation or explain why it's necessary to
-  //  ignore.
-  // eslint-disable-next-line @typescript-eslint/no-base-to-string, @typescript-eslint/restrict-template-expressions
   vfile.data.canonicalPath = `local:${vfile.data.canonicalPath}`;
   return vfile;
 }

--- a/packages/snaps-controllers/src/snaps/location/npm.test.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.test.ts
@@ -49,6 +49,9 @@ describe('NpmLocation', () => {
         }),
       } as any)
       .mockResolvedValue({
+        // eslint-disable-next-line no-restricted-globals
+        headers: new Headers({ 'content-length': '5477' }),
+        ok: true,
         body: Readable.toWeb(
           createReadStream(
             path.resolve(
@@ -57,9 +60,6 @@ describe('NpmLocation', () => {
             ),
           ),
         ),
-        // eslint-disable-next-line no-restricted-globals
-        headers: new Headers({ 'content-length': '5477' }),
-        ok: true,
       } as any);
 
     const location = new NpmLocation(

--- a/packages/snaps-controllers/src/snaps/location/npm.test.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.test.ts
@@ -49,8 +49,6 @@ describe('NpmLocation', () => {
         }),
       } as any)
       .mockResolvedValue({
-        ok: true,
-        headers: new Headers({ 'content-length': '5477' }),
         body: Readable.toWeb(
           createReadStream(
             path.resolve(
@@ -59,6 +57,9 @@ describe('NpmLocation', () => {
             ),
           ),
         ),
+        // eslint-disable-next-line no-restricted-globals
+        headers: new Headers({ 'content-length': '5477' }),
+        ok: true,
       } as any);
 
     const location = new NpmLocation(
@@ -131,6 +132,7 @@ describe('NpmLocation', () => {
 
     customFetchMock.mockResolvedValue({
       ok: true,
+      // eslint-disable-next-line no-restricted-globals
       headers: new Headers({ 'content-length': '5477' }),
       body: Readable.toWeb(
         createReadStream(
@@ -200,6 +202,7 @@ describe('NpmLocation', () => {
 
     customFetchMock.mockResolvedValue({
       ok: true,
+      // eslint-disable-next-line no-restricted-globals
       headers: new Headers({ 'content-length': '5477' }),
       body: Readable.toWeb(
         createReadStream(

--- a/packages/snaps-controllers/src/snaps/location/npm.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.ts
@@ -422,6 +422,7 @@ const NPM_TARBALL_PATH_PREFIX = /^package\//u;
  * @param stream - The stream to convert.
  * @returns The given stream as a Node.js Readable stream.
  */
+// eslint-disable-next-line no-restricted-globals
 function getNodeStream(stream: ReadableStream): Readable {
   if (typeof stream.getReader !== 'function') {
     return stream as unknown as Readable;

--- a/packages/snaps-execution-environments/src/common/globalObject.ts
+++ b/packages/snaps-execution-environments/src/common/globalObject.ts
@@ -23,7 +23,9 @@ if (typeof globalThis !== 'undefined') {
 } else if (typeof window !== 'undefined') {
   _rootRealmGlobal = window;
   _rootRealmGlobalName = GlobalObjectNames.window;
+  // eslint-disable-next-line no-restricted-globals
 } else if (typeof global !== 'undefined') {
+  // eslint-disable-next-line no-restricted-globals
   _rootRealmGlobal = global;
   _rootRealmGlobalName = GlobalObjectNames.global;
 } else {

--- a/packages/snaps-execution-environments/src/webview/WebViewExecutorStream.test.ts
+++ b/packages/snaps-execution-environments/src/webview/WebViewExecutorStream.test.ts
@@ -18,6 +18,7 @@ describe('WebViewExecutorStream', () => {
       removeEventListener: jest.fn(),
     };
 
+    // eslint-disable-next-line no-restricted-globals
     global.window = mockWindow as any;
   });
 

--- a/packages/snaps-simulator/src/features/handlers/transactions/components/TransactionPrefill.test.tsx
+++ b/packages/snaps-simulator/src/features/handlers/transactions/components/TransactionPrefill.test.tsx
@@ -8,7 +8,6 @@ describe('TransactionPrefill', () => {
       render(
         <TransactionPrefill
           name="ERC-20"
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           {...TRANSACTION_PRESETS[0].transaction}
           onClick={jest.fn()}
         />,

--- a/packages/snaps-simulator/src/utils/environment.ts
+++ b/packages/snaps-simulator/src/utils/environment.ts
@@ -5,4 +5,5 @@
 export const IS_TEST_BUILD =
   // @ts-expect-error - Webpack replaces the value of SNAPS_TEST with a boolean
   // at build time, but TypeScript doesn't know that.
+  // eslint-disable-next-line no-restricted-globals
   process.env.SNAPS_TEST === true || process.env.SNAPS_TEST === 'true';

--- a/packages/test-snaps/src/utils/id.ts
+++ b/packages/test-snaps/src/utils/id.ts
@@ -25,6 +25,7 @@ export function getSnapId(
     return localId;
   }
 
+  // eslint-disable-next-line no-restricted-globals
   const isProduction = process.env.NODE_ENV === 'production';
   return isProduction ? snapId : localId;
 }


### PR DESCRIPTION
This updates the ESLint configuration to fix errors related to Node.js and browser globals, and disables some rules that were too strict.