### PR TITLE
feat: Add `onProtocolRequest` to `snaps-jest`

### DIFF
--- a/packages/examples/packages/protocol/package.json
+++ b/packages/examples/packages/protocol/package.json
@@ -47,6 +47,7 @@
     "@metamask/utils": "^11.4.0"
   },
   "devDependencies": {
+    "@jest/globals": "^29.5.0",
     "@lavamoat/allow-scripts": "^3.3.3",
     "@metamask/auto-changelog": "^5.0.2",
     "@metamask/snaps-cli": "workspace:^",

--- a/packages/examples/packages/protocol/src/index.test.ts
+++ b/packages/examples/packages/protocol/src/index.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from '@jest/globals';
+import { installSnap } from '@metamask/snaps-jest';
+
+const SCOPE = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1';
+
+describe('onProtocolRequest', () => {
+  it('returns the block height', async () => {
+    const { onProtocolRequest } = await installSnap();
+    const response = await onProtocolRequest(SCOPE, {
+      method: 'getBlockHeight',
+    });
+
+    expect(response).toRespondWith(expect.any(Number));
+  });
+});

--- a/packages/examples/packages/protocol/src/index.ts
+++ b/packages/examples/packages/protocol/src/index.ts
@@ -33,7 +33,7 @@ async function rpcRequest(method: string) {
  * This handler handles two methods:
  *
  * - `getBlockHeight`: Returns the block height of the Solana devnet.
- * - `getBlockHeight`: Returns the genesis hash of the Solana devnet.
+ * - `getGenesisHash`: Returns the genesis hash of the Solana devnet.
  *
  * @param params - The request parameters.
  * @param params.scope - The CAIP-2 scope of the request.

--- a/packages/snaps-jest/src/helpers.ts
+++ b/packages/snaps-jest/src/helpers.ts
@@ -188,6 +188,7 @@ export async function installSnap<
     onInstall,
     onUpdate,
     onNameLookup,
+    onProtocolRequest,
     mockJsonRpc,
     close,
   } = await getEnvironment().installSnap(...resolvedOptions);
@@ -207,6 +208,7 @@ export async function installSnap<
     onInstall,
     onUpdate,
     onNameLookup,
+    onProtocolRequest,
     mockJsonRpc,
     close: async () => {
       log('Closing execution service.');

--- a/packages/snaps-simulation/src/helpers.test.tsx
+++ b/packages/snaps-simulation/src/helpers.test.tsx
@@ -701,6 +701,66 @@ describe('helpers', () => {
     });
   });
 
+  describe('onProtocolRequest', () => {
+    it('sends a onProtocolRequest request and returns the result', async () => {
+      jest.spyOn(console, 'log').mockImplementation();
+
+      const { snapId, close: closeServer } = await getMockServer({
+        sourceCode: `
+          module.exports.onProtocolRequest = async () => {
+            return 1;
+          };
+         `,
+      });
+
+      const { onProtocolRequest, close } = await installSnap(snapId);
+      const response = await onProtocolRequest(
+        'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+        { method: 'getBlockHeight' },
+      );
+
+      expect(response).toStrictEqual(
+        expect.objectContaining({
+          response: {
+            result: 1,
+          },
+        }),
+      );
+
+      await close();
+      await closeServer();
+    });
+
+    it('sends a onProtocolRequest request including parameters and returns the result', async () => {
+      jest.spyOn(console, 'log').mockImplementation();
+
+      const { snapId, close: closeServer } = await getMockServer({
+        sourceCode: `
+          module.exports.onProtocolRequest = async () => {
+            return 1;
+          };
+         `,
+      });
+
+      const { onProtocolRequest, close } = await installSnap(snapId);
+      const response = await onProtocolRequest(
+        'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+        { method: 'getBlockHeight', params: ['latest'] },
+      );
+
+      expect(response).toStrictEqual(
+        expect.objectContaining({
+          response: {
+            result: 1,
+          },
+        }),
+      );
+
+      await close();
+      await closeServer();
+    });
+  });
+
   describe('mockJsonRpc', () => {
     it('mocks a JSON-RPC method', async () => {
       jest.spyOn(console, 'log').mockImplementation();

--- a/packages/snaps-simulation/src/types.ts
+++ b/packages/snaps-simulation/src/types.ts
@@ -2,7 +2,12 @@ import type { NotificationType, EnumToUnion } from '@metamask/snaps-sdk';
 import type { JSXElement } from '@metamask/snaps-sdk/jsx';
 import type { InferMatching } from '@metamask/snaps-utils';
 import type { Infer } from '@metamask/superstruct';
-import type { Json, JsonRpcId, JsonRpcParams } from '@metamask/utils';
+import type {
+  CaipChainId,
+  Json,
+  JsonRpcId,
+  JsonRpcParams,
+} from '@metamask/utils';
 
 import type {
   NameLookupOptionsStruct,
@@ -494,6 +499,19 @@ export type Snap = {
    */
   onNameLookup(
     nameLookupRequest: NameLookupOptions,
+  ): Promise<SnapResponseWithoutInterface>;
+
+  /**
+   * Send a JSON-RPC protocol request to the Snap.
+   *
+   * @param scope - A CAIP-2 scope.
+   * @param request - The request. This is similar to a JSON-RPC request, but
+   * has an extra `origin` field.
+   * @returns The response promise, with extra {@link SnapRequestObject} fields.
+   */
+  onProtocolRequest(
+    scope: CaipChainId,
+    request: RequestOptions,
   ): Promise<SnapResponseWithoutInterface>;
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3946,6 +3946,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/protocol-example-snap@workspace:packages/examples/packages/protocol"
   dependencies:
+    "@jest/globals": "npm:^29.5.0"
     "@lavamoat/allow-scripts": "npm:^3.3.3"
     "@metamask/auto-changelog": "npm:^5.0.2"
     "@metamask/snaps-cli": "workspace:^"


### PR DESCRIPTION
Add support for `onProtocolRequest` to `snaps-jest`, also adds a test to the protocol example Snap.

Closes https://github.com/MetaMask/snaps/issues/3187