### PR TITLE
fix: Update `name` and `symbol` to be optional in a fungible asset type

### DIFF
--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ipeiQKWLZEg5Snm73jZkQ7VeusFnAMPd4ws5zWo7/NI=",
+    "shasum": "2uIeFUIcHICTP107dLNcmwrygQ30DCecekANd1w8H5w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/browserify/snap.manifest.json
+++ b/packages/examples/packages/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "uPtVkZpOxZzVcTSWX40MuXbED38DLAf9hNiNAR88+10=",
+    "shasum": "IAqCgqZhLCgTRIjIzVwfBIMVDVoCjZNcefMp/Vlmsz8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 93.48,
+  "branches": 93.54,
   "functions": 97.38,
   "lines": 98.34,
   "statements": 98.08

--- a/packages/snaps-controllers/src/interface/utils.test.tsx
+++ b/packages/snaps-controllers/src/interface/utils.test.tsx
@@ -1064,6 +1064,78 @@ describe('getAssetSelectorStateValue', () => {
       ),
     ).toBeNull();
   });
+
+  it('sets the asset name to the symbol if the asset name is undefined in state', () => {
+    getAssetsState.mockReturnValue({
+      assetsMetadata: {
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501': {
+          symbol: 'SOL',
+        },
+      },
+      accountsAssets: {
+        [MOCK_ACCOUNT_ID]: [],
+      },
+    });
+
+    expect(
+      getAssetSelectorStateValue(
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+        getAssetsState,
+      ),
+    ).toStrictEqual({
+      asset: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+      name: 'SOL',
+      symbol: 'SOL',
+    });
+  });
+
+  it('sets the asset symbol to "Unknown" if the asset symbol is undefined in state', () => {
+    getAssetsState.mockReturnValue({
+      assetsMetadata: {
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501': {
+          name: 'Solana',
+        },
+      },
+      accountsAssets: {
+        [MOCK_ACCOUNT_ID]: [],
+      },
+    });
+
+    expect(
+      getAssetSelectorStateValue(
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+        getAssetsState,
+      ),
+    ).toStrictEqual({
+      asset: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+      name: 'Solana',
+      symbol: 'Unknown',
+    });
+  });
+
+  it('sets the asset symbol and name to "Unknown" if both are undefined in state', () => {
+    getAssetsState.mockReturnValue({
+      assetsMetadata: {
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501': {
+          fungible: true,
+        },
+      },
+      accountsAssets: {
+        [MOCK_ACCOUNT_ID]: [],
+      },
+    });
+
+    expect(
+      getAssetSelectorStateValue(
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+        getAssetsState,
+      ),
+    ).toStrictEqual({
+      asset: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+      name: 'Unknown',
+      symbol: 'Unknown',
+    });
+  });
 });
 
 describe('getDefaultAsset', () => {

--- a/packages/snaps-controllers/src/interface/utils.ts
+++ b/packages/snaps-controllers/src/interface/utils.ts
@@ -280,8 +280,8 @@ export function getAssetSelectorStateValue(
 
   return {
     asset: value,
-    name: asset.name,
-    symbol: asset.symbol,
+    name: asset.name ?? asset.symbol ?? 'Unknown',
+    symbol: asset.symbol ?? 'Unknown',
   };
 }
 

--- a/packages/snaps-sdk/src/types/handlers/assets-lookup.test.ts
+++ b/packages/snaps-sdk/src/types/handlers/assets-lookup.test.ts
@@ -33,6 +33,31 @@ describe('FungibleAssetMetadataStruct', () => {
         },
       ],
     },
+    {
+      fungible: true,
+      iconUrl: 'https://metamask.io/sol.svg',
+      units: [
+        {
+          decimals: 9,
+        },
+      ],
+    },
+    {
+      name: 'Solana',
+      symbol: 'SOL',
+      fungible: true,
+      iconUrl: 'https://metamask.io/sol.svg',
+      units: [
+        {
+          name: 'Solana',
+          symbol: 'SOL',
+          decimals: 9,
+        },
+        {
+          decimals: 10,
+        },
+      ],
+    },
   ])('validates an object', (value) => {
     expect(is(value, FungibleAssetMetadataStruct)).toBe(true);
   });

--- a/packages/snaps-sdk/src/types/handlers/assets-lookup.ts
+++ b/packages/snaps-sdk/src/types/handlers/assets-lookup.ts
@@ -9,6 +9,7 @@ import {
   string,
   record,
   nullable,
+  optional,
 } from '@metamask/superstruct';
 import {
   assert,
@@ -17,8 +18,8 @@ import {
 } from '@metamask/utils';
 
 export const FungibleAssetUnitStruct = object({
-  name: string(),
-  symbol: string(),
+  name: optional(string()),
+  symbol: optional(string()),
   decimals: number(),
 });
 
@@ -39,8 +40,8 @@ export const AssetIconUrlStruct = refine(string(), 'Asset URL', (value) => {
 });
 
 export const FungibleAssetMetadataStruct = object({
-  name: string(),
-  symbol: string(),
+  name: optional(string()),
+  symbol: optional(string()),
   fungible: literal(true),
   iconUrl: AssetIconUrlStruct,
   units: size(array(FungibleAssetUnitStruct), 1, Infinity),


### PR DESCRIPTION
This makes the `name` and `symbol` of an asset optional per the SIP-29 update.