### PR TITLE
fix: Properly catch cronjob errors during initialization

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 93.51,
-  "functions": 97.61,
-  "lines": 98.38,
-  "statements": 98.21
+  "functions": 98.14,
+  "lines": 98.48,
+  "statements": 98.31
 }

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 93.51,
-  "functions": 97.36,
-  "lines": 98.33,
-  "statements": 98.17
+  "functions": 97.61,
+  "lines": 98.38,
+  "statements": 98.21
 }


### PR DESCRIPTION
This PR fixes two issues:

Firstly, we were not catching errors thrown during the "daily checkin" of the `CronjobController`, this means that if one Snap failed we would not complete the initialization of the controller and no cronjobs would run.

Secondly, we were running all the cronjobs sequentially during "daily check" which seems unintentional given that we don't need the result of the cronjob invocation.