### PR TITLE
Release 111.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "110.0.0",
+  "version": "111.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/snaps-controllers/CHANGELOG.md
+++ b/packages/snaps-controllers/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [12.3.1]
+
+### Uncategorized
+
+- fix: Support lifecycle hooks for preinstalled Snaps ([#3426](https://github.com/MetaMask/snaps/pull/3426))
+
 ## [12.3.0]
 
 ### Added
@@ -780,7 +786,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The version of the package no longer needs to match the version of all other
     MetaMask Snaps packages.
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@12.3.0...HEAD
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@12.3.1...HEAD
+[12.3.1]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@12.3.0...@metamask/snaps-controllers@12.3.1
 [12.3.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@12.2.0...@metamask/snaps-controllers@12.3.0
 [12.2.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@12.1.0...@metamask/snaps-controllers@12.2.0
 [12.1.0]: https://github.com/MetaMask/snaps/compare/@metamask/snaps-controllers@12.0.1...@metamask/snaps-controllers@12.1.0

--- a/packages/snaps-controllers/CHANGELOG.md
+++ b/packages/snaps-controllers/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [12.3.1]
 
-### Uncategorized
+### Fixed
 
-- fix: Support lifecycle hooks for preinstalled Snaps ([#3426](https://github.com/MetaMask/snaps/pull/3426))
+- Support lifecycle hooks for preinstalled Snaps ([#3426](https://github.com/MetaMask/snaps/pull/3426))
 
 ## [12.3.0]
 

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-controllers",
-  "version": "12.3.0",
+  "version": "12.3.1",
   "description": "Controllers for MetaMask Snaps",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
Addition to the previous release to get a patch out for a `snaps-controllers` issue.