### PR TITLE
Fix typo in documentation in `TransactionParams`

### DIFF
--- a/packages/snaps-controllers/src/types/controllers.ts
+++ b/packages/snaps-controllers/src/types/controllers.ts
@@ -34,7 +34,7 @@ export type TransactionMeta = {
  */
 export type TransactionParams = {
   /**
-   * Network ID as per EIP-155.
+   * Chain ID as per EIP-155.
    */
   chainId?: Hex;
 
@@ -74,7 +74,7 @@ export type TransactionParams = {
   gas?: string;
 
   /**
-   * Maxmimum number of units of gas to use for this transaction.
+   * Maximum number of units of gas to use for this transaction.
    */
   gasLimit?: string;
 
@@ -102,7 +102,7 @@ export type TransactionParams = {
   /**
    * Unique number to prevent replay attacks.
    */
-  nonce?: string;
+  nonce?: number | string;
 
   /**
    * Address to send this transaction to.

--- a/packages/snaps-controllers/src/types/controllers.ts
+++ b/packages/snaps-controllers/src/types/controllers.ts
@@ -102,7 +102,7 @@ export type TransactionParams = {
   /**
    * Unique number to prevent replay attacks.
    */
-  nonce?: number | string;
+  nonce?: string;
 
   /**
    * Address to send this transaction to.


### PR DESCRIPTION
Fixed incorrect terminology: 
  - `"Network ID as per EIP-155"` → `"Chain ID as per EIP-155"` (EIP-155 defines `chainId`, not `network ID`).  
  
Fixed spelling mistake:
  - `"Maxmimum"` → `"Maximum"`. 
