### PR TITLE
chore: Refactor stateful component check in `constructState`

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 93.51,
+  "branches": 93.34,
   "functions": 97.36,
   "lines": 98.33,
   "statements": 98.06

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -2,5 +2,5 @@
   "branches": 93.34,
   "functions": 97.36,
   "lines": 98.33,
-  "statements": 98.06
+  "statements": 98.07
 }

--- a/packages/snaps-controllers/src/interface/utils.test.tsx
+++ b/packages/snaps-controllers/src/interface/utils.test.tsx
@@ -25,6 +25,7 @@ import {
   getAssetSelectorStateValue,
   getDefaultAsset,
   getJsxInterface,
+  isStatefulComponent,
 } from './utils';
 import { MOCK_ACCOUNT_ID } from '../test-utils';
 
@@ -1220,5 +1221,15 @@ describe('getDefaultAsset', () => {
     ).toThrow(
       'Account not found for address: solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv.',
     );
+  });
+});
+
+describe('isStatefulComponent', () => {
+  it('returns true for stateful components', () => {
+    expect(isStatefulComponent(<Input name="foo" />)).toBe(true);
+  });
+
+  it('returns false for stateless components', () => {
+    expect(isStatefulComponent(<Text>foo</Text>)).toBe(false);
   });
 });

--- a/packages/snaps-controllers/src/interface/utils.test.tsx
+++ b/packages/snaps-controllers/src/interface/utils.test.tsx
@@ -1225,11 +1225,43 @@ describe('getDefaultAsset', () => {
 });
 
 describe('isStatefulComponent', () => {
-  it('returns true for stateful components', () => {
+  it.each([
+    <Input name="foo" />,
+    <Dropdown name="foo">
+      <Option value="option1">Option 1</Option>
+    </Dropdown>,
+    <RadioGroup name="foo">
+      <Radio value="option1">Option 1</Radio>
+    </RadioGroup>,
+    <Checkbox name="foo" />,
+    <Selector name="foo" title="Choose an option">
+      <SelectorOption value="option1">
+        <Text>Option 1</Text>
+      </SelectorOption>
+    </Selector>,
+    <AssetSelector
+      name="foo"
+      addresses={[
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv',
+      ]}
+    />,
+    <FileInput name="foo" />,
+    <AddressInput name="foo" chainId="eip155:1" />,
+  ])('returns true for "%p"', () => {
     expect(isStatefulComponent(<Input name="foo" />)).toBe(true);
   });
 
   it('returns false for stateless components', () => {
     expect(isStatefulComponent(<Text>foo</Text>)).toBe(false);
+  });
+
+  it('returns false for nested stateful components', () => {
+    expect(
+      isStatefulComponent(
+        <Box>
+          <Input name="foo" />
+        </Box>,
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -69,7 +69,6 @@ type StatefulComponentType = (typeof STATEFUL_COMPONENT_TYPES)[number];
  */
 export function isStatefulComponent(component: { type: string }): component is {
   type: StatefulComponentType;
-  props: Record<string, any>;
 } {
   return STATEFUL_COMPONENT_TYPES.includes(
     component.type as StatefulComponentType,

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -43,7 +43,7 @@ import {
 /**
  * A list of stateful component types.
  */
-export const STATEFUL_COMPONENT_TYPES = [
+const STATEFUL_COMPONENT_TYPES = [
   'Input',
   'Dropdown',
   'RadioGroup',

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -41,6 +41,42 @@ import {
 } from '@metamask/utils';
 
 /**
+ * A list of stateful component types.
+ */
+export const STATEFUL_COMPONENT_TYPES = [
+  'Input',
+  'Dropdown',
+  'RadioGroup',
+  'FileInput',
+  'Checkbox',
+  'Selector',
+  'AssetSelector',
+  'AddressInput',
+] as const;
+
+/**
+ * Type for stateful component types.
+ */
+type StatefulComponentType = (typeof STATEFUL_COMPONENT_TYPES)[number];
+
+/**
+ * Check if a component is a stateful component.
+ *
+ * @param component - The component to check.
+ * @param component.type - The type of the component.
+ *
+ * @returns Whether the component is a stateful component.
+ */
+export function isStatefulComponent(component: { type: string }): component is {
+  type: StatefulComponentType;
+  props: Record<string, any>;
+} {
+  return STATEFUL_COMPONENT_TYPES.includes(
+    component.type as StatefulComponentType,
+  );
+}
+
+/**
  * A function to get the MultichainAssetController state.
  *
  * @returns The MultichainAssetController state.
@@ -366,18 +402,7 @@ export function constructState(
     }
 
     // Stateful components inside a form
-    // TODO: This is becoming a bit of a mess, we should consider refactoring this.
-    if (
-      currentForm &&
-      (component.type === 'Input' ||
-        component.type === 'Dropdown' ||
-        component.type === 'RadioGroup' ||
-        component.type === 'FileInput' ||
-        component.type === 'Checkbox' ||
-        component.type === 'Selector' ||
-        component.type === 'AssetSelector' ||
-        component.type === 'AddressInput')
-    ) {
+    if (currentForm && isStatefulComponent(component)) {
       const formState = newState[currentForm.name] as FormState;
       assertNameIsUnique(formState, component.props.name);
       formState[component.props.name] = constructInputState(
@@ -390,17 +415,7 @@ export function constructState(
     }
 
     // Stateful components outside a form
-    // TODO: This is becoming a bit of a mess, we should consider refactoring this.
-    if (
-      component.type === 'Input' ||
-      component.type === 'Dropdown' ||
-      component.type === 'RadioGroup' ||
-      component.type === 'FileInput' ||
-      component.type === 'Checkbox' ||
-      component.type === 'Selector' ||
-      component.type === 'AssetSelector' ||
-      component.type === 'AddressInput'
-    ) {
+    if (isStatefulComponent(component)) {
       assertNameIsUnique(newState, component.props.name);
       newState[component.props.name] = constructInputState(
         oldState,


### PR DESCRIPTION
This PR refactors `constructState` to use an util function called `isStatefulComponent` that uses an array of component types that includes all the stateful components.

Fixes: #3235 