### PR TITLE
feat: Add the preferences example snap

### DIFF
--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -66,6 +66,9 @@ The following is a list of the snaps in this directory.
 - [**`packages/notifications`**](./packages/notifications): This snap
   demonstrates how to use the `snap_notify` method to display notifications to
   the user, either as a MetaMask notification or as a desktop notification.
+- - [**`packages/preferences`**](./packages/preferences): This snap
+    demonstrates how to use the `snap_getPreferences` method to get the user's preferences
+    from the executing client.
 - [**`packages/transaction-insights`**](./packages/transaction-insights):
   This snap demonstrates how to use `endowment:transaction-insights` permission,
   and provide transaction insights to the user.

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -66,7 +66,7 @@ The following is a list of the snaps in this directory.
 - [**`packages/notifications`**](./packages/notifications): This snap
   demonstrates how to use the `snap_notify` method to display notifications to
   the user, either as a MetaMask notification or as a desktop notification.
-- - [**`packages/preferences`**](./packages/preferences): This snap
+- [**`packages/preferences`**](./packages/preferences): This snap
     demonstrates how to use the `snap_getPreferences` method to get the user's preferences
     from the executing client.
 - [**`packages/transaction-insights`**](./packages/transaction-insights):

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -67,8 +67,8 @@ The following is a list of the snaps in this directory.
   demonstrates how to use the `snap_notify` method to display notifications to
   the user, either as a MetaMask notification or as a desktop notification.
 - [**`packages/preferences`**](./packages/preferences): This snap
-    demonstrates how to use the `snap_getPreferences` method to get the user's preferences
-    from the executing client.
+  demonstrates how to use the `snap_getPreferences` method to get the user's preferences
+  from the executing client.
 - [**`packages/transaction-insights`**](./packages/transaction-insights):
   This snap demonstrates how to use `endowment:transaction-insights` permission,
   and provide transaction insights to the user.

--- a/packages/examples/packages/preferences/.depcheckrc.json
+++ b/packages/examples/packages/preferences/.depcheckrc.json
@@ -1,0 +1,18 @@
+{
+  "ignore-patterns": ["dist", "coverage"],
+  "ignores": [
+    "@lavamoat/allow-scripts",
+    "@lavamoat/preinstall-always-fail",
+    "@metamask/auto-changelog",
+    "@metamask/eslint-*",
+    "@types/*",
+    "@typescript-eslint/*",
+    "eslint-config-*",
+    "eslint-plugin-*",
+    "jest-silent-reporter",
+    "prettier-plugin-packagejson",
+    "ts-node",
+    "typedoc",
+    "typescript"
+  ]
+}

--- a/packages/examples/packages/preferences/CHANGELOG.md
+++ b/packages/examples/packages/preferences/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/snaps/

--- a/packages/examples/packages/preferences/LICENSE.APACHE2
+++ b/packages/examples/packages/preferences/LICENSE.APACHE2
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 ConsenSys Software Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/examples/packages/preferences/LICENSE.APACHE2
+++ b/packages/examples/packages/preferences/LICENSE.APACHE2
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 ConsenSys Software Inc.
+   Copyright 2025 Consensys Software Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/examples/packages/preferences/LICENSE.MIT0
+++ b/packages/examples/packages/preferences/LICENSE.MIT0
@@ -1,6 +1,6 @@
 MIT No Attribution
 
-Copyright 2025 ConsenSys Software Inc.
+Copyright 2025 Consensys Software Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/packages/examples/packages/preferences/LICENSE.MIT0
+++ b/packages/examples/packages/preferences/LICENSE.MIT0
@@ -1,0 +1,16 @@
+MIT No Attribution
+
+Copyright 2025 ConsenSys Software Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/examples/packages/preferences/README.md
+++ b/packages/examples/packages/preferences/README.md
@@ -1,0 +1,10 @@
+# `@metamask/preferences-example-snap`
+
+This Snap demonstrates how to use `snap_getPreferences` to get the users preferences from the client.
+
+## Snap usage
+
+This Snap exposes an `onRpcRequest` handler, which supports the following
+JSON-RPC methods:
+
+- `getPreferences` - Return the preferences from the client.

