### PR TITLE
Fix JSDoc errors

### DIFF
--- a/packages/snaps-controllers/src/snaps/registry/registry.ts
+++ b/packages/snaps-controllers/src/snaps/registry/registry.ts
@@ -34,7 +34,6 @@ export type SnapsRegistry = {
    *
    * @param snapId - The ID of the snap we are trying to resolve a version for.
    * @param versionRange - The version range.
-   * @param refetch - An optional flag used to determine if we are refetching the registry.
    * @returns An allowlisted version within the specified version range.
    * @throws If an allowlisted version does not exist within the version range.
    */

--- a/packages/snaps-jest/src/global.ts
+++ b/packages/snaps-jest/src/global.ts
@@ -47,6 +47,8 @@ interface SnapsMatchers {
    * @param title - The title of an expanded notification.
    * @param content - The content of an expanded notification.
    * @param footerLink - The footer link of an expanded notification (if it exists).
+   * @param footerLink.text - The text of the footer link.
+   * @param footerLink.href - The href of the footer link.
    * @throws If the snap did not send a notification with the expected message.
    * @example
    * const response = await request({ method: 'foo' });

--- a/packages/snaps-utils/src/iframe.ts
+++ b/packages/snaps-utils/src/iframe.ts
@@ -3,7 +3,6 @@
  * forever if the iframe never loads, but the promise should be wrapped in
  * an initialization timeout in the SnapController.
  *
- *
  * @param options - The options for createWindow.
  * @param options.uri - The iframe URI.
  * @param options.id - The ID to assign to the iframe.


### PR DESCRIPTION
This fixes the following lint violations:

- jsdoc/check-param-names
- jsdoc/tag-lines