### PR TITLE
fix: Handle `withKeyring` breaking change in `MultichainRouter`

### DIFF
--- a/packages/snaps-controllers/src/multichain/MultichainRouter.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRouter.ts
@@ -72,7 +72,7 @@ type SnapKeyring = {
 
 // Expecting a bound function that calls KeyringController.withKeyring selecting the Snap keyring
 type WithSnapKeyringFunction = <ReturnType>(
-  operation: (keyring: SnapKeyring) => Promise<ReturnType>,
+  operation: ({ keyring }: { keyring: SnapKeyring }) => Promise<ReturnType>,
 ) => Promise<ReturnType>;
 
 export type AccountsControllerListMultichainAccountsAction = {
@@ -165,7 +165,7 @@ export class MultichainRouter {
     request: JsonRpcRequest,
   ) {
     try {
-      const result = await this.#withSnapKeyring(async (keyring) =>
+      const result = await this.#withSnapKeyring(async ({ keyring }) =>
         keyring.resolveAccountAddress(snapId, scope, request),
       );
       const address = result?.address;
@@ -323,7 +323,7 @@ export class MultichainRouter {
     );
 
     if (accountId) {
-      return this.#withSnapKeyring(async (keyring) =>
+      return this.#withSnapKeyring(async ({ keyring }) =>
         keyring.submitRequest({
           account: accountId,
           scope,

--- a/packages/snaps-controllers/src/test-utils/multichain.ts
+++ b/packages/snaps-controllers/src/test-utils/multichain.ts
@@ -95,7 +95,11 @@ type MockSnapKeyring = {
   ) => Promise<{ address: CaipAccountId } | null>;
 };
 
-type MockOperationCallback = (keyring: MockSnapKeyring) => Promise<Json>;
+type MockOperationCallback = ({
+  keyring,
+}: {
+  keyring: MockSnapKeyring;
+}) => Promise<Json>;
 
 export const getMockWithSnapKeyring = (
   { submitRequest = jest.fn(), resolveAccountAddress = jest.fn() } = {
@@ -105,7 +109,9 @@ export const getMockWithSnapKeyring = (
 ) => {
   return async (callback: MockOperationCallback) =>
     callback({
-      submitRequest,
-      resolveAccountAddress,
+      keyring: {
+        submitRequest,
+        resolveAccountAddress,
+      },
     });
 };


### PR DESCRIPTION
`KeyringController.withKeyring` had a breaking change in https://github.com/MetaMask/core/commit/8e15f01af8b6e10b68177ade5a687bcac29b29b9 where the format of the callback parameters was changed. This breaks the SIP-26 branch as the extension is already using the latest version of the `KeyringController`. This PR adjusts our usage of `withKeyring` to expect the new format.