### PR TITLE
Add `AddressInput` component

### DIFF
--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7m/tln4qf/bu8u9PdJnluGBWg7949ema1QUhYrL6Kys=",
+    "shasum": "e3eXjWGO/nmmRxBt/caaktmqj/3chjABsSkFq6leppU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "SeDH2s8fzM2/cxqbhyhF7G3TeztLsn01kRiWige7l2M=",
+    "shasum": "yvblLjVAXActFtH/3q3GxeTcbRopWjZCX2h4S21hscs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 93.46,
+  "branches": 93.51,
   "functions": 97.36,
   "lines": 98.33,
   "statements": 98.06

--- a/packages/snaps-controllers/src/interface/utils.test.tsx
+++ b/packages/snaps-controllers/src/interface/utils.test.tsx
@@ -306,7 +306,7 @@ describe('constructState', () => {
 
     const result = constructState({}, element);
     expect(result).toStrictEqual({
-      foo: '0x123',
+      foo: 'eip155:1:0x123',
     });
   });
 

--- a/packages/snaps-controllers/src/interface/utils.test.tsx
+++ b/packages/snaps-controllers/src/interface/utils.test.tsx
@@ -16,6 +16,7 @@ import {
   Card,
   SelectorOption,
   AssetSelector,
+  AddressInput,
 } from '@metamask/snaps-sdk/jsx';
 
 import {
@@ -293,6 +294,49 @@ describe('constructState', () => {
     const result = constructState({}, element, elementDataGetters);
     expect(result).toStrictEqual({
       foo: null,
+    });
+  });
+
+  it('handles root level AddressInput with value', () => {
+    const element = (
+      <Box>
+        <AddressInput name="foo" chainId="eip155:1" value="0x123" />
+      </Box>
+    );
+
+    const result = constructState({}, element);
+    expect(result).toStrictEqual({
+      foo: '0x123',
+    });
+  });
+
+  it('handles root level AddressInput without value', () => {
+    const element = (
+      <Box>
+        <AddressInput name="foo" chainId="eip155:1" />
+      </Box>
+    );
+
+    const result = constructState({}, element);
+    expect(result).toStrictEqual({
+      foo: null,
+    });
+  });
+
+  it('handles AddressInput in forms', () => {
+    const element = (
+      <Box>
+        <Form name="form">
+          <Field label="foo">
+            <AddressInput name="foo" chainId="eip155:1" />
+          </Field>
+        </Form>
+      </Box>
+    );
+
+    const result = constructState({}, element);
+    expect(result).toStrictEqual({
+      form: { foo: null },
     });
   });
 

--- a/packages/snaps-controllers/src/interface/utils.test.tsx
+++ b/packages/snaps-controllers/src/interface/utils.test.tsx
@@ -304,7 +304,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, elementDataGetters);
     expect(result).toStrictEqual({
       foo: 'eip155:1:0x123',
     });
@@ -317,7 +317,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, elementDataGetters);
     expect(result).toStrictEqual({
       foo: null,
     });