--- a/packages/examples/packages/preferences/jest.config.js
+++ b/packages/examples/packages/preferences/jest.config.js
@@ -1,0 +1,36 @@
+const deepmerge = require('deepmerge');
+
+const baseConfig = require('../../../../jest.config.base');
+
+module.exports = deepmerge(baseConfig, {
+  preset: '@metamask/snaps-jest',
+
+  // Since `@metamask/snaps-jest` runs in the browser, we can't collect
+  // coverage information.
+  collectCoverage: false,
+
+  // This is required for the tests to run inside the `MetaMask/snaps`
+  // repository. You don't need this in your own project.
+  moduleNameMapper: {
+    '^@metamask/(.+)/production/jsx-runtime': [
+      '<rootDir>/../../../$1/src/jsx/production/jsx-runtime',
+      '<rootDir>/../../../../node_modules/@metamask/$1/jsx/production/jsx-runtime',
+      '<rootDir>/node_modules/@metamask/$1/jsx/production/jsx-runtime',
+    ],
+    '^@metamask/(.+)/jsx': [
+      '<rootDir>/../../../$1/src/jsx',
+      '<rootDir>/../../../../node_modules/@metamask/$1/jsx',
+      '<rootDir>/node_modules/@metamask/$1/jsx',
+    ],
+    '^@metamask/(.+)/node$': [
+      '<rootDir>/../../../$1/src/node',
+      '<rootDir>/../../../../node_modules/@metamask/$1/node',
+      '<rootDir>/node_modules/@metamask/$1/node',
+    ],
+    '^@metamask/(.+)$': [
+      '<rootDir>/../../../$1/src',
+      '<rootDir>/../../../../node_modules/@metamask/$1',
+      '<rootDir>/node_modules/@metamask/$1',
+    ],
+  },
+});

--- a/packages/examples/packages/preferences/package.json
+++ b/packages/examples/packages/preferences/package.json
@@ -37,7 +37,7 @@
     "publish:preview": "yarn npm publish --tag preview",
     "since-latest-release": "../../../../scripts/since-latest-release.sh",
     "start": "mm-snap watch",
-    "test": "jest --reporters=jest-silent-reporter --passWithNoTests",
+    "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
     "test:watch": "jest --watch"

