### PR TITLE
Add `displayAvatar` prop to `AddressInput` component

### DIFF
--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1V2d/+iUgdA+QeXEVHKxmle1VvQJaVC6KaHqSevpWBQ=",
+    "shasum": "AeqQc68lkZfEaef23QUd9lXTOCn+1LUyQBA5QfoYyG8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "PNtdcFc5HFBGHnv3e/8CUhm16s6+Ksmmc38dF34lsSw=",
+    "shasum": "1V2d/+iUgdA+QeXEVHKxmle1VvQJaVC6KaHqSevpWBQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "AeqQc68lkZfEaef23QUd9lXTOCn+1LUyQBA5QfoYyG8=",
+    "shasum": "1V2d/+iUgdA+QeXEVHKxmle1VvQJaVC6KaHqSevpWBQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "niW4M91p3Q/KkPrzFuBzJEoAWw2f39zFB1LGl+icSBQ=",
+    "shasum": "/i4ajCNv/9R1NuYAfSTnq8j8czxSymcZhcjZgnhj3Pg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1V+pdRmIER1rMRFWU02Fzc+LXLUcCoCHAXsbu2JXgSI=",
+    "shasum": "/i4ajCNv/9R1NuYAfSTnq8j8czxSymcZhcjZgnhj3Pg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "/i4ajCNv/9R1NuYAfSTnq8j8czxSymcZhcjZgnhj3Pg=",
+    "shasum": "niW4M91p3Q/KkPrzFuBzJEoAWw2f39zFB1LGl+icSBQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/send-flow/package.json
+++ b/packages/examples/packages/send-flow/package.json
@@ -44,7 +44,9 @@
   },
   "dependencies": {
     "@metamask/rpc-errors": "^7.0.2",
-    "@metamask/snaps-sdk": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^",
+    "@metamask/superstruct": "^3.1.0",
+    "@metamask/utils": "^9.0.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/examples/packages/send-flow/package.json
+++ b/packages/examples/packages/send-flow/package.json
@@ -46,7 +46,7 @@
     "@metamask/rpc-errors": "^7.0.2",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/superstruct": "^3.1.0",
-    "@metamask/utils": "^9.0.0"
+    "@metamask/utils": "^11.2.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/examples/packages/send-flow/snap.manifest.json
+++ b/packages/examples/packages/send-flow/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "zAr/K0hYpWBpfji+m6hudSs03KUiIEAEAwqeqBM3ipU=",
+    "shasum": "zWciyY8Iz62wkpyU0dcxpo5ecYZsZMg0atGG/P1fQbI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/send-flow/snap.manifest.json
+++ b/packages/examples/packages/send-flow/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wE+wX6shyn8Q1Tu8SrUCOdSjARmQrq2jbCKiRqFz5EY=",
+    "shasum": "OdhUJIwQy3JPOALZ2oZgV8iKIX/yVpTwIDfQ/dj004w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/send-flow/snap.manifest.json
+++ b/packages/examples/packages/send-flow/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OdhUJIwQy3JPOALZ2oZgV8iKIX/yVpTwIDfQ/dj004w=",
+    "shasum": "zAr/K0hYpWBpfji+m6hudSs03KUiIEAEAwqeqBM3ipU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/send-flow/snap.manifest.json
+++ b/packages/examples/packages/send-flow/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "zWciyY8Iz62wkpyU0dcxpo5ecYZsZMg0atGG/P1fQbI=",
+    "shasum": "5qERUafayyDWQ12V/+htfEs2wzmQwhSn0EcQolI7quo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/send-flow/src/components/SendFlow.tsx
+++ b/packages/examples/packages/send-flow/src/components/SendFlow.tsx
@@ -16,7 +16,7 @@ import type { Account, Currency } from '../types';
  * @property total - The total cost of the transaction.
  * @property fees - The fees for the transaction.
  * @property errors - The form errors.
- * @property displayName - The display name of the address.
+ * @property displayAvatar - Whether to display the avatar of the address.
  */
 export type SendFlowProps = {
   accounts: Account[];
@@ -28,7 +28,7 @@ export type SendFlowProps = {
     amount?: string;
     to?: string;
   };
-  displayName?: string | undefined;
+  displayAvatar?: boolean | undefined;
 };
 
 /**
@@ -41,7 +41,7 @@ export type SendFlowProps = {
  * @param props.total - The total cost of the transaction.
  * @param props.errors - The form errors.
  * @param props.fees - The fees for the transaction.
- * @param props.displayName - The display name of the address.
+ * @param props.displayAvatar - Whether to display the avatar of the address.
  * @returns The SendFlow component.
  */
 export const SendFlow: SnapComponent<SendFlowProps> = ({
@@ -51,7 +51,7 @@ export const SendFlow: SnapComponent<SendFlowProps> = ({
   total,
   fees,
   errors,
-  displayName,
+  displayAvatar,
 }) => {
   return (
     <Container>
@@ -62,7 +62,7 @@ export const SendFlow: SnapComponent<SendFlowProps> = ({
           accounts={accounts}
           selectedCurrency={selectedCurrency}
           errors={errors}
-          displayName={displayName}
+          displayAvatar={displayAvatar}
         />
         <TransactionSummary fees={fees} total={total} />
       </Box>

--- a/packages/examples/packages/send-flow/src/components/SendFlow.tsx
+++ b/packages/examples/packages/send-flow/src/components/SendFlow.tsx
@@ -15,8 +15,8 @@ import type { Account, Currency } from '../types';
  * @property selectedCurrency - The selected currency to display.
  * @property total - The total cost of the transaction.
  * @property fees - The fees for the transaction.
- * @property flushToAddress - Whether to flush the address field or not.
  * @property errors - The form errors.
+ * @property displayName - The display name of the address.
  */
 export type SendFlowProps = {
   accounts: Account[];
@@ -24,11 +24,11 @@ export type SendFlowProps = {
   selectedCurrency: 'BTC' | '$';
   total: Currency;
   fees: Currency;
-  flushToAddress?: boolean;
   errors?: {
     amount?: string;
     to?: string;
   };
+  displayName?: string | undefined;
 };
 
 /**
@@ -41,7 +41,7 @@ export type SendFlowProps = {
  * @param props.total - The total cost of the transaction.
  * @param props.errors - The form errors.
  * @param props.fees - The fees for the transaction.
- * @param props.flushToAddress - Whether to flush the address field or not.
+ * @param props.displayName - The display name of the address.
  * @returns The SendFlow component.
  */
 export const SendFlow: SnapComponent<SendFlowProps> = ({
@@ -50,8 +50,8 @@ export const SendFlow: SnapComponent<SendFlowProps> = ({
   selectedCurrency,
   total,
   fees,
-  flushToAddress,
   errors,
+  displayName,
 }) => {
   return (
     <Container>
@@ -61,8 +61,8 @@ export const SendFlow: SnapComponent<SendFlowProps> = ({
           selectedAccount={selectedAccount}
           accounts={accounts}
           selectedCurrency={selectedCurrency}
-          flushToAddress={flushToAddress}
           errors={errors}
+          displayName={displayName}
         />
         <TransactionSummary fees={fees} total={total} />
       </Box>

--- a/packages/examples/packages/send-flow/src/components/SendForm.tsx
+++ b/packages/examples/packages/send-flow/src/components/SendForm.tsx
@@ -22,14 +22,14 @@ import type { Account, SendFormErrors } from '../types';
  * @property accounts - The available accounts.
  * @property errors - The form errors.
  * @property selectedCurrency - The selected currency to display.
- * @property displayName - The display name of the address.
+ * @property displayAvatar - Whether to display the avatar of the address.
  */
 export type SendFormProps = {
   selectedAccount: string;
   accounts: Account[];
   errors?: SendFormErrors;
   selectedCurrency: 'BTC' | '$';
-  displayName?: string | undefined;
+  displayAvatar?: boolean | undefined;
 };
 
 /**
@@ -40,7 +40,7 @@ export type SendFormProps = {
  * @param props.accounts - The available accounts.
  * @param props.errors - The form errors.
  * @param props.selectedCurrency - The selected currency to display.
- * @param props.displayName - The display name of the address.
+ * @param props.displayAvatar - Whether to display the avatar of the address.
  * @returns The SendForm component.
  */
 export const SendForm: SnapComponent<SendFormProps> = ({
@@ -48,7 +48,7 @@ export const SendForm: SnapComponent<SendFormProps> = ({
   accounts,
   errors,
   selectedCurrency,
-  displayName,
+  displayAvatar,
 }) => (
   <Form name="sendForm">
     <AccountSelector selectedAccount={selectedAccount} accounts={accounts} />
@@ -69,7 +69,7 @@ export const SendForm: SnapComponent<SendFormProps> = ({
         name="to"
         chainId="eip155:0"
         placeholder="Enter receiving address"
-        displayName={displayName}
+        displayAvatar={displayAvatar}
       />
     </Field>
   </Form>

--- a/packages/examples/packages/send-flow/src/components/SendForm.tsx
+++ b/packages/examples/packages/send-flow/src/components/SendForm.tsx
@@ -22,14 +22,14 @@ import type { Account, SendFormErrors } from '../types';
  * @property accounts - The available accounts.
  * @property errors - The form errors.
  * @property selectedCurrency - The selected currency to display.
- * @property flushToAddress - Whether to flush the address field or not.
+ * @property displayName - The display name of the address.
  */
 export type SendFormProps = {
   selectedAccount: string;
   accounts: Account[];
   errors?: SendFormErrors;
   selectedCurrency: 'BTC' | '$';
-  flushToAddress?: boolean;
+  displayName?: string | undefined;
 };
 
 /**
@@ -40,7 +40,7 @@ export type SendFormProps = {
  * @param props.accounts - The available accounts.
  * @param props.errors - The form errors.
  * @param props.selectedCurrency - The selected currency to display.
- * @param props.flushToAddress - Whether to flush the address field or not.
+ * @param props.displayName - The display name of the address.
  * @returns The SendForm component.
  */
 export const SendForm: SnapComponent<SendFormProps> = ({
@@ -48,7 +48,7 @@ export const SendForm: SnapComponent<SendFormProps> = ({
   accounts,
   errors,
   selectedCurrency,
-  flushToAddress,
+  displayName,
 }) => (
   <Form name="sendForm">
     <AccountSelector selectedAccount={selectedAccount} accounts={accounts} />
@@ -69,7 +69,7 @@ export const SendForm: SnapComponent<SendFormProps> = ({
         name="to"
         chainId="eip155:0"
         placeholder="Enter receiving address"
-        value={flushToAddress ? '' : undefined}
+        displayName={displayName}
       />
     </Field>
   </Form>

--- a/packages/examples/packages/send-flow/src/index.tsx
+++ b/packages/examples/packages/send-flow/src/index.tsx
@@ -98,7 +98,30 @@ export const onUserInput: OnUserInputHandler = async ({
   if (event.type === UserInputEventType.InputChangeEvent) {
     switch (event.name) {
       case 'amount':
-      case 'to':
+      case 'to': {
+        await snap.request({
+          method: 'snap_updateInterface',
+          params: {
+            id,
+            ui: (
+              <SendFlow
+                accounts={accountsArray}
+                selectedAccount={sendForm.accountSelector}
+                selectedCurrency={selectedCurrency}
+                total={total}
+                fees={fees}
+                errors={formErrors}
+                displayName={
+                  event.value === '0x0000000000000000000000000000000000000000'
+                    ? 'Zero Address'
+                    : undefined
+                }
+              />
+            ),
+          },
+        });
+        break;
+      }
       case 'accountSelector': {
         await snap.request({
           method: 'snap_updateInterface',
@@ -119,30 +142,6 @@ export const onUserInput: OnUserInputHandler = async ({
 
         break;
       }
-      default:
-        break;
-    }
-  } else if (event.type === UserInputEventType.ButtonClickEvent) {
-    switch (event.name) {
-      case 'clear':
-        await snap.request({
-          method: 'snap_updateInterface',
-          params: {
-            id,
-            ui: (
-              <SendFlow
-                accounts={accountsArray}
-                selectedAccount={sendForm.accountSelector}
-                selectedCurrency={selectedCurrency}
-                total={total}
-                fees={fees}
-                flushToAddress={true}
-                errors={formErrors}
-              />
-            ),
-          },
-        });
-        break;
       default:
         break;
     }

--- a/packages/examples/packages/send-flow/src/index.tsx
+++ b/packages/examples/packages/send-flow/src/index.tsx
@@ -99,27 +99,26 @@ export const onUserInput: OnUserInputHandler = async ({
     switch (event.name) {
       case 'amount':
       case 'to': {
-        await snap.request({
-          method: 'snap_updateInterface',
-          params: {
-            id,
-            ui: (
-              <SendFlow
-                accounts={accountsArray}
-                selectedAccount={sendForm.accountSelector}
-                selectedCurrency={selectedCurrency}
-                total={total}
-                fees={fees}
-                errors={formErrors}
-                displayName={
-                  event.value === '0x0000000000000000000000000000000000000000'
-                    ? 'Zero Address'
-                    : undefined
-                }
-              />
-            ),
-          },
-        });
+        // For testing purposes, we display the avatar of the zero address.
+        if (event.value === '0x0000000000000000000000000000000000000000') {
+          await snap.request({
+            method: 'snap_updateInterface',
+            params: {
+              id,
+              ui: (
+                <SendFlow
+                  accounts={accountsArray}
+                  selectedAccount={sendForm.accountSelector}
+                  selectedCurrency={selectedCurrency}
+                  total={total}
+                  fees={fees}
+                  errors={formErrors}
+                  displayAvatar={true}
+                />
+              ),
+            },
+          });
+        }
         break;
       }
       case 'accountSelector': {

--- a/packages/examples/packages/send-flow/src/index.tsx
+++ b/packages/examples/packages/send-flow/src/index.tsx
@@ -5,6 +5,8 @@ import type {
   OnRpcRequestHandler,
 } from '@metamask/snaps-sdk';
 import { UserInputEventType } from '@metamask/snaps-sdk';
+import { is } from '@metamask/superstruct';
+import { HexChecksumAddressStruct } from '@metamask/utils';
 
 import { SendFlow } from './components';
 import { accountsArray, accounts } from './data';
@@ -99,8 +101,8 @@ export const onUserInput: OnUserInputHandler = async ({
     switch (event.name) {
       case 'amount':
       case 'to': {
-        // For testing purposes, we display the avatar of the zero address.
-        if (event.value === '0x0000000000000000000000000000000000000000') {
+        // For testing purposes, we display the avatar if the address is a valid hex checksum address.
+        if (is(event.value, HexChecksumAddressStruct)) {
           await snap.request({
             method: 'snap_updateInterface',
             params: {

--- a/packages/examples/packages/send-flow/src/index.tsx
+++ b/packages/examples/packages/send-flow/src/index.tsx
@@ -102,25 +102,23 @@ export const onUserInput: OnUserInputHandler = async ({
       case 'amount':
       case 'to': {
         // For testing purposes, we display the avatar if the address is a valid hex checksum address.
-        if (is(event.value, HexChecksumAddressStruct)) {
-          await snap.request({
-            method: 'snap_updateInterface',
-            params: {
-              id,
-              ui: (
-                <SendFlow
-                  accounts={accountsArray}
-                  selectedAccount={sendForm.accountSelector}
-                  selectedCurrency={selectedCurrency}
-                  total={total}
-                  fees={fees}
-                  errors={formErrors}
-                  displayAvatar={true}
-                />
-              ),
-            },
-          });
-        }
+        await snap.request({
+          method: 'snap_updateInterface',
+          params: {
+            id,
+            ui: (
+              <SendFlow
+                accounts={accountsArray}
+                selectedAccount={sendForm.accountSelector}
+                selectedCurrency={selectedCurrency}
+                total={total}
+                fees={fees}
+                errors={formErrors}
+                displayAvatar={is(event.value, HexChecksumAddressStruct)}
+              />
+            ),
+          },
+        });
         break;
       }
       case 'accountSelector': {

--- a/packages/snaps-sdk/src/jsx/components/form/AddressInput.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/AddressInput.ts
@@ -8,7 +8,7 @@ export type AddressInputProps = {
   chainId: CaipChainId;
   placeholder?: string | undefined;
   disabled?: boolean | undefined;
-  displayAvatar?: boolean | undefined;
+  displayName?: string | undefined;
 };
 
 const TYPE = 'AddressInput';
@@ -22,7 +22,7 @@ const TYPE = 'AddressInput';
  * @param props.chainId - The CAIP-2 chain ID of the address.
  * @param props.placeholder - The placeholder text of the input field.
  * @param props.disabled - Whether the input field is disabled.
- * @param props.displayAvatar - Whether to display the avatar of the address.
+ * @param props.displayName - The display name of the address.
  * @returns An input element.
  * @example
  * <AddressInput name="address" value="0x1234567890123456789012345678901234567890" chainId="eip155:1" />

--- a/packages/snaps-sdk/src/jsx/components/form/AddressInput.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/AddressInput.ts
@@ -8,7 +8,7 @@ export type AddressInputProps = {
   chainId: CaipChainId;
   placeholder?: string | undefined;
   disabled?: boolean | undefined;
-  displayName?: string | undefined;
+  displayAvatar?: boolean | undefined;
 };
 
 const TYPE = 'AddressInput';
@@ -22,7 +22,7 @@ const TYPE = 'AddressInput';
  * @param props.chainId - The CAIP-2 chain ID of the address.
  * @param props.placeholder - The placeholder text of the input field.
  * @param props.disabled - Whether the input field is disabled.
- * @param props.displayName - The display name of the address.
+ * @param props.displayAvatar - Whether to display the avatar of the address.
  * @returns An input element.
  * @example
  * <AddressInput name="address" value="0x1234567890123456789012345678901234567890" chainId="eip155:1" />

--- a/packages/snaps-sdk/src/jsx/components/form/AddressInput.ts
+++ b/packages/snaps-sdk/src/jsx/components/form/AddressInput.ts
@@ -8,6 +8,7 @@ export type AddressInputProps = {
   chainId: CaipChainId;
   placeholder?: string | undefined;
   disabled?: boolean | undefined;
+  displayAvatar?: boolean | undefined;
 };
 
 const TYPE = 'AddressInput';
@@ -21,6 +22,7 @@ const TYPE = 'AddressInput';
  * @param props.chainId - The CAIP-2 chain ID of the address.
  * @param props.placeholder - The placeholder text of the input field.
  * @param props.disabled - Whether the input field is disabled.
+ * @param props.displayAvatar - Whether to display the avatar of the address.
  * @returns An input element.
  * @example
  * <AddressInput name="address" value="0x1234567890123456789012345678901234567890" chainId="eip155:1" />

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -224,7 +224,7 @@ describe('AddressInputStruct', () => {
     <AddressInput
       name="address"
       chainId="eip155:1"
-      displayAvatar={true}
+      displayName="foo"
       value="0x1234567890abcdef1234567890abcdef12345678"
     />,
   ])('validates an address input element', (value) => {
@@ -252,7 +252,7 @@ describe('AddressInputStruct', () => {
       name="foo"
       chainId="eip155:1"
       // @ts-expect-error - Invalid props.
-      displayAvatar="bar"
+      displayName={123}
       value="0x1234567890abcdef1234567890abcdef12345678"
     />,
   ])('does not validate "%p"', (value) => {

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -221,6 +221,12 @@ describe('AddressInputStruct', () => {
     />,
     <AddressInput name="address" chainId="eip155:1" placeholder="foo" />,
     <AddressInput name="address" chainId="eip155:1" disabled={true} />,
+    <AddressInput
+      name="address"
+      chainId="eip155:1"
+      displayAvatar={true}
+      value="0x1234567890abcdef1234567890abcdef12345678"
+    />,
   ])('validates an address input element', (value) => {
     expect(is(value, AddressInputStruct)).toBe(true);
   });
@@ -242,6 +248,13 @@ describe('AddressInputStruct', () => {
     <AddressInput name="foo" chainId="eip155:1" placeholder={32} />,
     // @ts-expect-error - Invalid props.
     <AddressInput name="foo" chainId="eip155:1" disabled="bar" />,
+    <AddressInput
+      name="foo"
+      chainId="eip155:1"
+      // @ts-expect-error - Invalid props.
+      displayAvatar="bar"
+      value="0x1234567890abcdef1234567890abcdef12345678"
+    />,
   ])('does not validate "%p"', (value) => {
     expect(is(value, AddressInputStruct)).toBe(false);
   });

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -224,7 +224,7 @@ describe('AddressInputStruct', () => {
     <AddressInput
       name="address"
       chainId="eip155:1"
-      displayName="foo"
+      displayAvatar={true}
       value="0x1234567890abcdef1234567890abcdef12345678"
     />,
   ])('validates an address input element', (value) => {
@@ -252,7 +252,7 @@ describe('AddressInputStruct', () => {
       name="foo"
       chainId="eip155:1"
       // @ts-expect-error - Invalid props.
-      displayName={123}
+      displayAvatar={123}
       value="0x1234567890abcdef1234567890abcdef12345678"
     />,
   ])('does not validate "%p"', (value) => {

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -358,7 +358,7 @@ export const AddressInputStruct: Describe<AddressInputElement> = element(
     value: optional(string()),
     placeholder: optional(string()),
     disabled: optional(boolean()),
-    displayName: optional(string()),
+    displayAvatar: optional(boolean()),
   },
 );
 

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -358,7 +358,7 @@ export const AddressInputStruct: Describe<AddressInputElement> = element(
     value: optional(string()),
     placeholder: optional(string()),
     disabled: optional(boolean()),
-    displayAvatar: optional(boolean()),
+    displayName: optional(string()),
   },
 );
 

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -358,6 +358,7 @@ export const AddressInputStruct: Describe<AddressInputElement> = element(
     value: optional(string()),
     placeholder: optional(string()),
     disabled: optional(boolean()),
+    displayAvatar: optional(boolean()),
   },
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5425,6 +5425,8 @@ __metadata:
     "@metamask/snaps-cli": "workspace:^"
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^9.0.0"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
     "@types/node": "npm:18.14.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5426,7 +5426,7 @@ __metadata:
     "@metamask/snaps-jest": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^9.0.0"
+    "@metamask/utils": "npm:^11.2.0"
     "@swc/core": "npm:1.3.78"
     "@swc/jest": "npm:^0.2.26"
     "@types/node": "npm:18.14.2"


### PR DESCRIPTION
The `displayAvatar` prop is being added to the `AddressInput` component to allow a snap to indicate that it has validated the value of the component itself. Updated the send flow example snap as well, removed dead code that was missed previously.