@@ -334,7 +334,7 @@ describe('constructState', () => {
       </Box>
     );
 
-    const result = constructState({}, element);
+    const result = constructState({}, element, elementDataGetters);
     expect(result).toStrictEqual({
       form: { foo: null },
     });

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -21,6 +21,7 @@ import type {
   SelectorElement,
   SelectorOptionElement,
   AssetSelectorElement,
+  AddressInputElement,
 } from '@metamask/snaps-sdk/jsx';
 import { isJSXElementUnsafe } from '@metamask/snaps-sdk/jsx';
 import type { InternalAccount } from '@metamask/snaps-utils';
@@ -183,7 +184,8 @@ function constructComponentSpecificDefaultState(
     | RadioGroupElement
     | CheckboxElement
     | SelectorElement
-    | AssetSelectorElement,
+    | AssetSelectorElement
+    | AddressInputElement,
   elementDataGetters: ElementDataGetters,
 ) {
   switch (element.type) {
@@ -264,7 +266,8 @@ function getComponentStateValue(
     | RadioGroupElement
     | CheckboxElement
     | SelectorElement
-    | AssetSelectorElement,
+    | AssetSelectorElement
+    | AddressInputElement,
   { getAssetsState }: ElementDataGetters,
 ) {
   switch (element.type) {
@@ -297,7 +300,8 @@ function constructInputState(
     | FileInputElement
     | CheckboxElement
     | SelectorElement
-    | AssetSelectorElement,
+    | AssetSelectorElement
+    | AddressInputElement,
   elementDataGetters: ElementDataGetters,
   form?: string,
 ) {
@@ -360,7 +364,8 @@ export function constructState(
         component.type === 'FileInput' ||
         component.type === 'Checkbox' ||
         component.type === 'Selector' ||
-        component.type === 'AssetSelector')
+        component.type === 'AssetSelector' ||
+        component.type === 'AddressInput')
     ) {
       const formState = newState[currentForm.name] as FormState;
       assertNameIsUnique(formState, component.props.name);
@@ -382,7 +387,8 @@ export function constructState(
       component.type === 'FileInput' ||
       component.type === 'Checkbox' ||
       component.type === 'Selector' ||
-      component.type === 'AssetSelector'
+      component.type === 'AssetSelector' ||
+      component.type === 'AddressInput'
     ) {
       assertNameIsUnique(newState, component.props.name);
       newState[component.props.name] = constructInputState(

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -73,6 +73,7 @@ type ElementDataGetters = {
   getAssetsState: GetAssetsState;
   getAccountByAddress: GetAccountByAddress;
 };
+
 /**
  * Get a JSX element from a component or JSX element. If the component is a
  * JSX element, it is returned as is. Otherwise, the component is converted to

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -277,6 +277,14 @@ function getComponentStateValue(
     case 'AssetSelector':
       return getAssetSelectorStateValue(element.props.value, getAssetsState);
 
+    case 'AddressInput':
+      if (!element.props.value) {
+        return null;
+      }
+
+      // Construct CAIP-10 Id
+      return `${element.props.chainId}:${element.props.value}`;
+
     default:
       return element.props.value;
   }

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -36,8 +36,9 @@ import {
   type CaipAccountId,
   parseCaipAccountId,
   parseCaipAssetType,
+  toCaipAccountId,
+  parseCaipChainId,
 } from '@metamask/utils';
-import { toCaipAccountId } from '@metamask/utils';
 
 /**
  * A function to get the MultichainAssetController state.
@@ -283,7 +284,7 @@ function getComponentStateValue(
       }
 
       // Construct CAIP-10 Id
-      const [namespace, reference] = element.props.chainId.split(':');
+      const { namespace, reference } = parseCaipChainId(element.props.chainId);
       return toCaipAccountId(namespace, reference, element.props.value);
     }
     default:

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -37,6 +37,7 @@ import {
   parseCaipAccountId,
   parseCaipAssetType,
 } from '@metamask/utils';
+import { toCaipAccountId } from '@metamask/utils';
 
 /**
  * A function to get the MultichainAssetController state.
@@ -71,7 +72,6 @@ type ElementDataGetters = {
   getAssetsState: GetAssetsState;
   getAccountByAddress: GetAccountByAddress;
 };
-
 /**
  * Get a JSX element from a component or JSX element. If the component is a
  * JSX element, it is returned as is. Otherwise, the component is converted to
@@ -277,14 +277,15 @@ function getComponentStateValue(
     case 'AssetSelector':
       return getAssetSelectorStateValue(element.props.value, getAssetsState);
 
-    case 'AddressInput':
+    case 'AddressInput': {
       if (!element.props.value) {
         return null;
       }
 
       // Construct CAIP-10 Id
-      return `${element.props.chainId}:${element.props.value}`;
-
+      const [namespace, reference] = element.props.chainId.split(':');
+      return toCaipAccountId(namespace, reference, element.props.value);
+    }
     default:
       return element.props.value;
   }

--- a/packages/snaps-rpc-methods/src/permitted/createInterface.test.tsx
+++ b/packages/snaps-rpc-methods/src/permitted/createInterface.test.tsx
@@ -141,7 +141,7 @@ describe('snap_createInterface', () => {
       error: {
         code: -32602,
         message:
-          'Invalid params: At path: ui -- Expected type to be one of: "Address", "AddressInput", "AssetSelector", "Bold", "Box", "Button", "Copyable", "Divider", "Dropdown", "RadioGroup", "Field", "FileInput", "Form", "Heading", "Input", "Image", "Italic", "Link", "Row", "Spinner", "Text", "Tooltip", "Checkbox", "Card", "Icon", "Selector", "Section", "Avatar", "Banner", "Skeleton", "Container", but received: undefined.',
+          'Invalid params: At path: ui -- Expected type to be one of: "Address", "AssetSelector", "AddressInput", "Bold", "Box", "Button", "Copyable", "Divider", "Dropdown", "RadioGroup", "Field", "FileInput", "Form", "Heading", "Input", "Image", "Italic", "Link", "Row", "Spinner", "Text", "Tooltip", "Checkbox", "Card", "Icon", "Selector", "Section", "Avatar", "Banner", "Skeleton", "Container", but received: undefined.',
         stack: expect.any(String),
       },
       id: 1,
@@ -191,7 +191,7 @@ describe('snap_createInterface', () => {
       error: {
         code: -32602,
         message:
-          'Invalid params: At path: ui.props.children.props.children -- Expected type to be one of: "AddressInput", "AssetSelector", "Input", "Dropdown", "RadioGroup", "FileInput", "Checkbox", "Selector", but received: "Copyable".',
+          'Invalid params: At path: ui.props.children.props.children -- Expected type to be one of: "AssetSelector", "AddressInput", "Input", "Dropdown", "RadioGroup", "FileInput", "Checkbox", "Selector", but received: "Copyable".',
         stack: expect.any(String),
       },
       id: 1,

--- a/packages/snaps-rpc-methods/src/permitted/createInterface.test.tsx
+++ b/packages/snaps-rpc-methods/src/permitted/createInterface.test.tsx
@@ -141,7 +141,7 @@ describe('snap_createInterface', () => {
       error: {
         code: -32602,
         message:
-          'Invalid params: At path: ui -- Expected type to be one of: "Address", "AssetSelector", "Bold", "Box", "Button", "Copyable", "Divider", "Dropdown", "RadioGroup", "Field", "FileInput", "Form", "Heading", "Input", "Image", "Italic", "Link", "Row", "Spinner", "Text", "Tooltip", "Checkbox", "Card", "Icon", "Selector", "Section", "Avatar", "Banner", "Skeleton", "Container", but received: undefined.',
+          'Invalid params: At path: ui -- Expected type to be one of: "Address", "AddressInput", "AssetSelector", "Bold", "Box", "Button", "Copyable", "Divider", "Dropdown", "RadioGroup", "Field", "FileInput", "Form", "Heading", "Input", "Image", "Italic", "Link", "Row", "Spinner", "Text", "Tooltip", "Checkbox", "Card", "Icon", "Selector", "Section", "Avatar", "Banner", "Skeleton", "Container", but received: undefined.',
         stack: expect.any(String),
       },
       id: 1,
@@ -191,7 +191,7 @@ describe('snap_createInterface', () => {
       error: {
         code: -32602,
         message:
-          'Invalid params: At path: ui.props.children.props.children -- Expected type to be one of: "AssetSelector", "Input", "Dropdown", "RadioGroup", "FileInput", "Checkbox", "Selector", but received: "Copyable".',
+          'Invalid params: At path: ui.props.children.props.children -- Expected type to be one of: "AddressInput", "AssetSelector", "Input", "Dropdown", "RadioGroup", "FileInput", "Checkbox", "Selector", but received: "Copyable".',
         stack: expect.any(String),
       },
       id: 1,

--- a/packages/snaps-sdk/src/internals/jsx.ts
+++ b/packages/snaps-sdk/src/internals/jsx.ts
@@ -10,6 +10,7 @@ import type {
   Struct,
   UnionToIntersection,
 } from '@metamask/superstruct';
+import type { CaipChainId } from '@metamask/utils';
 
 import { union } from './structs';
 import type { EmptyObject } from '../types';
@@ -34,11 +35,13 @@ type StructSchema<Type> =
       : [Type] extends [string | undefined | null]
         ? [Type] extends [`0x${string}`]
           ? null
-          : [Type] extends [IsMatch<Type, string | undefined | null>]
+          : [Type] extends [CaipChainId]
             ? null
-            : [Type] extends [IsUnion<Type>]
-              ? EnumSchema<Type>
-              : Type
+            : [Type] extends [IsMatch<Type, string | undefined | null>]
+              ? null
+              : [Type] extends [IsUnion<Type>]
+                ? EnumSchema<Type>
+                : Type
         : [Type] extends [number | undefined | null]
           ? [Type] extends [IsMatch<Type, number | undefined | null>]
             ? null

--- a/packages/snaps-sdk/src/jsx/components/form/AddressInput.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/AddressInput.test.tsx
@@ -1,0 +1,16 @@
+import { AddressInput } from './AddressInput';
+
+describe('AddressInput', () => {
+  it('renders an address input', () => {
+    const result = <AddressInput name="address" chainId="eip155:1" />;
+
+    expect(result).toStrictEqual({
+      type: 'AddressInput',
+      props: {
+        name: 'address',
+        chainId: 'eip155:1',
+      },
+      key: null,
+    });
+  });
+});

--- a/packages/snaps-sdk/src/jsx/components/form/AddressInput.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/AddressInput.ts
@@ -6,6 +6,8 @@ export type AddressInputProps = {
   name: string;
   value?: string | undefined;
   chainId: CaipChainId;
+  placeholder?: string | undefined;
+  disabled?: boolean | undefined;
 };
 
 const TYPE = 'AddressInput';
@@ -17,6 +19,8 @@ const TYPE = 'AddressInput';
  * @param props.name - The name of the input field.
  * @param props.value - The value of the input field.
  * @param props.chainId - The CAIP-2 chain ID of the address.
+ * @param props.placeholder - The placeholder text of the input field.
+ * @param props.disabled - Whether the input field is disabled.
  * @returns An input element.
  * @example
  * <AddressInput name="address" value="0x1234567890123456789012345678901234567890" chainId="eip155:1" />

--- a/packages/snaps-sdk/src/jsx/components/form/AddressInput.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/AddressInput.ts
@@ -1,0 +1,28 @@
+import type { CaipChainId } from '@metamask/utils';
+
+import { createSnapComponent } from '../../component';
+
+export type AddressInputProps = {
+  name: string;
+  value?: string | undefined;
+  chainId: CaipChainId;
+};
+
+const TYPE = 'AddressInput';
+
+/**
+ * An input component for entering an address. Resolves the address to a display name and avatar.
+ *
+ * @param props - The props of the component.
+ * @param props.name - The name of the input field.
+ * @param props.value - The value of the input field.
+ * @param props.chainId - The CAIP-2 chain ID of the address.
+ * @returns An input element.
+ * @example
+ * <AddressInput name="address" value="0x1234567890123456789012345678901234567890" chainId="eip155:1" />
+ */
+export const AddressInput = createSnapComponent<AddressInputProps, typeof TYPE>(
+  TYPE,
+);
+
+export type AddressInputElement = ReturnType<typeof AddressInput>;

--- a/packages/snaps-sdk/src/jsx/components/form/Field.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/form/Field.test.tsx
@@ -1,3 +1,4 @@
+import { AddressInput } from './AddressInput';
 import { Button } from './Button';
 import { Dropdown } from './Dropdown';
 import { Field } from './Field';
@@ -317,6 +318,30 @@ describe('Field', () => {
                 },
               },
             ],
+          },
+        },
+      },
+    });
+  });
+
+  it('renders a field element with an address input', () => {
+    const result = (
+      <Field label="Label">
+        <AddressInput name="address" chainId="eip155:1" />
+      </Field>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'Field',
+      key: null,
+      props: {
+        label: 'Label',
+        children: {
+          type: 'AddressInput',
+          key: null,
+          props: {
+            name: 'address',
+            chainId: 'eip155:1',
           },
         },
       },

--- a/packages/snaps-sdk/src/jsx/components/form/Field.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Field.ts
@@ -1,3 +1,4 @@
+import type { AddressInputElement } from './AddressInput';
 import type { AssetSelectorElement } from './AssetSelector';
 import type { CheckboxElement } from './Checkbox';
 import type { DropdownElement } from './Dropdown';
@@ -28,7 +29,8 @@ export type FieldProps = {
     | InputElement
     | CheckboxElement
     | SelectorElement
-    | AssetSelectorElement;
+    | AssetSelectorElement
+    | AddressInputElement;
 };
 
 const TYPE = 'Field';

--- a/packages/snaps-sdk/src/jsx/components/form/Field.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/Field.ts
@@ -6,8 +6,8 @@ import type { FileInputElement } from './FileInput';
 import type { InputElement } from './Input';
 import type { RadioGroupElement } from './RadioGroup';
 import type { SelectorElement } from './Selector';
-import { createSnapComponent } from '../../component';
 import type { GenericSnapChildren } from '../../component';
+import { createSnapComponent } from '../../component';
 
 /**
  * The props of the {@link Field} component.

--- a/packages/snaps-sdk/src/jsx/components/form/index.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/index.ts
@@ -1,3 +1,4 @@
+import type { AddressInputElement } from './AddressInput';
 import type { AssetSelectorElement } from './AssetSelector';
 import type { ButtonElement } from './Button';
 import type { CheckboxElement } from './Checkbox';
@@ -25,9 +26,11 @@ export * from './Form';
 export * from './Input';
 export * from './Selector';
 export * from './SelectorOption';
+export * from './AddressInput';
 
 export type StandardFormElement =
   | AssetSelectorElement
+  | AddressInputElement
   | ButtonElement
   | CheckboxElement
   | FormElement

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -36,6 +36,7 @@ import {
   Banner,
   Skeleton,
   AssetSelector,
+  AddressInput,
 } from './components';
 import {
   AddressStruct,
@@ -76,6 +77,7 @@ import {
   BannerStruct,
   SkeletonStruct,
   AssetSelectorStruct,
+  AddressInputStruct,
 } from './validation';
 
 describe('KeyStruct', () => {
@@ -209,6 +211,36 @@ describe('ButtonStruct', () => {
   });
 });
 
+describe('AddressInputStruct', () => {
+  it.each([
+    <AddressInput name="address" chainId="eip155:1" />,
+    <AddressInput
+      name="address"
+      chainId="eip155:1"
+      value="0x1234567890abcdef1234567890abcdef12345678"
+    />,
+  ])('validates an address input element', (value) => {
+    expect(is(value, AddressInputStruct)).toBe(true);
+  });
+
+  it.each([
+    'foo',
+    42,
+    null,
+    undefined,
+    {},
+    [],
+    // @ts-expect-error - Invalid props.
+    <AddressInput />,
+    // @ts-expect-error - Invalid props.
+    <AddressInput name="foo" chainId="foo" />,
+    // @ts-expect-error - Invalid props.
+    <AddressInput chainId="eip155:1" />,
+  ])('does not validate "%p"', (value) => {
+    expect(is(value, AddressInputStruct)).toBe(false);
+  });
+});
+
 describe('InputStruct', () => {
   it.each([
     <Input name="foo" type="text" />,
@@ -321,6 +353,9 @@ describe('FieldStruct', () => {
           'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv',
         ]}
       />
+    </Field>,
+    <Field label="foo">
+      <AddressInput name="address" chainId="eip155:1" />
     </Field>,
   ])('validates a field element', (value) => {
     expect(is(value, FieldStruct)).toBe(true);

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -219,6 +219,8 @@ describe('AddressInputStruct', () => {
       chainId="eip155:1"
       value="0x1234567890abcdef1234567890abcdef12345678"
     />,
+    <AddressInput name="address" chainId="eip155:1" placeholder="foo" />,
+    <AddressInput name="address" chainId="eip155:1" disabled={true} />,
   ])('validates an address input element', (value) => {
     expect(is(value, AddressInputStruct)).toBe(true);
   });
@@ -236,6 +238,10 @@ describe('AddressInputStruct', () => {
     <AddressInput name="foo" chainId="foo" />,
     // @ts-expect-error - Invalid props.
     <AddressInput chainId="eip155:1" />,
+    // @ts-expect-error - Invalid props.
+    <AddressInput name="foo" chainId="eip155:1" placeholder={32} />,
+    // @ts-expect-error - Invalid props.
+    <AddressInput name="foo" chainId="eip155:1" disabled="bar" />,
   ])('does not validate "%p"', (value) => {
     expect(is(value, AddressInputStruct)).toBe(false);
   });

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -348,12 +348,17 @@ export const InputStruct: Describe<InputElement> = elementWithSelectiveProps(
   },
 );
 
+/**
+ * A struct for the {@link AddressInputElement} type.
+ */
 export const AddressInputStruct: Describe<AddressInputElement> = element(
   'AddressInput',
   {
     name: string(),
     chainId: CaipChainIdStruct as unknown as Struct<CaipChainId, CaipChainId>,
     value: optional(string()),
+    placeholder: optional(string()),
+    disabled: optional(boolean()),
   },
 );
 

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -21,8 +21,10 @@ import {
   assign,
   union,
 } from '@metamask/superstruct';
+import type { CaipChainId } from '@metamask/utils';
 import {
   CaipAccountIdStruct,
+  CaipChainIdStruct,
   hasProperty,
   HexChecksumAddressStruct,
   isPlainObject,
@@ -40,6 +42,7 @@ import type {
   StringElement,
 } from './component';
 import type {
+  AddressInputElement,
   AssetSelectorElement,
   AvatarElement,
   SkeletonElement,
@@ -345,6 +348,15 @@ export const InputStruct: Describe<InputElement> = elementWithSelectiveProps(
   },
 );
 
+export const AddressInputStruct: Describe<AddressInputElement> = element(
+  'AddressInput',
+  {
+    name: string(),
+    chainId: CaipChainIdStruct as unknown as Struct<CaipChainId, CaipChainId>,
+    value: optional(string()),
+  },
+);
+
 /**
  * A struct for the {@link OptionElement} type.
  */
@@ -499,6 +511,7 @@ const BOX_INPUT_BOTH = [
  */
 const FIELD_CHILDREN_ARRAY = [
   AssetSelectorStruct,
+  AddressInputStruct,
   InputStruct,
   DropdownStruct,
   RadioGroupStruct,
@@ -507,6 +520,7 @@ const FIELD_CHILDREN_ARRAY = [
   SelectorStruct,
 ] as [
   typeof AssetSelectorStruct,
+  typeof AddressInputStruct,
   typeof InputStruct,
   typeof DropdownStruct,
   typeof RadioGroupStruct,
@@ -552,7 +566,8 @@ const FieldChildStruct = selectiveUnion((value) => {
   | InputElement
   | CheckboxElement
   | SelectorElement
-  | AssetSelectorElement,
+  | AssetSelectorElement
+  | AddressInputElement,
   null
 >;
 
@@ -900,6 +915,7 @@ export const SpinnerStruct: Describe<SpinnerElement> = element('Spinner');
 export const BoxChildStruct = typedUnion([
   AddressStruct,
   AssetSelectorStruct,
+  AddressInputStruct,
   BoldStruct,
   BoxStruct,
   ButtonStruct,
@@ -964,6 +980,7 @@ export const RootJSXElementStruct = typedUnion([
  */
 export const JSXElementStruct: Describe<JSXElement> = typedUnion([
   AssetSelectorStruct,
+  AddressInputStruct,
   ButtonStruct,
   InputStruct,
   FileInputStruct,

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -21,7 +21,6 @@ import {
   assign,
   union,
 } from '@metamask/superstruct';
-import type { CaipChainId } from '@metamask/utils';
 import {
   CaipAccountIdStruct,
   CaipChainIdStruct,
@@ -30,6 +29,7 @@ import {
   isPlainObject,
   JsonStruct,
 } from '@metamask/utils';
+import type { CaipChainId } from '@metamask/utils';
 
 import type {
   GenericSnapChildren,

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -29,7 +29,6 @@ import {
   isPlainObject,
   JsonStruct,
 } from '@metamask/utils';
-import type { CaipChainId } from '@metamask/utils';
 
 import type {
   GenericSnapChildren,
@@ -355,7 +354,7 @@ export const AddressInputStruct: Describe<AddressInputElement> = element(
   'AddressInput',
   {
     name: string(),
-    chainId: CaipChainIdStruct as unknown as Struct<CaipChainId, CaipChainId>,
+    chainId: CaipChainIdStruct,
     value: optional(string()),
     placeholder: optional(string()),
     disabled: optional(boolean()),

--- a/packages/snaps-sdk/src/types/interface.ts
+++ b/packages/snaps-sdk/src/types/interface.ts
@@ -6,7 +6,12 @@ import {
   string,
   union,
 } from '@metamask/superstruct';
-import { JsonStruct, hasProperty, isObject } from '@metamask/utils';
+import {
+  CaipAccountIdStruct,
+  JsonStruct,
+  hasProperty,
+  isObject,
+} from '@metamask/utils';
 
 import { AssetSelectorStateStruct, FileStruct } from './handlers';
 import { selectiveUnion } from '../internals';
@@ -27,6 +32,7 @@ export const StateStruct = union([
   FileStruct,
   string(),
   boolean(),
+  CaipAccountIdStruct,
 ]);
 
 export const FormStateStruct = record(string(), nullable(StateStruct));


### PR DESCRIPTION
Closes #2812 

This adds an `AddressInput` component that takes a CAIP-2 `chainId` to identify the chain the address needs resolution on and resolves to a display name and avatar (if it exists). The resolution is to be made against the user's own saved accounts.