### PR TITLE
fix: use correct method names for background event snap in test-snaps

### DIFF
--- a/packages/test-snaps/CHANGELOG.md
+++ b/packages/test-snaps/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use correct method names in click handlers for background events example Snap ([#3411](https://https://github.com/MetaMask/snaps/pull/3411))
+
 ## [2.23.0]
 
 ### Added

--- a/packages/test-snaps/src/features/snaps/background-events/components/CancelBackgroundEvent.tsx
+++ b/packages/test-snaps/src/features/snaps/background-events/components/CancelBackgroundEvent.tsx
@@ -22,7 +22,7 @@ export const CancelBackgroundEvent: FunctionComponent = () => {
     event.preventDefault();
     invokeSnap({
       snapId: getSnapId(BACKGROUND_EVENTS_SNAP_ID, BACKGROUND_EVENTS_SNAP_PORT),
-      method: 'cancelNotification',
+      method: 'cancelDialog',
       params: {
         id,
       },

--- a/packages/test-snaps/src/features/snaps/background-events/components/ScheduleBackgroundEvent.tsx
+++ b/packages/test-snaps/src/features/snaps/background-events/components/ScheduleBackgroundEvent.tsx
@@ -28,7 +28,7 @@ export const ScheduleBackgroundEvent: FunctionComponent = () => {
     event.preventDefault();
     invokeSnap({
       snapId: getSnapId(BACKGROUND_EVENTS_SNAP_ID, BACKGROUND_EVENTS_SNAP_PORT),
-      method: 'scheduleNotificationWithDate',
+      method: 'scheduleDialogWithDate',
       params: {
         date,
       },
@@ -39,7 +39,7 @@ export const ScheduleBackgroundEvent: FunctionComponent = () => {
     event.preventDefault();
     invokeSnap({
       snapId: getSnapId(BACKGROUND_EVENTS_SNAP_ID, BACKGROUND_EVENTS_SNAP_PORT),
-      method: 'scheduleNotificationWithDuration',
+      method: 'scheduleDialogWithDuration',
       params: {
         duration,
       },


### PR DESCRIPTION
We had the wrong method names in the click handlers for background-events in test-snaps.