### PR TITLE
fix: Remove undefined params in `MultichainRouter`

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 93.61,
+  "branches": 93.63,
   "functions": 98.16,
   "lines": 98.5,
   "statements": 98.33

--- a/packages/snaps-controllers/src/multichain/MultichainRouter.test.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRouter.test.ts
@@ -1,5 +1,8 @@
 import { HandlerType } from '@metamask/snaps-utils';
-import { getTruncatedSnap } from '@metamask/snaps-utils/test-utils';
+import {
+  getTruncatedSnap,
+  MOCK_SNAP_ID,
+} from '@metamask/snaps-utils/test-utils';
 
 import { MultichainRouter } from './MultichainRouter';
 import {
@@ -148,6 +151,7 @@ describe('MultichainRouter', () => {
       const result = await messenger.call('MultichainRouter:handleRequest', {
         connectedAddresses: [],
         scope: SOLANA_CAIP2,
+        origin: 'metamask',
         request: {
           method: 'getVersion',
         },
@@ -157,6 +161,27 @@ describe('MultichainRouter', () => {
         'feature-set': 2891131721,
         'solana-core': '1.16.7',
       });
+
+      expect(rootMessenger.call).toHaveBeenNthCalledWith(
+        5,
+        'SnapController:handleRequest',
+        {
+          snapId: MOCK_SNAP_ID,
+          handler: HandlerType.OnProtocolRequest,
+          origin: 'metamask',
+          request: {
+            method: '',
+            params: {
+              request: {
+                id: expect.any(String),
+                jsonrpc: '2.0',
+                method: 'getVersion',
+              },
+              scope: SOLANA_CAIP2,
+            },
+          },
+        },
+      );
     });
 
     it('throws if no suitable Snaps are found', async () => {

--- a/packages/snaps-controllers/src/multichain/MultichainRouter.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRouter.ts
@@ -301,7 +301,7 @@ export class MultichainRouter {
       jsonrpc: '2.0' as const,
       id: rawRequest.id ?? nanoid(),
       method: rawRequest.method,
-      params: rawRequest.params,
+      ...(rawRequest.params ? { params: rawRequest.params } : {}),
     };
 
     const { method, params } = request;


### PR DESCRIPTION
The `MultichainRouter` incorrectly passes on `params` that could be undefined, this PR fixes that.