### PR TITLE
Fix Jest-related errors

### DIFF
--- a/packages/examples/packages/network-access/src/index.test.ts
+++ b/packages/examples/packages/network-access/src/index.test.ts
@@ -22,6 +22,7 @@ describe('onRpcRequest', () => {
 
   describe('fetch', () => {
     // This test is disabled as it is flaky.
+    // eslint-disable-next-line jest/no-disabled-tests
     it.skip('fetches a URL and returns the JSON response', async () => {
       const { request } = await installSnap();
 

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -1841,6 +1841,7 @@ describe('SnapController', () => {
   });
 
   // This isn't stable in CI unfortunately
+  // eslint-disable-next-line jest/no-disabled-tests
   it.skip('throws if the Snap is terminated while executing', async () => {
     const { manifest, sourceCode, svgIcon } =
       await getMockSnapFilesWithUpdatedChecksum({

--- a/packages/snaps-controllers/src/snaps/location/http.ts
+++ b/packages/snaps-controllers/src/snaps/location/http.ts
@@ -17,7 +17,7 @@ export type HttpOptions = {
    */
   fetch?: typeof fetch;
   fetchOptions?: RequestInit;
-}
+};
 
 export class HttpLocation implements SnapLocation {
   private readonly cache = new Map<string, VirtualFile>();

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -2261,7 +2261,7 @@ describe('BaseSnapExecutor', () => {
       params: [MOCK_SNAP_ID, HandlerType.OnRpcRequest, MOCK_ORIGIN, {}],
     });
 
-    expect(consoleSpy.calls[0]?.args[0]).toStrictEqual(
+    expect(consoleSpy.calls[0]?.args[0]).toBe(
       'Command stream received a non-JSON-RPC request, and was unable to respond.',
     );
   });

--- a/packages/snaps-execution-environments/src/webworker/executor/WebWorkerSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/webworker/executor/WebWorkerSnapExecutor.test.browser.ts
@@ -128,6 +128,7 @@ describe('WebWorkerSnapExecutor', () => {
   });
 
   // TODO: Re-enable this test after investigating error handling further.
+  // eslint-disable-next-line jest/no-disabled-tests
   it.skip('handles closing the stream', async () => {
     const mockStream = new MockWindowPostMessageStream();
 
@@ -141,12 +142,13 @@ describe('WebWorkerSnapExecutor', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 1));
 
-    expect(closeSpy.calls.length).toBe(1);
+    expect(closeSpy.calls).toHaveLength(1);
 
     closeSpy.reset();
   });
 
   // TODO: Re-enable this test after investigating error handling further.
+  // eslint-disable-next-line jest/no-disabled-tests
   it.skip('handles stream errors', async () => {
     const mockStream = new MockWindowPostMessageStream();
 
@@ -158,8 +160,8 @@ describe('WebWorkerSnapExecutor', () => {
     WebWorkerSnapExecutor.initialize(mockStream);
     mockStream.emit('error', new Error('test error'));
 
-    expect(closeSpy.calls.length).toBe(1);
-    expect(consoleSpy.calls.length).toBe(3);
+    expect(closeSpy.calls).toHaveLength(1);
+    expect(consoleSpy.calls).toHaveLength(3);
     expect(consoleSpy.calls[0].args[0]).toBe(
       'Parent stream failure, closing worker.',
     );

--- a/packages/snaps-execution-environments/src/webworker/pool/WebWorkerPool.test.browser.ts
+++ b/packages/snaps-execution-environments/src/webworker/pool/WebWorkerPool.test.browser.ts
@@ -109,14 +109,14 @@ describe('WebWorkerPool', () => {
     await terminateJob(mockStream);
 
     expect(executor.jobs.get(MOCK_JOB_ID)).toBeUndefined();
-    expect(terminateSpy.calls.length).toBe(1);
+    expect(terminateSpy.calls).toHaveLength(1);
   });
 
   it('creates a worker pool', async () => {
     const mockStream = new MockPostMessageStream();
 
     const executor = WebWorkerPool.initialize(mockStream, WORKER_URL);
-    expect(executor.pool.length).toBe(0);
+    expect(executor.pool).toHaveLength(0);
 
     // Send ping to ensure that the worker is created.
     writeMessage(mockStream, {
@@ -131,7 +131,7 @@ describe('WebWorkerPool', () => {
     // Wait for the response, so that we know the worker is created.
     await getResponse(mockStream);
 
-    expect(executor.pool.length).toBe(3);
+    expect(executor.pool).toHaveLength(3);
     const nextWorker = executor.pool[0];
 
     writeMessage(
@@ -150,7 +150,7 @@ describe('WebWorkerPool', () => {
     // Wait for the response, so that we know the worker is created.
     await getResponse(mockStream);
 
-    expect(executor.pool.length).toBe(3);
+    expect(executor.pool).toHaveLength(3);
     expect(executor.pool[0]).not.toBe(nextWorker);
   });
 
@@ -183,6 +183,6 @@ describe('WebWorkerPool', () => {
       },
     });
 
-    expect(fetchSpy.calls.length).toBe(1);
+    expect(fetchSpy.calls).toHaveLength(1);
   });
 });


### PR DESCRIPTION
This fixes lint violations for the following rules:

- jest/no-disabled-tests
- jest/prefer-to-be
- jest/prefer-to-have-length
