### PR TITLE
perf: Change request notification order

### DIFF
--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 90,
   "functions": 94.57,
-  "lines": 90.13,
-  "statements": 89.5
+  "lines": 90.15,
+  "statements": 89.52
 }

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -531,12 +531,15 @@ export class BaseSnapExecutor {
       assertSnapOutboundRequest(sanitizedArgs);
       return await withTeardown(
         (async () => {
-          await this.#notify({
-            method: 'OutboundRequest',
-            params: { source: 'snap.request' },
-          });
           try {
-            return await originalRequest(sanitizedArgs);
+            const promise = originalRequest(sanitizedArgs);
+
+            await this.#notify({
+              method: 'OutboundRequest',
+              params: { source: 'snap.request' },
+            });
+
+            return await promise;
           } finally {
             await this.#notify({
               method: 'OutboundResponse',
@@ -573,12 +576,15 @@ export class BaseSnapExecutor {
       assertEthereumOutboundRequest(sanitizedArgs);
       return await withTeardown(
         (async () => {
-          await this.#notify({
-            method: 'OutboundRequest',
-            params: { source: 'ethereum.request' },
-          });
           try {
-            return await originalRequest(sanitizedArgs);
+            const promise = originalRequest(sanitizedArgs);
+
+            await this.#notify({
+              method: 'OutboundRequest',
+              params: { source: 'ethereum.request' },
+            });
+
+            return await promise;
           } finally {
             await this.#notify({
               method: 'OutboundResponse',

--- a/packages/snaps-execution-environments/src/common/endowments/network.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/network.ts
@@ -226,13 +226,14 @@ const createNetwork = ({ notify }: EndowmentFactoryOptions = {}) => {
     return await withTeardown(
       (async () => {
         try {
-          await notify({
-            method: 'OutboundRequest',
-            params: { source: 'fetch' },
-          });
           const fetchPromise = fetch(input, {
             ...init,
             signal: abortController.signal,
+          });
+
+          await notify({
+            method: 'OutboundRequest',
+            params: { source: 'fetch' },
           });
 
           openFetchConnection = {


### PR DESCRIPTION
Moved some of the ideas from https://github.com/MetaMask/snaps/pull/3356 to this PR which will be a simple to merge right away. The other referenced PR needs some more work, but is eventually what we should do.

This PR let's Snaps start their outbound request before waiting for the notification to land, this should be a small perf improvement to all requests made from the Snap.