### PR TITLE
perf: Use cheaper guard to determine if message is a notification

### DIFF
--- a/packages/snaps-controllers/src/services/AbstractExecutionService.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.ts
@@ -13,9 +13,9 @@ import type {
 import {
   Duration,
   assertIsJsonRpcRequest,
+  hasProperty,
   inMilliseconds,
   isJsonRpcFailure,
-  isJsonRpcNotification,
   isObject,
 } from '@metamask/utils';
 import { nanoid } from 'nanoid';
@@ -278,7 +278,7 @@ export abstract class AbstractExecutionService<WorkerType>
         | JsonRpcRequest
         | JsonRpcNotification<Json[] | Record<string, Json>>,
     ) => {
-      if (!isJsonRpcNotification(message)) {
+      if (hasProperty(message, 'id')) {
         return;
       }
 


### PR DESCRIPTION
When handling notifications on the command stream we already know that the values are valid JSON, therefore we can use `hasProperty` as a type guard instead of validating the notification entirely.