### PR TITLE
Revert "Group Dependabot minor and patch updates for MetaMask dependencies (#3207)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,11 +14,3 @@ updates:
     target-branch: 'main'
     versioning-strategy: 'increase'
     open-pull-requests-limit: 10
-    groups:
-      metamask:
-        applies-to: version-updates
-        patterns:
-          - '@metamask/*'
-        update-types:
-          - 'minor'
-          - 'patch'


### PR DESCRIPTION
This reverts commit ba54f3772191dce9183b7ac512f598aea1abb76e.