### PR TITLE
fix: Log errors that cause a crash

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -3626,6 +3626,10 @@ export class SnapController extends BaseController<
       const [jsonRpcError, handled] = unwrapError(error);
 
       if (!handled) {
+        logError(
+          `"${snapId}" threw an unhandled error and crashed:`,
+          jsonRpcError,
+        );
         await this.stopSnap(snapId, SnapStatusEvents.Crash);
       }
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -3627,7 +3627,7 @@ export class SnapController extends BaseController<
 
       if (!handled) {
         logError(
-          `"${snapId}" threw an unhandled error and crashed:`,
+          `"${snapId}" crashed due to an unhandled error:`,
           jsonRpcError,
         );
         await this.stopSnap(snapId, SnapStatusEvents.Crash);


### PR DESCRIPTION
Log errors that cause the Snap to crash for debugging purposes. Sometimes the caller may be swallowing the error, so its important that we log it directly.