### PR TITLE
Group Dependabot minor and patch updates for MetaMask dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,11 @@ updates:
     target-branch: 'main'
     versioning-strategy: 'increase'
     open-pull-requests-limit: 10
+    groups:
+      metamask:
+        applies-to: version-updates
+        patterns:
+          - '@metamask/*'
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
This enables grouping of Dependabot PRs for minor and patch updates to `@metamask/*` dependencies. Major dependencies are still done separately, as they may require more action.