### PR TITLE
fix: Stop refreshing phishing list when updating interfaces

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -2,5 +2,5 @@
   "branches": 93.34,
   "functions": 97.37,
   "lines": 98.33,
-  "statements": 98.07
+  "statements": 98.06
 }

--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.test.tsx
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.test.tsx
@@ -147,11 +147,6 @@ describe('SnapInterfaceController', () => {
 
       expect(rootMessenger.call).toHaveBeenNthCalledWith(
         2,
-        'PhishingController:maybeUpdateState',
-      );
-
-      expect(rootMessenger.call).toHaveBeenNthCalledWith(
-        3,
         'PhishingController:testOrigin',
         'https://foo.bar/',
       );
@@ -187,7 +182,7 @@ describe('SnapInterfaceController', () => {
       );
 
       expect(rootMessenger.call).toHaveBeenNthCalledWith(
-        4,
+        3,
         'MultichainAssetsController:getState',
       );
 
@@ -243,11 +238,6 @@ describe('SnapInterfaceController', () => {
 
       expect(rootMessenger.call).toHaveBeenNthCalledWith(
         2,
-        'PhishingController:maybeUpdateState',
-      );
-
-      expect(rootMessenger.call).toHaveBeenNthCalledWith(
-        3,
         'PhishingController:testOrigin',
         'https://foo.bar/',
       );
@@ -367,11 +357,6 @@ describe('SnapInterfaceController', () => {
       );
 
       rootMessenger.registerActionHandler(
-        'PhishingController:maybeUpdateState',
-        jest.fn(),
-      );
-
-      rootMessenger.registerActionHandler(
         'PhishingController:testOrigin',
         () => ({ result: true, type: 'all' }),
       );
@@ -399,11 +384,6 @@ describe('SnapInterfaceController', () => {
 
       expect(rootMessenger.call).toHaveBeenNthCalledWith(
         2,
-        'PhishingController:maybeUpdateState',
-      );
-
-      expect(rootMessenger.call).toHaveBeenNthCalledWith(
-        3,
         'PhishingController:testOrigin',
         'https://foo.bar/',
       );
@@ -414,11 +394,6 @@ describe('SnapInterfaceController', () => {
       const controllerMessenger = getRestrictedSnapInterfaceControllerMessenger(
         rootMessenger,
         false,
-      );
-
-      rootMessenger.registerActionHandler(
-        'PhishingController:maybeUpdateState',
-        jest.fn(),
       );
 
       rootMessenger.registerActionHandler(
@@ -449,11 +424,6 @@ describe('SnapInterfaceController', () => {
 
       expect(rootMessenger.call).toHaveBeenNthCalledWith(
         2,
-        'PhishingController:maybeUpdateState',
-      );
-
-      expect(rootMessenger.call).toHaveBeenNthCalledWith(
-        3,
         'PhishingController:testOrigin',
         'https://foo.bar/',
       );
@@ -464,11 +434,6 @@ describe('SnapInterfaceController', () => {
       const controllerMessenger = getRestrictedSnapInterfaceControllerMessenger(
         rootMessenger,
         false,
-      );
-
-      rootMessenger.registerActionHandler(
-        'PhishingController:maybeUpdateState',
-        jest.fn(),
       );
 
       rootMessenger.registerActionHandler(
@@ -500,7 +465,7 @@ describe('SnapInterfaceController', () => {
       );
 
       expect(rootMessenger.call).toHaveBeenNthCalledWith(
-        3,
+        2,
         'SnapController:get',
         MOCK_SNAP_ID,
       );
@@ -511,11 +476,6 @@ describe('SnapInterfaceController', () => {
       const controllerMessenger = getRestrictedSnapInterfaceControllerMessenger(
         rootMessenger,
         false,
-      );
-
-      rootMessenger.registerActionHandler(
-        'PhishingController:maybeUpdateState',
-        jest.fn(),
       );
 
       rootMessenger.registerActionHandler(
@@ -563,7 +523,7 @@ describe('SnapInterfaceController', () => {
       );
 
       expect(rootMessenger.call).toHaveBeenNthCalledWith(
-        3,
+        2,
         'AccountsController:getAccountByAddress',
         '7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv',
       );
@@ -934,11 +894,6 @@ describe('SnapInterfaceController', () => {
       );
 
       rootMessenger.registerActionHandler(
-        'PhishingController:maybeUpdateState',
-        jest.fn(),
-      );
-
-      rootMessenger.registerActionHandler(
         'PhishingController:testOrigin',
         () => ({ result: true, type: 'all' }),
       );
@@ -977,12 +932,7 @@ describe('SnapInterfaceController', () => {
       ).rejects.toThrow('Invalid URL: The specified URL is not allowed.');
 
       expect(rootMessenger.call).toHaveBeenNthCalledWith(
-        4,
-        'PhishingController:maybeUpdateState',
-      );
-
-      expect(rootMessenger.call).toHaveBeenNthCalledWith(
-        5,
+        3,
         'PhishingController:testOrigin',
         'https://foo.bar/',
       );
@@ -993,11 +943,6 @@ describe('SnapInterfaceController', () => {
       const controllerMessenger = getRestrictedSnapInterfaceControllerMessenger(
         rootMessenger,
         false,
-      );
-
-      rootMessenger.registerActionHandler(
-        'PhishingController:maybeUpdateState',
-        jest.fn(),
       );
 
       rootMessenger.registerActionHandler(
@@ -1043,12 +988,7 @@ describe('SnapInterfaceController', () => {
       ).rejects.toThrow('Invalid URL: The specified URL is not allowed.');
 
       expect(rootMessenger.call).toHaveBeenNthCalledWith(
-        4,
-        'PhishingController:maybeUpdateState',
-      );
-
-      expect(rootMessenger.call).toHaveBeenNthCalledWith(
-        5,
+        3,
         'PhishingController:testOrigin',
         'https://foo.bar/',
       );

--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
@@ -8,10 +8,7 @@ import type {
   ControllerStateChangeEvent,
 } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
-import type {
-  MaybeUpdateState,
-  TestOrigin,
-} from '@metamask/phishing-controller';
+import type { TestOrigin } from '@metamask/phishing-controller';
 import type {
   InterfaceState,
   SnapId,
@@ -91,7 +88,6 @@ type MultichainAssetsControllerGetStateAction = ControllerGetStateAction<
 
 export type SnapInterfaceControllerAllowedActions =
   | TestOrigin
-  | MaybeUpdateState
   | HasApprovalRequest
   | AcceptRequest
   | GetSnap
@@ -407,13 +403,6 @@ export class SnapInterfaceController extends BaseController<
   }
 
   /**
-   * Trigger a Phishing list update if needed.
-   */
-  async #triggerPhishingListUpdate() {
-    await this.messagingSystem.call('PhishingController:maybeUpdateState');
-  }
-
-  /**
    * Check an origin against the phishing list.
    *
    * @param origin - The origin to check.
@@ -499,8 +488,6 @@ export class SnapInterfaceController extends BaseController<
       size <= MAX_UI_CONTENT_SIZE,
       `A Snap UI may not be larger than ${MAX_UI_CONTENT_SIZE / 1000000} MB.`,
     );
-
-    await this.#triggerPhishingListUpdate();
 
     validateJsxElements(element, {
       isOnPhishingList: this.#checkPhishingList.bind(this),

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -491,7 +491,6 @@ export const getSnapControllerMessenger = (
       'PermissionController:revokePermissionForAllSubjects',
       'PermissionController:updateCaveat',
       'PermissionController:getSubjectNames',
-      'PhishingController:maybeUpdateState',
       'PhishingController:testOrigin',
       'SnapController:get',
       'SnapController:handleRequest',
@@ -781,7 +780,6 @@ export const getRestrictedSnapInterfaceControllerMessenger = (
     name: 'SnapInterfaceController',
     allowedActions: [
       'PhishingController:testOrigin',
-      'PhishingController:maybeUpdateState',
       'ApprovalController:hasRequest',
       'ApprovalController:acceptRequest',
       'MultichainAssetsController:getState',
@@ -795,11 +793,6 @@ export const getRestrictedSnapInterfaceControllerMessenger = (
   });
 
   if (mocked) {
-    messenger.registerActionHandler(
-      'PhishingController:maybeUpdateState',
-      async () => Promise.resolve(),
-    );
-
     messenger.registerActionHandler('PhishingController:testOrigin', () => ({
       result: false,
       type: 'all',

--- a/packages/snaps-jest/src/test-utils/controller.ts
+++ b/packages/snaps-jest/src/test-utils/controller.ts
@@ -10,11 +10,6 @@ export const getRootControllerMessenger = (mocked = true) => {
   >();
 
   if (mocked) {
-    messenger.registerActionHandler(
-      'PhishingController:maybeUpdateState',
-      async () => Promise.resolve(),
-    );
-
     messenger.registerActionHandler('PhishingController:testOrigin', () => ({
       result: false,
       type: 'all',
@@ -51,7 +46,6 @@ export const getRestrictedSnapInterfaceControllerMessenger = (
     name: 'SnapInterfaceController',
     allowedActions: [
       'PhishingController:testOrigin',
-      'PhishingController:maybeUpdateState',
       'ApprovalController:hasRequest',
       'ApprovalController:acceptRequest',
     ],

--- a/packages/snaps-simulation/src/controllers.ts
+++ b/packages/snaps-simulation/src/controllers.ts
@@ -84,7 +84,6 @@ export function getControllers(options: GetControllersOptions): Controllers {
     messenger: controllerMessenger.getRestricted({
       name: 'SnapInterfaceController',
       allowedActions: [
-        'PhishingController:maybeUpdateState',
         'PhishingController:testOrigin',
         'ApprovalController:hasRequest',
         'ApprovalController:acceptRequest',

--- a/packages/snaps-simulation/src/request.test.tsx
+++ b/packages/snaps-simulation/src/request.test.tsx
@@ -419,7 +419,7 @@ describe('getInterfaceApi', () => {
     await snapInterface.clickElement('foo');
 
     expect(controllerMessenger.call).toHaveBeenNthCalledWith(
-      5,
+      4,
       'ExecutionService:handleRpcRequest',
       MOCK_SNAP_ID,
       {
@@ -466,7 +466,7 @@ describe('getInterfaceApi', () => {
     await snapInterface.typeInField('foo', 'bar');
 
     expect(controllerMessenger.call).toHaveBeenNthCalledWith(
-      6,
+      5,
       'ExecutionService:handleRpcRequest',
       MOCK_SNAP_ID,
       {
@@ -519,7 +519,7 @@ describe('getInterfaceApi', () => {
     await snapInterface.selectInDropdown('foo', 'option2');
 
     expect(controllerMessenger.call).toHaveBeenNthCalledWith(
-      6,
+      5,
       'ExecutionService:handleRpcRequest',
       MOCK_SNAP_ID,
       {
@@ -572,7 +572,7 @@ describe('getInterfaceApi', () => {
     await snapInterface.selectFromRadioGroup('foo', 'option2');
 
     expect(controllerMessenger.call).toHaveBeenNthCalledWith(
-      6,
+      5,
       'ExecutionService:handleRpcRequest',
       MOCK_SNAP_ID,
       {
@@ -629,7 +629,7 @@ describe('getInterfaceApi', () => {
     await snapInterface.selectFromSelector('foo', 'option2');
 
     expect(controllerMessenger.call).toHaveBeenNthCalledWith(
-      6,
+      5,
       'ExecutionService:handleRpcRequest',
       MOCK_SNAP_ID,
       {

--- a/packages/snaps-simulation/src/simulation.test.ts
+++ b/packages/snaps-simulation/src/simulation.test.ts
@@ -631,14 +631,6 @@ describe('registerActions', () => {
   const { runSaga, store } = createStore(getMockOptions());
   const controllerMessenger = getRootControllerMessenger(false);
 
-  it('registers `PhishingController:maybeUpdateState`', async () => {
-    registerActions(controllerMessenger, runSaga);
-
-    expect(
-      await controllerMessenger.call('PhishingController:maybeUpdateState'),
-    ).toBeUndefined();
-  });
-
   it('registers `PhishingController:testOrigin`', async () => {
     registerActions(controllerMessenger, runSaga);
 

--- a/packages/snaps-simulation/src/simulation.test.ts
+++ b/packages/snaps-simulation/src/simulation.test.ts
@@ -491,7 +491,7 @@ describe('getPermittedHooks', () => {
     await updateInterface(id, content);
 
     expect(controllerMessenger.call).toHaveBeenNthCalledWith(
-      3,
+      2,
       'SnapInterfaceController:updateInterface',
       snapId,
       id,
@@ -532,7 +532,7 @@ describe('getPermittedHooks', () => {
     const result = getInterfaceState(id);
 
     expect(controllerMessenger.call).toHaveBeenNthCalledWith(
-      3,
+      2,
       'SnapInterfaceController:getInterface',
       snapId,
       id,
@@ -573,7 +573,7 @@ describe('getPermittedHooks', () => {
     const result = getInterfaceContext(id);
 
     expect(controllerMessenger.call).toHaveBeenNthCalledWith(
-      3,
+      2,
       'SnapInterfaceController:getInterface',
       snapId,
       id,
@@ -616,7 +616,7 @@ describe('getPermittedHooks', () => {
     await resolveInterface(id, 'foobar');
 
     expect(controllerMessenger.call).toHaveBeenNthCalledWith(
-      2,
+      1,
       'SnapInterfaceController:resolveInterface',
       snapId,
       id,

--- a/packages/snaps-simulation/src/simulation.ts
+++ b/packages/snaps-simulation/src/simulation.ts
@@ -471,11 +471,6 @@ export function registerActions(
   runSaga: RunSagaFunction,
 ) {
   controllerMessenger.registerActionHandler(
-    'PhishingController:maybeUpdateState',
-    async () => Promise.resolve(),
-  );
-
-  controllerMessenger.registerActionHandler(
     'PhishingController:testOrigin',
     () => ({ result: false, type: PhishingDetectorResultType.All }),
   );

--- a/packages/snaps-simulation/src/test-utils/controller.ts
+++ b/packages/snaps-simulation/src/test-utils/controller.ts
@@ -14,11 +14,6 @@ export const getRootControllerMessenger = (mocked = true) => {
   >();
 
   if (mocked) {
-    messenger.registerActionHandler(
-      'PhishingController:maybeUpdateState',
-      async () => Promise.resolve(),
-    );
-
     messenger.registerActionHandler('PhishingController:testOrigin', () => ({
       result: false,
       type: PhishingDetectorResultType.All,
@@ -56,7 +51,6 @@ export const getRestrictedSnapInterfaceControllerMessenger = (
     name: 'SnapInterfaceController',
     allowedActions: [
       'PhishingController:testOrigin',
-      'PhishingController:maybeUpdateState',
       'ApprovalController:hasRequest',
       'ApprovalController:acceptRequest',
     ],

--- a/packages/snaps-simulator/jest.config.js
+++ b/packages/snaps-simulator/jest.config.js
@@ -8,9 +8,9 @@ module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 54.33,
-      functions: 60.43,
-      lines: 80.49,
-      statements: 80.79,
+      functions: 60.32,
+      lines: 80.47,
+      statements: 80.77,
     },
   },
   setupFiles: ['./jest.setup.js'],

--- a/packages/snaps-simulator/src/features/simulation/sagas.ts
+++ b/packages/snaps-simulator/src/features/simulation/sagas.ts
@@ -98,11 +98,6 @@ export function registerActions(messenger: Messenger<any, any>) {
   messenger.registerActionHandler('PhishingController:testOrigin', () => ({
     result: false,
   }));
-
-  messenger.registerActionHandler(
-    'PhishingController:maybeUpdateState',
-    async () => Promise.resolve(),
-  );
 }
 
 /**
@@ -202,10 +197,7 @@ export function* initSaga({ payload }: PayloadAction<string>) {
   const snapInterfaceController = new SnapInterfaceController({
     messenger: messenger.getRestricted({
       name: 'SnapInterfaceController',
-      allowedActions: [
-        `PhishingController:testOrigin`,
-        `PhishingController:maybeUpdateState`,
-      ],
+      allowedActions: [`PhishingController:testOrigin`],
       allowedEvents: [
         'NotificationServicesController:notificationsListUpdated',
       ],

--- a/packages/snaps-simulator/src/features/simulation/test/controllers.ts
+++ b/packages/snaps-simulator/src/features/simulation/test/controllers.ts
@@ -16,10 +16,7 @@ export function getSnapInterfaceController() {
   return new SnapInterfaceController({
     messenger: messenger.getRestricted({
       name: 'SnapInterfaceController',
-      allowedActions: [
-        'PhishingController:maybeUpdateState',
-        'PhishingController:testOrigin',
-      ],
+      allowedActions: ['PhishingController:testOrigin'],
       allowedEvents: [
         'NotificationServicesController:notificationsListUpdated',
       ],


### PR DESCRIPTION
Before this PR we would sometimes (every 5 minutes or so) update the phishing list before validating interfaces. When the phishing list is out of date it takes multiple seconds for this call to resolve causing an unacceptable experience.

From now on, we will assume that the phishing list is kept up to date by other controllers (or the user visiting dapps for instance).