### PR TITLE
fix: Clear unencrypted Snap state properly

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -9222,6 +9222,12 @@ describe('SnapController', () => {
           messenger,
           state: {
             snaps: getPersistedSnapsState(),
+            snapStates: {
+              [MOCK_SNAP_ID]: JSON.stringify({ foo: 'bar' }),
+            },
+            unencryptedSnapStates: {
+              [MOCK_SNAP_ID]: JSON.stringify({ foo: 'bar' }),
+            },
           },
         }),
       );
@@ -9242,6 +9248,12 @@ describe('SnapController', () => {
         'PermissionController:revokeAllPermissions',
         MOCK_SNAP_ID,
       );
+
+      expect(snapController.state).toStrictEqual({
+        snaps: {},
+        snapStates: {},
+        unencryptedSnapStates: {},
+      });
 
       snapController.destroy();
     });

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2172,12 +2172,14 @@ export class SnapController extends BaseController<
     await this.messagingSystem.call('ExecutionService:terminateAllSnaps');
     snapIds.forEach((snapId) => this.#revokeAllSnapPermissions(snapId));
 
-    this.update((state: any) => {
+    this.update((state) => {
       state.snaps = {};
       state.snapStates = {};
+      state.unencryptedSnapStates = {};
     });
 
     this.#snapsRuntimeData.clear();
+    this.#rollbackSnapshots.clear();
 
     // We want to remove all snaps & permissions, except for preinstalled snaps
     if (this.#preinstalledSnaps) {


### PR DESCRIPTION
Clear unencrypted state properly when calling `clearState`. Without this change, state from previously installed Snaps or preinstalled Snaps would retain even when resetting the client.

Also just clearing `rollbackSnapshots` which I noticed we weren't properly clearing.