### PR TITLE
ci: Use conventional commits-style pull request titles

### DIFF
--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -1,0 +1,21 @@
+name: Validate pull request title
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  validate-pull-request-title:
+    name: Validate pull request title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate title
+        # `amannn/action-semantic-pull-request@v5.4.0`
+        uses: amannn/action-semantic-pull-request@e9fabac35e210fea40ca5b14c0da95a099eff26f
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -1,4 +1,4 @@
-name: Validate pull request title
+name: Validate pull request
 on:
   pull_request:
     branches:
@@ -11,7 +11,7 @@ on:
 
 jobs:
   validate-pull-request-title:
-    name: Validate pull request title
+    name: Validate title
     runs-on: ubuntu-latest
     steps:
       - name: Validate title


### PR DESCRIPTION
This PR adds a new workflow to CI which will enforce titles to use a conventional commits-style format.