### PR TITLE
fix: Prevent scheduling background events less than 1 second in the future

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 94.41,
+  "branches": 94.42,
   "functions": 98.4,
-  "lines": 98.68,
+  "lines": 98.69,
   "statements": 98.52
 }

--- a/packages/snaps-controllers/src/cronjob/CronjobController.test.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.test.ts
@@ -435,7 +435,7 @@ describe('CronjobController', () => {
 
     const backgroundEvent = {
       snapId: MOCK_SNAP_ID,
-      date: '2022-01-01T01:00Z',
+      date: '2025-05-21T13:25:21.500Z',
       request: {
         method: 'handleEvent',
         params: ['p1'],
@@ -449,7 +449,7 @@ describe('CronjobController', () => {
       {
         id,
         snapId: MOCK_SNAP_ID,
-        date: '2022-01-01T01:00Z',
+        date: '2025-05-21T13:25:21Z',
         request: {
           method: 'handleEvent',
           params: ['p1'],
@@ -1023,7 +1023,7 @@ describe('CronjobController', () => {
           'CronjobController:scheduleBackgroundEvent',
           {
             snapId: MOCK_SNAP_ID,
-            date: '2022-01-01T01:00Z',
+            date: '2025-05-21T13:25:21.500Z',
             request: {
               method: 'handleExport',
               params: ['p1'],
@@ -1036,7 +1036,7 @@ describe('CronjobController', () => {
             id,
             snapId: MOCK_SNAP_ID,
             scheduledAt: expect.any(String),
-            date: '2022-01-01T01:00Z',
+            date: '2025-05-21T13:25:21.500Z',
             request: {
               method: 'handleExport',
               params: ['p1'],
@@ -1054,7 +1054,7 @@ describe('CronjobController', () => {
             id,
             snapId: MOCK_SNAP_ID,
             scheduledAt: expect.any(String),
-            date: '2022-01-01T01:00Z',
+            date: '2025-05-21T13:25:21Z',
             request: {
               method: 'handleExport',
               params: ['p1'],

--- a/packages/snaps-controllers/src/cronjob/CronjobController.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.ts
@@ -19,6 +19,7 @@ import {
   parseCronExpression,
   logError,
   logWarning,
+  toCensoredISO8601String,
 } from '@metamask/snaps-utils';
 import { assert, Duration, hasProperty, inMilliseconds } from '@metamask/utils';
 import { castDraft } from 'immer';
@@ -419,11 +420,7 @@ export class CronjobController extends BaseController<
       .map((event) => ({
         ...event,
         // Truncate dates to remove milliseconds.
-        date: DateTime.fromISO(event.date, { setZone: true })
-          .startOf('second')
-          .toISO({
-            suppressMilliseconds: true,
-          }) as string,
+        date: toCensoredISO8601String(event.date),
       }));
   }
 

--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -10,7 +10,7 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 95,
+      branches: 95.03,
       functions: 98.65,
       lines: 98.78,
       statements: 98.47,

--- a/packages/snaps-rpc-methods/src/permitted/scheduleBackgroundEvent.ts
+++ b/packages/snaps-rpc-methods/src/permitted/scheduleBackgroundEvent.ts
@@ -12,6 +12,7 @@ import {
   CronjobRpcRequestStruct,
   ISO8601DateStruct,
   ISO8601DurationStruct,
+  toCensoredISO8601String,
 } from '@metamask/snaps-utils';
 import { StructError, create, object } from '@metamask/superstruct';
 import {
@@ -93,12 +94,8 @@ function getStartDate(params: ScheduleBackgroundEventParams) {
     return DateTime.fromJSDate(new Date()).toUTC().plus(duration).toISO();
   }
 
-  const date = DateTime.fromISO(params.date, { setZone: true });
-
   // Make sure any millisecond precision is removed.
-  return date.startOf('second').toISO({
-    suppressMilliseconds: true,
-  });
+  return toCensoredISO8601String(params.date);
 }
 
 /**

--- a/packages/snaps-rpc-methods/src/permitted/scheduleBackgroundEvent.ts
+++ b/packages/snaps-rpc-methods/src/permitted/scheduleBackgroundEvent.ts
@@ -84,12 +84,21 @@ export type ScheduleBackgroundEventParameters = InferMatching<
  */
 function getStartDate(params: ScheduleBackgroundEventParams) {
   if ('duration' in params) {
-    return DateTime.fromJSDate(new Date())
-      .toUTC()
-      .plus(Duration.fromISO(params.duration));
+    const parsed = Duration.fromISO(params.duration);
+
+    // Disallow durations less than 1 second.
+    const duration =
+      parsed.as('seconds') >= 1 ? parsed : Duration.fromObject({ seconds: 1 });
+
+    return DateTime.fromJSDate(new Date()).toUTC().plus(duration).toISO();
   }
 
-  return DateTime.fromISO(params.date, { setZone: true });
+  const date = DateTime.fromISO(params.date, { setZone: true });
+
+  // Make sure any millisecond precision is removed.
+  return date.startOf('second').toISO({
+    suppressMilliseconds: true,
+  });
 }
 
 /**
@@ -128,14 +137,9 @@ async function getScheduleBackgroundEventImplementation(
 
     const date = getStartDate(validatedParams);
 
-    // Make sure any millisecond precision is removed.
-    const truncatedDate = date.startOf('second').toISO({
-      suppressMilliseconds: true,
-    });
+    assert(date);
 
-    assert(truncatedDate);
-
-    const id = scheduleBackgroundEvent({ date: truncatedDate, request });
+    const id = scheduleBackgroundEvent({ date, request });
     res.result = id;
   } catch (error) {
     return end(error);

--- a/packages/snaps-utils/src/time.test.ts
+++ b/packages/snaps-utils/src/time.test.ts
@@ -1,7 +1,11 @@
 import { create, is } from '@metamask/superstruct';
 import { DateTime } from 'luxon';
 
-import { ISO8601DateStruct, ISO8601DurationStruct } from './time';
+import {
+  ISO8601DateStruct,
+  ISO8601DurationStruct,
+  toCensoredISO8601String,
+} from './time';
 
 describe('ISO8601DateStruct', () => {
   it('should return true for a valid ISO 8601 date', () => {
@@ -49,6 +53,20 @@ describe('ISO8601DurationStruct', () => {
     const value = '1Millisecond';
     expect(() => create(value, ISO8601DurationStruct)).toThrow(
       'Not a valid ISO 8601 duration',
+    );
+  });
+});
+
+describe('toCensoredISO8601String', () => {
+  it('returns ISO dates as-is with no millisecond precision', () => {
+    expect(toCensoredISO8601String('2025-05-21T13:25:25Z')).toBe(
+      '2025-05-21T13:25:25Z',
+    );
+  });
+
+  it('removes millisecond precision', () => {
+    expect(toCensoredISO8601String('2025-05-21T13:25:21.500Z')).toBe(
+      '2025-05-21T13:25:21Z',
     );
   });
 });

--- a/packages/snaps-utils/src/time.ts
+++ b/packages/snaps-utils/src/time.ts
@@ -40,8 +40,7 @@ export const ISO8601DateStruct = refine(string(), 'ISO 8601 date', (value) => {
 });
 
 /**
- * Parses an ISO 8601 date, removes millisecond precision and returns
- * an ISO 8601 date.
+ * Remove millisecond precision from an ISO 8601 string.
  *
  * @param value - A valid ISO 8601 date.
  * @returns A valid ISO 8601 date with millisecond precision removed.

--- a/packages/snaps-utils/src/time.ts
+++ b/packages/snaps-utils/src/time.ts
@@ -38,3 +38,19 @@ export const ISO8601DateStruct = refine(string(), 'ISO 8601 date', (value) => {
 
   return true;
 });
+
+/**
+ * Parses an ISO 8601 date, removes millisecond precision and returns
+ * an ISO 8601 date.
+ *
+ * @param value - A valid ISO 8601 date.
+ * @returns A valid ISO 8601 date with millisecond precision removed.
+ */
+export function toCensoredISO8601String(value: string) {
+  const date = DateTime.fromISO(value, { setZone: true });
+
+  // Make sure any millisecond precision is removed.
+  return date.startOf('second').toISO({
+    suppressMilliseconds: true,
+  }) as string;
+}


### PR DESCRIPTION
This PR fixes an issue with scheduling background events using durations. Since we were truncating durations to remove milliseconds we would effectively allow scheduling events less than 1 second into the future.

To work around this, durations are now allowed to be a minimum of 1 second and are untruncated. The execution date will still be truncated when the Snap requests it to prevent leakage of millisecond precision.