### PR TITLE
Fix `no-constant-binary-expression` errors

### DIFF
--- a/packages/snaps-cli/src/webpack/plugins.test.ts
+++ b/packages/snaps-cli/src/webpack/plugins.test.ts
@@ -170,7 +170,6 @@ describe('SnapsStatsPlugin', () => {
     expect(tap).toHaveBeenCalled();
     const callback = tap.mock.calls[0][1];
 
-    // eslint-disable-next-line n/callback-return
     await callback();
     expect(log).not.toHaveBeenCalled();
   });

--- a/packages/snaps-jest/src/matchers.ts
+++ b/packages/snaps-jest/src/matchers.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-invalid-this */
-
 // Note: Because this file imports from `@jest/globals`, it can only be used in
 // a Jest environment. This is why it's not exported from the index file.
 

--- a/packages/snaps-sdk/src/jsx/components/Box.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/Box.test.tsx
@@ -93,6 +93,7 @@ describe('Box', () => {
   it('renders a box with a conditional', () => {
     const result = (
       <Box direction="horizontal" alignment="space-between" center={true}>
+        {/* eslint-disable-next-line no-constant-binary-expression */}
         {false && <Text>Hello</Text>}
       </Box>
     );

--- a/packages/snaps-sdk/src/jsx/components/Heading.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/Heading.test.tsx
@@ -29,6 +29,7 @@ describe('Heading', () => {
     const result = (
       <Heading>
         Hello
+        {/* eslint-disable-next-line no-constant-binary-expression */}
         {false && 'world'}
       </Heading>
     );

--- a/packages/snaps-sdk/src/jsx/components/Link.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/Link.test.tsx
@@ -75,6 +75,7 @@ describe('Link', () => {
     const result = (
       <Link href="https://example.com">
         Hello
+        {/* eslint-disable-next-line no-constant-binary-expression */}
         {false && 'world'}
       </Link>
     );

--- a/packages/snaps-sdk/src/jsx/components/Tooltip.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/Tooltip.test.tsx
@@ -87,7 +87,10 @@ describe('Tooltip', () => {
 
   it('renders a tooltip with a conditional value', () => {
     const result = (
-      <Tooltip content="Hello">{false && <Text>World</Text>}</Tooltip>
+      <Tooltip content="Hello">
+        {/* eslint-disable-next-line no-constant-binary-expression */}
+        {false && <Text>World</Text>}
+      </Tooltip>
     );
 
     expect(result).toStrictEqual({

--- a/packages/snaps-sdk/src/jsx/components/form/Dropdown.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/Dropdown.test.tsx
@@ -42,6 +42,7 @@ describe('Dropdown', () => {
     const result = (
       <Dropdown name="dropdown" value="foo">
         <Option value="foo">Foo</Option>
+        {/* eslint-disable-next-line no-constant-binary-expression */}
         {false && <Option value="bar">Bar</Option>}
       </Dropdown>
     );

--- a/packages/snaps-sdk/src/jsx/components/form/Field.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/Field.test.tsx
@@ -327,6 +327,7 @@ describe('Field', () => {
     const result = (
       <Field>
         <Input name="foo" />
+        {/* eslint-disable-next-line no-constant-binary-expression */}
         {false && <Button type="submit">Submit</Button>}
       </Field>
     );

--- a/packages/snaps-sdk/src/jsx/components/form/Selector.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/Selector.test.tsx
@@ -64,6 +64,7 @@ describe('Selector', () => {
         <SelectorOption value="foo">
           <Card title="Foo" value="$1" />
         </SelectorOption>
+        {/* eslint-disable-next-line no-constant-binary-expression */}
         {false && (
           <SelectorOption value="bar">
             <Card title="Bar" value="$1" />

--- a/packages/snaps-sdk/src/jsx/components/formatting/Bold.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/formatting/Bold.test.tsx
@@ -29,6 +29,7 @@ describe('Bold', () => {
     const result = (
       <Bold>
         Hello
+        {/* eslint-disable-next-line no-constant-binary-expression */}
         {false && 'world'}
       </Bold>
     );

--- a/packages/snaps-sdk/src/jsx/components/formatting/Italic.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/formatting/Italic.test.tsx
@@ -29,6 +29,7 @@ describe('Italic', () => {
     const result = (
       <Italic>
         Hello
+        {/* eslint-disable-next-line no-constant-binary-expression */}
         {false && 'world'}
       </Italic>
     );

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -654,6 +654,7 @@ describe('FooterStruct', () => {
       <Button name="confirm">Confirm</Button>
     </Footer>,
     <Footer>
+      {/* eslint-disable-next-line no-constant-binary-expression */}
       <Button name="cancel">Cancel {true && 'foo'}</Button>
     </Footer>,
   ])('validates a footer element', (value) => {

--- a/packages/snaps-utils/src/ui.test.tsx
+++ b/packages/snaps-utils/src/ui.test.tsx
@@ -976,6 +976,7 @@ describe('getJsxChildren', () => {
     const element = (
       <Box>
         <Text>Hello</Text>
+        {/* eslint-disable-next-line no-constant-binary-expression */}
         {false && <Text>Foo</Text>}
         <Text>World</Text>
       </Box>
@@ -991,6 +992,7 @@ describe('getJsxChildren', () => {
     const element = (
       <Text>
         Hello
+        {/* eslint-disable-next-line no-constant-binary-expression */}
         {false && 'Foo'}
         World
       </Text>


### PR DESCRIPTION
This fixes all violations of the `no-constant-binary-expression` by ignoring them. We are using a constant binary expression on purpose in these cases.