### PR TITLE
fix: Make comparision case sensitive in MultichainRouter

### DIFF
--- a/packages/snaps-controllers/src/multichain/MultichainRouter.test.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRouter.test.ts
@@ -269,7 +269,7 @@ describe('MultichainRouter', () => {
       ).rejects.toThrow('No available account found for request.');
     });
 
-    it('throws if address resolution returns a lower case address that isnt available', async () => {
+    it(`throws if address resolution returns a lower case address that isn't available`, async () => {
       const rootMessenger = getRootMultichainRouterMessenger();
       const messenger = getRestrictedMultichainRouterMessenger(rootMessenger);
       const withSnapKeyring = getMockWithSnapKeyring({

--- a/packages/snaps-controllers/src/multichain/MultichainRouter.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRouter.ts
@@ -268,6 +268,9 @@ export class MultichainRouter {
    * Handle an incoming JSON-RPC request tied to a specific scope by routing
    * to either a procotol Snap or an account Snap.
    *
+   * Note: Addresses are considered case sensitive by the MultichainRouter as
+   * not all non-EVM chains are case insensitive.
+   *
    * @param options - An options bag.
    * @param options.connectedAddresses - Addresses currently connected to the origin.
    * @param options.origin - The origin of the RPC request.

--- a/packages/snaps-controllers/src/multichain/MultichainRouter.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRouter.ts
@@ -218,7 +218,7 @@ export class MultichainRouter {
     const selectedAccount = accounts.find(
       (account) =>
         parsedConnectedAddresses.includes(account.address) &&
-        (!address || account.address.toLowerCase() === address.toLowerCase()),
+        (!address || account.address === address),
     );
 
     if (!selectedAccount) {


### PR DESCRIPTION
As non-EVM accounts may be case sensitive, we cannot use `toLowerCase` for address comparision. This PR makes the `MultichainRouter` use case sensitive comparison instead.