### PR TITLE
fix: Pass `includeMarketData` to handler arguments

### DIFF
--- a/packages/snaps-execution-environments/CHANGELOG.md
+++ b/packages/snaps-execution-environments/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Pass forgotten `includeMarkeData` param in `onAssetsConversion` handler to the Snap ([#3323](https://github.com/MetaMask/snaps/pull/3323))
+- Add missing `includeMarketData` param to `onAssetsConversion` handler ([#3323](https://github.com/MetaMask/snaps/pull/3323))
 
 ## [7.2.0]
 

--- a/packages/snaps-execution-environments/CHANGELOG.md
+++ b/packages/snaps-execution-environments/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pass forgotten `includeMarkeData` param in `onAssetsConversion` handler to the Snap ([#3323](https://github.com/MetaMask/snaps/pull/3323))
+
 ## [7.2.0]
 
 ### Added

--- a/packages/snaps-execution-environments/src/common/commands.test.ts
+++ b/packages/snaps-execution-environments/src/common/commands.test.ts
@@ -41,6 +41,28 @@ describe('getHandlerArguments', () => {
     ).toThrow('Invalid request params');
   });
 
+  it('validates the request params for the OnAssetsConversion handler', () => {
+    expect(() =>
+      getHandlerArguments(MOCK_ORIGIN, HandlerType.OnAssetsConversion, {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'foo',
+        params: {},
+      }),
+    ).toThrow('Invalid request params');
+  });
+
+  it('validates the request params for the OnAssetsLookup handler', () => {
+    expect(() =>
+      getHandlerArguments(MOCK_ORIGIN, HandlerType.OnAssetsLookup, {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'foo',
+        params: {},
+      }),
+    ).toThrow('Invalid request params');
+  });
+
   it('validates the request params for the OnAssetHistoricalPrice handler', () => {
     expect(() =>
       getHandlerArguments(MOCK_ORIGIN, HandlerType.OnAssetHistoricalPrice, {

--- a/packages/snaps-execution-environments/src/common/commands.ts
+++ b/packages/snaps-execution-environments/src/common/commands.ts
@@ -74,8 +74,8 @@ export function getHandlerArguments(
     }
     case HandlerType.OnAssetsConversion: {
       assertIsOnAssetsConversionRequestArguments(request.params);
-      const { conversions } = request.params;
-      return { conversions };
+      const { conversions, includeMarketData } = request.params;
+      return { conversions, includeMarketData };
     }
     case HandlerType.OnNameLookup: {
       assertIsOnNameLookupRequestArguments(request.params);


### PR DESCRIPTION
This passes the missing param `includeMarketData` to the handler in the execution environment.