### PR TITLE
fix: Fix wrong event name for `Snap Export Used`

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -9423,7 +9423,7 @@ describe('SnapController', () => {
 
         expect(mockTrackEvent).toHaveBeenCalledTimes(1);
         expect(mockTrackEvent).toHaveBeenCalledWith({
-          event: 'SnapExportUsed',
+          event: 'Snap Export Used',
           category: 'Snaps',
           properties: {
             export: 'onRpcRequest',

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1047,7 +1047,7 @@ export class SnapController extends BaseController<
           snapId,
         );
         this.#trackEvent({
-          event: 'SnapExportUsed',
+          event: 'Snap Export Used',
           category: 'Snaps',
           properties: {
             // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
"SnapExportUsed" should be "Snap Export Used".