### PR TITLE
Add mutex to `getSnapState` to prevent concurrent decryption

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 93.34,
-  "functions": 97.36,
+  "functions": 97.37,
   "lines": 98.33,
   "statements": 98.07
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2051,7 +2051,7 @@ export class SnapController extends BaseController<
    */
   async getSnapState(snapId: SnapId, encrypted: boolean): Promise<Json> {
     const runtime = this.#getRuntimeExpect(snapId);
-    return await runtime.getStateMutex.runExclusive(() => {
+    return await runtime.getStateMutex.runExclusive(async () => {
       const cachedState = encrypted ? runtime.state : runtime.unencryptedState;
 
       if (cachedState !== undefined) {
@@ -2076,6 +2076,7 @@ export class SnapController extends BaseController<
       }
 
       const decrypted = await this.#decryptSnapState(snapId, state);
+      // eslint-disable-next-line require-atomic-updates
       runtime.state = decrypted;
 
       return decrypted;

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -286,6 +286,11 @@ export type SnapRuntimeData = {
    * A mutex to prevent concurrent state updates.
    */
   stateMutex: Mutex;
+
+  /**
+   * A mutex to prevent concurrent state decryption.
+   */
+  getStateMutex: Mutex;
 };
 
 export type SnapError = {
@@ -2046,33 +2051,35 @@ export class SnapController extends BaseController<
    */
   async getSnapState(snapId: SnapId, encrypted: boolean): Promise<Json> {
     const runtime = this.#getRuntimeExpect(snapId);
-    const cachedState = encrypted ? runtime.state : runtime.unencryptedState;
+    return await runtime.getStateMutex.runExclusive(() => {
+      const cachedState = encrypted ? runtime.state : runtime.unencryptedState;
 
-    if (cachedState !== undefined) {
-      return cachedState;
-    }
+      if (cachedState !== undefined) {
+        return cachedState;
+      }
 
-    const state = encrypted
-      ? this.state.snapStates[snapId]
-      : this.state.unencryptedSnapStates[snapId];
+      const state = encrypted
+        ? this.state.snapStates[snapId]
+        : this.state.unencryptedSnapStates[snapId];
 
-    if (state === null || state === undefined) {
-      return null;
-    }
+      if (state === null || state === undefined) {
+        return null;
+      }
 
-    if (!encrypted) {
-      // For performance reasons, we do not validate that the state is JSON,
-      // since we control serialization.
-      const json = JSON.parse(state);
-      runtime.unencryptedState = json;
+      if (!encrypted) {
+        // For performance reasons, we do not validate that the state is JSON,
+        // since we control serialization.
+        const json = JSON.parse(state);
+        runtime.unencryptedState = json;
 
-      return json;
-    }
+        return json;
+      }
 
-    const decrypted = await this.#decryptSnapState(snapId, state);
-    runtime.state = decrypted;
+      const decrypted = await this.#decryptSnapState(snapId, state);
+      runtime.state = decrypted;
 
-    return decrypted;
+      return decrypted;
+    });
   }
 
   /**
@@ -3968,6 +3975,7 @@ export class SnapController extends BaseController<
       interpreter,
       stopping: false,
       stateMutex: new Mutex(),
+      getStateMutex: new Mutex(),
     });
   }
 


### PR DESCRIPTION
This wraps `getSnapState` in a mutex, to ensure we only decrypt once when calling it at the same time. The first call will decrypt the state and cache it in the Snaps runtime, and the next call will just use the cached result.