### PR TITLE
test: Use simulation options for initial state

### DIFF
--- a/packages/examples/packages/manage-state/src/index.test.ts
+++ b/packages/examples/packages/manage-state/src/index.test.ts
@@ -133,12 +133,9 @@ describe('onRpcRequest', () => {
     });
 
     it('returns the state', async () => {
-      const { request } = await installSnap();
-
-      await request({
-        method: 'setState',
-        params: {
-          value: {
+      const { request } = await installSnap({
+        options: {
+          state: {
             items: ['foo'],
           },
         },
@@ -154,12 +151,9 @@ describe('onRpcRequest', () => {
     });
 
     it('returns the state at a specific key', async () => {
-      const { request } = await installSnap();
-
-      await request({
-        method: 'setState',
-        params: {
-          value: {
+      const { request } = await installSnap({
+        options: {
+          state: {
             nested: {
               key: 'foo',
             },
@@ -178,15 +172,11 @@ describe('onRpcRequest', () => {
     });
 
     it('returns the unencrypted state', async () => {
-      const { request } = await installSnap();
-
-      await request({
-        method: 'setState',
-        params: {
-          value: {
+      const { request } = await installSnap({
+        options: {
+          unencryptedState: {
             items: ['foo'],
           },
-          encrypted: false,
         },
       });
 


### PR DESCRIPTION
Use the simulation option to specify the initial state for the manage state example Snap tests.