### PR TITLE
ci: allow concurrency on main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'refs/heads/main')}}
+  cancel-in-progress: ${{ !contains(github.ref, 'refs/heads/main') }}
 
 jobs:
   check-workflows:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !contains(github.ref, 'refs/heads/main')}}
 
 jobs:
   check-workflows:


### PR DESCRIPTION
Related to https://github.com/MetaMask/snaps/pull/3351, this allows concurrency on main branches to allow semantic releases.