### PR TITLE
chore: Add `@lavamoat/*` to Dependabot allowlist

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       time: '06:00'
     allow:
       - dependency-name: '@metamask/*'
+      - dependency-name: '@lavamoat/*'
     target-branch: 'main'
     versioning-strategy: 'increase'
     open-pull-requests-limit: 10


### PR DESCRIPTION
This adds `@lavamoat/*` to the Dependabot allowlist, so LavaMoat packages are automatically bumped by Dependabot.