### PR TITLE
Fix start command in `test-snaps`

### DIFF
--- a/.yarn/plugins/local/plugin-workspaces-filter.js
+++ b/.yarn/plugins/local/plugin-workspaces-filter.js
@@ -144,6 +144,16 @@ module.exports = {
         validator: isBoolean,
       });
 
+      interlaced = Option.Boolean(`--interlaced`, false, {
+        description: `Print the output of commands in real-time instead of buffering it`,
+        validator: isBoolean,
+      });
+
+      jobs = Option.String(`--jobs`, {
+        description: `Number of jobs to run concurrently`,
+        validator: isString,
+      });
+
       include = Option.String('--include', {
         description: `List workspaces based on a glob pattern`,
         validator: isString,
@@ -176,6 +186,14 @@ module.exports = {
         if (this.topological) {
           extraArgs.push('--topological');
           extraArgs.push('--topological-dev');
+        }
+
+        if (this.interlaced) {
+          extraArgs.push('--interlaced');
+        }
+
+        if (this.jobs) {
+          extraArgs.push('--jobs', this.jobs.toString());
         }
 
         const includes = workspaces.map((workspace) => workspace.manifest.name)

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -32,7 +32,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --log-level warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!packages/**\" --ignore-path ../../.gitignore",
     "since-latest-release": "../../scripts/since-latest-release.sh",
-    "start": "yarn workspaces foreach --worktree --parallel --verbose --interlaced --no-private --jobs unlimited run start",
+    "start": "yarn workspaces filter --include 'packages/examples/packages/**' --parallel --interlaced --no-private --jobs unlimited run start",
     "start:test": "yarn start",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",

--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -32,7 +32,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --log-level warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
     "since-latest-release": "../../scripts/since-latest-release.sh",
-    "start": "yarn workspaces foreach --parallel --verbose --interlaced --all --include \"@metamask/test-snaps\" --include \"@metamask/example-snaps\" run start:test",
+    "start": "yarn workspaces foreach --parallel --interlaced --all --include \"@metamask/test-snaps\" --include \"@metamask/example-snaps\" run start:test",
     "start:test": "cross-env NODE_ENV=development webpack serve",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",


### PR DESCRIPTION
`yarn start` in the `test-snaps` folder was broken after #3094. This fixes it.