### PR TITLE
perf: Use `typedUnion` for `UserInputEventStruct`

### DIFF
--- a/packages/examples/packages/browserify-plugin/snap.manifest.json
+++ b/packages/examples/packages/browserify-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "zL83HjFa5hofKZgG1lsYhsolTSixKtwUdS2g8iK18uM=",
+    "shasum": "Xj6puDgrspKYR+BHRcf0vp03qLwS0laPAZ1KztBgglk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "qg8mFkhE2i4XDz2QmCI9LrWIrn80F/KsfvIiFSHP1vc=",
+    "shasum": "umssy2xlXevJQlh/v+RU+L5QwF4FJr+WQizX9RsgOGE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "pEE8JPwz3Urr7sa5EP3C8q6iEhEOYalo7HIv8So0HWo=",
+    "shasum": "VsNHRvsmcNSIE8NKs3pKP5DZ6JetuWxyafdnkqGYrNE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/home-page/snap.manifest.json
+++ b/packages/examples/packages/home-page/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "V+8kTcBPZp3cXzElRtior5z0e4OZXisW7oY3TbZ3BIo=",
+    "shasum": "QzOwwFy2NhbNCCJ8J69ddNXkk5VoZE70NH9nviUDlro=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "I+kz7pvB5o7oyC/2z5LnURYG7TrTHR9+oWueIcsuDyA=",
+    "shasum": "7qJ3NR2asUtSBhMG15SkPHGTeGu5eFpa+1bvCZYNjB8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/jsx/snap.manifest.json
+++ b/packages/examples/packages/jsx/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "isPAE28NBykLDCeydFGWiovrc9aYyrudj9du9zjgWiM=",
+    "shasum": "3QTvYDWz9SP5SuCXOJj9xMNcwGn914x9dgXafSWCduo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/preinstalled/snap.manifest.json
+++ b/packages/examples/packages/preinstalled/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "z5QBU52beVeE8yA3heabwzKZlBGdUq9HQ4f3/ia3byY=",
+    "shasum": "cgEBLKtGe25kAK63vHw55Stfgeiu82NEvyWoUkH9maA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/send-flow/snap.manifest.json
+++ b/packages/examples/packages/send-flow/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vxFi0vcu6DIa9NSSxqtQvq0e3dy0ZhvhgY3EfPQSkOw=",
+    "shasum": "8wvBp+qWyp9M9O5OJkFGl2cc8XRGxvV35oJJre+XIig=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-sdk/src/types/handlers/user-input.ts
+++ b/packages/snaps-sdk/src/types/handlers/user-input.ts
@@ -2,7 +2,6 @@ import type { Infer } from '@metamask/superstruct';
 import {
   number,
   assign,
-  literal,
   nullable,
   object,
   optional,
@@ -13,6 +12,7 @@ import {
 } from '@metamask/superstruct';
 import { CaipAssetTypeStruct } from '@metamask/utils';
 
+import { typedUnion, literal } from '../../internals';
 import type { InterfaceContext } from '../interface';
 
 /**
@@ -156,7 +156,7 @@ export const FileUploadEventStruct = assign(
  */
 export type FileUploadEvent = Infer<typeof FileUploadEventStruct>;
 
-export const UserInputEventStruct = union([
+export const UserInputEventStruct = typedUnion([
   ButtonClickEventStruct,
   FormSubmitEventStruct,
   InputChangeEventStruct,


### PR DESCRIPTION
Use `typedUnion` for `UserInputEventStruct`. This comes with some performance benefits and also makes the error message more readable.