### PR TITLE
Fix `no-restricted-syntax` errors

### DIFF
--- a/packages/snaps-controllers/src/cronjob/CronjobController.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.ts
@@ -565,6 +565,9 @@ export class CronjobController extends BaseController<
    *
    * @param snap - Basic Snap information.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private _handleSnapRegisterEvent(snap: TruncatedSnap) {
     this.register(snap.id);
   }
@@ -575,6 +578,9 @@ export class CronjobController extends BaseController<
    *
    * @param snap - Basic Snap information.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private _handleSnapEnabledEvent(snap: TruncatedSnap) {
     const events = this.getBackgroundEvents(snap.id);
     this.#rescheduleBackgroundEvents(events);
@@ -586,6 +592,9 @@ export class CronjobController extends BaseController<
    *
    * @param snap - Basic Snap information.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private _handleSnapUnregisterEvent(snap: TruncatedSnap) {
     this.unregister(snap.id);
   }
@@ -595,6 +604,9 @@ export class CronjobController extends BaseController<
    *
    * @param snap - Basic Snap information.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private _handleSnapDisabledEvent(snap: TruncatedSnap) {
     this.unregister(snap.id, true);
   }
@@ -604,6 +616,9 @@ export class CronjobController extends BaseController<
    *
    * @param snap - Basic Snap information.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private _handleEventSnapUpdated(snap: TruncatedSnap) {
     this.unregister(snap.id);
     this.register(snap.id);

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.ts
@@ -74,6 +74,7 @@ export abstract class AbstractExecutionService<WorkerType>
   protected jobs: Map<string, Job<WorkerType>>;
 
   // Cannot be hash private yet because of tests.
+  // eslint-disable-next-line no-restricted-syntax
   private readonly setupSnapProvider: SetupSnapProvider;
 
   readonly #snapToJobMap: Map<string, string>;
@@ -116,6 +117,9 @@ export abstract class AbstractExecutionService<WorkerType>
    * Constructor helper for registering the controller's messaging system
    * actions.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private registerMessageHandlers(): void {
     this.#messenger.registerActionHandler(
       `${controllerName}:handleRpcRequest`,
@@ -360,6 +364,9 @@ export abstract class AbstractExecutionService<WorkerType>
    * @param snapId - The id of the Snap whose message handler to get.
    * @returns The RPC request handler for the snap.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private getRpcRequestHandler(snapId: string) {
     return this.#snapRpcHooks.get(snapId);
   }
@@ -437,6 +444,7 @@ export abstract class AbstractExecutionService<WorkerType>
   }
 
   // Cannot be hash private yet because of tests.
+  // eslint-disable-next-line no-restricted-syntax
   private async command(
     jobId: string,
     message: JsonRpcRequest,

--- a/packages/snaps-controllers/src/services/webview/WebViewMessageStream.ts
+++ b/packages/snaps-controllers/src/services/webview/WebViewMessageStream.ts
@@ -72,6 +72,9 @@ export class WebViewMessageStream extends BasePostMessageStream {
     this.#webView.injectJavaScript(`window.postMessage([${bytes.toString()}])`);
   }
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private _onMessage(event: PostMessageEvent): void {
     if (typeof event.data !== 'string') {
       return;

--- a/packages/snaps-controllers/src/services/webworker/WebWorkerExecutionService.ts
+++ b/packages/snaps-controllers/src/services/webworker/WebWorkerExecutionService.ts
@@ -95,6 +95,9 @@ export class WebWorkerExecutionService extends AbstractExecutionService<string> 
    *
    * If the document already exists, this does nothing.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private async createDocument() {
     // We only want to create a single pool.
     if (document.getElementById(WORKER_POOL_ID)) {

--- a/packages/snaps-controllers/src/snaps/RequestQueue.ts
+++ b/packages/snaps-controllers/src/snaps/RequestQueue.ts
@@ -1,6 +1,9 @@
 export class RequestQueue {
   public readonly maxQueueSize: number;
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private readonly queueSizes: Map<string, number>;
 
   constructor(maxQueueSize: number) {

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -843,6 +843,7 @@ export class SnapController extends BaseController<
   readonly #maxIdleTime: number;
 
   // This property cannot be hash private yet because of tests.
+  // eslint-disable-next-line no-restricted-syntax
   private readonly maxRequestTime: number;
 
   readonly #encryptor: ExportableKeyEncryptor;
@@ -2556,6 +2557,9 @@ export class SnapController extends BaseController<
    * @param versionRange - The semver range of the snap to install.
    * @returns The resulting snap object, or an error if something went wrong.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private async processRequestedSnap(
     origin: string,
     snapId: SnapId,
@@ -3278,6 +3282,7 @@ export class SnapController extends BaseController<
    * @param pendingApproval - Pending approval to update.
    * @returns The snap's approvedPermissions.
    */
+  // eslint-disable-next-line no-restricted-syntax
   private async authorize(
     snapId: SnapId,
     pendingApproval: PendingApproval,

--- a/packages/snaps-controllers/src/snaps/Timer.ts
+++ b/packages/snaps-controllers/src/snaps/Timer.ts
@@ -3,6 +3,9 @@ import { assert } from '@metamask/utils';
 export type TimerStatus = 'stopped' | 'paused' | 'running' | 'finished';
 
 export class Timer {
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private state:
     | { value: 'stopped'; remaining: number }
     | {
@@ -129,6 +132,9 @@ export class Timer {
     this.state = { value: 'running', callback, remaining, start, timeout };
   }
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private onFinish(shouldCall: boolean) {
     assert(this.state.value === 'running' || this.state.value === 'paused');
 

--- a/packages/snaps-controllers/src/snaps/location/http.ts
+++ b/packages/snaps-controllers/src/snaps/location/http.ts
@@ -20,14 +20,29 @@ export type HttpOptions = {
 };
 
 export class HttpLocation implements SnapLocation {
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private readonly cache = new Map<string, VirtualFile>();
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private validatedManifest?: VirtualFile<SnapManifest>;
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private readonly url: URL;
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private readonly fetchFn: typeof fetch;
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private readonly fetchOptions?: RequestInit;
 
   constructor(url: URL, opts: HttpOptions = {}) {
@@ -100,6 +115,9 @@ export class HttpLocation implements SnapLocation {
     return new URL(this.url);
   }
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private toCanonical(path: string): URL {
     assert(!path.startsWith('/'), 'Tried to parse absolute path.');
     return new URL(path, this.url);

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -117,18 +117,39 @@ export type NotifyFunction = (
 ) => Promise<void>;
 
 export class BaseSnapExecutor {
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private readonly snapData: Map<string, SnapData>;
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private readonly commandStream: Duplex;
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private readonly rpcStream: Duplex;
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private readonly methods: CommandMethodsMapping;
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private snapErrorHandler?: (event: ErrorEvent) => void;
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private snapPromiseErrorHandler?: (event: PromiseRejectionEvent) => void;
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private lastTeardown = 0;
 
   protected constructor(commandStream: Duplex, rpcStream: Duplex) {
@@ -189,6 +210,9 @@ export class BaseSnapExecutor {
     );
   }
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private errorHandler(error: unknown, data: Record<string, Json>) {
     const serializedError = serializeError(error, {
       fallbackError: unhandledError,
@@ -214,6 +238,9 @@ export class BaseSnapExecutor {
     });
   }
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private async onCommandRequest(message: JsonRpcRequest) {
     if (!isJsonRpcRequest(message)) {
       if (
@@ -458,6 +485,9 @@ export class BaseSnapExecutor {
     this.snapData.clear();
   }
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private async registerSnapExports(snapId: string, snapModule: any) {
     const data = this.snapData.get(snapId);
     // Somebody deleted the snap before we could register.
@@ -486,6 +516,9 @@ export class BaseSnapExecutor {
    * @param provider - A StreamProvider connected to MetaMask.
    * @returns The snap provider object.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private createSnapGlobal(provider: StreamProvider): SnapsProvider {
     const originalRequest = provider.request.bind(provider);
 
@@ -523,6 +556,9 @@ export class BaseSnapExecutor {
    * @param provider - A StreamProvider connected to MetaMask.
    * @returns The EIP-1193 Ethereum provider object.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private createEIP1193Provider(
     provider: StreamProvider,
   ): SnapsEthereumProvider {
@@ -561,6 +597,9 @@ export class BaseSnapExecutor {
    *
    * @param snapId - The id of the snap to remove.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private removeSnap(snapId: string): void {
     this.snapData.delete(snapId);
   }
@@ -576,6 +615,9 @@ export class BaseSnapExecutor {
    * @returns The executor's return value.
    * @template Result - The return value of the executor.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private async executeInSnapContext<Result>(
     snapId: string,
     executor: () => Promise<Result> | Result,

--- a/packages/snaps-execution-environments/src/webview/WebViewExecutorStream.ts
+++ b/packages/snaps-execution-environments/src/webview/WebViewExecutorStream.ts
@@ -61,6 +61,9 @@ export class WebViewExecutorStream extends BasePostMessageStream {
     );
   }
 
+  // TODO: Either fix this lint violation or explain why it's necessary to
+  //  ignore.
+  // eslint-disable-next-line no-restricted-syntax
   private _onMessage(event: PostMessageEvent): void {
     if (!Array.isArray(event.data)) {
       return;

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -37,6 +37,9 @@ module.exports = defineConfig({
       const workspaceBasename = getWorkspaceBasename(workspace);
       const isChildWorkspace = workspace.cwd !== '.';
       const isPrivate =
+        // TODO: Either fix this lint violation or explain why it's necessary to
+        //  ignore.
+        // eslint-disable-next-line no-restricted-syntax
         'private' in workspace.manifest && workspace.manifest.private === true;
       const dependenciesByIdentAndType = getDependenciesByIdentAndType(
         Yarn.dependencies({ workspace }),
@@ -387,6 +390,9 @@ async function workspaceFileExists(workspace, path) {
   try {
     await getWorkspaceFile(workspace, path);
   } catch (error) {
+    // TODO: Either fix this lint violation or explain why it's necessary to
+    //  ignore.
+    // eslint-disable-next-line no-restricted-syntax
     if ('code' in error && error.code === 'ENOENT') {
       return false;
     }


### PR DESCRIPTION
This fixes lint violations caused by the `no-restricted-syntax` rule by suppressing these errors. We need to do additional research whether these can be fixed, as some may be used by tests.