### PR TITLE
fix: Improve error messages for `AddressStruct`

### DIFF
--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "T5ccDAybeUsAJ9yFxrXmWXVcQCVnavpmmc1fE3PlOpA=",
+    "shasum": "zIDqJzXMi7kdr4+TOIKO1lOK4o3r60fEDRMO4Q6lXzk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "UnuvG6B1bTtsFwaahkqTlmPJ70y1ZrXj5vu0m8tjISw=",
+    "shasum": "coTp9c/ZNMaIGqnTbDMfSpt867Gyq6kQCbmgsZzTARg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -385,7 +385,12 @@ export const DropdownStruct: Describe<DropdownElement> = element('Dropdown', {
  * A struct for the {@link AddressElement} type.
  */
 export const AddressStruct: Describe<AddressElement> = element('Address', {
-  address: nullUnion([HexChecksumAddressStruct, CaipAccountIdStruct]),
+  address: selectiveUnion((value) => {
+    if (typeof value === 'string' && value.startsWith('0x')) {
+      return HexChecksumAddressStruct;
+    }
+    return CaipAccountIdStruct;
+  }),
   truncate: optional(boolean()),
   displayName: optional(boolean()),
   avatar: optional(boolean()),


### PR DESCRIPTION
Improve error messages when validating `AddressStruct` by using `selectiveUnion`. This may also improve performance when validating JSX blobs.