### PR TITLE
Skip rerunning workflows in merge queue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,7 @@ jobs:
   re-run:
     name: Re-run failed jobs
     needs: lint-build-test
-    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event.pull_request.user.login != 'dependabot[bot]' && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     permissions:
       actions: write


### PR DESCRIPTION
If a workflow fails in the merge queue, it's removed from the queue right away. Rerunning jobs like this doesn't work unfortunately.