--- a/packages/examples/packages/preferences/package.json
+++ b/packages/examples/packages/preferences/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@metamask/preferences-example-snap",
+  "version": "0.0.0",
+  "description": "MetaMask example Snap demonstrating the use of `snap_getPreferences`",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/preferences#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/snaps.git"
+  },
+  "license": "(MIT-0 OR Apache-2.0)",
+  "sideEffects": false,
+  "main": "./dist/bundle.js",
+  "files": [
+    "dist",
+    "snap.manifest.json"
+  ],
+  "scripts": {
+    "build": "mm-snap build",
+    "build:clean": "yarn clean && yarn build",
+    "changelog:update": "../../../../scripts/update-changelog.sh @metamask/preferences-example-snap",
+    "changelog:validate": "../../../../scripts/validate-changelog.sh @metamask/preferences-example-snap",
+    "clean": "rimraf \"dist\"",
+    "lint": "yarn lint:eslint && yarn lint:misc --check && yarn changelog:validate && yarn lint:dependencies",
+    "lint:ci": "yarn lint",
+    "lint:dependencies": "depcheck",
+    "lint:eslint": "eslint . --cache",
+    "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
+    "lint:misc": "prettier --no-error-on-unmatched-pattern --log-level warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
+    "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
+    "start": "mm-snap watch",
+    "test": "jest --reporters=jest-silent-reporter --passWithNoTests",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
+  },
+  "dependencies": {
+    "@metamask/snaps-sdk": "workspace:^"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.5.0",
+    "@lavamoat/allow-scripts": "^3.0.4",
+    "@metamask/auto-changelog": "^4.1.0",
+    "@metamask/snaps-cli": "workspace:^",
+    "@metamask/snaps-jest": "workspace:^",
+    "@swc/core": "1.3.78",
+    "@swc/jest": "^0.2.26",
+    "@types/node": "18.14.2",
+    "deepmerge": "^4.2.2",
+    "depcheck": "^1.4.7",
+    "eslint": "^9.11.0",
+    "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
+    "prettier": "^3.3.3",
+    "rimraf": "^4.1.2",
+    "ts-node": "^10.9.1",
+    "typescript": "~5.3.3"
+  },
+  "engines": {
+    "node": "^18.16 || >=20"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/examples/packages/preferences/snap.config.ts
+++ b/packages/examples/packages/preferences/snap.config.ts
@@ -1,0 +1,17 @@
+import type { SnapConfig } from '@metamask/snaps-cli';
+import { resolve } from 'path';
+
+const config: SnapConfig = {
+  input: resolve(__dirname, 'src/index.ts'),
+  server: {
+    port: 8033,
+  },
+  typescript: {
+    enabled: true,
+  },
+  stats: {
+    buffer: false,
+  },
+};
+
+export default config;

--- a/packages/examples/packages/preferences/snap.manifest.json
+++ b/packages/examples/packages/preferences/snap.manifest.json
@@ -1,0 +1,28 @@
+{
+  "version": "0.0.0",
+  "description": "MetaMask example Snap demonstrating the use of `snap_getPreferences`",
+  "proposedName": "Preferences Example Snap",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/snaps.git"
+  },
+  "source": {
+    "shasum": "xb+s96cyPehIGt7HbyEaJwU9oA5vEyYKsGaMVOtor7o=",
+    "location": {
+      "npm": {
+        "filePath": "dist/bundle.js",
+        "packageName": "@metamask/preferences-example-snap",
+        "registry": "https://registry.npmjs.org/"
+      }
+    }
+  },
+  "initialPermissions": {
+    "endowment:rpc": {
+      "dapps": true,
+      "snaps": false
+    },
+    "snap_getPreferences": {}
+  },
+  "platformVersion": "6.18.0",
+  "manifestVersion": "0.1"
+}

--- a/packages/examples/packages/preferences/src/index.test.ts
+++ b/packages/examples/packages/preferences/src/index.test.ts
@@ -41,5 +41,33 @@ describe('onRpcRequest', () => {
         useExternalPricingData: true,
       });
     });
+
+    it('returns the result from snap_getPreferences with set options', async () => {
+      const { request } = await installSnap({
+        options: {
+          locale: 'foo',
+          useTokenDetection: false,
+          useNftDetection: false,
+          useExternalPricingData: false,
+        },
+      });
+
+      const response = await request({
+        method: 'getPreferences',
+      });
+
+      expect(response).toRespondWith({
+        currency: 'usd',
+        locale: 'foo',
+        hideBalances: false,
+        useSecurityAlerts: true,
+        simulateOnChainActions: true,
+        useTokenDetection: false,
+        batchCheckBalances: true,
+        displayNftMedia: true,
+        useNftDetection: false,
+        useExternalPricingData: false,
+      });
+    });
   });
 });

--- a/packages/examples/packages/preferences/src/index.test.ts
+++ b/packages/examples/packages/preferences/src/index.test.ts
@@ -1,0 +1,45 @@
+import { expect } from '@jest/globals';
+import { installSnap } from '@metamask/snaps-jest';
+
+describe('onRpcRequest', () => {
+  it('throws an error if the requested method does not exist', async () => {
+    const { request } = await installSnap();
+
+    const response = await request({
+      method: 'foo',
+    });
+
+    expect(response).toRespondWithError({
+      code: -32601,
+      message: 'The method does not exist / is not available.',
+      stack: expect.any(String),
+      data: {
+        method: 'foo',
+        cause: null,
+      },
+    });
+  });
+
+  describe('getPreferences', () => {
+    it('returns the result from snap_getPreferences', async () => {
+      const { request } = await installSnap();
+
+      const response = await request({
+        method: 'getPreferences',
+      });
+
+      expect(response).toRespondWith({
+        currency: 'usd',
+        locale: 'en',
+        hideBalances: false,
+        useSecurityAlerts: true,
+        simulateOnChainActions: true,
+        useTokenDetection: true,
+        batchCheckBalances: true,
+        displayNftMedia: true,
+        useNftDetection: true,
+        useExternalPricingData: true,
+      });
+    });
+  });
+});

