### PR TITLE
fix: Update `Box` `crossAlignment` default value

### DIFF
--- a/packages/snaps-sdk/src/jsx/components/Box.ts
+++ b/packages/snaps-sdk/src/jsx/components/Box.ts
@@ -7,7 +7,7 @@ import { createSnapComponent } from '../component';
  * @property children - The children of the box.
  * @property direction - The direction to stack the components within the box. Defaults to `vertical`.
  * @property alignment - The alignment mode to use within the box. Defaults to `start`.
- * @property crossAlignment - The cross alignment mode to use within the box. Defaults to `stretch`.
+ * @property crossAlignment - The cross alignment mode to use within the box.
  * @property center - Whether to center the children within the box. Defaults to `false`.
  */
 export type BoxProps = {
@@ -34,7 +34,7 @@ const TYPE = 'Box';
  * @param props.children - The children of the box.
  * @param props.direction - The direction to stack the components within the box. Defaults to `vertical`.
  * @param props.alignment - The alignment mode to use within the box. Defaults to `start`.
- * @param props.crossAlignment - The cross alignment mode to use within the box. Defaults to `stretch`.
+ * @param props.crossAlignment - The cross alignment mode to use within the box.
  * @param props.center - Whether to center the children within the box. Defaults to `false`.
  * @returns A box element.
  * @example

--- a/packages/snaps-sdk/src/jsx/components/Box.ts
+++ b/packages/snaps-sdk/src/jsx/components/Box.ts
@@ -7,7 +7,7 @@ import { createSnapComponent } from '../component';
  * @property children - The children of the box.
  * @property direction - The direction to stack the components within the box. Defaults to `vertical`.
  * @property alignment - The alignment mode to use within the box. Defaults to `start`.
- * @property crossAlignment - The cross alignment mode to use within the box. Defaults to `start`.
+ * @property crossAlignment - The cross alignment mode to use within the box. Defaults to `stretch`.
  * @property center - Whether to center the children within the box. Defaults to `false`.
  */
 export type BoxProps = {
@@ -32,6 +32,10 @@ const TYPE = 'Box';
  *
  * @param props - The props of the component.
  * @param props.children - The children of the box.
+ * @param props.direction - The direction to stack the components within the box. Defaults to `vertical`.
+ * @param props.alignment - The alignment mode to use within the box. Defaults to `start`.
+ * @param props.crossAlignment - The cross alignment mode to use within the box. Defaults to `stretch`.
+ * @param props.center - Whether to center the children within the box. Defaults to `false`.
  * @returns A box element.
  * @example
  * <Box>


### PR DESCRIPTION
This PR updates the JSDoc for `Box` `crossAlignment` prop to omit default value