### PR TITLE
Add the interface ID to the return value of `getInterface`

### DIFF
--- a/packages/snaps-jest/src/helpers.test.tsx
+++ b/packages/snaps-jest/src/helpers.test.tsx
@@ -412,6 +412,7 @@ describe('installSnap', () => {
         selectFromSelector: expect.any(Function),
         uploadFile: expect.any(Function),
         waitForUpdate: expect.any(Function),
+        id: expect.any(String),
         ok: expect.any(Function),
         cancel: expect.any(Function),
       });
@@ -475,6 +476,7 @@ describe('installSnap', () => {
         selectFromSelector: expect.any(Function),
         uploadFile: expect.any(Function),
         waitForUpdate: expect.any(Function),
+        id: expect.any(String),
         ok: expect.any(Function),
         cancel: expect.any(Function),
       });
@@ -538,6 +540,7 @@ describe('installSnap', () => {
         selectFromSelector: expect.any(Function),
         uploadFile: expect.any(Function),
         waitForUpdate: expect.any(Function),
+        id: expect.any(String),
         ok: expect.any(Function),
       });
 

--- a/packages/snaps-simulation/src/helpers.test.tsx
+++ b/packages/snaps-simulation/src/helpers.test.tsx
@@ -146,6 +146,7 @@ describe('helpers', () => {
         selectFromSelector: expect.any(Function),
         uploadFile: expect.any(Function),
         waitForUpdate: expect.any(Function),
+        id: expect.any(String),
         ok: expect.any(Function),
         cancel: expect.any(Function),
       });
@@ -209,6 +210,7 @@ describe('helpers', () => {
         selectFromSelector: expect.any(Function),
         uploadFile: expect.any(Function),
         waitForUpdate: expect.any(Function),
+        id: expect.any(String),
         ok: expect.any(Function),
         cancel: expect.any(Function),
       });
@@ -272,6 +274,7 @@ describe('helpers', () => {
         selectFromSelector: expect.any(Function),
         uploadFile: expect.any(Function),
         waitForUpdate: expect.any(Function),
+        id: expect.any(String),
         ok: expect.any(Function),
       });
 

