### PR TITLE
fix(simulation): `onKeyringRequest` not matching the implementation type

### DIFF
--- a/packages/snaps-simulation/src/types.ts
+++ b/packages/snaps-simulation/src/types.ts
@@ -448,9 +448,7 @@ export type Snap = {
    * @param keyringRequest - Keyring request options.
    * @returns The response.
    */
-  onKeyringRequest(
-    keyringRequest: KeyringOptions,
-  ): Promise<SnapResponseWithoutInterface>;
+  onKeyringRequest(keyringRequest: KeyringOptions): SnapRequest;
 
   /**
    * Get the response from the Snap's `onInstall` handler.


### PR DESCRIPTION
In https://github.com/MetaMask/snaps/commit/3556c3cc8fb5c65a0c0cc53f226b8483de5cd7cc I change the type of `onKeyringRequest` but apparently it is defined in more places and I forgot to change it here.