### PR TITLE
Make CI depend on `analyse-code` step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,9 @@ jobs:
   all-jobs-complete:
     name: All jobs complete
     runs-on: ubuntu-latest
-    needs: lint-build-test
+    needs:
+      - analyse-code
+      - lint-build-test
     outputs:
       passed: ${{ steps.set-output.outputs.passed }}
     steps:


### PR DESCRIPTION
CI should not be able to pass if the analyse code step is failing.