--- a/packages/snaps-simulation/src/interface.test.tsx
+++ b/packages/snaps-simulation/src/interface.test.tsx
@@ -99,6 +99,7 @@ describe('getInterfaceResponse', () => {
     const response = getInterfaceResponse(
       runSaga,
       DIALOG_APPROVAL_TYPES[DialogType.Alert],
+      'foo',
       <Text>foo</Text>,
       interfaceActions,
     );
@@ -106,6 +107,7 @@ describe('getInterfaceResponse', () => {
 
     expect(response).toStrictEqual({
       type: DialogType.Alert,
+      id: 'foo',
       content: <Text>foo</Text>,
       clickElement: expect.any(Function),
       typeInField: expect.any(Function),
@@ -127,6 +129,7 @@ describe('getInterfaceResponse', () => {
     const response = getInterfaceResponse(
       runSaga,
       DIALOG_APPROVAL_TYPES[DialogType.Confirmation],
+      'foo',
       <Text>foo</Text>,
       interfaceActions,
     );
@@ -134,6 +137,7 @@ describe('getInterfaceResponse', () => {
     assertIsConfirmationDialog(response);
     expect(response).toStrictEqual({
       type: DialogType.Confirmation,
+      id: 'foo',
       content: <Text>foo</Text>,
       clickElement: expect.any(Function),
       typeInField: expect.any(Function),
@@ -156,6 +160,7 @@ describe('getInterfaceResponse', () => {
     const response = getInterfaceResponse(
       runSaga,
       DIALOG_APPROVAL_TYPES[DialogType.Confirmation],
+      'foo',
       <Text>foo</Text>,
       interfaceActions,
     );
@@ -163,6 +168,7 @@ describe('getInterfaceResponse', () => {
     assertIsConfirmationDialog(response);
     expect(response).toStrictEqual({
       type: DialogType.Confirmation,
+      id: 'foo',
       content: <Text>foo</Text>,
       clickElement: expect.any(Function),
       typeInField: expect.any(Function),
@@ -185,6 +191,7 @@ describe('getInterfaceResponse', () => {
     const response = getInterfaceResponse(
       runSaga,
       DIALOG_APPROVAL_TYPES[DialogType.Prompt],
+      'foo',
       <Text>foo</Text>,
       interfaceActions,
     );
@@ -192,6 +199,7 @@ describe('getInterfaceResponse', () => {
     assertIsPromptDialog(response);
     expect(response).toStrictEqual({
       type: DialogType.Prompt,
+      id: 'foo',
       content: <Text>foo</Text>,
       clickElement: expect.any(Function),
       typeInField: expect.any(Function),
@@ -214,6 +222,7 @@ describe('getInterfaceResponse', () => {
     const response = getInterfaceResponse(
       runSaga,
       DIALOG_APPROVAL_TYPES[DialogType.Prompt],
+      'foo',
       <Text>foo</Text>,
       interfaceActions,
     );
@@ -221,6 +230,7 @@ describe('getInterfaceResponse', () => {
     assertIsPromptDialog(response);
     expect(response).toStrictEqual({
       type: DialogType.Prompt,
+      id: 'foo',
       content: <Text>foo</Text>,
       clickElement: expect.any(Function),
       typeInField: expect.any(Function),
@@ -243,6 +253,7 @@ describe('getInterfaceResponse', () => {
     const response = getInterfaceResponse(
       runSaga,
       DIALOG_APPROVAL_TYPES[DialogType.Prompt],
+      'foo',
       <Text>foo</Text>,
       interfaceActions,
     );
@@ -250,6 +261,7 @@ describe('getInterfaceResponse', () => {
     assertIsPromptDialog(response);
     expect(response).toStrictEqual({
       type: DialogType.Prompt,
+      id: 'foo',
       content: <Text>foo</Text>,
       clickElement: expect.any(Function),
       typeInField: expect.any(Function),
@@ -272,6 +284,7 @@ describe('getInterfaceResponse', () => {
     const response = getInterfaceResponse(
       runSaga,
       DIALOG_APPROVAL_TYPES.default,
+      'foo',
       <Container>
         <Box>
           <Text>foo</Text>
@@ -288,6 +301,7 @@ describe('getInterfaceResponse', () => {
     assertCustomDialogHasFooter(response);
 
     expect(response).toStrictEqual({
+      id: 'foo',
       content: (
         <Container>
           <Box>
@@ -314,6 +328,7 @@ describe('getInterfaceResponse', () => {
     const response = getInterfaceResponse(
       runSaga,
       DIALOG_APPROVAL_TYPES.default,
+      'foo',
       <Container>
         <Box>
           <Text>foo</Text>
@@ -329,6 +344,7 @@ describe('getInterfaceResponse', () => {
     assertCustomDialogHasPartialFooter(response);
 
     expect(response).toStrictEqual({
+      id: 'foo',
       content: (
         <Container>
           <Box>
@@ -355,6 +371,7 @@ describe('getInterfaceResponse', () => {
     const response = getInterfaceResponse(
       runSaga,
       DIALOG_APPROVAL_TYPES.default,
+      'foo',
       <Container>
         <Box>
           <Text>foo</Text>
@@ -367,6 +384,7 @@ describe('getInterfaceResponse', () => {
     assertCustomDialogHasNoFooter(response);
 
     expect(response).toStrictEqual({
+      id: 'foo',
       content: (
         <Container>
           <Box>
@@ -391,6 +409,7 @@ describe('getInterfaceResponse', () => {
     const response = getInterfaceResponse(
       runSaga,
       'Notification',
+      'foo',
       <Box>
         <Text>Foo</Text>
       </Box>,
@@ -398,6 +417,7 @@ describe('getInterfaceResponse', () => {
     );
 
     expect(response).toStrictEqual({
+      id: 'foo',
       content: (
         <Box>
           <Text>Foo</Text>
@@ -1280,6 +1300,7 @@ describe('getInterface', () => {
       rootControllerMessenger,
     ).toPromise();
     expect(result).toStrictEqual({
+      id,
       type,
       content: getJsxElementFromComponent(content),
       clickElement: expect.any(Function),
@@ -1311,6 +1332,7 @@ describe('getInterface', () => {
 
     const result = await promise;
     expect(result).toStrictEqual({
+      id,
       type,
       content: getJsxElementFromComponent(content),
       clickElement: expect.any(Function),

--- a/packages/snaps-simulation/src/interface.ts
+++ b/packages/snaps-simulation/src/interface.ts
@@ -48,6 +48,7 @@ const MAX_FILE_SIZE = 10_000_000; // 10 MB
  *
  * @param runSaga - A function to run a saga outside the usual Redux flow.
  * @param type - The type of the interface.
+ * @param id - The interface ID.
  * @param content - The content to show in the interface.
  * @param interfaceActions - The actions to interact with the interface.
  * @returns The user interface object.
@@ -55,6 +56,7 @@ const MAX_FILE_SIZE = 10_000_000; // 10 MB
 export function getInterfaceResponse(
   runSaga: RunSagaFunction,
   type: DialogApprovalTypes[DialogType | 'default'] | 'Notification',
+  id: string,
   content: JSXElement,
   interfaceActions: SnapInterfaceActions,
 ): SnapInterface {
@@ -64,6 +66,8 @@ export function getInterfaceResponse(
         ...interfaceActions,
         type: DialogType.Alert,
         content,
+        id,
+
         ok: resolveWith(runSaga, null),
       };
 
@@ -72,6 +76,7 @@ export function getInterfaceResponse(
         ...interfaceActions,
         type: DialogType.Confirmation,
         content,
+        id,
 
         ok: resolveWith(runSaga, true),
         cancel: resolveWith(runSaga, false),
@@ -82,6 +87,7 @@ export function getInterfaceResponse(
         ...interfaceActions,
         type: DialogType.Prompt,
         content,
+        id,
 
         ok: resolveWithInput(runSaga),
         cancel: resolveWith(runSaga, null),
@@ -95,6 +101,7 @@ export function getInterfaceResponse(
         return {
           ...interfaceActions,
           content,
+          id,
 
           ok: resolveWith(runSaga, null),
           cancel: resolveWith(runSaga, null),
@@ -106,6 +113,7 @@ export function getInterfaceResponse(
         return {
           ...interfaceActions,
           content,
+          id,
 
           cancel: resolveWith(runSaga, null),
         };
@@ -115,6 +123,7 @@ export function getInterfaceResponse(
       return {
         ...interfaceActions,
         content,
+        id,
       };
     }
 
@@ -122,6 +131,7 @@ export function getInterfaceResponse(
       return {
         ...interfaceActions,
         content,
+        id,
       };
     }
 
@@ -1017,6 +1027,7 @@ export function* getInterface(
   return getInterfaceResponse(
     runSaga,
     storedInterface.type,
+    storedInterface.id,
     storedInterface.content,
     interfaceActions,
   );

--- a/packages/snaps-simulation/src/request.test.tsx
+++ b/packages/snaps-simulation/src/request.test.tsx
@@ -109,6 +109,7 @@ describe('handleRequest', () => {
         },
         key: null,
       },
+      id: expect.any(String),
       ok: expect.any(Function),
       selectFromRadioGroup: expect.any(Function),
       selectFromSelector: expect.any(Function),

--- a/packages/snaps-simulation/src/types.ts
+++ b/packages/snaps-simulation/src/types.ts
@@ -195,6 +195,11 @@ export type SnapAlertInterface = {
   content: JSXElement;
 
   /**
+   * The ID of the interface.
+   */
+  id: string;
+
+  /**
    * Close the alert.
    */
   ok(): Promise<void>;
@@ -213,6 +218,11 @@ export type SnapConfirmationInterface = {
    * The content to show in the confirmation.
    */
   content: JSXElement;
+
+  /**
+   * The ID of the interface.
+   */
+  id: string;
 
   /**
    * Close the confirmation.
@@ -240,6 +250,11 @@ export type SnapPromptInterface = {
   content: JSXElement;
 
   /**
+   * The ID of the interface.
+   */
+  id: string;
+
+  /**
    * Close the prompt.
    *
    * @param value - The value to close the prompt with.
@@ -261,6 +276,11 @@ export type DefaultSnapInterfaceWithFooter = {
    * The content to show in the interface.
    */
   content: JSXElement;
+
+  /**
+   * The ID of the interface.
+   */
+  id: string;
 };
 
 /**


### PR DESCRIPTION
This adds the interface ID in the return value of `snap-jest` `getInterface`.