### PR TITLE
perf: Simplify executor return

### DIFF
--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 90.74,
+  "branches": 90.78,
   "functions": 94.96,
   "lines": 90.86,
   "statements": 90.28

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -184,14 +184,14 @@ export class BaseSnapExecutor {
           return null;
         }
 
-        let result = await this.executeInSnapContext(target, async () =>
+        const result = await this.executeInSnapContext(target, async () =>
           // TODO: fix handler args type cast
           handler(args as any),
         );
 
         // The handler might not return anything, but undefined is not valid JSON.
-        if (result === undefined) {
-          result = null;
+        if (result === undefined || result === null) {
+          return null;
         }
 
         // /!\ Always return only sanitized JSON to prevent security flaws. /!\


### PR DESCRIPTION
Not guaranteed to give any massive speed up, but we know `null` is safe to return as-is.