### PR TITLE
chore: Make interface actions synchronous

### DIFF
--- a/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
+++ b/packages/snaps-controllers/src/interface/SnapInterfaceController.ts
@@ -253,14 +253,14 @@ export class SnapInterfaceController extends BaseController<
    * @param contentType - The type of content.
    * @returns The newly interface id.
    */
-  async createInterface(
+  createInterface(
     snapId: SnapId,
     content: ComponentOrElement,
     context?: InterfaceContext,
     contentType?: ContentType,
   ) {
     const element = getJsxInterface(content);
-    await this.#validateContent(element);
+    this.#validateContent(element);
     validateInterfaceContext(context);
 
     const id = nanoid();
@@ -270,8 +270,6 @@ export class SnapInterfaceController extends BaseController<
     });
 
     this.update((draftState) => {
-      // @ts-expect-error - TS2589: Type instantiation is excessively deep and
-      // possibly infinite.
       draftState.interfaces[id] = {
         snapId,
         content: castDraft(element),
@@ -305,7 +303,7 @@ export class SnapInterfaceController extends BaseController<
    * @param content - The new content.
    * @param context - An optional interface context object.
    */
-  async updateInterface(
+  updateInterface(
     snapId: SnapId,
     id: string,
     content: ComponentOrElement,
@@ -313,7 +311,7 @@ export class SnapInterfaceController extends BaseController<
   ) {
     this.#validateArgs(snapId, id);
     const element = getJsxInterface(content);
-    await this.#validateContent(element);
+    this.#validateContent(element);
     validateInterfaceContext(context);
 
     const oldState = this.state.interfaces[id].state;
@@ -480,7 +478,7 @@ export class SnapInterfaceController extends BaseController<
    *
    * @param element - The JSX element to verify.
    */
-  async #validateContent(element: JSXElement) {
+  #validateContent(element: JSXElement) {
     // We assume the validity of this JSON to be validated by the caller.
     // E.g., in the RPC method implementation.
     const size = getJsonSizeUnsafe(element);

--- a/packages/snaps-rpc-methods/src/permitted/createInterface.ts
+++ b/packages/snaps-rpc-methods/src/permitted/createInterface.ts
@@ -32,7 +32,7 @@ export type CreateInterfaceMethodHooks = {
     ui: ComponentOrElement,
     context?: InterfaceContext,
     contentType?: ContentType,
-  ) => Promise<string>;
+  ) => string;
 };
 
 export const createInterfaceHandler: PermittedHandlerExport<
@@ -67,13 +67,13 @@ export type CreateInterfaceParameters = InferMatching<
  * @param hooks.createInterface - The function to create the interface.
  * @returns Nothing.
  */
-async function getCreateInterfaceImplementation(
+function getCreateInterfaceImplementation(
   req: JsonRpcRequest<CreateInterfaceParameters>,
   res: PendingJsonRpcResponse<CreateInterfaceResult>,
   _next: unknown,
   end: JsonRpcEngineEndCallback,
   { createInterface }: CreateInterfaceMethodHooks,
-): Promise<void> {
+): void {
   const { params } = req;
 
   try {
@@ -81,7 +81,7 @@ async function getCreateInterfaceImplementation(
 
     const { ui, context } = validatedParams;
 
-    res.result = await createInterface(ui, context);
+    res.result = createInterface(ui, context);
   } catch (error) {
     return end(error);
   }

--- a/packages/snaps-rpc-methods/src/permitted/updateInterface.ts
+++ b/packages/snaps-rpc-methods/src/permitted/updateInterface.ts
@@ -38,7 +38,7 @@ export type UpdateInterfaceMethodHooks = {
     id: string,
     ui: ComponentOrElement,
     context?: InterfaceContext,
-  ) => Promise<void>;
+  ) => void;
 };
 
 export const updateInterfaceHandler: PermittedHandlerExport<
@@ -74,13 +74,13 @@ export type UpdateInterfaceParameters = InferMatching<
  * @param hooks.updateInterface - The function to update the interface.
  * @returns Nothing.
  */
-async function getUpdateInterfaceImplementation(
+function getUpdateInterfaceImplementation(
   req: JsonRpcRequest<UpdateInterfaceParameters>,
   res: PendingJsonRpcResponse<UpdateInterfaceResult>,
   _next: unknown,
   end: JsonRpcEngineEndCallback,
   { updateInterface }: UpdateInterfaceMethodHooks,
-): Promise<void> {
+): void {
   const { params } = req;
 
   try {
@@ -88,7 +88,7 @@ async function getUpdateInterfaceImplementation(
 
     const { id, ui, context } = validatedParams;
 
-    await updateInterface(id, ui, context);
+    updateInterface(id, ui, context);
     res.result = null;
   } catch (error) {
     return end(error);


### PR DESCRIPTION
Interface actions used to be required to be asynchronous, this is no longer the case.