### PR TITLE
feat: Implement SIP-31

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 93.61,
+  "branches": 93.64,
   "functions": 98.16,
   "lines": 98.5,
-  "statements": 98.33
+  "statements": 98.34
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -4693,7 +4693,7 @@ describe('SnapController', () => {
       rootMessenger.registerActionHandler(
         'ExecutionService:handleRpcRequest',
         async () => ({
-            foo: 'bar',
+          foo: 'bar',
         }),
       );
 

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -4692,10 +4692,9 @@ describe('SnapController', () => {
 
       rootMessenger.registerActionHandler(
         'ExecutionService:handleRpcRequest',
-        async () =>
-          Promise.resolve({
+        async () => ({
             foo: 'bar',
-          }),
+        }),
       );
 
       expect(
@@ -4717,7 +4716,7 @@ describe('SnapController', () => {
       snapController.destroy();
     });
 
-    it('throws if the origin is not metamask', async () => {
+    it('throws if the origin is not "metamask"', async () => {
       const rootMessenger = getControllerMessenger();
       const messenger = getSnapControllerMessenger(rootMessenger);
       const snapController = getSnapController(

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -4671,6 +4671,94 @@ describe('SnapController', () => {
     });
   });
 
+  describe('onClientRequest', () => {
+    it('returns the value when `onClientRequest` returns a valid response', async () => {
+      const rootMessenger = getControllerMessenger();
+      const messenger = getSnapControllerMessenger(rootMessenger);
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(),
+          },
+        }),
+      );
+
+      rootMessenger.registerActionHandler(
+        'SubjectMetadataController:getSubjectMetadata',
+        () => MOCK_SNAP_SUBJECT_METADATA,
+      );
+
+      rootMessenger.registerActionHandler(
+        'ExecutionService:handleRpcRequest',
+        async () =>
+          Promise.resolve({
+            foo: 'bar',
+          }),
+      );
+
+      expect(
+        await snapController.handleRequest({
+          snapId: MOCK_SNAP_ID,
+          origin: 'metamask',
+          handler: HandlerType.OnClientRequest,
+          request: {
+            jsonrpc: '2.0',
+            method: 'foo',
+            params: {},
+            id: 1,
+          },
+        }),
+      ).toStrictEqual({
+        foo: 'bar',
+      });
+
+      snapController.destroy();
+    });
+
+    it('throws if the origin is not metamask', async () => {
+      const rootMessenger = getControllerMessenger();
+      const messenger = getSnapControllerMessenger(rootMessenger);
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(),
+          },
+        }),
+      );
+
+      rootMessenger.registerActionHandler(
+        'SubjectMetadataController:getSubjectMetadata',
+        () => MOCK_SNAP_SUBJECT_METADATA,
+      );
+
+      rootMessenger.registerActionHandler(
+        'ExecutionService:handleRpcRequest',
+        async () =>
+          Promise.resolve({
+            foo: 'bar',
+          }),
+      );
+
+      await expect(
+        snapController.handleRequest({
+          snapId: MOCK_SNAP_ID,
+          origin: MOCK_ORIGIN,
+          handler: HandlerType.OnClientRequest,
+          request: {
+            jsonrpc: '2.0',
+            method: 'foo',
+            params: {},
+            id: 1,
+          },
+        }),
+      ).rejects.toThrow('"onClientRequest" can only be invoked by MetaMask.');
+
+      snapController.destroy();
+    });
+  });
+
   describe('getRpcRequestHandler', () => {
     it('handlers populate the "jsonrpc" property if missing', async () => {
       const rootMessenger = getControllerMessenger();

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -77,6 +77,7 @@ import { inc } from 'semver';
 
 import {
   LEGACY_ENCRYPTION_KEY_DERIVATION_OPTIONS,
+  METAMASK_ORIGIN,
   STATE_DEBOUNCE_TIMEOUT,
 } from './constants';
 import { SnapsRegistryStatus } from './registry';
@@ -2243,7 +2244,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: snap.id,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnUserInput,
           request: {
             jsonrpc: '2.0',
@@ -2294,7 +2295,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: snap.id,
-          origin: 'metamask',
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnRpcRequest,
           request: { jsonrpc: '2.0', method: 'test' },
         }),
@@ -2341,7 +2342,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: snap.id,
-          origin: 'metamask',
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnKeyringRequest,
           request: { jsonrpc: '2.0', method: 'test' },
         }),
@@ -2807,7 +2808,7 @@ describe('SnapController', () => {
 
       await snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: MOCK_ORIGIN,
+        origin: METAMASK_ORIGIN,
         handler: HandlerType.OnUserInput,
         request: {
           jsonrpc: '2.0',
@@ -2827,7 +2828,7 @@ describe('SnapController', () => {
         'ExecutionService:handleRpcRequest',
         MOCK_SNAP_ID,
         {
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnUserInput,
           request: {
             id: expect.any(String),
@@ -2896,7 +2897,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnTransaction,
           request: {
             jsonrpc: '2.0',
@@ -2952,7 +2953,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnTransaction,
           request: {
             jsonrpc: '2.0',
@@ -3007,7 +3008,7 @@ describe('SnapController', () => {
 
       const result = await snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: MOCK_ORIGIN,
+        origin: METAMASK_ORIGIN,
         handler: HandlerType.OnTransaction,
         request: {
           jsonrpc: '2.0',
@@ -3062,7 +3063,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnTransaction,
           request: {
             jsonrpc: '2.0',
@@ -3120,7 +3121,7 @@ describe('SnapController', () => {
 
       const result = await snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: MOCK_ORIGIN,
+        origin: METAMASK_ORIGIN,
         handler: HandlerType.OnTransaction,
         request: {
           jsonrpc: '2.0',
@@ -3183,7 +3184,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnSignature,
           request: {
             jsonrpc: '2.0',
@@ -3239,7 +3240,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnSignature,
           request: {
             jsonrpc: '2.0',
@@ -3295,7 +3296,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnSignature,
           request: {
             jsonrpc: '2.0',
@@ -3348,7 +3349,7 @@ describe('SnapController', () => {
 
       const result = await snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: MOCK_ORIGIN,
+        origin: METAMASK_ORIGIN,
         handler: HandlerType.OnSignature,
         request: {
           jsonrpc: '2.0',
@@ -3402,7 +3403,7 @@ describe('SnapController', () => {
     expect(
       await snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: MOCK_ORIGIN,
+        origin: METAMASK_ORIGIN,
         handler: HandlerType.OnTransaction,
         request: {
           jsonrpc: '2.0',
@@ -3454,7 +3455,7 @@ describe('SnapController', () => {
     expect(
       await snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: MOCK_ORIGIN,
+        origin: METAMASK_ORIGIN,
         handler: HandlerType.OnSignature,
         request: {
           jsonrpc: '2.0',
@@ -3516,7 +3517,7 @@ describe('SnapController', () => {
     await expect(
       snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: MOCK_ORIGIN,
+        origin: METAMASK_ORIGIN,
         handler: HandlerType.OnHomePage,
         request: {
           jsonrpc: '2.0',
@@ -3570,7 +3571,7 @@ describe('SnapController', () => {
     await expect(
       snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: MOCK_ORIGIN,
+        origin: METAMASK_ORIGIN,
         handler: HandlerType.OnHomePage,
         request: {
           jsonrpc: '2.0',
@@ -3623,7 +3624,7 @@ describe('SnapController', () => {
 
     const result = await snapController.handleRequest({
       snapId: MOCK_SNAP_ID,
-      origin: MOCK_ORIGIN,
+      origin: METAMASK_ORIGIN,
       handler: HandlerType.OnHomePage,
       request: {
         jsonrpc: '2.0',
@@ -3686,7 +3687,7 @@ describe('SnapController', () => {
     await expect(
       snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: MOCK_ORIGIN,
+        origin: METAMASK_ORIGIN,
         handler: HandlerType.OnSettingsPage,
         request: {
           jsonrpc: '2.0',
@@ -3740,7 +3741,7 @@ describe('SnapController', () => {
     await expect(
       snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: MOCK_ORIGIN,
+        origin: METAMASK_ORIGIN,
         handler: HandlerType.OnSettingsPage,
         request: {
           jsonrpc: '2.0',
@@ -3793,7 +3794,7 @@ describe('SnapController', () => {
 
     const result = await snapController.handleRequest({
       snapId: MOCK_SNAP_ID,
-      origin: MOCK_ORIGIN,
+      origin: METAMASK_ORIGIN,
       handler: HandlerType.OnSettingsPage,
       request: {
         jsonrpc: '2.0',
@@ -3849,7 +3850,7 @@ describe('SnapController', () => {
     await expect(
       snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: 'metamask',
+        origin: METAMASK_ORIGIN,
         handler: HandlerType.OnNameLookup,
         request: {
           jsonrpc: '2.0',
@@ -3912,7 +3913,7 @@ describe('SnapController', () => {
 
     const result = await snapController.handleRequest({
       snapId: MOCK_SNAP_ID,
-      origin: MOCK_ORIGIN,
+      origin: METAMASK_ORIGIN,
       handler: HandlerType.OnNameLookup,
       request: {
         jsonrpc: '2.0',
@@ -3965,7 +3966,7 @@ describe('SnapController', () => {
     expect(
       await snapController.handleRequest({
         snapId: MOCK_SNAP_ID,
-        origin: MOCK_ORIGIN,
+        origin: METAMASK_ORIGIN,
         handler: HandlerType.OnNameLookup,
         request: {
           jsonrpc: '2.0',
@@ -4026,7 +4027,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnAssetsLookup,
           request: {
             jsonrpc: '2.0',
@@ -4102,7 +4103,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnAssetsLookup,
           request: {
             jsonrpc: '2.0',
@@ -4178,7 +4179,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnAssetsLookup,
           request: {
             jsonrpc: '2.0',
@@ -4258,7 +4259,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnAssetsConversion,
           request: {
             jsonrpc: '2.0',
@@ -4327,7 +4328,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnAssetsConversion,
           request: {
             jsonrpc: '2.0',
@@ -4401,7 +4402,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnAssetsConversion,
           request: {
             jsonrpc: '2.0',
@@ -4492,7 +4493,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnAssetsConversion,
           request: {
             jsonrpc: '2.0',
@@ -4579,7 +4580,7 @@ describe('SnapController', () => {
       await expect(
         snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnAssetHistoricalPrice,
           request: {
             jsonrpc: '2.0',
@@ -4646,7 +4647,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnAssetHistoricalPrice,
           request: {
             jsonrpc: '2.0',
@@ -4700,7 +4701,7 @@ describe('SnapController', () => {
       expect(
         await snapController.handleRequest({
           snapId: MOCK_SNAP_ID,
-          origin: 'metamask',
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnClientRequest,
           request: {
             jsonrpc: '2.0',
@@ -5749,7 +5750,7 @@ describe('SnapController', () => {
       expect(rootMessenger.publish).toHaveBeenCalledWith(
         'SnapController:snapInstalled',
         getTruncatedSnap(),
-        'metamask',
+        METAMASK_ORIGIN,
         true,
       );
 
@@ -5988,7 +5989,7 @@ describe('SnapController', () => {
           },
         }),
         '1.0.0',
-        'metamask',
+        METAMASK_ORIGIN,
         true,
       );
 
@@ -9566,7 +9567,7 @@ describe('SnapController', () => {
 
         await snapController.handleRequest({
           snapId: snap.id,
-          origin: MOCK_ORIGIN,
+          origin: METAMASK_ORIGIN,
           handler: HandlerType.OnCronjob,
           request: {
             jsonrpc: '2.0',
@@ -9744,7 +9745,7 @@ describe('SnapController', () => {
         await messenger.call('SnapController:handleRequest', {
           snapId: MOCK_SNAP_ID,
           handler: HandlerType.OnNameLookup,
-          origin: 'metamask',
+          origin: METAMASK_ORIGIN,
           request: {},
         }),
       ).toBe(true);
@@ -11011,7 +11012,7 @@ describe('SnapController', () => {
         MOCK_SNAP_ID,
         {
           handler: HandlerType.OnInstall,
-          origin: 'metamask',
+          origin: METAMASK_ORIGIN,
           request: {
             jsonrpc: '2.0',
             id: expect.any(String),
@@ -11154,7 +11155,7 @@ describe('SnapController', () => {
         MOCK_SNAP_ID,
         {
           handler: HandlerType.OnUpdate,
-          origin: 'metamask',
+          origin: METAMASK_ORIGIN,
           request: {
             jsonrpc: '2.0',
             id: expect.any(String),

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -3455,6 +3455,8 @@ export class SnapController extends BaseController<
         ]
       : undefined;
 
+    // TODO: Enforce only metamask origin for onClientRequest.
+
     if (
       permissionName === SnapEndowments.Rpc ||
       permissionName === SnapEndowments.Keyring

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -138,6 +138,7 @@ import {
   ALLOWED_PERMISSIONS,
   CLIENT_ONLY_HANDLERS,
   LEGACY_ENCRYPTION_KEY_DERIVATION_OPTIONS,
+  METAMASK_ORIGIN,
   STATE_DEBOUNCE_TIMEOUT,
 } from './constants';
 import type { SnapLocation } from './location';
@@ -1312,7 +1313,7 @@ export class SnapController extends BaseController<
       // Add snap to the SnapController state
       this.#set({
         id: snapId,
-        origin: 'metamask',
+        origin: METAMASK_ORIGIN,
         files: filesObject,
         removable,
         hidden,
@@ -1351,14 +1352,14 @@ export class SnapController extends BaseController<
           'SnapController:snapUpdated',
           this.getTruncatedExpect(snapId),
           existingSnap.version,
-          'metamask',
+          METAMASK_ORIGIN,
           true,
         );
       } else {
         this.messagingSystem.publish(
           'SnapController:snapInstalled',
           this.getTruncatedExpect(snapId),
-          'metamask',
+          METAMASK_ORIGIN,
           true,
         );
       }
@@ -3416,7 +3417,7 @@ export class SnapController extends BaseController<
     this.#assertCanUsePlatform();
 
     assert(
-      origin === 'metamask' || isValidUrl(origin),
+      origin === METAMASK_ORIGIN || isValidUrl(origin),
       "'origin' must be a valid URL or 'metamask'.",
     );
 
@@ -3486,7 +3487,10 @@ export class SnapController extends BaseController<
       }
     }
 
-    if (origin !== 'metamask' && CLIENT_ONLY_HANDLERS.includes(handlerType)) {
+    if (
+      origin !== METAMASK_ORIGIN &&
+      CLIENT_ONLY_HANDLERS.includes(handlerType)
+    ) {
       throw new Error(`"${handlerType}" can only be invoked by MetaMask.`);
     }
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -136,6 +136,7 @@ import { gt } from 'semver';
 
 import {
   ALLOWED_PERMISSIONS,
+  CLIENT_ONLY_HANDLERS,
   LEGACY_ENCRYPTION_KEY_DERIVATION_OPTIONS,
   STATE_DEBOUNCE_TIMEOUT,
 } from './constants';
@@ -3455,8 +3456,6 @@ export class SnapController extends BaseController<
         ]
       : undefined;
 
-    // TODO: Enforce only metamask origin for onClientRequest.
-
     if (
       permissionName === SnapEndowments.Rpc ||
       permissionName === SnapEndowments.Keyring
@@ -3485,6 +3484,10 @@ export class SnapController extends BaseController<
           `Snap "${snapId}" is not permitted to handle requests from "${origin}".`,
         );
       }
+    }
+
+    if (origin !== 'metamask' && CLIENT_ONLY_HANDLERS.includes(handlerType)) {
+      throw new Error(`"${handlerType}" can only be invoked by MetaMask.`);
     }
 
     const handler = this.#getRpcRequestHandler(snapId);

--- a/packages/snaps-controllers/src/snaps/constants.ts
+++ b/packages/snaps-controllers/src/snaps/constants.ts
@@ -27,14 +27,15 @@ export const LEGACY_ENCRYPTION_KEY_DERIVATION_OPTIONS = {
  */
 export const STATE_DEBOUNCE_TIMEOUT = 500;
 
+// The origin used to indicate requests coming from the client.
+export const METAMASK_ORIGIN = 'metamask';
+
 // These handlers are only allowed to be invoked by the client.
 export const CLIENT_ONLY_HANDLERS = Object.freeze([
   HandlerType.OnClientRequest,
   HandlerType.OnSignature,
   HandlerType.OnTransaction,
   HandlerType.OnCronjob,
-  HandlerType.OnInstall,
-  HandlerType.OnUpdate,
   HandlerType.OnNameLookup,
   HandlerType.OnHomePage,
   HandlerType.OnSettingsPage,

--- a/packages/snaps-controllers/src/snaps/constants.ts
+++ b/packages/snaps-controllers/src/snaps/constants.ts
@@ -30,4 +30,16 @@ export const STATE_DEBOUNCE_TIMEOUT = 500;
 // These handlers are only allowed to be invoked by the client.
 export const CLIENT_ONLY_HANDLERS = Object.freeze([
   HandlerType.OnClientRequest,
+  HandlerType.OnSignature,
+  HandlerType.OnTransaction,
+  HandlerType.OnCronjob,
+  HandlerType.OnInstall,
+  HandlerType.OnUpdate,
+  HandlerType.OnNameLookup,
+  HandlerType.OnHomePage,
+  HandlerType.OnSettingsPage,
+  HandlerType.OnUserInput,
+  HandlerType.OnAssetsLookup,
+  HandlerType.OnAssetsConversion,
+  HandlerType.OnAssetHistoricalPrice,
 ]);

--- a/packages/snaps-controllers/src/snaps/constants.ts
+++ b/packages/snaps-controllers/src/snaps/constants.ts
@@ -1,4 +1,5 @@
 import { SnapEndowments } from '@metamask/snaps-rpc-methods';
+import { HandlerType } from '@metamask/snaps-utils';
 
 // These permissions are allowed without being on the allowlist.
 export const ALLOWED_PERMISSIONS = Object.freeze([
@@ -25,3 +26,8 @@ export const LEGACY_ENCRYPTION_KEY_DERIVATION_OPTIONS = {
  * The timeout for debouncing state updates.
  */
 export const STATE_DEBOUNCE_TIMEOUT = 500;
+
+// These handlers are only allowed to be invoked by the client.
+export const CLIENT_ONLY_HANDLERS = Object.freeze([
+  HandlerType.OnClientRequest,
+]);

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 90,
+  "branches": 90.04,
   "functions": 94.57,
-  "lines": 90.15,
-  "statements": 89.52
+  "lines": 90.16,
+  "statements": 89.53
 }

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1821,6 +1821,39 @@ describe('BaseSnapExecutor', () => {
     });
   });
 
+  it('supports onClientRequest export', async () => {
+    const CODE = `
+      module.exports.onClientRequest = ({ request }) => ({ request });
+    `;
+
+    const executor = new TestSnapExecutor();
+    await executor.executeSnap(1, MOCK_SNAP_ID, CODE, []);
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'OK',
+    });
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'snapRpc',
+      params: [
+        MOCK_SNAP_ID,
+        HandlerType.OnClientRequest,
+        MOCK_ORIGIN,
+        { jsonrpc: '2.0', method: 'foo', params: [] },
+      ],
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      id: 2,
+      jsonrpc: '2.0',
+      result: { request: { jsonrpc: '2.0', method: 'foo', params: [] } },
+    });
+  });
+
   describe('lifecycle hooks', () => {
     const LIFECYCLE_HOOKS = [HandlerType.OnInstall, HandlerType.OnUpdate];
 

--- a/packages/snaps-execution-environments/src/common/commands.ts
+++ b/packages/snaps-execution-environments/src/common/commands.ts
@@ -107,6 +107,7 @@ export function getHandlerArguments(
     case HandlerType.OnKeyringRequest:
       return { origin, request };
 
+    case HandlerType.OnClientRequest:
     case HandlerType.OnCronjob:
       return { request };
 

--- a/packages/snaps-rpc-methods/src/endowments/index.ts
+++ b/packages/snaps-rpc-methods/src/endowments/index.ts
@@ -130,6 +130,7 @@ export const handlerEndowments: Record<HandlerType, string | null> = {
   [HandlerType.OnAssetsLookup]: assetsEndowmentBuilder.targetName,
   [HandlerType.OnAssetsConversion]: assetsEndowmentBuilder.targetName,
   [HandlerType.OnProtocolRequest]: protocolEndowmentBuilder.targetName,
+  [HandlerType.OnClientRequest]: null,
 };
 
 export * from './enum';

--- a/packages/snaps-sdk/src/types/handlers/client-request.ts
+++ b/packages/snaps-sdk/src/types/handlers/client-request.ts
@@ -1,0 +1,16 @@
+import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
+
+/**
+ * The `onClientRequest` handler, which is called when a Snap receives a JSON-RPC
+ * request from the client exclusively.
+ *
+ * @param args - The request arguments.
+ * @param args.request - The JSON-RPC request sent to the snap. This includes
+ * the method name and parameters.
+ * @returns The response to the JSON-RPC request. This must be a
+ * JSON-serializable value. In order to return an error, throw a `SnapError`
+ * instead.
+ */
+export type OnClientRequestHandler<
+  Params extends JsonRpcParams = JsonRpcParams,
+> = (args: { request: JsonRpcRequest<Params> }) => Promise<Json>;

--- a/packages/snaps-sdk/src/types/handlers/index.ts
+++ b/packages/snaps-sdk/src/types/handlers/index.ts
@@ -1,6 +1,7 @@
 export type * from './asset-historical-price';
 export type * from './assets-conversion';
 export * from './assets-lookup';
+export type * from './client-request';
 export type * from './cronjob';
 export type * from './home-page';
 export type * from './keyring';

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -2,5 +2,5 @@
   "branches": 99.75,
   "functions": 98.95,
   "lines": 98.57,
-  "statements": 97.07
+  "statements": 97.08
 }

--- a/packages/snaps-utils/src/handlers/exports.test.ts
+++ b/packages/snaps-utils/src/handlers/exports.test.ts
@@ -30,6 +30,7 @@ describe('SNAP_EXPORT_NAMES', () => {
       'onAssetsConversion',
       'onAssetHistoricalPrice',
       'onProtocolRequest',
+      'onClientRequest',
     ]);
   });
 });

--- a/packages/snaps-utils/src/handlers/exports.ts
+++ b/packages/snaps-utils/src/handlers/exports.ts
@@ -2,6 +2,7 @@ import type {
   OnAssetHistoricalPriceHandler,
   OnAssetsConversionHandler,
   OnAssetsLookupHandler,
+  OnClientRequestHandler,
   OnCronjobHandler,
   OnHomePageHandler,
   OnInstallHandler,
@@ -127,6 +128,13 @@ export const SNAP_EXPORTS = {
     validator: (
       snapExport: unknown,
     ): snapExport is OnProtocolRequestHandler => {
+      return typeof snapExport === 'function';
+    },
+  },
+  [HandlerType.OnClientRequest]: {
+    type: HandlerType.OnClientRequest,
+    required: true,
+    validator: (snapExport: unknown): snapExport is OnClientRequestHandler => {
       return typeof snapExport === 'function';
     },
   },

--- a/packages/snaps-utils/src/handlers/types.ts
+++ b/packages/snaps-utils/src/handlers/types.ts
@@ -44,6 +44,7 @@ export enum HandlerType {
   OnAssetsConversion = 'onAssetsConversion',
   OnAssetHistoricalPrice = 'onAssetHistoricalPrice',
   OnProtocolRequest = 'onProtocolRequest',
+  OnClientRequest = 'onClientRequest',
 }
 
 export type SnapHandler = {


### PR DESCRIPTION
Introduces the `onClientRequest` handler as specified in SIP-31. This handler can only be called by MetaMask and is available to all Snaps without permission. It can be used for general purpose communication that must not be exposed to dapps (as `onRpcRequest`).

This handler is enforced to only be callable by the `metamask` origin, as part of this PR this same validation is applied to all handlers in `CLIENT_ONLY_HANDLERS`.

Closes https://github.com/MetaMask/snaps/issues/3392