### PR TITLE
feat: Use `initialConnections` in preinstalled example

### DIFF
--- a/packages/examples/packages/preinstalled/snap.manifest.json
+++ b/packages/examples/packages/preinstalled/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "tUE/8LQSsPWm8s11NIBMMXowty2rk5W7kOvOjmE1X6g=",
+    "shasum": "7LKyOyu1hkpkjYSbmBLrJgtK28HXI2H6BAp2qiz7AI4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -15,6 +15,9 @@
         "registry": "https://registry.npmjs.org/"
       }
     }
+  },
+  "initialConnections": {
+    "https://metamask.github.io": {}
   },
   "initialPermissions": {
     "endowment:rpc": {

--- a/packages/examples/packages/preinstalled/src/index.tsx
+++ b/packages/examples/packages/preinstalled/src/index.tsx
@@ -15,7 +15,7 @@ type SnapState = {
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the
- * `wallet_invokeSnap` method. This handler handles a single method:
+ * `wallet_invokeSnap` method. This handler handles two methods:
  *
  * - `showDialog` - Opens a dialog.
  * - `getSettings`: Get the settings state from the snap state.


### PR DESCRIPTION
Use `initialConnections` in our preinstalled example Snap. This will let us E2E test `initialConnections` in the clients.