### PR TITLE
fix: Support lifecycle hooks for preinstalled Snaps

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 95.14,
-  "functions": 98.43,
+  "functions": 98.42,
   "lines": 98.79,
   "statements": 98.62
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1055,13 +1055,13 @@ export class SnapController extends BaseController<
     this.#initializeStateMachine();
     this.#registerMessageHandlers();
 
-    if (this.#preinstalledSnaps) {
-      this.#handlePreinstalledSnaps(this.#preinstalledSnaps);
-    }
-
     Object.values(this.state?.snaps ?? {}).forEach((snap) =>
       this.#setupRuntime(snap.id),
     );
+
+    if (this.#preinstalledSnaps) {
+      this.#handlePreinstalledSnaps(this.#preinstalledSnaps);
+    }
 
     this.#trackSnapExport = throttleTracking(
       (snapId: SnapId, handler: string, success: boolean, origin: string) => {
@@ -1371,6 +1371,8 @@ export class SnapController extends BaseController<
       this.update((state) => {
         state.snaps[snapId].status = SnapStatus.Stopped;
       });
+
+      this.#setupRuntime(snapId);
 
       // Emit events
       if (isUpdate) {
@@ -2232,10 +2234,6 @@ export class SnapController extends BaseController<
     // We want to remove all snaps & permissions, except for preinstalled snaps
     if (this.#preinstalledSnaps) {
       this.#handlePreinstalledSnaps(this.#preinstalledSnaps);
-
-      Object.values(this.state?.snaps).forEach((snap) =>
-        this.#setupRuntime(snap.id),
-      );
     }
   }
 


### PR DESCRIPTION
Lifecycle hooks were broken for preinstalled Snaps because the Snap runtime wasn't setup when `snapInstalled` and `snapUpdated` was emitted. This PR moves `setupRuntime` around so that preinstalled Snaps have their runtime set up as soon as they are added.