### PR TITLE
feat: Add `getChainId` method to Ethereum provider example

### DIFF
--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZvZeD71njHCYz1luaRATtzJgNbu7S/Kq4zjyAw2nzGY=",
+    "shasum": "caZ/yWFuxoz8zSE78Anp+6/K1zhJ+CPEwuC63ujX86Q=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "7i20r0cCFwMESzBcTMgRNOt82AjwHneiM6LtD7vXCGw=",
+    "shasum": "ZvZeD71njHCYz1luaRATtzJgNbu7S/Kq4zjyAw2nzGY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/src/index.test.ts
+++ b/packages/examples/packages/ethereum-provider/src/index.test.ts
@@ -42,7 +42,7 @@ describe('onRpcRequest', () => {
   });
 
   describe('getVersion', () => {
-    const MOCK_VERSION = '0x01'; // Ethereum Mainnet
+    const MOCK_VERSION = '1'; // Ethereum Mainnet
 
     it('returns the current network version', async () => {
       const { request } = await installSnap();
@@ -52,6 +52,20 @@ describe('onRpcRequest', () => {
       });
 
       expect(response).toRespondWith(MOCK_VERSION);
+    });
+  });
+
+  describe('getChainId', () => {
+    const MOCK_CHAIN_ID = '0x01'; // Ethereum Mainnet
+
+    it('returns the current network version', async () => {
+      const { request } = await installSnap();
+
+      const response = await request({
+        method: 'getChainId',
+      });
+
+      expect(response).toRespondWith(MOCK_CHAIN_ID);
     });
   });
 

--- a/packages/examples/packages/ethereum-provider/src/index.test.ts
+++ b/packages/examples/packages/ethereum-provider/src/index.test.ts
@@ -42,7 +42,7 @@ describe('onRpcRequest', () => {
   });
 
   describe('getVersion', () => {
-    const MOCK_VERSION = '1'; // Ethereum Mainnet
+    const MOCK_VERSION = '0x01'; // Ethereum Mainnet
 
     it('returns the current network version', async () => {
       const { request } = await installSnap();

--- a/packages/examples/packages/ethereum-provider/src/index.ts
+++ b/packages/examples/packages/ethereum-provider/src/index.ts
@@ -72,7 +72,7 @@ async function getVersion() {
  * Note that using the `ethereum` global requires the
  * `endowment:ethereum-provider` permission.
  *
- * @returns The current network version as a string.
+ * @returns The current chain ID as a string.
  * @see https://docs.metamask.io/snaps/reference/permissions/#endowmentethereum-provider
  */
 async function getChainId() {

--- a/packages/examples/packages/ethereum-provider/src/index.ts
+++ b/packages/examples/packages/ethereum-provider/src/index.ts
@@ -47,6 +47,24 @@ async function getGasPrice() {
 }
 
 /**
+ * Get the current network version using the `ethereum` global. This is
+ * essentially the same as the `window.ethereum` global, but does not have
+ * access to all methods.
+ *
+ * Note that using the `ethereum` global requires the
+ * `endowment:ethereum-provider` permission.
+ *
+ * @returns The current network version as a string.
+ * @see https://docs.metamask.io/snaps/reference/permissions/#endowmentethereum-provider
+ */
+async function getVersion() {
+  const version = await ethereum.request<string>({ method: 'net_version' });
+  assert(version, 'Ethereum provider did not return a version.');
+
+  return version;
+}
+
+/**
  * Get the current chain ID using the `ethereum` global. This is essentially
  * the same as the `window.ethereum` global, but does not have access to all
  * methods.
@@ -57,11 +75,14 @@ async function getGasPrice() {
  * @returns The current network version as a string.
  * @see https://docs.metamask.io/snaps/reference/permissions/#endowmentethereum-provider
  */
-async function getVersion() {
-  const version = await ethereum.request<string>({ method: 'eth_chainId' });
-  assert(version, 'Ethereum provider did not return a chain ID.');
+async function getChainId() {
+  const chainId = await ethereum.request<string>({
+    method: 'eth_chainId',
+  });
 
-  return version;
+  assert(chainId, 'Ethereum provider did not return a chain ID.');
+
+  return chainId;
 }
 
 /**
@@ -208,10 +229,11 @@ async function signTypedData(message: string, from: string) {
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the
- * `wallet_invokeSnap` method. This handler handles five methods:
+ * `wallet_invokeSnap` method. This handler handles six methods:
  *
  * - `getGasPrice`: Get the current Ethereum gas price as a hexadecimal string.
  * - `getVersion`: Get the current Ethereum network version as a string.
+ * - `getChainId`: Get the current Ethereum chain ID as a string.
  * - `getAccounts`: Get the Ethereum accounts that the snap has access to.
  * - `personalSign`: Sign a message using an Ethereum account.
  * - `signTypedData` Sign a struct using an Ethereum account.
@@ -232,6 +254,9 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 
     case 'getVersion':
       return await getVersion();
+
+    case 'getChainId':
+      return await getChainId();
 
     case 'getAccounts':
       return await getAccounts();

--- a/packages/examples/packages/ethereum-provider/src/index.ts
+++ b/packages/examples/packages/ethereum-provider/src/index.ts
@@ -47,9 +47,9 @@ async function getGasPrice() {
 }
 
 /**
- * Get the current network version using the `ethereum` global. This is
- * essentially the same as the `window.ethereum` global, but does not have
- * access to all methods.
+ * Get the current chain ID using the `ethereum` global. This is essentially
+ * the same as the `window.ethereum` global, but does not have access to all
+ * methods.
  *
  * Note that using the `ethereum` global requires the
  * `endowment:ethereum-provider` permission.
@@ -58,8 +58,8 @@ async function getGasPrice() {
  * @see https://docs.metamask.io/snaps/reference/permissions/#endowmentethereum-provider
  */
 async function getVersion() {
-  const version = await ethereum.request<string>({ method: 'net_version' });
-  assert(version, 'Ethereum provider did not return a version.');
+  const version = await ethereum.request<string>({ method: 'eth_chainId' });
+  assert(version, 'Ethereum provider did not return a chain ID.');
 
   return version;
 }

--- a/packages/test-snaps/src/features/snaps/ethereum-provider/EthereumProvider.tsx
+++ b/packages/test-snaps/src/features/snaps/ethereum-provider/EthereumProvider.tsx
@@ -28,7 +28,7 @@ export const EthereumProvider: FunctionComponent = () => {
     }).catch(logError);
   };
 
-  const handleGetVersion = () => handleSubmit('getVersion');
+  const handleGetChainId = () => handleSubmit('getChainId');
   const handleGetAccounts = () => handleSubmit('getAccounts');
 
   return (
@@ -46,9 +46,9 @@ export const EthereumProvider: FunctionComponent = () => {
           id="sendEthprovider"
           className="mb-3"
           disabled={isLoading}
-          onClick={handleGetVersion}
+          onClick={handleGetChainId}
         >
-          Get Version
+          Get Chain ID
         </Button>
         <Button
           variant="primary"


### PR DESCRIPTION
`net_version` seems to be mocked in the extension E2E environment, so we can't use it to test the switch functionality.