### PR TITLE
perf: Reduce unnecessary validation on responses

### DIFF
--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 90.74,
   "functions": 94.96,
-  "lines": 90.85,
-  "statements": 90.27
+  "lines": 90.84,
+  "statements": 90.26
 }

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -346,7 +346,7 @@ export class BaseSnapExecutor {
     });
   }
 
-  async #respond(id: JsonRpcId, response: Record<string, unknown>) {
+  async #respond(id: JsonRpcId, response: Record<string, Json>) {
     if (!isValidResponse(response)) {
       // Instead of throwing, we directly respond with an error.
       // This prevents an issue where we wouldn't respond when errors were non-serializable

--- a/packages/snaps-execution-environments/src/common/utils.test.ts
+++ b/packages/snaps-execution-environments/src/common/utils.test.ts
@@ -63,10 +63,6 @@ describe('isValidResponse', () => {
     expect(isValidResponse('foo')).toBe(false);
   });
 
-  it('returns false if the value is not JSON serializable', () => {
-    expect(isValidResponse({ foo: BigInt(0) })).toBe(false);
-  });
-
   it('returns false if the value is too large', () => {
     expect(isValidResponse({ foo: '1'.repeat(100_000_000) })).toBe(false);
   });

--- a/packages/snaps-execution-environments/src/common/utils.ts
+++ b/packages/snaps-execution-environments/src/common/utils.ts
@@ -1,6 +1,8 @@
 import type { RequestArguments } from '@metamask/providers';
 import { rpcErrors } from '@metamask/rpc-errors';
-import { assert, getJsonSize, getSafeJson, isObject } from '@metamask/utils';
+import { getJsonSizeByteAccurateUnsafe } from '@metamask/snaps-utils';
+import type { Json } from '@metamask/utils';
+import { assert, getSafeJson, isObject } from '@metamask/utils';
 
 import { log } from '../logging';
 
@@ -128,14 +130,13 @@ export function sanitizeRequestArguments(value: unknown): RequestArguments {
  * @param response - The response.
  * @returns True if the response is valid, otherwise false.
  */
-export function isValidResponse(response: Record<string, unknown>) {
+export function isValidResponse(response: Record<string, Json>) {
   if (!isObject(response)) {
     return false;
   }
 
   try {
-    // If the JSON is invalid this will throw and we should return false.
-    const size = getJsonSize(response);
+    const size = getJsonSizeByteAccurateUnsafe(response);
     return size < MAX_RESPONSE_JSON_SIZE;
   } catch {
     return false;

--- a/packages/snaps-execution-environments/src/common/utils.ts
+++ b/packages/snaps-execution-environments/src/common/utils.ts
@@ -1,6 +1,6 @@
 import type { RequestArguments } from '@metamask/providers';
 import { rpcErrors } from '@metamask/rpc-errors';
-import { getJsonSizeByteAccurateUnsafe } from '@metamask/snaps-utils';
+import { getJsonSizeUnsafe } from '@metamask/snaps-utils';
 import type { Json } from '@metamask/utils';
 import { assert, getSafeJson, isObject } from '@metamask/utils';
 
@@ -135,10 +135,8 @@ export function isValidResponse(response: Record<string, Json>) {
     return false;
   }
 
-  try {
-    const size = getJsonSizeByteAccurateUnsafe(response);
-    return size < MAX_RESPONSE_JSON_SIZE;
-  } catch {
-    return false;
-  }
+  // We know that the response is valid JSON already and we don't
+  // need the size to be exact.
+  const size = getJsonSizeUnsafe(response);
+  return size < MAX_RESPONSE_JSON_SIZE;
 }

--- a/packages/snaps-utils/src/index.executionenv.ts
+++ b/packages/snaps-utils/src/index.executionenv.ts
@@ -3,5 +3,6 @@ export * from './errors';
 export * from './handlers/exports';
 export * from './handlers/types';
 export * from './iframe';
+export * from './json';
 export * from './logging';
 export * from './types';

--- a/packages/snaps-utils/src/json.ts
+++ b/packages/snaps-utils/src/json.ts
@@ -34,3 +34,16 @@ export function getJsonSizeUnsafe(value: Json): number {
   // We intentionally don't use `TextEncoder` because of bad performance on React Native.
   return json.length;
 }
+
+/**
+ * Get the size of a JSON blob without validating that is valid JSON.
+ *
+ * This may sometimes be preferred over `getJsonSize` for performance reasons.
+ *
+ * @param value - The JSON value to get the size of.
+ * @returns The size of the JSON value in bytes.
+ */
+export function getJsonSizeByteAccurateUnsafe(value: Json): number {
+  const json = JSON.stringify(value);
+  return new TextEncoder().encode(json).byteLength;
+}

--- a/packages/snaps-utils/src/json.ts
+++ b/packages/snaps-utils/src/json.ts
@@ -34,16 +34,3 @@ export function getJsonSizeUnsafe(value: Json): number {
   // We intentionally don't use `TextEncoder` because of bad performance on React Native.
   return json.length;
 }
-
-/**
- * Get the size of a JSON blob without validating that is valid JSON.
- *
- * This may sometimes be preferred over `getJsonSize` for performance reasons.
- *
- * @param value - The JSON value to get the size of.
- * @returns The size of the JSON value in bytes.
- */
-export function getJsonSizeByteAccurateUnsafe(value: Json): number {
-  const json = JSON.stringify(value);
-  return new TextEncoder().encode(json).byteLength;
-}


### PR DESCRIPTION
Previously we were validating that responses were JSON, but we already do that elsewhere and are guaranteed for the responses to be valid by the time we get to `isValidResponse`. Additionally, we don't need an entirely byte accurate length for the response, if the Snap goes beyond the limit they simply won't receive a response from the Snap.