### PR TITLE
ci: Fix building execution environments for deployment

### DIFF
--- a/.github/workflows/publish-environment.yml
+++ b/.github/workflows/publish-environment.yml
@@ -23,11 +23,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: true
-      - name: Restore build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: publish-release-artifacts-${{ github.sha }}
-      - run: yarn build:lavamoat
+      - run: yarn build
       - name: configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef
         with:

--- a/.github/workflows/publish-environment.yml
+++ b/.github/workflows/publish-environment.yml
@@ -23,7 +23,10 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: true
-      - run: yarn build
+      - name: Build dependencies
+        run: yarn build:ci
+      - name: Build execution environments
+        run: yarn build:lavamoat
       - name: configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef
         with:

--- a/.github/workflows/publish-environment.yml
+++ b/.github/workflows/publish-environment.yml
@@ -23,6 +23,10 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: true
+      - name: Restore build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: publish-release-artifacts-${{ github.sha }}
       - run: yarn build:lavamoat
       - name: configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef


### PR DESCRIPTION
Since building the execution environments with Webpack require the other packages to be built, we modify the `publish-environment` workflow to build the dependencies first.