### PR TITLE
Add `enableAnalytics` to `getPreferences`

### DIFF
--- a/packages/snaps-rpc-methods/src/restricted/getPreferences.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getPreferences.test.ts
@@ -37,6 +37,7 @@ describe('snap_getPreferences', () => {
           displayNftMedia: false,
           useNftDetection: false,
           useExternalPricingData: true,
+          enableAnalytics: false,
         }),
       };
 
@@ -60,6 +61,7 @@ describe('snap_getPreferences', () => {
         displayNftMedia: false,
         useNftDetection: false,
         useExternalPricingData: true,
+        enableAnalytics: false,
       });
     });
   });

--- a/packages/snaps-sdk/src/types/methods/get-preferences.ts
+++ b/packages/snaps-sdk/src/types/methods/get-preferences.ts
@@ -20,6 +20,7 @@ export type GetPreferencesParams = never;
  * @property displayNftMedia - Whether to display NFT media.
  * @property useNftDetection - Whether to auto-detect NFTs.
  * @property useExternalPricingData - Whether to get token price data from an external source.
+ * @property enableAnalytics - Whether the user has chosen to participate in analytics.
  */
 export type GetPreferencesResult = {
   locale: string;
@@ -32,4 +33,5 @@ export type GetPreferencesResult = {
   displayNftMedia: boolean;
   useNftDetection: boolean;
   useExternalPricingData: boolean;
+  enableAnalytics: boolean;
 };

--- a/packages/snaps-simulation/src/methods/hooks/get-preferences.test.ts
+++ b/packages/snaps-simulation/src/methods/hooks/get-preferences.test.ts
@@ -20,6 +20,7 @@ describe('getGetPreferencesMethodImplementation', () => {
       displayNftMedia: true,
       useNftDetection: true,
       useExternalPricingData: true,
+      enableAnalytics: true,
     });
   });
 
@@ -41,6 +42,7 @@ describe('getGetPreferencesMethodImplementation', () => {
       displayNftMedia: true,
       useNftDetection: true,
       useExternalPricingData: true,
+      enableAnalytics: true,
     });
   });
 
@@ -62,6 +64,7 @@ describe('getGetPreferencesMethodImplementation', () => {
       displayNftMedia: true,
       useNftDetection: true,
       useExternalPricingData: true,
+      enableAnalytics: true,
     });
   });
 
@@ -83,6 +86,7 @@ describe('getGetPreferencesMethodImplementation', () => {
       displayNftMedia: true,
       useNftDetection: true,
       useExternalPricingData: true,
+      enableAnalytics: true,
     });
   });
 });

--- a/packages/snaps-simulation/src/methods/hooks/get-preferences.ts
+++ b/packages/snaps-simulation/src/methods/hooks/get-preferences.ts
@@ -14,6 +14,7 @@ import type { SimulationOptions } from '../../options';
  * @param options.displayNftMedia - Whether to display NFT media.
  * @param options.useNftDetection - Whether to auto-detect NFTs.
  * @param options.useExternalPricingData - Whether to get token price data from an external source.
+ * @param options.enableAnalytics - Whether to enable analytics.
  * @returns The implementation of the `getPreferences` hook.
  */
 export function getGetPreferencesMethodImplementation({
@@ -27,6 +28,7 @@ export function getGetPreferencesMethodImplementation({
   displayNftMedia,
   useNftDetection,
   useExternalPricingData,
+  enableAnalytics,
 }: SimulationOptions) {
   return () => {
     return {
@@ -40,6 +42,7 @@ export function getGetPreferencesMethodImplementation({
       displayNftMedia,
       useNftDetection,
       useExternalPricingData,
+      enableAnalytics,
     };
   };
 }

--- a/packages/snaps-simulation/src/options.test.ts
+++ b/packages/snaps-simulation/src/options.test.ts
@@ -19,6 +19,7 @@ describe('getOptions', () => {
         "useNftDetection": true,
         "useSecurityAlerts": true,
         "useTokenDetection": true,
+        "enableAnalytics": true,
       }
     `);
   });
@@ -44,6 +45,7 @@ describe('getOptions', () => {
         "useNftDetection": true,
         "useSecurityAlerts": true,
         "useTokenDetection": true,
+        "enableAnalytics": true,
       }
     `);
   });

--- a/packages/snaps-simulation/src/options.ts
+++ b/packages/snaps-simulation/src/options.ts
@@ -30,6 +30,7 @@ const SimulationOptionsStruct = object({
   displayNftMedia: defaulted(optional(boolean()), true),
   useNftDetection: defaulted(optional(boolean()), true),
   useExternalPricingData: defaulted(optional(boolean()), true),
+  enableAnalytics: defaulted(optional(boolean()), true),
 });
 
 /**
@@ -48,6 +49,7 @@ const SimulationOptionsStruct = object({
  * @property displayNftMedia - Whether to display NFT media.
  * @property useNftDetection - Whether to auto-detect NFTs.
  * @property useExternalPricingData - Whether to get token price data from an external source.
+ * @property enableAnalytics - Whether to enable analytics.
  */
 export type SimulationUserOptions = Infer<typeof SimulationOptionsStruct>;
 

--- a/packages/snaps-simulation/src/test-utils/options.ts
+++ b/packages/snaps-simulation/src/test-utils/options.ts
@@ -18,6 +18,7 @@ import type { SimulationOptions } from '../options';
  * @param options.displayNftMedia - Whether to display NFT media.
  * @param options.useNftDetection - Whether to auto-detect NFTs.
  * @param options.useExternalPricingData - Whether to get token price data from an external source.
+ * @param options.enableAnalytics - Whether to enable analytics.
  * @returns The options for the simulation.
  */
 export function getMockOptions({
@@ -34,6 +35,7 @@ export function getMockOptions({
   displayNftMedia = true,
   useNftDetection = true,
   useExternalPricingData = true,
+  enableAnalytics = true,
 }: Partial<SimulationOptions> = {}): SimulationOptions {
   return {
     currency,
@@ -49,5 +51,6 @@ export function getMockOptions({
     displayNftMedia,
     useNftDetection,
     useExternalPricingData,
+    enableAnalytics,
   };
 }

--- a/packages/snaps-simulator/src/features/simulation/sagas.ts
+++ b/packages/snaps-simulator/src/features/simulation/sagas.ts
@@ -141,6 +141,7 @@ export function* initSaga({ payload }: PayloadAction<string>) {
         displayNftMedia: true,
         useNftDetection: true,
         useExternalPricingData: true,
+        enableAnalytics: true,
       }),
       getUnlockPromise: async () => Promise.resolve(true),
       showDialog: async (...args: Parameters<typeof showDialog>) =>


### PR DESCRIPTION
This PR adds a new property to `getPreferences` called `enableAnalytics`.

Fixes: #3150 