### PR TITLE
fix: Recover from a crash more gracefully

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 95.14,
+  "branches": 95.15,
   "functions": 98.42,
   "lines": 98.79,
   "statements": 98.62

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -2040,8 +2040,9 @@ describe('SnapController', () => {
 
     expect(spy).toHaveBeenCalledTimes(2);
 
+    // @ts-expect-error Accessing protected value.
+    service.terminateJob = originalTerminateFunction;
     snapController.destroy();
-
     await service.terminateAllSnaps();
   });
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1718,8 +1718,9 @@ export class SnapController extends BaseController<
       throw new Error(`The snap "${snapId}" is not running.`);
     }
 
-    // No-op if the Snap is already stopping.
+    // If we are already stopping, wait for that to finish.
     if (runtime.stopPromise) {
+      await runtime.stopPromise;
       return;
     }
 
@@ -4090,6 +4091,7 @@ export class SnapController extends BaseController<
     this.#snapsRuntimeData.set(snapId, {
       lastRequest: null,
       startPromise: null,
+      stopPromise: null,
       installPromise: null,
       encryptionKey: null,
       encryptionSalt: null,
@@ -4097,7 +4099,6 @@ export class SnapController extends BaseController<
       pendingInboundRequests: [],
       pendingOutboundRequests: 0,
       interpreter,
-      stopping: false,
       stateMutex: new Mutex(),
       getStateMutex: new Mutex(),
     });

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -129,6 +129,7 @@ import {
   isValidSemVerRange,
   satisfiesVersionRange,
   timeSince,
+  createDeferredPromise,
 } from '@metamask/utils';
 import type { StateMachine } from '@xstate/fsm';
 import { createMachine, interpret } from '@xstate/fsm';
@@ -235,6 +236,11 @@ export type SnapRuntimeData = {
   startPromise: null | Promise<void>;
 
   /**
+   * A promise that resolves when the Snap has finished stopping
+   */
+  stopPromise: null | Promise<void>;
+
+  /**
    * A Unix timestamp for the last time the Snap received an RPC request
    */
   lastRequest: null | number;
@@ -272,11 +278,6 @@ export type SnapRuntimeData = {
    * Cached encryption salt used for state encryption.
    */
   encryptionSalt: string | null;
-
-  /**
-   * A boolean flag to determine whether the Snap is currently being stopped.
-   */
-  stopping: boolean;
 
   /**
    * Cached encrypted state of the Snap.
@@ -1718,13 +1719,14 @@ export class SnapController extends BaseController<
     }
 
     // No-op if the Snap is already stopping.
-    if (runtime.stopping) {
+    if (runtime.stopPromise) {
       return;
     }
 
     // Flag that the Snap is actively stopping, this prevents other calls to stopSnap
     // while we are handling termination of the Snap
-    runtime.stopping = true;
+    const { promise, resolve } = createDeferredPromise();
+    runtime.stopPromise = promise;
 
     try {
       if (this.isRunning(snapId)) {
@@ -1736,10 +1738,11 @@ export class SnapController extends BaseController<
       runtime.lastRequest = null;
       runtime.pendingInboundRequests = [];
       runtime.pendingOutboundRequests = 0;
-      runtime.stopping = false;
+      runtime.stopPromise = null;
       if (this.isRunning(snapId)) {
         this.#transition(snapId, statusEvent);
       }
+      resolve();
     }
   }
 
@@ -3550,8 +3553,13 @@ export class SnapController extends BaseController<
 
     const timeout = this.#getExecutionTimeout(handlerPermissions);
 
+    const runtime = this.#getRuntimeExpect(snapId);
+
+    if (runtime.stopPromise) {
+      await runtime.stopPromise;
+    }
+
     if (!this.isRunning(snapId)) {
-      const runtime = this.#getRuntimeExpect(snapId);
       if (!runtime.startPromise) {
         runtime.startPromise = this.startSnap(snapId);
       }


### PR DESCRIPTION
The current behavior for stopping Snaps (in case of crashes or idling) was prone to race conditions when requests to the Snap were dispatched around the time that the Snap crashed. 

We saw this in production here: https://github.com/MetaMask/metamask-extension/issues/33411

To prevent this, we can turn the `stopping` flag into a promise that we can await in case of multiple calls to `stopSnap`, but also before considering whether the Snap is started for a subsequent request.