### PR TITLE
fix: Inject `context` into `onUserInput` calls

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 93.44,
+  "branches": 93.48,
   "functions": 97.38,
   "lines": 98.34,
   "statements": 98.08

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -3789,7 +3789,7 @@ export class SnapController extends BaseController<
         assert(request.params && hasProperty(request.params, 'id'));
 
         const interfaceId = request.params.id as string;
-        const interfaceState = this.messagingSystem.call(
+        const { context } = this.messagingSystem.call(
           'SnapInterfaceController:getInterface',
           snapId,
           interfaceId,
@@ -3797,7 +3797,7 @@ export class SnapController extends BaseController<
 
         return {
           ...request,
-          params: { ...request.params, context: interfaceState.context },
+          params: { ...request.params, context },
         };
       }
 

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -22,7 +22,8 @@ import {
   SnapEndowments,
   WALLET_SNAP_PERMISSION_KEY,
 } from '@metamask/snaps-rpc-methods';
-import type { SnapId, text } from '@metamask/snaps-sdk';
+import type { SnapId } from '@metamask/snaps-sdk';
+import { text } from '@metamask/snaps-sdk';
 import { SnapCaveatType } from '@metamask/snaps-utils';
 import {
   MockControllerMessenger,
@@ -440,7 +441,12 @@ export const getControllerMessenger = (registry = new MockSnapsRegistry()) => {
       if (id !== MOCK_INTERFACE_ID) {
         throw new Error(`Interface with id '${id}' not found.`);
       }
-      return { snapId, content: text('foo bar'), state: {} } as StoredInterface;
+      return {
+        snapId,
+        content: text('foo bar'),
+        state: {},
+        context: null,
+      } as StoredInterface;
     },
   );
 


### PR DESCRIPTION
Inject `context` into `onUserInput` requests, this reduces complexity on the client-side where the UI system no longer has to keep `context` up to date. Also fixes a problem where we weren't keeping the context properly up to date.

Fixes https://github.com/MetaMask/snaps/issues/3069