### PR TITLE
chore: Fix background events example changelog

### DIFF
--- a/packages/examples/packages/background-events/CHANGELOG.md
+++ b/packages/examples/packages/background-events/CHANGELOG.md
@@ -10,3 +10,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added background events example snap ([#3404](https://github.com/MetaMask/snaps/pull/3404))
+
+[Unreleased]: https://github.com/MetaMask/snaps/


### PR DESCRIPTION
The changelog was missing the "Unreleased" reference.