### PR TITLE
fix: Add missing `displayAvatar` props 

### DIFF
--- a/packages/examples/packages/send-flow/snap.manifest.json
+++ b/packages/examples/packages/send-flow/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "u6ivnu9fXa7saZ10sruh8I3ZKZjeAur4W+9+LVp9BoU=",
+    "shasum": "A6EWaBqDoKUJIzRolke7nkQXKK/Ob5/q9NhaFs5qRk0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/send-flow/src/index.tsx
+++ b/packages/examples/packages/send-flow/src/index.tsx
@@ -113,7 +113,9 @@ export const onUserInput: OnUserInputHandler = async ({
                 errors={formErrors}
                 // For testing purposes, we display the avatar if the address is
                 // a valid hex checksum address.
-                displayAvatar={isCaipHexAddress(event.value)}
+                displayAvatar={isCaipHexAddress(
+                  event.name === 'to' ? event.value : sendForm.to,
+                )}
               />
             ),
           },
@@ -134,6 +136,7 @@ export const onUserInput: OnUserInputHandler = async ({
                 total={total}
                 fees={fees}
                 errors={formErrors}
+                displayAvatar={isCaipHexAddress(sendForm.to)}
               />
             ),
           },


### PR DESCRIPTION
The send-flow example snap is only passing the `displayAvatar` prop in the `to` scenario but not in the others. This can land you in a situation where you paste a valid address in the to field, start to type an amount in the amount field, then the avatar disappears because no `displayAvatar` prop is being passed.