### PR TITLE
Preload encrypted state of preinstalled Snaps

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -462,6 +462,11 @@ export type GetSnapFile = {
   handler: SnapController['getSnapFile'];
 };
 
+export type PreloadSnap = {
+  type: `${typeof controllerName}:preloadSnap`;
+  handler: SnapController['preloadSnap'];
+};
+
 export type SnapControllerGetStateAction = ControllerGetStateAction<
   typeof controllerName,
   SnapControllerState
@@ -489,7 +494,8 @@ export type SnapControllerActions =
   | RevokeDynamicPermissions
   | GetSnapFile
   | SnapControllerGetStateAction
-  | StopAllSnaps;
+  | StopAllSnaps
+  | PreloadSnap;
 
 // Controller Messenger Events
 
@@ -602,6 +608,11 @@ export type SnapControllerStateChangeEvent = ControllerStateChangeEvent<
   SnapControllerState
 >;
 
+type KeyringControllerUnlock = {
+  type: 'KeyringController:unlock';
+  payload: [];
+};
+
 type KeyringControllerLock = {
   type: 'KeyringController:lock';
   payload: [];
@@ -652,6 +663,7 @@ export type AllowedEvents =
   | ExecutionServiceEvents
   | SnapInstalled
   | SnapUpdated
+  | KeyringControllerUnlock
   | KeyringControllerLock;
 
 type SnapControllerMessenger = RestrictedMessenger<
@@ -1011,6 +1023,11 @@ export class SnapController extends BaseController<
     );
 
     this.messagingSystem.subscribe(
+      'KeyringController:unlock',
+      this.#handleUnlock.bind(this),
+    );
+
+    this.messagingSystem.subscribe(
       'KeyringController:lock',
       this.#handleLock.bind(this),
     );
@@ -1203,6 +1220,11 @@ export class SnapController extends BaseController<
     this.messagingSystem.registerActionHandler(
       `${controllerName}:stopAllSnaps`,
       async (...args) => this.stopAllSnaps(...args),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      `${controllerName}:preloadSnap`,
+      async (...args) => this.preloadSnap(...args),
     );
   }
 
@@ -1567,6 +1589,24 @@ export class SnapController extends BaseController<
     this.update((state: any) => {
       state.snaps[snapId].status = interpreter.state.value;
     });
+  }
+
+  /**
+   * Preload the state of the given Snap. This is a no-op if the Snap is already
+   * loaded.
+   *
+   * @param snapId - The id of the Snap to preload.
+   */
+  async preloadSnap(snapId: SnapId): Promise<void> {
+    this.#assertCanUsePlatform();
+    const runtime = this.#getRuntimeExpect(snapId);
+
+    if (runtime.state !== undefined) {
+      return;
+    }
+
+    // Calling `getSnapState` caches the state in the Snap runtime data.
+    await this.getSnapState(snapId, true);
   }
 
   /**
@@ -4243,6 +4283,40 @@ export class SnapController extends BaseController<
         method: handler,
       },
     });
+  }
+
+  /**
+   * Handle the `KeyringController:unlock` event.
+   *
+   * Currently this preloads all preinstalled Snaps.
+   */
+  #handleUnlock() {
+    if (this.#preinstalledSnaps) {
+      const promises = this.#preinstalledSnaps.map(async ({ snapId }) =>
+        this.preloadSnap(snapId)
+          .then(() => ({ snapId, status: 'fulfilled' }))
+          .catch((error) => ({ snapId, status: 'rejected', reason: error })),
+      );
+
+      Promise.all(promises)
+        .then((results) => {
+          const failedSnaps = results.filter(
+            (result) => result.status === 'rejected',
+          );
+
+          if (failedSnaps.length > 0) {
+            logWarning(
+              `Failed to preload ${failedSnaps.length} preinstalled Snap(s):`,
+              failedSnaps,
+            );
+          }
+        })
+        .catch((error) => {
+          // This should never happen since we catch all errors in the promises
+          // above, but just in case, we log it.
+          logError('An unknown error occurred while preloading Snaps.', error);
+        });
+    }
   }
 
   /**


### PR DESCRIPTION
This adds a new `preloadSnap` function to the SnapController, which is automatically called for preinstalled Snaps when the client is unlocked (i.e., when `KeyringController:unlock` is emitted). It decrypts and caches the state for the Snaps, so state doesn't need to be decrypted when first interacting with the Snap.

This change requires `KeyringController:unlock` to be added to the list of allowed events for the `SnapController`.