### PR TITLE
perf: Speed up JSON size calculation

### DIFF
--- a/packages/snaps-utils/src/json.ts
+++ b/packages/snaps-utils/src/json.ts
@@ -31,5 +31,6 @@ export function parseJson<Type extends Json = Json>(json: string) {
  */
 export function getJsonSizeUnsafe(value: Json): number {
   const json = JSON.stringify(value);
+  // We intentionally don't use `TextEncoder` because of bad performance on React Native.
   return json.length;
 }

--- a/packages/snaps-utils/src/json.ts
+++ b/packages/snaps-utils/src/json.ts
@@ -23,10 +23,13 @@ export function parseJson<Type extends Json = Json>(json: string) {
  *
  * This may sometimes be preferred over `getJsonSize` for performance reasons.
  *
+ * Note: This function does not encode the string to bytes, thus the input may
+ * be about 4x larger in practice. Use this function with caution.
+ *
  * @param value - The JSON value to get the size of.
  * @returns The size of the JSON value in bytes.
  */
 export function getJsonSizeUnsafe(value: Json): number {
   const json = JSON.stringify(value);
-  return new TextEncoder().encode(json).byteLength;
+  return json.length;
 }


### PR DESCRIPTION
Alters `getJsonSizeUnsafe` to not use `TextEncoder` as this has proven slow on mobile. We don't need full byte length accuracy for the uses of `getJsonSizeUnsafe` anyway, so this is an OK tradeoff for performance.