### PR TITLE
Use Webpack plugin example Snap for testing updates

### DIFF
--- a/packages/test-snaps/src/features/snaps/updates/constants.ts
+++ b/packages/test-snaps/src/features/snaps/updates/constants.ts
@@ -1,3 +1,3 @@
-export const UPDATES_SNAP_ID = 'npm:@metamask/bip32-example-snap';
-export const UPDATES_SNAP_OLD_VERSION = '0.35.0-flask.1';
-export const UPDATES_SNAP_NEW_VERSION = '0.35.2-flask.1';
+export const UPDATES_SNAP_ID = 'npm:@metamask/webpack-plugin-example-snap';
+export const UPDATES_SNAP_OLD_VERSION = '2.0.0';
+export const UPDATES_SNAP_NEW_VERSION = '2.1.3';


### PR DESCRIPTION
Bumping the BIP-32 example in #3185 caused issues in the MetaMask extension E2E tests. We don't update the Webpack plugin example so often, and it's not on the `test-snaps` page directly, so less likely to cause issues in the future.