### PR TITLE
fix: Increase boot request queue limit

### DIFF
--- a/packages/snaps-controllers/CHANGELOG.md
+++ b/packages/snaps-controllers/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Increase size of request queue when Snap is booting ([#3340](https://github.com/MetaMask/snaps/pull/3340))
+
 ## [11.2.1]
 
 ### Fixed

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -4814,63 +4814,21 @@ describe('SnapController', () => {
       );
 
       // Fill up the request queue
-      const finishPromise = Promise.all([
-        snapController.handleRequest({
-          snapId,
-          origin: MOCK_ORIGIN,
-          handler: HandlerType.OnRpcRequest,
-          request: {
-            jsonrpc: '2.0',
-            method: 'bar',
-            params: {},
-            id: 1,
-          },
-        }),
-        snapController.handleRequest({
-          snapId,
-          origin: MOCK_ORIGIN,
-          handler: HandlerType.OnRpcRequest,
-          request: {
-            jsonrpc: '2.0',
-            method: 'bar',
-            params: {},
-            id: 2,
-          },
-        }),
-        snapController.handleRequest({
-          snapId,
-          origin: MOCK_ORIGIN,
-          handler: HandlerType.OnRpcRequest,
-          request: {
-            jsonrpc: '2.0',
-            method: 'bar',
-            params: {},
-            id: 3,
-          },
-        }),
-        snapController.handleRequest({
-          snapId,
-          origin: MOCK_ORIGIN,
-          handler: HandlerType.OnRpcRequest,
-          request: {
-            jsonrpc: '2.0',
-            method: 'bar',
-            params: {},
-            id: 4,
-          },
-        }),
-        snapController.handleRequest({
-          snapId,
-          origin: MOCK_ORIGIN,
-          handler: HandlerType.OnRpcRequest,
-          request: {
-            jsonrpc: '2.0',
-            method: 'bar',
-            params: {},
-            id: 5,
-          },
-        }),
-      ]);
+      const finishPromise = Promise.all(
+        new Array(100).fill(1).map(async (_, id) =>
+          snapController.handleRequest({
+            snapId,
+            origin: MOCK_ORIGIN,
+            handler: HandlerType.OnRpcRequest,
+            request: {
+              jsonrpc: '2.0',
+              method: 'bar',
+              params: {},
+              id,
+            },
+          }),
+        ),
+      );
 
       await expect(
         snapController.handleRequest({
@@ -4881,7 +4839,7 @@ describe('SnapController', () => {
             jsonrpc: '2.0',
             method: 'bar',
             params: {},
-            id: 6,
+            id: 100,
           },
         }),
       ).rejects.toThrow(

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -3504,7 +3504,7 @@ export class SnapController extends BaseController<
       return existingHandler;
     }
 
-    const requestQueue = new RequestQueue(5);
+    const requestQueue = new RequestQueue(100);
     // We need to set up this promise map to map snapIds to their respective startPromises,
     // because otherwise we would lose context on the correct startPromise.
     const startPromises = new Map<string, Promise<void>>();


### PR DESCRIPTION
Increase the limit of the `RequestQueue` to `100` pending requests. This request queue is only used when the Snap has not yet booted, to detect issues where the Snap is failing to boot. The current limit of `5` seems too low to hit accidentally, therefore `100` was chosen which seems less likely to hit with a real use-case.