### PR TITLE
feat: Add `isMinimumPlatformVersion` action

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 93.67,
-  "functions": 98.16,
+  "branches": 93.68,
+  "functions": 98.17,
   "lines": 98.51,
-  "statements": 98.34
+  "statements": 98.35
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -11582,8 +11582,8 @@ describe('SnapController', () => {
     });
   });
 
-  describe('SnapController:isPlatformVersionSupported', () => {
-    it('returns true or false depending on whether the version is supported', async () => {
+  describe('SnapController:isMinimumPlatformVersion', () => {
+    it('returns true or false depending on whether the minimum version is supported', async () => {
       const messenger = getSnapControllerMessenger();
 
       const manifest = getSnapManifest({
@@ -11601,7 +11601,7 @@ describe('SnapController', () => {
 
       expect(
         messenger.call(
-          'SnapController:isPlatformVersionSupported',
+          'SnapController:isMinimumPlatformVersion',
           MOCK_SNAP_ID,
           '1.0.0' as SemVerVersion,
         ),
@@ -11609,7 +11609,7 @@ describe('SnapController', () => {
 
       expect(
         messenger.call(
-          'SnapController:isPlatformVersionSupported',
+          'SnapController:isMinimumPlatformVersion',
           MOCK_SNAP_ID,
           manifest.platformVersion as SemVerVersion,
         ),
@@ -11617,7 +11617,7 @@ describe('SnapController', () => {
 
       expect(
         messenger.call(
-          'SnapController:isPlatformVersionSupported',
+          'SnapController:isMinimumPlatformVersion',
           MOCK_SNAP_ID,
           '7.0.0' as SemVerVersion,
         ),
@@ -11643,7 +11643,7 @@ describe('SnapController', () => {
 
       expect(
         messenger.call(
-          'SnapController:isPlatformVersionSupported',
+          'SnapController:isMinimumPlatformVersion',
           MOCK_SNAP_ID,
           '999.0.0' as SemVerVersion,
         ),

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -11583,7 +11583,34 @@ describe('SnapController', () => {
   });
 
   describe('SnapController:isMinimumPlatformVersion', () => {
-    it('returns true or false depending on whether the minimum version is supported', async () => {
+    it('returns true if the platform version is equal to the specified version', async () => {
+      const messenger = getSnapControllerMessenger();
+
+      const manifest = getSnapManifest({
+        platformVersion: '6.0.0' as SemVerVersion,
+      });
+
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(getPersistedSnapObject({ manifest })),
+          },
+        }),
+      );
+
+      expect(
+        messenger.call(
+          'SnapController:isMinimumPlatformVersion',
+          MOCK_SNAP_ID,
+          manifest.platformVersion as SemVerVersion,
+        ),
+      ).toBe(true);
+
+      snapController.destroy();
+    });
+
+    it('returns true if the platform version is greater than the specified version', async () => {
       const messenger = getSnapControllerMessenger();
 
       const manifest = getSnapManifest({
@@ -11607,13 +11634,24 @@ describe('SnapController', () => {
         ),
       ).toBe(true);
 
-      expect(
-        messenger.call(
-          'SnapController:isMinimumPlatformVersion',
-          MOCK_SNAP_ID,
-          manifest.platformVersion as SemVerVersion,
-        ),
-      ).toBe(true);
+      snapController.destroy();
+    });
+
+    it('returns false if the platform version is lesser than the specified version', async () => {
+      const messenger = getSnapControllerMessenger();
+
+      const manifest = getSnapManifest({
+        platformVersion: '6.0.0' as SemVerVersion,
+      });
+
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(getPersistedSnapObject({ manifest })),
+          },
+        }),
+      );
 
       expect(
         messenger.call(

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -11581,4 +11581,75 @@ describe('SnapController', () => {
       snapController.destroy();
     });
   });
+
+  describe('SnapController:isPlatformVersionSupported', () => {
+    it('returns true or false depending on whether the version is supported', async () => {
+      const messenger = getSnapControllerMessenger();
+
+      const manifest = getSnapManifest({
+        platformVersion: '6.0.0' as SemVerVersion,
+      });
+
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(getPersistedSnapObject({ manifest })),
+          },
+        }),
+      );
+
+      expect(
+        messenger.call(
+          'SnapController:isPlatformVersionSupported',
+          MOCK_SNAP_ID,
+          '1.0.0' as SemVerVersion,
+        ),
+      ).toBe(true);
+
+      expect(
+        messenger.call(
+          'SnapController:isPlatformVersionSupported',
+          MOCK_SNAP_ID,
+          manifest.platformVersion as SemVerVersion,
+        ),
+      ).toBe(true);
+
+      expect(
+        messenger.call(
+          'SnapController:isPlatformVersionSupported',
+          MOCK_SNAP_ID,
+          '7.0.0' as SemVerVersion,
+        ),
+      ).toBe(false);
+
+      snapController.destroy();
+    });
+
+    it('returns false if the platformVersion is undefined', async () => {
+      const messenger = getSnapControllerMessenger();
+
+      const manifest = getSnapManifest();
+      delete manifest.platformVersion;
+
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(getPersistedSnapObject({ manifest })),
+          },
+        }),
+      );
+
+      expect(
+        messenger.call(
+          'SnapController:isPlatformVersionSupported',
+          MOCK_SNAP_ID,
+          '999.0.0' as SemVerVersion,
+        ),
+      ).toBe(false);
+
+      snapController.destroy();
+    });
+  });
 });

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2191,7 +2191,7 @@ export class SnapController extends BaseController<
   }
 
   /**
-   * Determine if a given Snap ID supports a given miniumum version of the Snaps platform
+   * Determine if a given Snap ID supports a given minimum version of the Snaps platform
    * by inspecting the platformVersion in the Snap manifest.
    *
    * @param snapId - The Snap ID.

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -463,9 +463,9 @@ export type GetSnapFile = {
   handler: SnapController['getSnapFile'];
 };
 
-export type IsPlatformVersionSupported = {
-  type: `${typeof controllerName}:isPlatformVersionSupported`;
-  handler: SnapController['isPlatformVersionSupported'];
+export type IsMinimumPlatformVersion = {
+  type: `${typeof controllerName}:isMinimumPlatformVersion`;
+  handler: SnapController['isMinimumPlatformVersion'];
 };
 
 export type SnapControllerGetStateAction = ControllerGetStateAction<
@@ -495,7 +495,7 @@ export type SnapControllerActions =
   | GetSnapFile
   | SnapControllerGetStateAction
   | StopAllSnaps
-  | IsPlatformVersionSupported;
+  | IsMinimumPlatformVersion;
 
 // Controller Messenger Events
 
@@ -1265,8 +1265,8 @@ export class SnapController extends BaseController<
     );
 
     this.messagingSystem.registerActionHandler(
-      `${controllerName}:isPlatformVersionSupported`,
-      (...args) => this.isPlatformVersionSupported(...args),
+      `${controllerName}:isMinimumPlatformVersion`,
+      (...args) => this.isMinimumPlatformVersion(...args),
     );
   }
 
@@ -2191,14 +2191,14 @@ export class SnapController extends BaseController<
   }
 
   /**
-   * Determine if a given Snap ID supports a given version of the Snaps platform
+   * Determine if a given Snap ID supports a given miniumum version of the Snaps platform
    * by inspecting the platformVersion in the Snap manifest.
    *
    * @param snapId - The Snap ID.
    * @param version - The version.
    * @returns True if the platform version is equal or greater to the passed version, false otherwise.
    */
-  isPlatformVersionSupported(snapId: SnapId, version: SemVerVersion): boolean {
+  isMinimumPlatformVersion(snapId: SnapId, version: SemVerVersion): boolean {
     const snap = this.getExpect(snapId);
 
     const { platformVersion } = snap.manifest;

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -113,6 +113,7 @@ import type {
   CaipAssetType,
   JsonRpcRequest,
   Hex,
+  SemVerVersion,
 } from '@metamask/utils';
 import {
   hexToNumber,
@@ -134,7 +135,7 @@ import { createMachine, interpret } from '@xstate/fsm';
 import { Mutex } from 'async-mutex';
 import type { Patch } from 'immer';
 import { nanoid } from 'nanoid';
-import { gt } from 'semver';
+import { gt, gte } from 'semver';
 
 import {
   ALLOWED_PERMISSIONS,
@@ -462,6 +463,11 @@ export type GetSnapFile = {
   handler: SnapController['getSnapFile'];
 };
 
+export type IsPlatformVersionSupported = {
+  type: `${typeof controllerName}:isPlatformVersionSupported`;
+  handler: SnapController['isPlatformVersionSupported'];
+};
+
 export type SnapControllerGetStateAction = ControllerGetStateAction<
   typeof controllerName,
   SnapControllerState
@@ -488,7 +494,8 @@ export type SnapControllerActions =
   | RevokeDynamicPermissions
   | GetSnapFile
   | SnapControllerGetStateAction
-  | StopAllSnaps;
+  | StopAllSnaps
+  | IsPlatformVersionSupported;
 
 // Controller Messenger Events
 
@@ -1255,6 +1262,11 @@ export class SnapController extends BaseController<
     this.messagingSystem.registerActionHandler(
       `${controllerName}:stopAllSnaps`,
       async (...args) => this.stopAllSnaps(...args),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      `${controllerName}:isPlatformVersionSupported`,
+      (...args) => this.isPlatformVersionSupported(...args),
     );
   }
 
@@ -2176,6 +2188,26 @@ export class SnapController extends BaseController<
     );
 
     return encoded;
+  }
+
+  /**
+   * Determine if a given Snap ID supports a given version of the Snaps platform
+   * by inspecting the platformVersion in the Snap manifest.
+   *
+   * @param snapId - The Snap ID.
+   * @param version - The version.
+   * @returns True if the platform version is equal or greater to the passed version, false otherwise.
+   */
+  isPlatformVersionSupported(snapId: SnapId, version: SemVerVersion): boolean {
+    const snap = this.getExpect(snapId);
+
+    const { platformVersion } = snap.manifest;
+
+    if (!platformVersion) {
+      return false;
+    }
+
+    return gte(platformVersion, version);
   }
 
   /**


### PR DESCRIPTION
Add a `isMinimumPlatformVersion` action which can be used to determine if a given Snap supports a minimum version specified in its `platformVersion`. For now, if the Snap hasn't specified this we default to false.