### PR TITLE
ci: Allow `release: [version]` as release PR title

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,9 +61,9 @@ jobs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
     steps:
       - id: is-release
-        uses: MetaMask/action-is-release@v1
+        uses: MetaMask/action-is-release@v2
         with:
-          commit-starts-with: 'Release [version]'
+          commit-starts-with: 'Release [version],Release `[version]`,release: [version],release: `[version]`'
 
   publish-release:
     name: Publish release


### PR DESCRIPTION
This updates `MetaMask/action-is-release` to `v2` which supports multiple commit titles for releases. I've added support for the following, in addition to the current "Release [version]":

- Release `[version]`
- release: [version]
- release: `[version]`