### PR TITLE
build: Handle Webpack compilation errors when building execution environments

### DIFF
--- a/packages/snaps-execution-environments/scripts/build.js
+++ b/packages/snaps-execution-environments/scripts/build.js
@@ -25,6 +25,23 @@ webpack(config, (error, stats) => {
     );
 
     console.log(indent(error.message, 2));
+    process.exitCode = 1;
+    return;
+  }
+
+  if (stats.hasErrors()) {
+    console.error(
+      'Webpack failed to build. See the error(s) below for more details.',
+    );
+
+    console.log(
+      stats.toString({
+        all: false,
+        colors: true,
+        errors: true,
+      }),
+    );
+    process.exitCode = 1;
     return;
   }
 

--- a/packages/snaps-execution-environments/scripts/build.js
+++ b/packages/snaps-execution-environments/scripts/build.js
@@ -30,19 +30,7 @@ webpack(config, (error, stats) => {
   }
 
   if (stats.hasErrors()) {
-    console.error(
-      'Webpack failed to build. See the error(s) below for more details.',
-    );
-
-    console.log(
-      stats.toString({
-        all: false,
-        colors: true,
-        errors: true,
-      }),
-    );
     process.exitCode = 1;
-    return;
   }
 
   console.log(


### PR DESCRIPTION
Handle Webpack compilation errors when building execution environments and set `exitCode` for CI purposes.