### PR TITLE
fix: Log unhandled Snap errors

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1510,7 +1510,7 @@ export class SnapController extends BaseController<
   _onUnhandledSnapError(snapId: string, error: SnapErrorJson) {
     // Log the error that caused the crash
     // so it gets raised to the developer for debugging purposes.
-    logError(error);
+    logError(`Unhandled error from "${snapId}": ${error}`);
     this.stopSnap(snapId as SnapId, SnapStatusEvents.Crash).catch(
       (stopSnapError) => {
         // TODO: Decide how to handle errors.

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1510,7 +1510,7 @@ export class SnapController extends BaseController<
   _onUnhandledSnapError(snapId: string, error: SnapErrorJson) {
     // Log the error that caused the crash
     // so it gets raised to the developer for debugging purposes.
-    logError(`Unhandled error from "${snapId}": ${error}`);
+    logError(`Unhandled error from "${snapId}":`, error);
     this.stopSnap(snapId as SnapId, SnapStatusEvents.Crash).catch(
       (stopSnapError) => {
         // TODO: Decide how to handle errors.

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1507,7 +1507,10 @@ export class SnapController extends BaseController<
     );
   }
 
-  _onUnhandledSnapError(snapId: string, _error: SnapErrorJson) {
+  _onUnhandledSnapError(snapId: string, error: SnapErrorJson) {
+    // Log the error that caused the crash
+    // so it gets raised to the developer for debugging purposes.
+    logError(error);
     this.stopSnap(snapId as SnapId, SnapStatusEvents.Crash).catch(
       (stopSnapError) => {
         // TODO: Decide how to handle errors.


### PR DESCRIPTION
Log unhandled Snap errors for easier debugging when a Snap is crashing. This lets developers dig up the actual reason for their Snap being terminated in the logs.