### PR TITLE
feat: Add disabled state to interactive UI example

### DIFF
--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "MKhxamQ1r71iszu+D6MB9gusRuJz2oU3/35yx4UTdN8=",
+    "shasum": "zFzFqq872D4tY3eDs3iSF5XYT9EMqBEzKPmejUhc2yU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "zFzFqq872D4tY3eDs3iSF5XYT9EMqBEzKPmejUhc2yU=",
+    "shasum": "ZfrR4llZ3X3UXNIvRClCXQoQ7qSZKdgO3PgVq6L1Gxk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ldOmsuDgyS+Dz5o+bZtxtgb4Ss5XVJQ0fYpJtbHFtz8=",
+    "shasum": "MKhxamQ1r71iszu+D6MB9gusRuJz2oU3/35yx4UTdN8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/src/components/InteractiveForm.tsx
+++ b/packages/examples/packages/interactive-ui/src/components/InteractiveForm.tsx
@@ -14,6 +14,8 @@ import {
   Dropdown,
   Option,
   Checkbox,
+  Container,
+  Footer,
 } from '@metamask/snaps-sdk/jsx';
 
 /**
@@ -46,54 +48,72 @@ export type InteractiveFormState = {
   'example-selector': string;
 };
 
-export const InteractiveForm: SnapComponent = () => {
+export const InteractiveForm: SnapComponent<{ disabled?: boolean }> = ({
+  disabled,
+}) => {
   return (
-    <Box>
-      <Heading>Interactive UI Example Snap</Heading>
-      <Form name="example-form">
-        <Field label="Example Input">
-          <Input name="example-input" placeholder="Enter something..." />
-        </Field>
-        <Field label="Example Dropdown">
-          <Dropdown name="example-dropdown">
-            <Option value="option1">Option 1</Option>
-            <Option value="option2">Option 2</Option>
-            <Option value="option3">Option 3</Option>
-          </Dropdown>
-        </Field>
-        <Field label="Example RadioGroup">
-          <RadioGroup name="example-radiogroup">
-            <Radio value="option1">Option 1</Radio>
-            <Radio value="option2">Option 2</Radio>
-            <Radio value="option3">Option 3</Radio>
-          </RadioGroup>
-        </Field>
-        <Field label="Example Checkbox">
-          <Checkbox name="example-checkbox" label="Checkbox" />
-        </Field>
-        <Field label="Example Selector">
-          <Selector
-            name="example-selector"
-            title="Choose an option"
-            value="option1"
-          >
-            <SelectorOption value="option1">
-              <Card title="Option 1" value="option1" />
-            </SelectorOption>
-            <SelectorOption value="option2">
-              <Card title="Option 2" value="option2" />
-            </SelectorOption>
-            <SelectorOption value="option3">
-              <Card title="Option 3" value="option3" />
-            </SelectorOption>
-          </Selector>
-        </Field>
-        <Box center>
-          <Button type="submit" name="submit">
-            Submit
-          </Button>
-        </Box>
-      </Form>
-    </Box>
+    <Container>
+      <Box>
+        <Heading>Interactive UI Example Snap</Heading>
+        <Form name="example-form">
+          <Field label="Example Input">
+            <Input
+              name="example-input"
+              placeholder="Enter something..."
+              disabled={disabled}
+            />
+          </Field>
+          <Field label="Example Dropdown">
+            <Dropdown name="example-dropdown" disabled={disabled}>
+              <Option value="option1">Option 1</Option>
+              <Option value="option2">Option 2</Option>
+              <Option value="option3">Option 3</Option>
+            </Dropdown>
+          </Field>
+          <Field label="Example RadioGroup">
+            <RadioGroup name="example-radiogroup" disabled={disabled}>
+              <Radio value="option1">Option 1</Radio>
+              <Radio value="option2">Option 2</Radio>
+              <Radio value="option3">Option 3</Radio>
+            </RadioGroup>
+          </Field>
+          <Field label="Example Checkbox">
+            <Checkbox
+              name="example-checkbox"
+              label="Checkbox"
+              disabled={disabled}
+            />
+          </Field>
+          <Field label="Example Selector">
+            <Selector
+              name="example-selector"
+              title="Choose an option"
+              value="option1"
+              disabled={disabled}
+            >
+              <SelectorOption value="option1">
+                <Card title="Option 1" value="option1" />
+              </SelectorOption>
+              <SelectorOption value="option2">
+                <Card title="Option 2" value="option2" />
+              </SelectorOption>
+              <SelectorOption value="option3">
+                <Card title="Option 3" value="option3" />
+              </SelectorOption>
+            </Selector>
+          </Field>
+        </Form>
+      </Box>
+      <Footer>
+        <Button
+          type="submit"
+          name="submit"
+          form="example-form"
+          disabled={disabled}
+        >
+          Submit
+        </Button>
+      </Footer>
+    </Container>
   );
 };

--- a/packages/examples/packages/interactive-ui/src/components/Result.tsx
+++ b/packages/examples/packages/interactive-ui/src/components/Result.tsx
@@ -1,5 +1,13 @@
 import type { SnapComponent } from '@metamask/snaps-sdk/jsx';
-import { Heading, Button, Box, Text, Copyable } from '@metamask/snaps-sdk/jsx';
+import {
+  Heading,
+  Button,
+  Box,
+  Text,
+  Copyable,
+  Container,
+  Footer,
+} from '@metamask/snaps-sdk/jsx';
 
 import type { InteractiveFormState } from './InteractiveForm';
 
@@ -9,17 +17,20 @@ type ResultProps = {
 
 export const Result: SnapComponent<ResultProps> = ({ values }) => {
   return (
-    <Box>
-      <Heading>Interactive UI Example Snap</Heading>
-      <Text>You submitted the following values:</Text>
+    <Container>
       <Box>
-        {Object.values(values).map((value) => (
-          <Copyable value={value?.toString() ?? ''} />
-        ))}
+        <Heading>Interactive UI Example Snap</Heading>
+        <Text>You submitted the following values:</Text>
+        <Box>
+          {Object.values(values).map((value) => (
+            <Copyable value={value?.toString() ?? ''} />
+          ))}
+        </Box>
       </Box>
-      <Box center>
+      <Footer>
         <Button name="back">Back</Button>
-      </Box>
-    </Box>
+        <Button name="ok">OK</Button>
+      </Footer>
+    </Container>
   );
 };

--- a/packages/examples/packages/interactive-ui/src/index.test.tsx
+++ b/packages/examples/packages/interactive-ui/src/index.test.tsx
@@ -1,5 +1,5 @@
 import { expect } from '@jest/globals';
-import { assertIsConfirmationDialog, installSnap } from '@metamask/snaps-jest';
+import { assertIsCustomDialog, installSnap } from '@metamask/snaps-jest';
 
 import {
   Insight,
@@ -52,7 +52,7 @@ describe('onRpcRequest', () => {
       await formScreen.clickElement('submit');
 
       const resultScreen = await response.getInterface();
-      assertIsConfirmationDialog(resultScreen);
+      assertIsCustomDialog(resultScreen);
 
       expect(resultScreen).toRender(
         <Result
@@ -65,9 +65,9 @@ describe('onRpcRequest', () => {
           }}
         />,
       );
-      await resultScreen.ok();
+      await resultScreen.clickElement('ok');
 
-      expect(await response).toRespondWith(true);
+      expect(await response).toRespondWith(null);
     });
 
     it('lets users input nothing', async () => {
@@ -84,7 +84,7 @@ describe('onRpcRequest', () => {
       await formScreen.clickElement('submit');
 
       const resultScreen = await response.getInterface();
-      assertIsConfirmationDialog(resultScreen);
+      assertIsCustomDialog(resultScreen);
 
       expect(resultScreen).toRender(
         <Result
@@ -97,9 +97,9 @@ describe('onRpcRequest', () => {
           }}
         />,
       );
-      await resultScreen.ok();
+      await resultScreen.clickElement('ok');
 
-      expect(await response).toRespondWith(true);
+      expect(await response).toRespondWith(null);
     });
   });
 });

--- a/packages/examples/packages/interactive-ui/src/index.tsx
+++ b/packages/examples/packages/interactive-ui/src/index.tsx
@@ -32,11 +32,19 @@ import { decodeData } from './utils';
 export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   switch (request.method) {
     case 'dialog': {
+      const params = request.params as { disabled: boolean };
+      const { disabled } = params;
+      const interfaceId = await snap.request({
+        method: 'snap_createInterface',
+        params: {
+          ui: <InteractiveForm disabled={disabled} />,
+          context: { disabled },
+        },
+      });
       return await snap.request({
         method: 'snap_dialog',
         params: {
-          type: 'confirmation',
-          content: <InteractiveForm />,
+          id: interfaceId,
         },
       });
     }
@@ -139,7 +147,17 @@ export const onUserInput: OnUserInputHandler = async ({
           method: 'snap_updateInterface',
           params: {
             id,
-            ui: <InteractiveForm />,
+            ui: <InteractiveForm disabled={context?.disabled as boolean} />,
+          },
+        });
+        break;
+
+      case 'ok':
+        await snap.request({
+          method: 'snap_resolveInterface',
+          params: {
+            id,
+            value: null,
           },
         });
         break;

--- a/packages/examples/packages/interactive-ui/src/index.tsx
+++ b/packages/examples/packages/interactive-ui/src/index.tsx
@@ -33,7 +33,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   switch (request.method) {
     case 'dialog': {
       const params = request.params as { disabled: boolean };
-      const { disabled } = params;
+      const disabled = params?.disabled;
       const interfaceId = await snap.request({
         method: 'snap_createInterface',
         params: {

--- a/packages/test-snaps/src/features/snaps/interactive-ui/InteractiveUI.tsx
+++ b/packages/test-snaps/src/features/snaps/interactive-ui/InteractiveUI.tsx
@@ -14,10 +14,13 @@ import { getSnapId } from '../../../utils';
 export const InteractiveUI: FunctionComponent = () => {
   const [invokeSnap, { isLoading, data, error }] = useInvokeMutation();
 
-  const handleClick = (method: string) => () => {
+  const handleClick = (method: string, disabled: boolean) => () => {
     invokeSnap({
       snapId: getSnapId(INTERACTIVE_UI_SNAP_ID, INTERACTIVE_UI_SNAP_PORT),
       method,
+      params: {
+        disabled,
+      },
     }).catch(logError);
   };
   return (
@@ -33,16 +36,17 @@ export const InteractiveUI: FunctionComponent = () => {
           variant="primary"
           id="createDialogButton"
           disabled={isLoading}
-          onClick={handleClick('dialog')}
+          onClick={handleClick('dialog', false)}
         >
           Create Dialog
         </Button>
         <Button
           variant="primary"
-          id="getInterfaceStateButton"
-          onClick={handleClick('getState')}
+          id="createDisabledDialogButton"
+          disabled={isLoading}
+          onClick={handleClick('dialog', true)}
         >
-          Get interface state
+          Create Disabled Dialog
         </Button>
       </ButtonGroup>
       <Result>


### PR DESCRIPTION
Makes a couple of improvements to the interactive UI example Snap:
- Use custom dialog type with footers instead of regular buttons
- Add a `disabled` parameter which disables all of the components for testing and visual inspection
- Remove broken "Get interface state" button

![image](https://github.com/user-attachments/assets/91fb1988-55e0-47fc-ab3a-1d1ee3d8270a)
