### PR TITLE
feat!: Remove `useCaip25Permission` feature flag and enable behaviour by default

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 93.68,
+  "branches": 93.66,
   "functions": 98.17,
   "lines": 98.51,
   "statements": 98.35

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -5696,7 +5696,7 @@ describe('SnapController', () => {
       snapController.destroy();
     });
 
-    it('grants the `endowment:caip25` permission to a Snap with `endowment:ethereum-provider` if the `useCaip25Permission` feature flag is enabled', async () => {
+    it('grants the `endowment:caip25` permission to a Snap with `endowment:ethereum-provider`', async () => {
       const rootMessenger = getControllerMessenger();
       const messenger = getSnapControllerMessenger(rootMessenger);
 
@@ -5732,9 +5732,6 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           messenger,
           detectSnapLocation: loopbackDetect({ manifest }),
-          featureFlags: {
-            useCaip25Permission: true,
-          },
         }),
       );
 
@@ -5778,7 +5775,7 @@ describe('SnapController', () => {
       snapController.destroy();
     });
 
-    it('grants the `endowment:caip25` permission when updating a Snap with `endowment:ethereum-provider` if the `useCaip25Permission` feature flag is enabled', async () => {
+    it('grants the `endowment:caip25` permission when updating a Snap with `endowment:ethereum-provider`', async () => {
       const newVersion = '1.0.2';
       const newVersionRange = '>=1.0.1';
 
@@ -5838,9 +5835,6 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           messenger,
           detectSnapLocation: detectLocationMock,
-          featureFlags: {
-            useCaip25Permission: true,
-          },
         }),
       );
 
@@ -5911,71 +5905,6 @@ describe('SnapController', () => {
       controller.destroy();
     });
 
-    it('does not grant the `endowment:caip25` permission to a Snap with `endowment:ethereum-provider` if the `useCaip25Permission` feature flag is disabled', async () => {
-      const rootMessenger = getControllerMessenger();
-      const messenger = getSnapControllerMessenger(rootMessenger);
-
-      rootMessenger.registerActionHandler(
-        'PermissionController:getPermissions',
-        () => ({}),
-      );
-
-      rootMessenger.registerActionHandler(
-        'SelectedNetworkController:getNetworkClientIdForDomain',
-        () => 'mainnet',
-      );
-
-      rootMessenger.registerActionHandler(
-        'NetworkController:getNetworkClientById',
-        () => ({
-          configuration: {
-            chainId: '0x1',
-          },
-        }),
-      );
-
-      const { manifest } = await getMockSnapFilesWithUpdatedChecksum({
-        manifest: getSnapManifest({
-          initialPermissions: {
-            'endowment:page-home': {},
-            'endowment:ethereum-provider': {},
-          },
-        }),
-      });
-
-      const snapController = getSnapController(
-        getSnapControllerOptions({
-          messenger,
-          detectSnapLocation: loopbackDetect({ manifest }),
-          featureFlags: {
-            useCaip25Permission: false,
-          },
-        }),
-      );
-
-      await snapController.installSnaps(MOCK_ORIGIN, {
-        [MOCK_SNAP_ID]: {},
-      });
-
-      const approvedPermissions = {
-        'endowment:page-home': {
-          caveats: null,
-        },
-        'endowment:ethereum-provider': {},
-      };
-
-      expect(messenger.call).toHaveBeenCalledWith(
-        'PermissionController:grantPermissions',
-        {
-          approvedPermissions,
-          subject: { origin: MOCK_SNAP_ID },
-          requestData: expect.any(Object),
-        },
-      );
-
-      snapController.destroy();
-    });
-
     it('does not grant the `endowment:caip25` permission if the Snap does not have the `endowment:ethereum-provider` permission', async () => {
       const rootMessenger = getControllerMessenger();
       const messenger = getSnapControllerMessenger(rootMessenger);
@@ -6011,9 +5940,6 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           messenger,
           detectSnapLocation: loopbackDetect({ manifest }),
-          featureFlags: {
-            useCaip25Permission: true,
-          },
         }),
       );
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -689,7 +689,6 @@ type FeatureFlags = {
   allowLocalSnaps?: boolean;
   disableSnapInstallation?: boolean;
   rejectInvalidPlatformVersion?: boolean;
-  useCaip25Permission?: boolean;
 };
 
 type DynamicFeatureFlags = {
@@ -4254,10 +4253,7 @@ export class SnapController extends BaseController<
    * @returns The permissions to grant to the Snap.
    */
   #getPermissionsToGrant(snapId: SnapId, newPermissions: RequestedPermissions) {
-    if (
-      this.#featureFlags.useCaip25Permission &&
-      Object.keys(newPermissions).includes(SnapEndowments.EthereumProvider)
-    ) {
+    if (Object.keys(newPermissions).includes(SnapEndowments.EthereumProvider)) {
       // This will return the globally selected network if the Snap doesn't have
       // one set.
       const networkClientId = this.messagingSystem.call(


### PR DESCRIPTION
This removes the `useCaip25Permission` feature flag for the `SnapController` and enables the CAIP-25 behaviour by default.

## Breaking changes

- The `SnapController` no longer accepts the `useCaip25Permission` feature flag.