### PR TITLE
perf!: Use mnemonic seed for entropy RPC methods

### DIFF
--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -10,7 +10,7 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 94.96,
+      branches: 94.98,
       functions: 98.64,
       lines: 98.76,
       statements: 98.45,

--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -10,10 +10,10 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 95.2,
-      functions: 98.63,
-      lines: 98.83,
-      statements: 98.51,
+      branches: 94.96,
+      functions: 98.64,
+      lines: 98.76,
+      statements: 98.45,
     },
   },
 });

--- a/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.test.ts
@@ -257,6 +257,7 @@ describe('getBip32EntropyImplementation', () => {
       `);
 
       expect(getMnemonic).toHaveBeenCalledWith('source-id');
+      expect(getMnemonicSeed).not.toHaveBeenCalled();
     });
 
     it('calls `getMnemonicSeed` with a different entropy source', async () => {
@@ -300,6 +301,7 @@ describe('getBip32EntropyImplementation', () => {
       `);
 
       expect(getMnemonicSeed).toHaveBeenCalledWith('source-id');
+      expect(getMnemonic).not.toHaveBeenCalled();
     });
 
     it('uses custom client cryptography functions', async () => {

--- a/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.ts
@@ -16,7 +16,11 @@ import type { NonEmptyArray } from '@metamask/utils';
 import { assert } from '@metamask/utils';
 
 import type { MethodHooksObject } from '../utils';
-import { getSecretRecoveryPhrase, getNode } from '../utils';
+import {
+  getNodeFromMnemonic,
+  getNodeFromSeed,
+  getValueFromEntropySource,
+} from '../utils';
 
 const targetName = 'snap_getBip32Entropy';
 
@@ -30,6 +34,16 @@ export type GetBip32EntropyMethodHooks = {
    * source is provided.
    */
   getMnemonic: (source?: string | undefined) => Promise<Uint8Array>;
+
+  /**
+   * Get the mnemonic seed of the provided source. If no source is provided, the
+   * mnemonic seed of the primary keyring will be returned.
+   *
+   * @param source - The optional ID of the source to get the mnemonic of.
+   * @returns The mnemonic seed of the provided source, or the default source if no
+   * source is provided.
+   */
+  getMnemonicSeed: (source?: string | undefined) => Promise<Uint8Array>;
 
   /**
    * Waits for the extension to be unlocked.
@@ -95,6 +109,7 @@ const specificationBuilder: PermissionSpecificationBuilder<
 
 const methodHooks: MethodHooksObject<GetBip32EntropyMethodHooks> = {
   getMnemonic: true,
+  getMnemonicSeed: true,
   getUnlockPromise: true,
   getClientCryptography: true,
 };
@@ -110,6 +125,7 @@ export const getBip32EntropyBuilder = Object.freeze({
  *
  * @param hooks - The RPC method hooks.
  * @param hooks.getMnemonic - A function to retrieve the Secret Recovery Phrase of the user.
+ * @param hooks.getMnemonicSeed - A function to retrieve the BIP-39 seed of the user.
  * @param hooks.getUnlockPromise - A function that resolves once the MetaMask extension is unlocked
  * and prompts the user to unlock their MetaMask if it is locked.
  * @param hooks.getClientCryptography - A function to retrieve the cryptographic
@@ -119,6 +135,7 @@ export const getBip32EntropyBuilder = Object.freeze({
  */
 export function getBip32EntropyImplementation({
   getMnemonic,
+  getMnemonicSeed,
   getUnlockPromise,
   getClientCryptography,
 }: GetBip32EntropyMethodHooks) {
@@ -130,12 +147,29 @@ export function getBip32EntropyImplementation({
     const { params } = args;
     assert(params);
 
-    const secretRecoveryPhrase = await getSecretRecoveryPhrase(
+    // Using the seed is much faster, but we can only do it for these specific curves.
+    if (params.curve === 'secp256k1' || params.curve === 'ed25519') {
+      const seed = await getValueFromEntropySource(
+        getMnemonicSeed,
+        params.source,
+      );
+
+      const node = await getNodeFromSeed({
+        curve: params.curve,
+        path: params.path,
+        seed,
+        cryptographicFunctions: getClientCryptography(),
+      });
+
+      return node.toJSON();
+    }
+
+    const secretRecoveryPhrase = await getValueFromEntropySource(
       getMnemonic,
       params.source,
     );
 
-    const node = await getNode({
+    const node = await getNodeFromMnemonic({
       curve: params.curve,
       path: params.path,
       secretRecoveryPhrase,

--- a/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.test.ts
@@ -174,7 +174,7 @@ describe('getBip32PublicKeyImplementation', () => {
           },
         }),
       ).toMatchInlineSnapshot(
-        `"0x042de17487a660993177ce2a85bb73b6cd9ad436184d57bdf5a93f5db430bea914f7c31d378fe68f4723b297a04e49ef55fbf490605c4a3f9ca947a4af4f06526a"`,
+        `"0x022de17487a660993177ce2a85bb73b6cd9ad436184d57bdf5a93f5db430bea914"`,
       );
     });
 
@@ -277,7 +277,7 @@ describe('getBip32PublicKeyImplementation', () => {
           },
         }),
       ).toMatchInlineSnapshot(
-        `"0x042de17487a660993177ce2a85bb73b6cd9ad436184d57bdf5a93f5db430bea914f7c31d378fe68f4723b297a04e49ef55fbf490605c4a3f9ca947a4af4f06526a"`,
+        `"0x022de17487a660993177ce2a85bb73b6cd9ad436184d57bdf5a93f5db430bea914"`,
       );
 
       expect(hmacSha512).toHaveBeenCalledTimes(6);

--- a/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.test.ts
@@ -209,6 +209,7 @@ describe('getBip32PublicKeyImplementation', () => {
       );
 
       expect(getMnemonic).toHaveBeenCalledWith('source-id');
+      expect(getMnemonicSeed).not.toHaveBeenCalled();
     });
 
     it('calls `getMnemonicSeed` with a different entropy source', async () => {
@@ -242,6 +243,7 @@ describe('getBip32PublicKeyImplementation', () => {
       );
 
       expect(getMnemonicSeed).toHaveBeenCalledWith('source-id');
+      expect(getMnemonic).not.toHaveBeenCalled();
     });
 
     it('uses custom client cryptography functions', async () => {

--- a/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.test.ts
@@ -3,7 +3,10 @@ import { SnapCaveatType } from '@metamask/snaps-utils';
 import {
   MOCK_SNAP_ID,
   TEST_SECRET_RECOVERY_PHRASE_BYTES,
+  TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES,
 } from '@metamask/snaps-utils/test-utils';
+import { hmac } from '@noble/hashes/hmac';
+import { sha512 } from '@noble/hashes/sha512';
 
 import {
   getBip32PublicKeyBuilder,
@@ -13,6 +16,7 @@ import {
 describe('specificationBuilder', () => {
   const methodHooks = {
     getMnemonic: jest.fn(),
+    getMnemonicSeed: jest.fn(),
     getUnlockPromise: jest.fn(),
     getClientCryptography: jest.fn(),
   };
@@ -66,12 +70,16 @@ describe('getBip32PublicKeyImplementation', () => {
       const getMnemonic = jest
         .fn()
         .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES);
+      const getMnemonicSeed = jest
+        .fn()
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES);
       const getClientCryptography = jest.fn().mockReturnValue({});
 
       expect(
         await getBip32PublicKeyImplementation({
           getUnlockPromise,
           getMnemonic,
+          getMnemonicSeed,
           getClientCryptography,
           // @ts-expect-error Missing other required properties.
         })({
@@ -90,12 +98,16 @@ describe('getBip32PublicKeyImplementation', () => {
       const getMnemonic = jest
         .fn()
         .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES);
+      const getMnemonicSeed = jest
+        .fn()
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES);
       const getClientCryptography = jest.fn().mockReturnValue({});
 
       expect(
         await getBip32PublicKeyImplementation({
           getUnlockPromise,
           getMnemonic,
+          getMnemonicSeed,
           getClientCryptography,
           // @ts-expect-error Missing other required properties.
         })({
@@ -114,12 +126,16 @@ describe('getBip32PublicKeyImplementation', () => {
       const getMnemonic = jest
         .fn()
         .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES);
+      const getMnemonicSeed = jest
+        .fn()
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES);
       const getClientCryptography = jest.fn().mockReturnValue({});
 
       expect(
         await getBip32PublicKeyImplementation({
           getUnlockPromise,
           getMnemonic,
+          getMnemonicSeed,
           getClientCryptography,
           // @ts-expect-error Missing other required properties.
         })({
@@ -138,12 +154,16 @@ describe('getBip32PublicKeyImplementation', () => {
       const getMnemonic = jest
         .fn()
         .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES);
+      const getMnemonicSeed = jest
+        .fn()
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES);
       const getClientCryptography = jest.fn().mockReturnValue({});
 
       expect(
         await getBip32PublicKeyImplementation({
           getUnlockPromise,
           getMnemonic,
+          getMnemonicSeed,
           getClientCryptography,
           // @ts-expect-error Missing other required properties.
         })({
@@ -154,7 +174,7 @@ describe('getBip32PublicKeyImplementation', () => {
           },
         }),
       ).toMatchInlineSnapshot(
-        `"0x022de17487a660993177ce2a85bb73b6cd9ad436184d57bdf5a93f5db430bea914"`,
+        `"0x042de17487a660993177ce2a85bb73b6cd9ad436184d57bdf5a93f5db430bea914f7c31d378fe68f4723b297a04e49ef55fbf490605c4a3f9ca947a4af4f06526a"`,
       );
     });
 
@@ -162,6 +182,9 @@ describe('getBip32PublicKeyImplementation', () => {
       const getMnemonic = jest
         .fn()
         .mockImplementation(() => TEST_SECRET_RECOVERY_PHRASE_BYTES);
+      const getMnemonicSeed = jest
+        .fn()
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES);
 
       const getUnlockPromise = jest.fn();
       const getClientCryptography = jest.fn().mockReturnValue({});
@@ -170,6 +193,40 @@ describe('getBip32PublicKeyImplementation', () => {
         await getBip32PublicKeyImplementation({
           getUnlockPromise,
           getMnemonic,
+          getMnemonicSeed,
+          getClientCryptography,
+        })({
+          method: 'snap_getBip32PublicKey',
+          context: { origin: MOCK_SNAP_ID },
+          params: {
+            path: ['m', "44'", "1'", '1', '2', '3'],
+            curve: 'ed25519Bip32',
+            source: 'source-id',
+          },
+        }),
+      ).toMatchInlineSnapshot(
+        `"0x03303da49ddfafc90587b7559eacdd5523028e75be81f2a9f158733fee1211a6"`,
+      );
+
+      expect(getMnemonic).toHaveBeenCalledWith('source-id');
+    });
+
+    it('calls `getMnemonicSeed` with a different entropy source', async () => {
+      const getMnemonic = jest
+        .fn()
+        .mockImplementation(() => TEST_SECRET_RECOVERY_PHRASE_BYTES);
+      const getMnemonicSeed = jest
+        .fn()
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES);
+
+      const getUnlockPromise = jest.fn();
+      const getClientCryptography = jest.fn().mockReturnValue({});
+
+      expect(
+        await getBip32PublicKeyImplementation({
+          getUnlockPromise,
+          getMnemonic,
+          getMnemonicSeed,
           getClientCryptography,
         })({
           method: 'snap_getBip32PublicKey',
@@ -184,7 +241,7 @@ describe('getBip32PublicKeyImplementation', () => {
         `"0x042de17487a660993177ce2a85bb73b6cd9ad436184d57bdf5a93f5db430bea914f7c31d378fe68f4723b297a04e49ef55fbf490605c4a3f9ca947a4af4f06526a"`,
       );
 
-      expect(getMnemonic).toHaveBeenCalledWith('source-id');
+      expect(getMnemonicSeed).toHaveBeenCalledWith('source-id');
     });
 
     it('uses custom client cryptography functions', async () => {
@@ -192,16 +249,24 @@ describe('getBip32PublicKeyImplementation', () => {
       const getMnemonic = jest
         .fn()
         .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES);
+      const getMnemonicSeed = jest
+        .fn()
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES);
 
-      const pbkdf2Sha512 = jest.fn().mockResolvedValue(new Uint8Array(64));
+      const hmacSha512 = jest
+        .fn()
+        .mockImplementation((key: Uint8Array, data: Uint8Array) =>
+          hmac(sha512, key, data),
+        );
       const getClientCryptography = jest.fn().mockReturnValue({
-        pbkdf2Sha512,
+        hmacSha512,
       });
 
       expect(
         await getBip32PublicKeyImplementation({
           getUnlockPromise,
           getMnemonic,
+          getMnemonicSeed,
           getClientCryptography,
           // @ts-expect-error Missing other required properties.
         })({
@@ -212,10 +277,10 @@ describe('getBip32PublicKeyImplementation', () => {
           },
         }),
       ).toMatchInlineSnapshot(
-        `"0x03102d63c39b6dda3f9aa06b247c50653cd9d01a91efce00ccc8735e9714058a01"`,
+        `"0x042de17487a660993177ce2a85bb73b6cd9ad436184d57bdf5a93f5db430bea914f7c31d378fe68f4723b297a04e49ef55fbf490605c4a3f9ca947a4af4f06526a"`,
       );
 
-      expect(pbkdf2Sha512).toHaveBeenCalledTimes(1);
+      expect(hmacSha512).toHaveBeenCalledTimes(6);
     });
   });
 });

--- a/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -182,6 +182,10 @@ export function getBip32PublicKeyImplementation({
         cryptographicFunctions: getClientCryptography(),
       });
 
+      if (params.compressed) {
+        return node.compressedPublicKey;
+      }
+
       return node.publicKey;
     }
 

--- a/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -22,7 +22,11 @@ import type { NonEmptyArray } from '@metamask/utils';
 import { assertStruct } from '@metamask/utils';
 
 import type { MethodHooksObject } from '../utils';
-import { getSecretRecoveryPhrase, getNode } from '../utils';
+import {
+  getValueFromEntropySource,
+  getNodeFromMnemonic,
+  getNodeFromSeed,
+} from '../utils';
 
 const targetName = 'snap_getBip32PublicKey';
 
@@ -36,6 +40,16 @@ export type GetBip32PublicKeyMethodHooks = {
    * source is provided.
    */
   getMnemonic: (source?: string | undefined) => Promise<Uint8Array>;
+
+  /**
+   * Get the mnemonic seed of the provided source. If no source is provided, the
+   * mnemonic seed of the primary keyring will be returned.
+   *
+   * @param source - The optional ID of the source to get the mnemonic of.
+   * @returns The mnemonic seed of the provided source, or the default source if no
+   * source is provided.
+   */
+  getMnemonicSeed: (source?: string | undefined) => Promise<Uint8Array>;
 
   /**
    * Waits for the extension to be unlocked.
@@ -110,6 +124,7 @@ const specificationBuilder: PermissionSpecificationBuilder<
 
 const methodHooks: MethodHooksObject<GetBip32PublicKeyMethodHooks> = {
   getMnemonic: true,
+  getMnemonicSeed: true,
   getUnlockPromise: true,
   getClientCryptography: true,
 };
@@ -125,6 +140,7 @@ export const getBip32PublicKeyBuilder = Object.freeze({
  *
  * @param hooks - The RPC method hooks.
  * @param hooks.getMnemonic - A function to retrieve the Secret Recovery Phrase of the user.
+ * @param hooks.getMnemonicSeed - A function to retrieve the BIP-39 seed of the user.
  * @param hooks.getUnlockPromise - A function that resolves once the MetaMask extension is unlocked
  * and prompts the user to unlock their MetaMask if it is locked.
  * @param hooks.getClientCryptography - A function to retrieve the cryptographic
@@ -134,6 +150,7 @@ export const getBip32PublicKeyBuilder = Object.freeze({
  */
 export function getBip32PublicKeyImplementation({
   getMnemonic,
+  getMnemonicSeed,
   getUnlockPromise,
   getClientCryptography,
 }: GetBip32PublicKeyMethodHooks) {
@@ -150,12 +167,30 @@ export function getBip32PublicKeyImplementation({
     );
 
     const { params } = args;
-    const secretRecoveryPhrase = await getSecretRecoveryPhrase(
+
+    // Using the seed is much faster, but we can only do it for these specific curves.
+    if (params.curve === 'secp256k1' || params.curve === 'ed25519') {
+      const seed = await getValueFromEntropySource(
+        getMnemonicSeed,
+        params.source,
+      );
+
+      const node = await getNodeFromSeed({
+        curve: params.curve,
+        path: params.path,
+        seed,
+        cryptographicFunctions: getClientCryptography(),
+      });
+
+      return node.publicKey;
+    }
+
+    const secretRecoveryPhrase = await getValueFromEntropySource(
       getMnemonic,
       params.source,
     );
 
-    const node = await getNode({
+    const node = await getNodeFromMnemonic({
       curve: params.curve,
       path: params.path,
       secretRecoveryPhrase,

--- a/packages/snaps-rpc-methods/src/restricted/getBip44Entropy.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip44Entropy.test.ts
@@ -2,8 +2,10 @@ import { SubjectType, PermissionType } from '@metamask/permission-controller';
 import { SnapCaveatType } from '@metamask/snaps-utils';
 import {
   MOCK_SNAP_ID,
-  TEST_SECRET_RECOVERY_PHRASE_BYTES,
+  TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES,
 } from '@metamask/snaps-utils/test-utils';
+import { hmac } from '@noble/hashes/hmac';
+import { sha512 } from '@noble/hashes/sha512';
 
 import {
   getBip44EntropyBuilder,
@@ -12,7 +14,7 @@ import {
 
 describe('specificationBuilder', () => {
   const methodHooks = {
-    getMnemonic: jest.fn(),
+    getMnemonicSeed: jest.fn(),
     getUnlockPromise: jest.fn(),
     getClientCryptography: jest.fn(),
   };
@@ -63,15 +65,15 @@ describe('getBip44EntropyImplementation', () => {
   describe('getBip44Entropy', () => {
     it('derives the entropy from the path', async () => {
       const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
-      const getMnemonic = jest
+      const getMnemonicSeed = jest
         .fn()
-        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES);
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES);
       const getClientCryptography = jest.fn().mockReturnValue({});
 
       expect(
         await getBip44EntropyImplementation({
           getUnlockPromise,
-          getMnemonic,
+          getMnemonicSeed,
           getClientCryptography,
           // @ts-expect-error Missing other required properties.
         })({
@@ -94,9 +96,9 @@ describe('getBip44EntropyImplementation', () => {
     });
 
     it('calls `getMnemonic` with a different entropy source', async () => {
-      const getMnemonic = jest
+      const getMnemonicSeed = jest
         .fn()
-        .mockImplementation(() => TEST_SECRET_RECOVERY_PHRASE_BYTES);
+        .mockImplementation(() => TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES);
 
       const getUnlockPromise = jest.fn();
       const getClientCryptography = jest.fn().mockReturnValue({});
@@ -104,7 +106,7 @@ describe('getBip44EntropyImplementation', () => {
       expect(
         await getBip44EntropyImplementation({
           getUnlockPromise,
-          getMnemonic,
+          getMnemonicSeed,
           getClientCryptography,
         })({
           method: 'snap_getBip44Entropy',
@@ -126,24 +128,28 @@ describe('getBip44EntropyImplementation', () => {
         }
       `);
 
-      expect(getMnemonic).toHaveBeenCalledWith('source-id');
+      expect(getMnemonicSeed).toHaveBeenCalledWith('source-id');
     });
 
     it('uses custom client cryptography functions', async () => {
       const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
-      const getMnemonic = jest
+      const getMnemonicSeed = jest
         .fn()
-        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES);
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES);
 
-      const pbkdf2Sha512 = jest.fn().mockResolvedValue(new Uint8Array(64));
+      const hmacSha512 = jest
+        .fn()
+        .mockImplementation((key: Uint8Array, data: Uint8Array) =>
+          hmac(sha512, key, data),
+        );
       const getClientCryptography = jest.fn().mockReturnValue({
-        pbkdf2Sha512,
+        hmacSha512,
       });
 
       expect(
         await getBip44EntropyImplementation({
           getUnlockPromise,
-          getMnemonic,
+          getMnemonicSeed,
           getClientCryptography,
           // @ts-expect-error Missing other required properties.
         })({
@@ -151,20 +157,20 @@ describe('getBip44EntropyImplementation', () => {
         }),
       ).toMatchInlineSnapshot(`
         {
-          "chainCode": "0x8472428420c7fd8ef7280545bb6d2bde1d7c6b490556ccd59895f242716388d1",
+          "chainCode": "0x50ccfa58a885b48b5eed09486b3948e8454f34856fb81da5d7b8519d7997abd1",
           "coin_type": 1,
           "depth": 2,
           "index": 2147483649,
-          "masterFingerprint": 3276136937,
+          "masterFingerprint": 1404659567,
           "network": "mainnet",
-          "parentFingerprint": 1981505209,
+          "parentFingerprint": 1829122711,
           "path": "m / bip32:44' / bip32:1'",
-          "privateKey": "0x71d945aba22cd337ff26a107073ae2606dee5dbf7ecfe5c25870b8eaf62b9f1b",
-          "publicKey": "0x0491c4b234ca9b394f40d90f09092e04fd3bca2aa68c57e1311b25acfd972c5a6fc7ffd19e7812127473aa2bd827917b6ec7b57bec73cf022fc1f1fa0593f48770",
+          "privateKey": "0xc73cedb996e7294f032766853a8b7ba11ab4ce9755fc052f2f7b9000044c99af",
+          "publicKey": "0x048e129862c1de5ca86468add43b001d32fd34b8113de716ecd63fa355b7f1165f0e76f5dc6095100f9fdaa76ddf28aa3f21406ac5fda7c71ffbedb45634fe2ceb",
         }
       `);
 
-      expect(pbkdf2Sha512).toHaveBeenCalledTimes(1);
+      expect(hmacSha512).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/packages/snaps-rpc-methods/src/restricted/getEntropy.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getEntropy.ts
@@ -14,7 +14,7 @@ import type { NonEmptyArray } from '@metamask/utils';
 import { assertStruct } from '@metamask/utils';
 
 import type { MethodHooksObject } from '../utils';
-import { getSecretRecoveryPhrase, deriveEntropyFromMnemonic } from '../utils';
+import { getValueFromEntropySource, deriveEntropyFromSeed } from '../utils';
 
 const targetName = 'snap_getEntropy';
 
@@ -62,7 +62,7 @@ const specificationBuilder: PermissionSpecificationBuilder<
 };
 
 const methodHooks: MethodHooksObject<GetEntropyHooks> = {
-  getMnemonic: true,
+  getMnemonicSeed: true,
   getUnlockPromise: true,
   getClientCryptography: true,
 };
@@ -75,14 +75,14 @@ export const getEntropyBuilder = Object.freeze({
 
 export type GetEntropyHooks = {
   /**
-   * Get the mnemonic of the provided source. If no source is provided, the
-   * mnemonic of the primary keyring will be returned.
+   * Get the mnemonic seed of the provided source. If no source is provided, the
+   * mnemonic seed of the primary keyring will be returned.
    *
    * @param source - The optional ID of the source to get the mnemonic of.
-   * @returns The mnemonic of the provided source, or the default source if no
+   * @returns The mnemonic seed of the provided source, or the default source if no
    * source is provided.
    */
-  getMnemonic: (source?: string | undefined) => Promise<Uint8Array>;
+  getMnemonicSeed: (source?: string | undefined) => Promise<Uint8Array>;
 
   /**
    * Waits for the extension to be unlocked.
@@ -107,8 +107,8 @@ export type GetEntropyHooks = {
  * [SIP-6](https://metamask.github.io/SIPs/SIPS/sip-6).
  *
  * @param hooks - The RPC method hooks.
- * @param hooks.getMnemonic - The method to get the mnemonic of the user's
- * primary keyring.
+ * @param hooks.getMnemonicSeed - A function to retrieve the BIP-39 seed
+ * of the user.
  * @param hooks.getUnlockPromise - The method to get a promise that resolves
  * once the extension is unlocked.
  * @param hooks.getClientCryptography - A function to retrieve the cryptographic
@@ -116,7 +116,7 @@ export type GetEntropyHooks = {
  * @returns The method implementation.
  */
 function getEntropyImplementation({
-  getMnemonic,
+  getMnemonicSeed,
   getUnlockPromise,
   getClientCryptography,
 }: GetEntropyHooks) {
@@ -136,15 +136,15 @@ function getEntropyImplementation({
     );
 
     await getUnlockPromise(true);
-    const mnemonicPhrase = await getSecretRecoveryPhrase(
-      getMnemonic,
+    const seed = await getValueFromEntropySource(
+      getMnemonicSeed,
       params.source,
     );
 
-    return deriveEntropyFromMnemonic({
+    return deriveEntropyFromSeed({
       input: origin,
       salt: params.salt,
-      mnemonicPhrase,
+      seed,
       magic: SIP_6_MAGIC_VALUE,
       cryptographicFunctions: getClientCryptography(),
     });

--- a/packages/snaps-rpc-methods/src/utils.ts
+++ b/packages/snaps-rpc-methods/src/utils.ts
@@ -9,7 +9,6 @@ import { SLIP10Node } from '@metamask/key-tree';
 import { rpcErrors } from '@metamask/rpc-errors';
 import type { MagicValue } from '@metamask/snaps-utils';
 import { refine, string } from '@metamask/superstruct';
-import type { Hex } from '@metamask/utils';
 import {
   assertExhaustive,
   add0x,
@@ -120,13 +119,6 @@ type SeedDeriveEntropyOptions = BaseDeriveEntropyOptions & {
   seed: Uint8Array;
 };
 
-type MnemonicDeriveEntropyOptions = BaseDeriveEntropyOptions & {
-  /**
-   * The mnemonic phrase to use for entropy derivation.
-   */
-  mnemonicPhrase: Uint8Array;
-};
-
 /**
  * Get the derivation path to use for entropy derivation.
  *
@@ -203,51 +195,6 @@ export async function deriveEntropyFromSeed({
 }
 
 /**
- * Derive entropy from the given mnemonic phrase and salt.
- *
- * This is based on the reference implementation of
- * [SIP-6](https://metamask.github.io/SIPs/SIPS/sip-6).
- *
- * @param options - The options for entropy derivation.
- * @param options.input - The input value to derive entropy from.
- * @param options.salt - An optional salt to use when deriving entropy.
- * @param options.mnemonicPhrase - The mnemonic phrase to use for entropy
- * derivation.
- * @param options.magic - A hardened BIP-32 index, which is used to derive the
- * root key from the mnemonic phrase.
- * @param options.cryptographicFunctions - The cryptographic functions to use
- * for the derivation.
- * @returns The derived entropy.
- */
-export async function deriveEntropyFromMnemonic({
-  input,
-  salt = '',
-  mnemonicPhrase,
-  magic,
-  cryptographicFunctions,
-}: MnemonicDeriveEntropyOptions): Promise<Hex> {
-  const computedDerivationPath = getEntropyDerivationPath({
-    input,
-    salt,
-    magic,
-  });
-
-  // Derive the private key using BIP-32.
-  const { privateKey } = await SLIP10Node.fromDerivationPath(
-    {
-      derivationPath: [mnemonicPhrase, ...computedDerivationPath],
-      curve: 'secp256k1',
-    },
-    cryptographicFunctions,
-  );
-
-  // This should never happen, but this keeps TypeScript happy.
-  assert(privateKey, 'Failed to derive the entropy.');
-
-  return add0x(privateKey);
-}
-
-/**
  * Get the path prefix to use for key derivation in `key-tree`. This assumes the
  * following:
  *
@@ -277,11 +224,18 @@ export function getPathPrefix(
   }
 }
 
-type GetNodeArgs = {
+type BaseGetNodeArgs = {
   curve: SupportedCurve;
-  secretRecoveryPhrase: Uint8Array;
   path: string[];
   cryptographicFunctions: CryptographicFunctions | undefined;
+};
+
+type GetNodeArgsMnemonic = BaseGetNodeArgs & {
+  secretRecoveryPhrase: Uint8Array;
+};
+
+type GetNodeArgsSeed = BaseGetNodeArgs & {
+  seed: Uint8Array;
 };
 
 /**
@@ -300,12 +254,12 @@ type GetNodeArgs = {
  * for the node.
  * @returns The `key-tree` SLIP-10 node.
  */
-export async function getNode({
+export async function getNodeFromMnemonic({
   curve,
   secretRecoveryPhrase,
   path,
   cryptographicFunctions,
-}: GetNodeArgs) {
+}: GetNodeArgsMnemonic) {
   const prefix = getPathPrefix(curve);
 
   return await SLIP10Node.fromDerivationPath(
@@ -313,6 +267,44 @@ export async function getNode({
       curve,
       derivationPath: [
         secretRecoveryPhrase,
+        ...(path.slice(1).map((index) => `${prefix}:${index}`) as
+          | BIP32Node[]
+          | SLIP10PathNode[]),
+      ],
+    },
+    cryptographicFunctions,
+  );
+}
+
+/**
+ * Get a `key-tree`-compatible node.
+ *
+ * Note: This function assumes that all the parameters have been validated
+ * beforehand.
+ *
+ * @param options - The derivation options.
+ * @param options.curve - The curve to use for derivation.
+ * @param options.seed - The BIP-39 to use for
+ * derivation.
+ * @param options.path - The derivation path to use as array, starting with an
+ * "m" as the first item.
+ * @param options.cryptographicFunctions - The cryptographic functions to use
+ * for the node.
+ * @returns The `key-tree` SLIP-10 node.
+ */
+export async function getNodeFromSeed({
+  curve,
+  seed,
+  path,
+  cryptographicFunctions,
+}: GetNodeArgsSeed) {
+  const prefix = getPathPrefix(curve);
+
+  return await SLIP10Node.fromSeed(
+    {
+      curve,
+      derivationPath: [
+        seed,
         ...(path.slice(1).map((index) => `${prefix}:${index}`) as
           | BIP32Node[]
           | SLIP10PathNode[]),
@@ -345,19 +337,20 @@ export const StateKeyStruct = refine(string(), 'state key', (value) => {
 });
 
 /**
- * Get the secret recovery phrase of the user. This calls the `getMnemonic` hook
- * and handles any errors that occur, throwing formatted JSON-RPC errors.
+ * Get a value using the entropy source hooks: getMnemonic or getMnemonicSeed.
+ * This function calls the passed hook and handles any errors that occur,
+ * throwing formatted JSON-RPC errors.
  *
- * @param getMnemonic - The `getMnemonic` hook.
+ * @param hook - The hook.
  * @param source - The entropy source to use.
  * @returns The secret recovery phrase.
  */
-export async function getSecretRecoveryPhrase(
-  getMnemonic: (source?: string | undefined) => Promise<Uint8Array>,
+export async function getValueFromEntropySource(
+  hook: (source?: string | undefined) => Promise<Uint8Array>,
   source?: string | undefined,
 ): Promise<Uint8Array> {
   try {
-    return await getMnemonic(source);
+    return await hook(source);
   } catch (error) {
     if (error instanceof Error) {
       throw rpcErrors.invalidParams({

--- a/packages/snaps-simulation/src/methods/hooks/get-mnemonic-seed.test.ts
+++ b/packages/snaps-simulation/src/methods/hooks/get-mnemonic-seed.test.ts
@@ -1,0 +1,44 @@
+import { mnemonicPhraseToBytes } from '@metamask/key-tree';
+
+import { getGetMnemonicSeedImplementation } from './get-mnemonic-seed';
+import { DEFAULT_ALTERNATIVE_SRP, DEFAULT_SRP } from '../../constants';
+
+describe('getGetMnemonicSeedImplementation', () => {
+  it('returns the default mnemonic seed', async () => {
+    const getMnemonicSeed = getGetMnemonicSeedImplementation();
+    expect(await getMnemonicSeed()).toStrictEqual(
+      mnemonicPhraseToBytes(DEFAULT_SRP),
+    );
+
+    expect(await getMnemonicSeed('default')).toStrictEqual(
+      mnemonicPhraseToBytes(DEFAULT_SRP),
+    );
+  });
+
+  it('returns the seed of the provided default mnemonic phrase', async () => {
+    const getMnemonicSeed = getGetMnemonicSeedImplementation(
+      DEFAULT_ALTERNATIVE_SRP,
+    );
+    expect(await getMnemonicSeed()).toStrictEqual(
+      mnemonicPhraseToBytes(DEFAULT_ALTERNATIVE_SRP),
+    );
+
+    expect(await getMnemonicSeed('default')).toStrictEqual(
+      mnemonicPhraseToBytes(DEFAULT_ALTERNATIVE_SRP),
+    );
+  });
+
+  it('returns the alternative mnemonic seed', async () => {
+    const getMnemonicSeed = getGetMnemonicSeedImplementation();
+    expect(await getMnemonicSeed('alternative')).toStrictEqual(
+      mnemonicPhraseToBytes(DEFAULT_ALTERNATIVE_SRP),
+    );
+  });
+
+  it('throws an error for an unknown entropy source', async () => {
+    const getMnemonicSeed = getGetMnemonicSeedImplementation();
+    await expect(getMnemonicSeed('unknown')).rejects.toThrow(
+      'Entropy source with ID "unknown" not found.',
+    );
+  });
+});

--- a/packages/snaps-simulation/src/methods/hooks/get-mnemonic-seed.test.ts
+++ b/packages/snaps-simulation/src/methods/hooks/get-mnemonic-seed.test.ts
@@ -1,17 +1,24 @@
-import { mnemonicPhraseToBytes } from '@metamask/key-tree';
+import { TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES } from '@metamask/snaps-utils/test-utils';
 
 import { getGetMnemonicSeedImplementation } from './get-mnemonic-seed';
-import { DEFAULT_ALTERNATIVE_SRP, DEFAULT_SRP } from '../../constants';
+import { DEFAULT_ALTERNATIVE_SRP } from '../../constants';
 
 describe('getGetMnemonicSeedImplementation', () => {
+  const alternativeSeedBytes = new Uint8Array([
+    94, 176, 11, 189, 220, 240, 105, 8, 72, 137, 168, 171, 145, 85, 86, 129,
+    101, 245, 196, 83, 204, 184, 94, 112, 129, 26, 174, 214, 246, 218, 95, 193,
+    154, 90, 196, 11, 56, 156, 211, 112, 208, 134, 32, 109, 236, 138, 166, 196,
+    61, 174, 166, 105, 15, 32, 173, 61, 141, 72, 178, 210, 206, 158, 56, 228,
+  ]);
+
   it('returns the default mnemonic seed', async () => {
     const getMnemonicSeed = getGetMnemonicSeedImplementation();
     expect(await getMnemonicSeed()).toStrictEqual(
-      mnemonicPhraseToBytes(DEFAULT_SRP),
+      TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES,
     );
 
     expect(await getMnemonicSeed('default')).toStrictEqual(
-      mnemonicPhraseToBytes(DEFAULT_SRP),
+      TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES,
     );
   });
 
@@ -19,19 +26,17 @@ describe('getGetMnemonicSeedImplementation', () => {
     const getMnemonicSeed = getGetMnemonicSeedImplementation(
       DEFAULT_ALTERNATIVE_SRP,
     );
-    expect(await getMnemonicSeed()).toStrictEqual(
-      mnemonicPhraseToBytes(DEFAULT_ALTERNATIVE_SRP),
-    );
+    expect(await getMnemonicSeed()).toStrictEqual(alternativeSeedBytes);
 
     expect(await getMnemonicSeed('default')).toStrictEqual(
-      mnemonicPhraseToBytes(DEFAULT_ALTERNATIVE_SRP),
+      alternativeSeedBytes,
     );
   });
 
   it('returns the alternative mnemonic seed', async () => {
     const getMnemonicSeed = getGetMnemonicSeedImplementation();
     expect(await getMnemonicSeed('alternative')).toStrictEqual(
-      mnemonicPhraseToBytes(DEFAULT_ALTERNATIVE_SRP),
+      alternativeSeedBytes,
     );
   });
 

--- a/packages/snaps-simulation/src/methods/hooks/get-mnemonic-seed.ts
+++ b/packages/snaps-simulation/src/methods/hooks/get-mnemonic-seed.ts
@@ -1,0 +1,29 @@
+import { mnemonicToSeed } from '@metamask/key-tree';
+
+import { DEFAULT_ALTERNATIVE_SRP, DEFAULT_SRP } from '../../constants';
+
+/**
+ * Get the implementation of the `getMnemonicSeed` method.
+ *
+ * @param defaultSecretRecoveryPhrase - The default secret recovery phrase to
+ * use.
+ * @returns The implementation of the `getMnemonicSeed` method.
+ */
+export function getGetMnemonicSeedImplementation(
+  defaultSecretRecoveryPhrase: string = DEFAULT_SRP,
+) {
+  return async (source?: string | undefined): Promise<Uint8Array> => {
+    if (!source) {
+      return mnemonicToSeed(defaultSecretRecoveryPhrase);
+    }
+
+    switch (source) {
+      case 'default':
+        return mnemonicToSeed(defaultSecretRecoveryPhrase);
+      case 'alternative':
+        return mnemonicToSeed(DEFAULT_ALTERNATIVE_SRP);
+      default:
+        throw new Error(`Entropy source with ID "${source}" not found.`);
+    }
+  };
+}

--- a/packages/snaps-simulation/src/simulation.ts
+++ b/packages/snaps-simulation/src/simulation.ts
@@ -44,6 +44,7 @@ import {
   getGetEntropySourcesImplementation,
   getGetMnemonicImplementation,
 } from './methods/hooks';
+import { getGetMnemonicSeedImplementation } from './methods/hooks/get-mnemonic-seed';
 import { createJsonRpcEngine } from './middleware';
 import type { SimulationOptions, SimulationUserOptions } from './options';
 import { getOptions } from './options';
@@ -107,6 +108,14 @@ export type RestrictedMiddlewareHooks = {
    * @returns The user's secret recovery phrase.
    */
   getMnemonic: (source?: string | undefined) => Promise<Uint8Array>;
+
+  /**
+   * A hook that returns the seed derived from the user's secret recovery phrase.
+   *
+   * @param source - The entropy source to get the seed from.
+   * @returns The seed.
+   */
+  getMnemonicSeed: (source?: string | undefined) => Promise<Uint8Array>;
 
   /**
    * A hook that returns whether the client is locked or not.
@@ -382,6 +391,9 @@ export function getRestrictedHooks(
 ): RestrictedMiddlewareHooks {
   return {
     getMnemonic: getGetMnemonicImplementation(options.secretRecoveryPhrase),
+    getMnemonicSeed: getGetMnemonicSeedImplementation(
+      options.secretRecoveryPhrase,
+    ),
     getIsLocked: () => false,
     getClientCryptography: () => ({}),
   };

--- a/packages/snaps-simulator/jest.config.js
+++ b/packages/snaps-simulator/jest.config.js
@@ -8,9 +8,9 @@ module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 54.33,
-      functions: 60.59,
-      lines: 80.54,
-      statements: 80.83,
+      functions: 60.43,
+      lines: 80.49,
+      statements: 80.79,
     },
   },
   setupFiles: ['./jest.setup.js'],

--- a/packages/snaps-simulator/src/features/simulation/sagas.ts
+++ b/packages/snaps-simulator/src/features/simulation/sagas.ts
@@ -2,7 +2,7 @@ import { Messenger } from '@metamask/base-controller';
 import { createFetchMiddleware } from '@metamask/eth-json-rpc-middleware';
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 import { createEngineStream } from '@metamask/json-rpc-middleware-stream';
-import { mnemonicPhraseToBytes } from '@metamask/key-tree';
+import { mnemonicPhraseToBytes, mnemonicToSeed } from '@metamask/key-tree';
 import type { GenericPermissionController } from '@metamask/permission-controller';
 import {
   PermissionController,
@@ -122,6 +122,7 @@ export function* initSaga({ payload }: PayloadAction<string>) {
 
   const sharedHooks = {
     getMnemonic: async () => mnemonicPhraseToBytes(srp),
+    getMnemonicSeed: async () => mnemonicToSeed(srp),
   };
 
   const permissionSpecifications = {


### PR DESCRIPTION
This PR adjusts the implementations of the entropy RPC methods to use `getMnemonicSeed` if the curve being used is either `secp256k1` or `ed25519`. This let's us skip the most computationally heavy part of the key derivation by re-using the already derived BIP-39 seed.

Closes #3219 

**Breaking changes**
- A `getMnemonicSeed` hook is now required to support all entropy RPC methods.
  - Note that `getMnemonic` can not be removed as that is still also in use.