--- a/packages/examples/packages/preferences/src/index.ts
+++ b/packages/examples/packages/preferences/src/index.ts
@@ -15,6 +15,7 @@ import {
  * @returns The JSON-RPC response.
  * @see https://docs.metamask.io/snaps/reference/exports/#onrpcrequest
  * @see https://docs.metamask.io/snaps/reference/rpc-api/#wallet_invokesnap
+ * @see https://docs.metamask.io/snaps/reference/snaps-api/#snap_getpreferences
  */
 export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   switch (request.method) {

--- a/packages/examples/packages/preferences/src/index.ts
+++ b/packages/examples/packages/preferences/src/index.ts
@@ -1,0 +1,28 @@
+import {
+  MethodNotFoundError,
+  type OnRpcRequestHandler,
+} from '@metamask/snaps-sdk';
+
+/**
+ * Handle incoming JSON-RPC requests from the dapp, sent through the
+ * `wallet_invokeSnap` method. This handler handles a single method:
+ *
+ * - `getPreferences`: Get the user's preferences from the executing client. This demonstrates
+ * that a snap can access user's preferences of the client that is executing the snap at runtime.
+ *
+ * @param params - The request parameters.
+ * @param params.request - The JSON-RPC request object.
+ * @returns The JSON-RPC response.
+ * @see https://docs.metamask.io/snaps/reference/exports/#onrpcrequest
+ * @see https://docs.metamask.io/snaps/reference/rpc-api/#wallet_invokesnap
+ */
+export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
+  switch (request.method) {
+    case 'getPreferences': {
+      return snap.request({ method: 'snap_getPreferences' });
+    }
+
+    default:
+      throw new MethodNotFoundError({ method: request.method });
+  }
+};

--- a/packages/examples/packages/preferences/tsconfig.json
+++ b/packages/examples/packages/preferences/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "baseUrl": "./"
+  },
+  "include": ["src", "snap.config.ts"]
+}

--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -64,6 +64,7 @@
     "@metamask/name-lookup-example-snap": "workspace:^",
     "@metamask/network-example-snap": "workspace:^",
     "@metamask/notification-example-snap": "workspace:^",
+    "@metamask/preferences-example-snap": "workspace:^",
     "@metamask/preinstalled-example-snap": "workspace:^",
     "@metamask/protocol-example-snap": "workspace:^",
     "@metamask/send-flow-example-snap": "workspace:^",

--- a/packages/test-snaps/src/features/snaps/index.ts
+++ b/packages/test-snaps/src/features/snaps/index.ts
@@ -22,6 +22,7 @@ export * from './name-lookup';
 export * from './network-access';
 export * from './notifications';
 export * from './preinstalled';
+export * from './preferences';
 export * from './protocol';
 export * from './transaction-insights';
 export * from './signature-insights';

