### PR TITLE
fix: Validate origin in `handleRequest`

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 93.36,
+  "branches": 93.38,
   "functions": 97.38,
   "lines": 98.34,
   "statements": 98.07

--- a/packages/snaps-controllers/src/cronjob/CronjobController.test.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.test.ts
@@ -48,7 +48,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'exampleMethodOne',
@@ -79,7 +79,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'exampleMethodOne',
@@ -126,7 +126,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'exampleMethod',
@@ -177,7 +177,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'exampleMethod',
@@ -232,7 +232,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'exampleMethod',
@@ -274,7 +274,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'handleEvent',
@@ -347,7 +347,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'handleEvent',
@@ -459,7 +459,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'handleEvent',
@@ -503,7 +503,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'exampleMethodOne',
@@ -579,7 +579,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'exampleMethodOne',
@@ -592,7 +592,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'handleEvent',
@@ -644,7 +644,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'exampleMethodOne',
@@ -659,7 +659,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'handleEvent',
@@ -713,7 +713,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'exampleMethodOne',
@@ -728,7 +728,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'handleEvent',
@@ -807,7 +807,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'exampleMethodOne',
@@ -821,7 +821,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'handleEvent',
@@ -857,7 +857,7 @@ describe('CronjobController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnCronjob,
         request: {
           method: 'exampleMethodOne',
@@ -911,7 +911,7 @@ describe('CronjobController', () => {
           'SnapController:handleRequest',
           {
             snapId: MOCK_SNAP_ID,
-            origin: '',
+            origin: 'metamask',
             handler: HandlerType.OnCronjob,
             request: {
               method: 'handleExport',

--- a/packages/snaps-controllers/src/cronjob/CronjobController.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.ts
@@ -301,7 +301,7 @@ export class CronjobController extends BaseController<
     this.#updateJobLastRunState(job.id, Date.now());
     await this.messagingSystem.call('SnapController:handleRequest', {
       snapId: job.snapId,
-      origin: '',
+      origin: 'metamask',
       handler: HandlerType.OnCronjob,
       request: job.request,
     });
@@ -386,7 +386,7 @@ export class CronjobController extends BaseController<
       this.messagingSystem
         .call('SnapController:handleRequest', {
           snapId: event.snapId,
-          origin: '',
+          origin: 'metamask',
           handler: HandlerType.OnCronjob,
           request: event.request,
         })

--- a/packages/snaps-controllers/src/insights/SnapInsightsController.test.ts
+++ b/packages/snaps-controllers/src/insights/SnapInsightsController.test.ts
@@ -91,7 +91,7 @@ describe('SnapInsightsController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnTransaction,
         request: {
           method: '',
@@ -108,7 +108,7 @@ describe('SnapInsightsController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_LOCAL_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnTransaction,
         request: {
           method: '',
@@ -216,7 +216,7 @@ describe('SnapInsightsController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnSignature,
         request: {
           method: '',
@@ -237,7 +237,7 @@ describe('SnapInsightsController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_LOCAL_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnSignature,
         request: {
           method: '',
@@ -341,7 +341,7 @@ describe('SnapInsightsController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnSignature,
         request: {
           method: '',
@@ -361,7 +361,7 @@ describe('SnapInsightsController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_LOCAL_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnSignature,
         request: {
           method: '',
@@ -515,7 +515,7 @@ describe('SnapInsightsController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnTransaction,
         request: {
           method: '',
@@ -532,7 +532,7 @@ describe('SnapInsightsController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_LOCAL_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnTransaction,
         request: {
           method: '',
@@ -613,7 +613,7 @@ describe('SnapInsightsController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnSignature,
         request: {
           method: '',
@@ -633,7 +633,7 @@ describe('SnapInsightsController', () => {
       'SnapController:handleRequest',
       {
         snapId: MOCK_LOCAL_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnSignature,
         request: {
           method: '',

--- a/packages/snaps-controllers/src/insights/SnapInsightsController.ts
+++ b/packages/snaps-controllers/src/insights/SnapInsightsController.ts
@@ -361,7 +361,7 @@ export class SnapInsightsController extends BaseController<
   }) {
     return this.messagingSystem.call('SnapController:handleRequest', {
       snapId,
-      origin: '',
+      origin: 'metamask',
       handler,
       request: {
         method: '',

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -3771,7 +3771,7 @@ describe('SnapController', () => {
     await expect(
       snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnNameLookup,
         request: {
           jsonrpc: '2.0',
@@ -9220,7 +9220,7 @@ describe('SnapController', () => {
         await messenger.call('SnapController:handleRequest', {
           snapId: MOCK_SNAP_ID,
           handler: HandlerType.OnNameLookup,
-          origin: '',
+          origin: 'metamask',
           request: {},
         }),
       ).toBe(true);
@@ -10516,7 +10516,7 @@ describe('SnapController', () => {
         MOCK_SNAP_ID,
         {
           handler: HandlerType.OnInstall,
-          origin: '',
+          origin: 'metamask',
           request: {
             jsonrpc: '2.0',
             id: expect.any(String),
@@ -10659,7 +10659,7 @@ describe('SnapController', () => {
         MOCK_SNAP_ID,
         {
           handler: HandlerType.OnUpdate,
-          origin: '',
+          origin: 'metamask',
           request: {
             jsonrpc: '2.0',
             id: expect.any(String),

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -425,7 +425,7 @@ describe('SnapController', () => {
 
     await snapController.handleRequest({
       snapId: snap.id,
-      origin: 'foo.com',
+      origin: MOCK_ORIGIN,
       handler: HandlerType.OnRpcRequest,
       request: {
         jsonrpc: '2.0',
@@ -475,7 +475,7 @@ describe('SnapController', () => {
     await expect(
       snapController.handleRequest({
         snapId: snap.id,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnRpcRequest,
         request: {
           jsonrpc: '2.0',
@@ -536,7 +536,7 @@ describe('SnapController', () => {
 
     const results = await snapController.handleRequest({
       snapId: snap.id,
-      origin: 'foo.com',
+      origin: MOCK_ORIGIN,
       handler: HandlerType.OnRpcRequest,
       request: {
         jsonrpc: '2.0',
@@ -1424,7 +1424,7 @@ describe('SnapController', () => {
     await expect(
       snapController.handleRequest({
         snapId: snap.id,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnRpcRequest,
         request: {
           jsonrpc: '2.0',
@@ -1527,7 +1527,7 @@ describe('SnapController', () => {
     await expect(
       snapController.handleRequest({
         snapId: snap.id,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnRpcRequest,
         request: {
           jsonrpc: '2.0',
@@ -1612,7 +1612,7 @@ describe('SnapController', () => {
     await expect(
       snapController.handleRequest({
         snapId: snap.id,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnRpcRequest,
         request: {
           jsonrpc: '2.0',
@@ -1683,7 +1683,7 @@ describe('SnapController', () => {
     expect(
       await snapController.handleRequest({
         snapId: snap.id,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnRpcRequest,
         request: {
           jsonrpc: '2.0',
@@ -1761,7 +1761,7 @@ describe('SnapController', () => {
     expect(
       await snapController.handleRequest({
         snapId: snap.id,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnRpcRequest,
         request: {
           jsonrpc: '2.0',
@@ -1809,7 +1809,7 @@ describe('SnapController', () => {
     const results = (await Promise.allSettled([
       snapController.handleRequest({
         snapId: snap.id,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnRpcRequest,
         request: {
           jsonrpc: '2.0',
@@ -1820,7 +1820,7 @@ describe('SnapController', () => {
       }),
       snapController.handleRequest({
         snapId: snap.id,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnRpcRequest,
         request: {
           jsonrpc: '2.0',
@@ -1875,7 +1875,7 @@ describe('SnapController', () => {
 
     const promise = snapController.handleRequest({
       snapId: snap.id,
-      origin: 'foo.com',
+      origin: MOCK_ORIGIN,
       handler: HandlerType.OnRpcRequest,
       request: {
         jsonrpc: '2.0',
@@ -1928,7 +1928,7 @@ describe('SnapController', () => {
 
     const promise = snapController.handleRequest({
       snapId: snap.id,
-      origin: 'foo.com',
+      origin: MOCK_ORIGIN,
       handler: HandlerType.OnRpcRequest,
       request: {
         jsonrpc: '2.0',
@@ -1993,7 +1993,7 @@ describe('SnapController', () => {
     expect(
       await snapController.handleRequest({
         snapId: snap.id,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnRpcRequest,
         request: {
           jsonrpc: '2.0',
@@ -2099,7 +2099,7 @@ describe('SnapController', () => {
     await expect(
       snapController.handleRequest({
         snapId: snap.id,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnRpcRequest,
         request: {
           jsonrpc: '2.0',
@@ -2205,7 +2205,7 @@ describe('SnapController', () => {
         await expect(
           snapController.handleRequest({
             snapId: snap.id,
-            origin: 'foo.com',
+            origin: MOCK_ORIGIN,
             handler,
             request: { jsonrpc: '2.0', method: 'test' },
           }),
@@ -2240,7 +2240,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: snap.id,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnUserInput,
           request: { jsonrpc: '2.0', method: 'test' },
         }),
@@ -2270,7 +2270,7 @@ describe('SnapController', () => {
               {
                 type: SnapCaveatType.RpcOrigin,
                 value: {
-                  allowedOrigins: ['foo.com'],
+                  allowedOrigins: [MOCK_ORIGIN],
                 },
               },
             ],
@@ -2317,7 +2317,7 @@ describe('SnapController', () => {
               {
                 type: SnapCaveatType.KeyringOrigin,
                 value: {
-                  allowedOrigins: ['foo.com'],
+                  allowedOrigins: [MOCK_ORIGIN],
                 },
               },
             ],
@@ -2364,7 +2364,7 @@ describe('SnapController', () => {
               {
                 type: SnapCaveatType.RpcOrigin,
                 value: {
-                  allowedOrigins: ['foo.com'],
+                  allowedOrigins: [MOCK_ORIGIN],
                 },
               },
             ],
@@ -2381,7 +2381,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: snap.id,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnRpcRequest,
           request: { jsonrpc: '2.0', method: 'test' },
         }),
@@ -2411,7 +2411,7 @@ describe('SnapController', () => {
               {
                 type: SnapCaveatType.KeyringOrigin,
                 value: {
-                  allowedOrigins: ['foo.com'],
+                  allowedOrigins: [MOCK_ORIGIN],
                 },
               },
             ],
@@ -2428,7 +2428,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: snap.id,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnKeyringRequest,
           request: { jsonrpc: '2.0', method: 'test' },
         }),
@@ -2476,7 +2476,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: snap.id,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnRpcRequest,
           request: { jsonrpc: '2.0', method: 'test' },
         }),
@@ -2585,11 +2585,11 @@ describe('SnapController', () => {
         snaps: true,
       },
       {
-        allowedOrigins: ['foo.com'],
+        allowedOrigins: [MOCK_ORIGIN],
       },
       {
         snaps: true,
-        allowedOrigins: ['foo.com'],
+        allowedOrigins: [MOCK_ORIGIN],
       },
     ])(
       'throws if the origin is not in the `allowedOrigins` list (%p)',
@@ -2629,12 +2629,12 @@ describe('SnapController', () => {
         await expect(
           snapController.handleRequest({
             snapId: snap.id,
-            origin: 'bar.com',
+            origin: 'https://bar.com',
             handler: HandlerType.OnRpcRequest,
             request: { jsonrpc: '2.0', method: 'test' },
           }),
         ).rejects.toThrow(
-          `Snap "${snap.id}" is not permitted to handle requests from "bar.com".`,
+          `Snap "${snap.id}" is not permitted to handle requests from "https://bar.com".`,
         );
 
         snapController.destroy();
@@ -2742,7 +2742,7 @@ describe('SnapController', () => {
               {
                 type: SnapCaveatType.KeyringOrigin,
                 value: {
-                  allowedOrigins: ['foo.com'],
+                  allowedOrigins: [MOCK_ORIGIN],
                 },
               },
             ],
@@ -2759,12 +2759,12 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: snap.id,
-          origin: 'bar.com',
+          origin: 'https://bar.com',
           handler: HandlerType.OnKeyringRequest,
           request: { jsonrpc: '2.0', method: 'test' },
         }),
       ).rejects.toThrow(
-        'Snap "npm:@metamask/example-snap" is not permitted to handle requests from "bar.com".',
+        'Snap "npm:@metamask/example-snap" is not permitted to handle requests from "https://bar.com".',
       );
 
       snapController.destroy();
@@ -2818,7 +2818,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnTransaction,
           request: {
             jsonrpc: '2.0',
@@ -2874,7 +2874,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnTransaction,
           request: {
             jsonrpc: '2.0',
@@ -2929,7 +2929,7 @@ describe('SnapController', () => {
 
       const result = await snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnTransaction,
         request: {
           jsonrpc: '2.0',
@@ -2984,7 +2984,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnTransaction,
           request: {
             jsonrpc: '2.0',
@@ -3042,7 +3042,7 @@ describe('SnapController', () => {
 
       const result = await snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnTransaction,
         request: {
           jsonrpc: '2.0',
@@ -3105,7 +3105,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnSignature,
           request: {
             jsonrpc: '2.0',
@@ -3161,7 +3161,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnSignature,
           request: {
             jsonrpc: '2.0',
@@ -3217,7 +3217,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnSignature,
           request: {
             jsonrpc: '2.0',
@@ -3270,7 +3270,7 @@ describe('SnapController', () => {
 
       const result = await snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnSignature,
         request: {
           jsonrpc: '2.0',
@@ -3324,7 +3324,7 @@ describe('SnapController', () => {
     expect(
       await snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnTransaction,
         request: {
           jsonrpc: '2.0',
@@ -3376,7 +3376,7 @@ describe('SnapController', () => {
     expect(
       await snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnSignature,
         request: {
           jsonrpc: '2.0',
@@ -3438,7 +3438,7 @@ describe('SnapController', () => {
     await expect(
       snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnHomePage,
         request: {
           jsonrpc: '2.0',
@@ -3492,7 +3492,7 @@ describe('SnapController', () => {
     await expect(
       snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnHomePage,
         request: {
           jsonrpc: '2.0',
@@ -3545,7 +3545,7 @@ describe('SnapController', () => {
 
     const result = await snapController.handleRequest({
       snapId: MOCK_SNAP_ID,
-      origin: 'foo.com',
+      origin: MOCK_ORIGIN,
       handler: HandlerType.OnHomePage,
       request: {
         jsonrpc: '2.0',
@@ -3608,7 +3608,7 @@ describe('SnapController', () => {
     await expect(
       snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnSettingsPage,
         request: {
           jsonrpc: '2.0',
@@ -3662,7 +3662,7 @@ describe('SnapController', () => {
     await expect(
       snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnSettingsPage,
         request: {
           jsonrpc: '2.0',
@@ -3715,7 +3715,7 @@ describe('SnapController', () => {
 
     const result = await snapController.handleRequest({
       snapId: MOCK_SNAP_ID,
-      origin: 'foo.com',
+      origin: MOCK_ORIGIN,
       handler: HandlerType.OnSettingsPage,
       request: {
         jsonrpc: '2.0',
@@ -3834,7 +3834,7 @@ describe('SnapController', () => {
 
     const result = await snapController.handleRequest({
       snapId: MOCK_SNAP_ID,
-      origin: 'foo.com',
+      origin: MOCK_ORIGIN,
       handler: HandlerType.OnNameLookup,
       request: {
         jsonrpc: '2.0',
@@ -3887,7 +3887,7 @@ describe('SnapController', () => {
     expect(
       await snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnNameLookup,
         request: {
           jsonrpc: '2.0',
@@ -3948,7 +3948,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnAssetsLookup,
           request: {
             jsonrpc: '2.0',
@@ -4024,7 +4024,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnAssetsLookup,
           request: {
             jsonrpc: '2.0',
@@ -4100,7 +4100,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnAssetsLookup,
           request: {
             jsonrpc: '2.0',
@@ -4180,7 +4180,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnAssetsConversion,
           request: {
             jsonrpc: '2.0',
@@ -4249,7 +4249,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnAssetsConversion,
           request: {
             jsonrpc: '2.0',
@@ -4323,7 +4323,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnAssetsConversion,
           request: {
             jsonrpc: '2.0',
@@ -4374,7 +4374,7 @@ describe('SnapController', () => {
 
       await snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         handler: HandlerType.OnRpcRequest,
         request: {
           jsonrpc: '2.0',
@@ -4389,7 +4389,7 @@ describe('SnapController', () => {
         'ExecutionService:handleRpcRequest',
         MOCK_SNAP_ID,
         {
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnRpcRequest,
           request: {
             id: 1,
@@ -4419,7 +4419,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnRpcRequest,
           request: {
             jsonrpc: 'kaplar',
@@ -4452,7 +4452,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnRpcRequest,
           request: {
             method: 'bar',
@@ -4499,7 +4499,7 @@ describe('SnapController', () => {
       const finishPromise = Promise.all([
         snapController.handleRequest({
           snapId,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnRpcRequest,
           request: {
             jsonrpc: '2.0',
@@ -4510,7 +4510,7 @@ describe('SnapController', () => {
         }),
         snapController.handleRequest({
           snapId,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnRpcRequest,
           request: {
             jsonrpc: '2.0',
@@ -4521,7 +4521,7 @@ describe('SnapController', () => {
         }),
         snapController.handleRequest({
           snapId,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnRpcRequest,
           request: {
             jsonrpc: '2.0',
@@ -4532,7 +4532,7 @@ describe('SnapController', () => {
         }),
         snapController.handleRequest({
           snapId,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnRpcRequest,
           request: {
             jsonrpc: '2.0',
@@ -4543,7 +4543,7 @@ describe('SnapController', () => {
         }),
         snapController.handleRequest({
           snapId,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnRpcRequest,
           request: {
             jsonrpc: '2.0',
@@ -4557,7 +4557,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId,
-          origin: 'foo.com',
+          origin: MOCK_ORIGIN,
           handler: HandlerType.OnRpcRequest,
           request: {
             jsonrpc: '2.0',
@@ -8688,7 +8688,7 @@ describe('SnapController', () => {
 
       const mockSnapA = getMockSnapData({
         id: 'npm:exampleA' as SnapId,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
       });
 
       const mockSnapB = getMockSnapData({
@@ -8758,7 +8758,7 @@ describe('SnapController', () => {
 
       const mockSnap = getMockSnapData({
         id: 'npm:example' as SnapId,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
       });
 
       const snapController = getSnapController(
@@ -8794,7 +8794,7 @@ describe('SnapController', () => {
 
       const mockSnapA = getMockSnapData({
         id: 'npm:exampleA' as SnapId,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         blocked: true,
         enabled: false,
       });
@@ -8856,7 +8856,7 @@ describe('SnapController', () => {
 
       const mockSnap = getMockSnapData({
         id: 'npm:example' as SnapId,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
       });
 
       const snapController = getSnapController(
@@ -8900,7 +8900,7 @@ describe('SnapController', () => {
 
       const mockSnap = getMockSnapData({
         id: 'npm:example' as SnapId,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
       });
 
       const snapController = getSnapController(
@@ -9931,7 +9931,7 @@ describe('SnapController', () => {
       const messenger = getSnapControllerMessenger();
       const mockSnap = getMockSnapData({
         id: 'npm:example' as SnapId,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         enabled: false,
       });
 
@@ -9956,7 +9956,7 @@ describe('SnapController', () => {
       const messenger = getSnapControllerMessenger();
       const mockSnap = getMockSnapData({
         id: 'npm:example' as SnapId,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         enabled: true,
       });
 
@@ -9981,7 +9981,7 @@ describe('SnapController', () => {
       const messenger = getSnapControllerMessenger();
       const mockSnap = getMockSnapData({
         id: 'npm:example' as SnapId,
-        origin: 'foo.com',
+        origin: MOCK_ORIGIN,
         enabled: true,
       });
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -3392,6 +3392,11 @@ export class SnapController extends BaseController<
   }: SnapRpcHookArgs & { snapId: SnapId }): Promise<unknown> {
     this.#assertCanUsePlatform();
 
+    assert(
+      typeof origin === 'string' && origin.length > 0,
+      "'origin' must be a non-empty string.",
+    );
+
     const request = {
       jsonrpc: '2.0',
       id: nanoid(),

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -103,6 +103,7 @@ import {
   getLocalizedSnapManifest,
   MAX_FILE_SIZE,
   OnSettingsPageResponseStruct,
+  isValidUrl,
 } from '@metamask/snaps-utils';
 import type {
   Json,
@@ -3393,8 +3394,8 @@ export class SnapController extends BaseController<
     this.#assertCanUsePlatform();
 
     assert(
-      typeof origin === 'string' && origin.length > 0,
-      "'origin' must be a non-empty string.",
+      origin === 'metamask' || isValidUrl(origin),
+      "'origin' must be a valid URL or 'metamask'.",
     );
 
     const request = {

--- a/packages/snaps-simulation/src/interface.test.tsx
+++ b/packages/snaps-simulation/src/interface.test.tsx
@@ -565,7 +565,7 @@ describe('clickElement', () => {
     );
 
     expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
-      origin: '',
+      origin: 'metamask',
       handler: HandlerType.OnUserInput,
       request: {
         jsonrpc: '2.0',
@@ -602,7 +602,7 @@ describe('clickElement', () => {
     );
 
     expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
-      origin: '',
+      origin: 'metamask',
       handler: HandlerType.OnUserInput,
       request: {
         jsonrpc: '2.0',
@@ -619,7 +619,7 @@ describe('clickElement', () => {
     });
 
     expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
-      origin: '',
+      origin: 'metamask',
       handler: HandlerType.OnUserInput,
       request: {
         jsonrpc: '2.0',
@@ -667,7 +667,7 @@ describe('clickElement', () => {
     );
 
     expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
-      origin: '',
+      origin: 'metamask',
       handler: HandlerType.OnUserInput,
       request: {
         jsonrpc: '2.0',
@@ -684,7 +684,7 @@ describe('clickElement', () => {
     });
 
     expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
-      origin: '',
+      origin: 'metamask',
       handler: HandlerType.OnUserInput,
       request: {
         jsonrpc: '2.0',
@@ -736,7 +736,7 @@ describe('clickElement', () => {
     );
 
     expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
-      origin: '',
+      origin: 'metamask',
       handler: HandlerType.OnUserInput,
       request: {
         jsonrpc: '2.0',
@@ -754,7 +754,7 @@ describe('clickElement', () => {
     });
 
     expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
-      origin: '',
+      origin: 'metamask',
       handler: HandlerType.OnUserInput,
       request: {
         jsonrpc: '2.0',
@@ -906,7 +906,7 @@ describe('typeInField', () => {
     );
 
     expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
-      origin: '',
+      origin: 'metamask',
       handler: HandlerType.OnUserInput,
       request: {
         jsonrpc: '2.0',
@@ -1017,7 +1017,7 @@ describe('selectInDropdown', () => {
     );
 
     expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
-      origin: '',
+      origin: 'metamask',
       handler: HandlerType.OnUserInput,
       request: {
         jsonrpc: '2.0',
@@ -1150,7 +1150,7 @@ describe('uploadFile', () => {
     );
 
     expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
-      origin: '',
+      origin: 'metamask',
       handler: HandlerType.OnUserInput,
       request: {
         jsonrpc: '2.0',
@@ -1215,7 +1215,7 @@ describe('uploadFile', () => {
     );
 
     expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
-      origin: '',
+      origin: 'metamask',
       handler: HandlerType.OnUserInput,
       request: {
         jsonrpc: '2.0',
@@ -1370,7 +1370,7 @@ describe('getInterface', () => {
       'ExecutionService:handleRpcRequest',
       MOCK_SNAP_ID,
       {
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnUserInput,
         request: {
           jsonrpc: '2.0',
@@ -1412,7 +1412,7 @@ describe('getInterface', () => {
       'ExecutionService:handleRpcRequest',
       MOCK_SNAP_ID,
       {
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnUserInput,
         request: {
           jsonrpc: '2.0',
@@ -1460,7 +1460,7 @@ describe('getInterface', () => {
       'ExecutionService:handleRpcRequest',
       MOCK_SNAP_ID,
       {
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnUserInput,
         request: {
           jsonrpc: '2.0',
@@ -1507,7 +1507,7 @@ describe('getInterface', () => {
       'ExecutionService:handleRpcRequest',
       MOCK_SNAP_ID,
       {
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnUserInput,
         request: {
           jsonrpc: '2.0',
@@ -1615,7 +1615,7 @@ describe('selectFromRadioGroup', () => {
     );
 
     expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
-      origin: '',
+      origin: 'metamask',
       handler: HandlerType.OnUserInput,
       request: {
         jsonrpc: '2.0',
@@ -1761,7 +1761,7 @@ describe('selectFromSelector', () => {
     );
 
     expect(handleRpcRequestMock).toHaveBeenCalledWith(MOCK_SNAP_ID, {
-      origin: '',
+      origin: 'metamask',
       handler: HandlerType.OnUserInput,
       request: {
         jsonrpc: '2.0',

--- a/packages/snaps-simulation/src/interface.ts
+++ b/packages/snaps-simulation/src/interface.ts
@@ -348,7 +348,7 @@ async function handleEvent(
       'ExecutionService:handleRpcRequest',
       snapId,
       {
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnUserInput,
         request: {
           jsonrpc: '2.0',
@@ -539,7 +539,7 @@ export async function typeInField(
   );
 
   await controllerMessenger.call('ExecutionService:handleRpcRequest', snapId, {
-    origin: '',
+    origin: 'metamask',
     handler: HandlerType.OnUserInput,
     request: {
       jsonrpc: '2.0',
@@ -613,7 +613,7 @@ export async function selectInDropdown(
   );
 
   await controllerMessenger.call('ExecutionService:handleRpcRequest', snapId, {
-    origin: '',
+    origin: 'metamask',
     handler: HandlerType.OnUserInput,
     request: {
       jsonrpc: '2.0',
@@ -687,7 +687,7 @@ export async function selectFromRadioGroup(
   );
 
   await controllerMessenger.call('ExecutionService:handleRpcRequest', snapId, {
-    origin: '',
+    origin: 'metamask',
     handler: HandlerType.OnUserInput,
     request: {
       jsonrpc: '2.0',
@@ -761,7 +761,7 @@ export async function selectFromSelector(
   );
 
   await controllerMessenger.call('ExecutionService:handleRpcRequest', snapId, {
-    origin: '',
+    origin: 'metamask',
     handler: HandlerType.OnUserInput,
     request: {
       jsonrpc: '2.0',
@@ -901,7 +901,7 @@ export async function uploadFile(
   );
 
   await controllerMessenger.call('ExecutionService:handleRpcRequest', snapId, {
-    origin: '',
+    origin: 'metamask',
     handler: HandlerType.OnUserInput,
     request: {
       jsonrpc: '2.0',

--- a/packages/snaps-simulation/src/request.test.tsx
+++ b/packages/snaps-simulation/src/request.test.tsx
@@ -423,7 +423,7 @@ describe('getInterfaceApi', () => {
       'ExecutionService:handleRpcRequest',
       MOCK_SNAP_ID,
       {
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnUserInput,
         request: {
           jsonrpc: '2.0',
@@ -470,7 +470,7 @@ describe('getInterfaceApi', () => {
       'ExecutionService:handleRpcRequest',
       MOCK_SNAP_ID,
       {
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnUserInput,
         request: {
           jsonrpc: '2.0',
@@ -523,7 +523,7 @@ describe('getInterfaceApi', () => {
       'ExecutionService:handleRpcRequest',
       MOCK_SNAP_ID,
       {
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnUserInput,
         request: {
           jsonrpc: '2.0',
@@ -576,7 +576,7 @@ describe('getInterfaceApi', () => {
       'ExecutionService:handleRpcRequest',
       MOCK_SNAP_ID,
       {
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnUserInput,
         request: {
           jsonrpc: '2.0',
@@ -633,7 +633,7 @@ describe('getInterfaceApi', () => {
       'ExecutionService:handleRpcRequest',
       MOCK_SNAP_ID,
       {
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnUserInput,
         request: {
           jsonrpc: '2.0',

--- a/packages/snaps-simulator/src/contexts/SnapInterface.tsx
+++ b/packages/snaps-simulator/src/contexts/SnapInterface.tsx
@@ -103,7 +103,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
   ) => {
     dispatch(
       sendRequest({
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnUserInput,
         request: {
           jsonrpc: '2.0',

--- a/packages/snaps-simulator/src/features/handlers/cronjobs/slice.ts
+++ b/packages/snaps-simulator/src/features/handlers/cronjobs/slice.ts
@@ -13,7 +13,7 @@ type Response = JsonRpcResponse<Json>;
 
 export const INITIAL_STATE = {
   request: {
-    origin: '',
+    origin: 'metamask',
   },
   response: null,
   history: [],

--- a/packages/snaps-simulator/src/features/handlers/json-rpc/slice.ts
+++ b/packages/snaps-simulator/src/features/handlers/json-rpc/slice.ts
@@ -13,7 +13,7 @@ type Response = JsonRpcResponse<Json>;
 
 export const INITIAL_STATE = {
   request: {
-    origin: '',
+    origin: 'metamask',
   },
   response: null,
   history: [],

--- a/packages/snaps-simulator/src/features/handlers/transactions/components/Request.tsx
+++ b/packages/snaps-simulator/src/features/handlers/transactions/components/Request.tsx
@@ -64,7 +64,7 @@ export const Request: FunctionComponent = () => {
     const { chainId, transactionOrigin, ...transaction } = data;
     dispatch(
       sendRequest({
-        origin: '',
+        origin: 'metamask',
         handler: HandlerType.OnTransaction,
         request: {
           jsonrpc: '2.0',


### PR DESCRIPTION
We were using empty origins in a lot of places instead of specifying `metamask` for internal requests. This PR disallows doing that so we can be clear about where requests are coming from. `origin` must now be either a valid URL or `metamask`.