### PR TITLE
fix: Consider protocol Snaps when determining `isSupportedScope`

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 93.38,
+  "branches": 93.41,
   "functions": 97.38,
   "lines": 98.34,
   "statements": 98.07

--- a/packages/snaps-controllers/src/multichain/MultichainRouter.test.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRouter.test.ts
@@ -399,6 +399,15 @@ describe('MultichainRouter', () => {
         withSnapKeyring,
       });
 
+      rootMessenger.registerActionHandler('SnapController:getAll', () => {
+        return [getTruncatedSnap()];
+      });
+
+      rootMessenger.registerActionHandler(
+        'PermissionController:getPermissions',
+        () => ({}),
+      );
+
       rootMessenger.registerActionHandler(
         'AccountsController:listMultichainAccounts',
         () => MOCK_SOLANA_ACCOUNTS,
@@ -409,7 +418,7 @@ describe('MultichainRouter', () => {
       ).toBe(true);
     });
 
-    it('returns false if no account Snap is found', async () => {
+    it('returns true if a protocol Snap exists', async () => {
       const rootMessenger = getRootMultichainRouterMessenger();
       const messenger = getRestrictedMultichainRouterMessenger(rootMessenger);
       const withSnapKeyring = getMockWithSnapKeyring();
@@ -418,6 +427,40 @@ describe('MultichainRouter', () => {
       new MultichainRouter({
         messenger,
         withSnapKeyring,
+      });
+
+      rootMessenger.registerActionHandler('SnapController:getAll', () => {
+        return [getTruncatedSnap()];
+      });
+
+      rootMessenger.registerActionHandler(
+        'PermissionController:getPermissions',
+        () => MOCK_SOLANA_SNAP_PERMISSIONS,
+      );
+
+      rootMessenger.registerActionHandler(
+        'AccountsController:listMultichainAccounts',
+        () => [],
+      );
+
+      expect(
+        messenger.call('MultichainRouter:isSupportedScope', SOLANA_CAIP2),
+      ).toBe(true);
+    });
+
+    it('returns false if no Snap is found', async () => {
+      const rootMessenger = getRootMultichainRouterMessenger();
+      const messenger = getRestrictedMultichainRouterMessenger(rootMessenger);
+      const withSnapKeyring = getMockWithSnapKeyring();
+
+      /* eslint-disable-next-line no-new */
+      new MultichainRouter({
+        messenger,
+        withSnapKeyring,
+      });
+
+      rootMessenger.registerActionHandler('SnapController:getAll', () => {
+        return [];
       });
 
       rootMessenger.registerActionHandler(

--- a/packages/snaps-controllers/src/multichain/MultichainRouter.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRouter.ts
@@ -397,9 +397,11 @@ export class MultichainRouter {
    * @returns True if the router can service the scope, otherwise false.
    */
   isSupportedScope(scope: CaipChainId): boolean {
-    // We currently assume here that if one Snap exists that service the scope, we can service the scope generally.
-    return this.#messenger
+    const hasAccountSnap = this.#messenger
       .call('AccountsController:listMultichainAccounts', scope)
       .some((account: InternalAccount) => account.metadata.snap?.enabled);
+    const hasProtocolSnap = this.#getProtocolSnaps(scope).length > 0;
+    // We currently assume here that if one Snap exists that service the scope, we can service the scope generally.
+    return hasAccountSnap || hasProtocolSnap;
   }
 }

--- a/packages/snaps-controllers/src/multichain/MultichainRouter.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRouter.ts
@@ -400,8 +400,7 @@ export class MultichainRouter {
     const hasAccountSnap = this.#messenger
       .call('AccountsController:listMultichainAccounts', scope)
       .some((account: InternalAccount) => account.metadata.snap?.enabled);
-    const hasProtocolSnap = this.#getProtocolSnaps(scope).length > 0;
     // We currently assume here that if one Snap exists that service the scope, we can service the scope generally.
-    return hasAccountSnap || hasProtocolSnap;
+    return hasAccountSnap || this.#getProtocolSnaps(scope).length > 0;
   }
 }


### PR DESCRIPTION
As per request from the wallet API team and after discussion with them we want to consider protocol Snaps when determining the return value of `isSupportedScope`. Previously we assumed that a scope was not serviceable if no accounts existed, but that isn't entirely accurate enough.