### PR TITLE
Always run commit step in update PR workflow

### DIFF
--- a/.github/workflows/update-pull-request.yml
+++ b/.github/workflows/update-pull-request.yml
@@ -223,6 +223,7 @@ jobs:
   commit-result:
     name: Commit result
     runs-on: ubuntu-latest
+    if: ${{ !failure() && !cancelled() && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     needs:
       - prepare
       - dedupe-yarn-lock

--- a/.github/workflows/update-pull-request.yml
+++ b/.github/workflows/update-pull-request.yml
@@ -225,6 +225,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !failure() && !cancelled() && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     needs:
+      - is-fork-pull-request
       - prepare
       - dedupe-yarn-lock
       - regenerate-lavamoat-policies


### PR DESCRIPTION
`update-chrome` is a requirement for `commit-result`, but it turns out that if `update-chrome` is skipped, so is `commit-result`.  Adding the if condition makes the job always run (assuming it didn't fail or didn't get cancelled).