### PR TITLE
ci: Disable "validate pull request" workflow for release pull requests

### DIFF
--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -13,6 +13,7 @@ jobs:
   validate-pull-request-title:
     name: Validate title
     runs-on: ubuntu-latest
+    if: !startsWith(github.head_ref , 'release/')
     steps:
       - name: Validate title
         # `amannn/action-semantic-pull-request@v5.4.0`


### PR DESCRIPTION
The "validate pull request" workflow checks if the pull request title matches the conventional commits syntax. Unfortunately "release: version" doesn't seem to be considered as valid, so instead, we should disable the check for release pull requests.