### PR TITLE
refactor: Simplify AbstractExecutionService

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 93.68,
-  "functions": 98.17,
-  "lines": 98.51,
-  "statements": 98.35
+  "branches": 94.41,
+  "functions": 98.4,
+  "lines": 98.69,
+  "statements": 98.52
 }

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 94.41,
   "functions": 98.4,
-  "lines": 98.69,
+  "lines": 98.68,
   "statements": 98.52
 }

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.test.ts
@@ -94,4 +94,30 @@ describe('AbstractExecutionService', () => {
       }),
     ).rejects.toThrow(`${MOCK_SNAP_ID} failed to start.`);
   });
+
+  it('throws an error if the Snap is already running when trying to execute', async () => {
+    const { service } = createService(MockExecutionService);
+
+    await service.executeSnap({
+      snapId: MOCK_SNAP_ID,
+      sourceCode: `module.exports.onRpcRequest = () => {};`,
+      endowments: [],
+    });
+
+    await expect(
+      service.executeSnap({
+        snapId: MOCK_SNAP_ID,
+        sourceCode: `module.exports.onRpcRequest = () => {};`,
+        endowments: [],
+      }),
+    ).rejects.toThrow(`"${MOCK_SNAP_ID}" is already running.`);
+  });
+
+  it('throws an error if the Snap is not running when attempted to be terminated', async () => {
+    const { service } = createService(MockExecutionService);
+
+    await expect(service.terminateSnap(MOCK_SNAP_ID)).rejects.toThrow(
+      `"${MOCK_SNAP_ID}" is not currently running.`,
+    );
+  });
 });

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.test.ts
@@ -92,9 +92,8 @@ describe('AbstractExecutionService', () => {
 
   it('throws an error if RPC request handler is unavailable', async () => {
     const { service } = createService(MockExecutionService);
-    const snapId = 'TestSnap';
     await expect(
-      service.handleRpcRequest(snapId, {
+      service.handleRpcRequest(MOCK_SNAP_ID, {
         origin: 'foo.com',
         handler: HandlerType.OnRpcRequest,
         request: {
@@ -102,9 +101,7 @@ describe('AbstractExecutionService', () => {
           method: 'bar',
         },
       }),
-    ).rejects.toThrow(
-      `Snap execution service returned no RPC handler for running snap "${snapId}".`,
-    );
+    ).rejects.toThrow(`Snap "${MOCK_SNAP_ID}" is not currently running.`);
   });
 
   it('throws an error if execution environment fails to respond to ping', async () => {

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.test.ts
@@ -16,78 +16,11 @@ class MockExecutionService extends NodeThreadExecutionService {
       initTimeout: inMilliseconds(5, Duration.Second),
     });
   }
-
-  getJobs() {
-    return this.jobs;
-  }
 }
 
 describe('AbstractExecutionService', () => {
   afterEach(() => {
     jest.restoreAllMocks();
-  });
-
-  it('logs error for unrecognized notifications', async () => {
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-
-    const { service } = createService(MockExecutionService);
-
-    await service.executeSnap({
-      snapId: 'TestSnap',
-      sourceCode: `
-        module.exports.onRpcRequest = () => null;
-      `,
-      endowments: [],
-    });
-
-    const { streams } = service.getJobs().values().next().value;
-    streams.command.emit('data', {
-      jsonrpc: '2.0',
-      method: 'foo',
-    });
-
-    await service.terminateAllSnaps();
-
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      new Error(`Received unexpected command stream notification "foo".`),
-    );
-  });
-
-  it('logs error for malformed UnhandledError notification', async () => {
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-
-    const { service } = createService(MockExecutionService);
-
-    await service.executeSnap({
-      snapId: 'TestSnap',
-      sourceCode: `
-      module.exports.onRpcRequest = () => null;
-      `,
-      endowments: [],
-    });
-
-    const { streams } = service.getJobs().values().next().value;
-    streams.command.emit('data', {
-      jsonrpc: '2.0',
-      method: 'UnhandledError',
-      params: [2],
-    });
-
-    streams.command.emit('data', {
-      jsonrpc: '2.0',
-      method: 'UnhandledError',
-      params: { error: null },
-    });
-
-    await service.terminateAllSnaps();
-
-    const expectedError = new Error(
-      `Received malformed "UnhandledError" command stream notification.`,
-    );
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
-    expect(consoleErrorSpy).toHaveBeenNthCalledWith(1, expectedError);
-    expect(consoleErrorSpy).toHaveBeenNthCalledWith(2, expectedError);
   });
 
   it('throws an error if RPC request handler is unavailable', async () => {

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.test.ts
@@ -101,7 +101,7 @@ describe('AbstractExecutionService', () => {
           method: 'bar',
         },
       }),
-    ).rejects.toThrow(`Snap "${MOCK_SNAP_ID}" is not currently running.`);
+    ).rejects.toThrow(`"${MOCK_SNAP_ID}" is not currently running.`);
   });
 
   it('throws an error if execution environment fails to respond to ping', async () => {

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.ts
@@ -144,7 +144,7 @@ export abstract class AbstractExecutionService<WorkerType>
    *
    * @param snapId - The id of the Snap to be terminated.
    */
-  public async terminate(snapId: string): Promise<void> {
+  public async terminateSnap(snapId: string): Promise<void> {
     const job = this.#jobs.get(snapId);
     if (!job) {
       throw new Error(`"${snapId}" is not currently running.`);
@@ -307,20 +307,9 @@ export abstract class AbstractExecutionService<WorkerType>
     stream: BasePostMessageStream;
   }>;
 
-  /**
-   * Terminates the Snap with the specified ID. May throw an error if
-   * termination unexpectedly fails, but will not fail if no job for the Snap
-   * with the specified ID is found.
-   *
-   * @param snapId - The ID of the Snap to terminate.
-   */
-  async terminateSnap(snapId: string) {
-    await this.terminate(snapId);
-  }
-
   async terminateAllSnaps() {
     await Promise.all(
-      [...this.#jobs.keys()].map(async (snapId) => this.terminate(snapId)),
+      [...this.#jobs.keys()].map(async (snapId) => this.terminateSnap(snapId)),
     );
   }
 

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.ts
@@ -340,7 +340,7 @@ export abstract class AbstractExecutionService<WorkerType>
     endowments,
   }: SnapExecutionData): Promise<string> {
     if (this.#jobs.has(snapId)) {
-      throw new Error(`Snap "${snapId}" is already being executed.`);
+      throw new Error(`"${snapId}" is already running.`);
     }
 
     const timer = new Timer(this.#initTimeout);
@@ -456,9 +456,7 @@ export function setupMultiplex(
   const mux = new ObjectMultiplex();
   pipeline(connectionStream, mux, connectionStream, (error) => {
     if (error) {
-      streamName
-        ? logError(`"${streamName}" stream failure.`, error)
-        : logError(error);
+      logError(`"${streamName}" stream failure.`, error);
     }
   });
   return mux;

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.ts
@@ -145,8 +145,8 @@ export abstract class AbstractExecutionService<WorkerType>
    * @param snapId - The id of the Snap to be terminated.
    */
   public async terminate(snapId: string): Promise<void> {
-    const jobWrapper = this.#jobs.get(snapId);
-    if (!jobWrapper) {
+    const job = this.#jobs.get(snapId);
+    if (!job) {
       throw new Error(`"${snapId}" is not currently running.`);
     }
 
@@ -174,7 +174,7 @@ export abstract class AbstractExecutionService<WorkerType>
       // Ignore
     }
 
-    Object.values(jobWrapper.streams).forEach((stream) => {
+    Object.values(job.streams).forEach((stream) => {
       try {
         !stream.destroyed && stream.destroy();
         stream.removeAllListeners();
@@ -183,7 +183,7 @@ export abstract class AbstractExecutionService<WorkerType>
       }
     });
 
-    this.terminateJob(jobWrapper);
+    this.terminateJob(job);
 
     this.#jobs.delete(snapId);
     log(`Snap "${snapId}" terminated.`);

--- a/packages/snaps-controllers/src/services/iframe/IframeExecutionService.ts
+++ b/packages/snaps-controllers/src/services/iframe/IframeExecutionService.ts
@@ -33,13 +33,13 @@ export class IframeExecutionService extends AbstractExecutionService<Window> {
     document.getElementById(jobWrapper.id)?.remove();
   }
 
-  protected async initEnvStream(jobId: string): Promise<{
+  protected async initEnvStream(snapId: string): Promise<{
     worker: Window;
     stream: BasePostMessageStream;
   }> {
     const iframeWindow = await createWindow({
       uri: this.iframeUrl.toString(),
-      id: jobId,
+      id: snapId,
     });
 
     const stream = new WindowPostMessageStream({

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
@@ -41,15 +41,15 @@ export class OffscreenExecutionService extends ProxyExecutionService {
   }
 
   /**
-   * Create a new stream for the given job ID. This will wait for the offscreen
+   * Create a new stream for the given Snap ID. This will wait for the offscreen
    * environment to be ready before creating the stream.
    *
-   * @param jobId - The job ID to create a stream for.
-   * @returns The stream for the given job ID.
+   * @param snapId - The Snap ID to create a stream for.
+   * @returns The stream for the given Snap ID.
    */
-  protected async initEnvStream(jobId: string) {
+  protected async initEnvStream(snapId: string) {
     await this.#offscreenPromise;
 
-    return await super.initEnvStream(jobId);
+    return await super.initEnvStream(snapId);
   }
 }

--- a/packages/snaps-controllers/src/services/proxy/ProxyExecutionService.ts
+++ b/packages/snaps-controllers/src/services/proxy/ProxyExecutionService.ts
@@ -64,16 +64,16 @@ export class ProxyExecutionService extends AbstractExecutionService<string> {
   }
 
   /**
-   * Create a new stream for the specified job. This wraps the root stream
-   * in a stream specific to the job.
+   * Create a new stream for the specified Snap. This wraps the root stream
+   * in a stream specific to the Snap.
    *
-   * @param jobId - The job ID.
+   * @param snapId - The Snap ID.
    * @returns An object with the worker ID and stream.
    */
-  protected async initEnvStream(jobId: string) {
+  protected async initEnvStream(snapId: string) {
     const stream = new ProxyPostMessageStream({
       stream: this.#stream,
-      jobId,
+      jobId: snapId,
     });
 
     // Send a request and await any response before continuing
@@ -88,6 +88,6 @@ export class ProxyExecutionService extends AbstractExecutionService<string> {
       });
     });
 
-    return { worker: jobId, stream };
+    return { worker: snapId, stream };
   }
 }

--- a/packages/snaps-controllers/src/services/webview/WebViewExecutionService.ts
+++ b/packages/snaps-controllers/src/services/webview/WebViewExecutionService.ts
@@ -33,14 +33,14 @@ export class WebViewExecutionService extends AbstractExecutionService<WebViewInt
   }
 
   /**
-   * Create a new stream for the specified job. This wraps the runtime stream
-   * in a stream specific to the job.
+   * Create a new stream for the specified Snap. This wraps the runtime stream
+   * in a stream specific to the Snap.
    *
-   * @param jobId - The job ID.
-   * @returns An object with the worker ID and stream.
+   * @param snapId - The Snap ID.
+   * @returns An object with the webview and stream.
    */
-  protected async initEnvStream(jobId: string) {
-    const webView = await this.#createWebView(jobId);
+  protected async initEnvStream(snapId: string) {
+    const webView = await this.#createWebView(snapId);
 
     const stream = new WebViewMessageStream({
       name: 'parent',

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -9652,22 +9652,20 @@ describe('SnapController', () => {
 
   describe('clearState', () => {
     it('clears the state and terminates running snaps', async () => {
-      const rootMessenger = getControllerMessenger();
-      const messenger = getSnapControllerMessenger(rootMessenger);
-      const snapController = getSnapController(
-        getSnapControllerOptions({
-          messenger,
-          state: {
-            snaps: getPersistedSnapsState(),
-            snapStates: {
-              [MOCK_SNAP_ID]: JSON.stringify({ foo: 'bar' }),
-            },
-            unencryptedSnapStates: {
-              [MOCK_SNAP_ID]: JSON.stringify({ foo: 'bar' }),
-            },
+      const options = getSnapControllerWithEESOptions({
+        state: {
+          snaps: getPersistedSnapsState(),
+          snapStates: {
+            [MOCK_SNAP_ID]: JSON.stringify({ foo: 'bar' }),
           },
-        }),
-      );
+          unencryptedSnapStates: {
+            [MOCK_SNAP_ID]: JSON.stringify({ foo: 'bar' }),
+          },
+        },
+      });
+      const [snapController] = getSnapControllerWithEES(options);
+
+      const { messenger } = options;
 
       const callActionSpy = jest.spyOn(messenger, 'call');
 

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -94,6 +94,7 @@ import {
   DEFAULT_ENCRYPTION_KEY_DERIVATION_OPTIONS,
   ExecutionEnvironmentStub,
   getControllerMessenger,
+  getNodeEES,
   getNodeEESMessenger,
   getPersistedSnapsState,
   getSnapController,
@@ -474,8 +475,10 @@ describe('SnapController', () => {
     // @ts-expect-error `maxRequestTime` is a private property.
     snapController.maxRequestTime = 50;
 
-    // @ts-expect-error `command` is a private property.
-    service.command = async () => sleep(100);
+    rootMessenger.registerActionHandler(
+      'ExecutionService:handleRpcRequest',
+      async () => sleep(100),
+    );
 
     await expect(
       snapController.handleRequest({
@@ -1653,30 +1656,31 @@ describe('SnapController', () => {
       },
     });
 
-    const [snapController, service] = getSnapControllerWithEES(options);
-    const snap = snapController.getExpect(MOCK_SNAP_ID);
-
-    jest
-      // Cast because we are mocking a private property
-      .spyOn(service, 'setupSnapProvider' as any)
-      .mockImplementation((_snapId, rpcStream) => {
-        const mux = setupMultiplex(rpcStream as Duplex, 'foo');
-        const stream = mux.createStream('metamask-provider');
-        const engine = new JsonRpcEngine();
-        const middleware = createAsyncMiddleware(async (req, res, _next) => {
-          if (req.method === 'eth_blockNumber') {
-            await sleep(100);
-            res.result = MOCK_BLOCK_NUMBER;
-          }
-        });
-        engine.push(middleware);
-        const providerStream = createEngineStream({ engine });
-        pipeline(stream, providerStream, stream, (error) => {
-          if (error) {
-            logError(`Provider stream failure.`, error);
-          }
-        });
+    const setupSnapProvider = (_snapId: string, rpcStream: Duplex) => {
+      const mux = setupMultiplex(rpcStream, 'foo');
+      const stream = mux.createStream('metamask-provider');
+      const engine = new JsonRpcEngine();
+      const middleware = createAsyncMiddleware(async (req, res, _next) => {
+        if (req.method === 'eth_blockNumber') {
+          await sleep(100);
+          res.result = MOCK_BLOCK_NUMBER;
+        }
       });
+      engine.push(middleware);
+      const providerStream = createEngineStream({ engine });
+      pipeline(stream, providerStream, stream, (error) => {
+        if (error) {
+          logError(`Provider stream failure.`, error);
+        }
+      });
+    };
+
+    const service = getNodeEES(
+      getNodeEESMessenger(options.rootMessenger),
+      setupSnapProvider,
+    );
+    const [snapController] = getSnapControllerWithEES(options, service);
+    const snap = snapController.getExpect(MOCK_SNAP_ID);
 
     await snapController.startSnap(snap.id);
     expect(snapController.state.snaps[snap.id].status).toBe('running');
@@ -1726,35 +1730,37 @@ describe('SnapController', () => {
     });
 
     const { rootMessenger } = options;
-    const [snapController, service] = getSnapControllerWithEES(options);
+
+    const setupSnapProvider = (_snapId: string, rpcStream: Duplex) => {
+      const mux = setupMultiplex(rpcStream, 'foo');
+      const stream = mux.createStream('metamask-provider');
+      const engine = new JsonRpcEngine();
+      const middleware = createAsyncMiddleware(async (req, res, _next) => {
+        if (req.method === 'eth_blockNumber') {
+          await sleep(100);
+          res.result = MOCK_BLOCK_NUMBER;
+        }
+      });
+      engine.push(middleware);
+      const providerStream = createEngineStream({ engine });
+      pipeline(stream, providerStream, stream, (error) => {
+        if (error) {
+          logError(`Provider stream failure.`, error);
+        }
+      });
+    };
+
+    const service = getNodeEES(
+      getNodeEESMessenger(rootMessenger),
+      setupSnapProvider,
+    );
+    const [snapController] = getSnapControllerWithEES(options, service);
     const snap = snapController.getExpect(MOCK_SNAP_ID);
 
     rootMessenger.registerActionHandler(
       'PermissionController:hasPermission',
       () => true,
     );
-
-    jest
-      // Cast because we are mocking a private property
-      .spyOn(service, 'setupSnapProvider' as any)
-      .mockImplementation((_snapId, rpcStream) => {
-        const mux = setupMultiplex(rpcStream as Duplex, 'foo');
-        const stream = mux.createStream('metamask-provider');
-        const engine = new JsonRpcEngine();
-        const middleware = createAsyncMiddleware(async (req, res, _next) => {
-          if (req.method === 'eth_blockNumber') {
-            await sleep(100);
-            res.result = MOCK_BLOCK_NUMBER;
-          }
-        });
-        engine.push(middleware);
-        const providerStream = createEngineStream({ engine });
-        pipeline(stream, providerStream, stream, (error) => {
-          if (error) {
-            logError(`Provider stream failure.`, error);
-          }
-        });
-      });
 
     await snapController.startSnap(snap.id);
     expect(snapController.state.snaps[snap.id].status).toBe('running');


### PR DESCRIPTION
Remove the extra abstraction for "jobs" in the execution service. Instead, just map each Snap ID to one job. Additionally stop storing an RPC hook for each job as it is unnecessary. Also make all properties hash private and remove some dead branches that were untested and not reachable in practice