--- a/packages/test-snaps/src/features/snaps/preferences/Preferences.tsx
+++ b/packages/test-snaps/src/features/snaps/preferences/Preferences.tsx
@@ -1,0 +1,49 @@
+import { logError } from '@metamask/snaps-utils';
+import type { FunctionComponent } from 'react';
+import { Button } from 'react-bootstrap';
+
+import {
+  PREFERENCES_SNAP_ID,
+  PREFERENCES_SNAP_PORT,
+  PREFERENCES_VERSION,
+} from './constants';
+import { useInvokeMutation } from '../../../api';
+import { Result, Snap } from '../../../components';
+import { getSnapId } from '../../../utils';
+
+export const Preferences: FunctionComponent = () => {
+  const [invokeSnap, { isLoading, data, error }] = useInvokeMutation();
+
+  const handleSubmit = () => {
+    invokeSnap({
+      snapId: getSnapId(PREFERENCES_SNAP_ID, PREFERENCES_SNAP_PORT),
+      method: 'getPreferences',
+    }).catch(logError);
+  };
+
+  return (
+    <Snap
+      name="Preferences Snap"
+      snapId={PREFERENCES_SNAP_ID}
+      port={PREFERENCES_SNAP_PORT}
+      version={PREFERENCES_VERSION}
+      testId="preferences"
+    >
+      <Button
+        variant="primary"
+        id="getPreferences"
+        className="mb-3"
+        disabled={isLoading}
+        onClick={handleSubmit}
+      >
+        Submit
+      </Button>
+      <Result>
+        <span id="preferencesResult">
+          {JSON.stringify(data, null, 2)}
+          {JSON.stringify(error, null, 2)}
+        </span>
+      </Result>
+    </Snap>
+  );
+};

--- a/packages/test-snaps/src/features/snaps/preferences/constants.ts
+++ b/packages/test-snaps/src/features/snaps/preferences/constants.ts
@@ -1,0 +1,5 @@
+import packageJson from '@metamask/preferences-example-snap/package.json';
+
+export const PREFERENCES_SNAP_ID = 'npm:@metamask/preferences-example-snap';
+export const PREFERENCES_SNAP_PORT = 8033;
+export const PREFERENCES_VERSION = packageJson.version;

--- a/packages/test-snaps/src/features/snaps/preferences/index.ts
+++ b/packages/test-snaps/src/features/snaps/preferences/index.ts
@@ -1,0 +1,1 @@
+export * from './Preferences';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5038,6 +5038,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/preferences-example-snap@workspace:^, @metamask/preferences-example-snap@workspace:packages/examples/packages/preferences":
+  version: 0.0.0-use.local
+  resolution: "@metamask/preferences-example-snap@workspace:packages/examples/packages/preferences"
+  dependencies:
+    "@jest/globals": "npm:^29.5.0"
+    "@lavamoat/allow-scripts": "npm:^3.0.4"
+    "@metamask/auto-changelog": "npm:^4.1.0"
+    "@metamask/snaps-cli": "workspace:^"
+    "@metamask/snaps-jest": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
+    "@swc/core": "npm:1.3.78"
+    "@swc/jest": "npm:^0.2.26"
+    "@types/node": "npm:18.14.2"
+    deepmerge: "npm:^4.2.2"
+    depcheck: "npm:^1.4.7"
+    eslint: "npm:^9.11.0"
+    jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
+    prettier: "npm:^3.3.3"
+    rimraf: "npm:^4.1.2"
+    ts-node: "npm:^10.9.1"
+    typescript: "npm:~5.3.3"
+  languageName: unknown
+  linkType: soft
+
 "@metamask/preinstalled-example-snap@workspace:^, @metamask/preinstalled-example-snap@workspace:packages/examples/packages/preinstalled":
   version: 0.0.0-use.local
   resolution: "@metamask/preinstalled-example-snap@workspace:packages/examples/packages/preinstalled"
@@ -5902,6 +5927,7 @@ __metadata:
     "@metamask/name-lookup-example-snap": "workspace:^"
     "@metamask/network-example-snap": "workspace:^"
     "@metamask/notification-example-snap": "workspace:^"
+    "@metamask/preferences-example-snap": "workspace:^"
     "@metamask/preinstalled-example-snap": "workspace:^"
     "@metamask/protocol-example-snap": "workspace:^"
     "@metamask/providers": "npm:^20.0.0"


### PR DESCRIPTION
Adds the `preferences-example-snap` to `examples` and `test-snaps`.

Fixes: #3153 