### PR TITLE
feat: Add WebSocket logic to network access Snap

### DIFF
--- a/packages/examples/packages/network-access/README.md
+++ b/packages/examples/packages/network-access/README.md
@@ -1,11 +1,12 @@
 # `@metamask/network-access-example-snap`
 
 This snap demonstrates how to use the `endowment:network-access` permission to
-get access to the `fetch` function from a snap.
+get access to the `fetch` function from a Snap. It also demonstrates how to use
+WebSockets.
 
 ## Snap manifest
 
-> **Note**: Using `fetch` requires the `endowment:network-access`
+> **Note**: Using `fetch` or WebSockets requires the `endowment:network-access`
 > permissions. Refer to [the documentation](https://docs.metamask.io/snaps/reference/permissions/#endowmentnetwork-access)
 > for more information.
 
@@ -29,6 +30,11 @@ JSON-RPC methods:
 
 - `fetch` - Fetch a JSON document from the optional `url`, and return the
   fetched data.
+- `startWebSocket` - Open a WebSocket connection to a local Ethereum node
+  and subscribe to block updates.
+- `stopWebSocket` - Close a WebSocket connection, if one exists.
+- `getState` - Get the state of the Snap, including the block number and whether
+  the WebSocket connection is active.
 
 For more information, you can refer to
 [the end-to-end tests](./src/index.test.ts).

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "jIA8HIUJKUlasU0G8ZppBteN6gVgSaBMddSWhYFhFNk=",
+    "shasum": "lQOEArGTw4fxV2GxGPHqPhG2RQlGQLQvnZXTDk85qLQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -21,7 +21,8 @@
       "dapps": true,
       "snaps": false
     },
-    "endowment:network-access": {}
+    "endowment:network-access": {},
+    "snap_manageState": {}
   },
   "platformVersion": "8.0.0",
   "manifestVersion": "0.1"

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "lQOEArGTw4fxV2GxGPHqPhG2RQlGQLQvnZXTDk85qLQ=",
+    "shasum": "2HlA1Jt3eX8cW5/Nudr49NmNjTlR7iw9CgGVP+1pGPs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "iITjGVG6EOAX3tWtzmHM5H/N4Q9cyULh+MSgI5gsbhg=",
+    "shasum": "rrThY3oXtGgw6Jm85xyEQ0mdHgxmVC7nfb2CFQlwrsY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2HlA1Jt3eX8cW5/Nudr49NmNjTlR7iw9CgGVP+1pGPs=",
+    "shasum": "iITjGVG6EOAX3tWtzmHM5H/N4Q9cyULh+MSgI5gsbhg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/src/types.ts
+++ b/packages/examples/packages/network-access/src/types.ts
@@ -1,7 +1,7 @@
 /**
- * The params for the `fetch` JSON-RPC method.
+ * Generic parameters containing an URL.
  */
-export type FetchParams = {
+export type UrlParams = {
   /**
    * The URL to fetch.
    */

--- a/packages/test-snaps/src/features/snaps/network-access/NetworkAccess.tsx
+++ b/packages/test-snaps/src/features/snaps/network-access/NetworkAccess.tsx
@@ -1,7 +1,7 @@
 import { logError } from '@metamask/snaps-utils';
 import type { ChangeEvent, FunctionComponent } from 'react';
 import { useState } from 'react';
-import { Button, Form } from 'react-bootstrap';
+import { Button, ButtonGroup, Form } from 'react-bootstrap';
 
 import {
   NETWORK_ACCESS_PORT,
@@ -20,11 +20,34 @@ export const NetworkAccess: FunctionComponent = () => {
     setUrl(event.target.value);
   };
 
-  const handleSubmit = () => {
+  const snapId = getSnapId(NETWORK_ACCESS_SNAP_ID, NETWORK_ACCESS_PORT);
+
+  const handleFetch = () => {
     invokeSnap({
-      snapId: getSnapId(NETWORK_ACCESS_SNAP_ID, NETWORK_ACCESS_PORT),
+      snapId,
       method: 'fetch',
       params: { url },
+    }).catch(logError);
+  };
+
+  const handleStartWebSocket = () => {
+    invokeSnap({
+      snapId,
+      method: 'startWebSocket',
+    }).catch(logError);
+  };
+
+  const handleStopWebSocket = () => {
+    invokeSnap({
+      snapId,
+      method: 'stopWebSocket',
+    }).catch(logError);
+  };
+
+  const handleGetBlockNumber = () => {
+    invokeSnap({
+      snapId,
+      method: 'getBlockNumber',
     }).catch(logError);
   };
 
@@ -49,10 +72,41 @@ export const NetworkAccess: FunctionComponent = () => {
         id="sendNetworkAccessTest"
         className="mb-3"
         disabled={isLoading}
-        onClick={handleSubmit}
+        onClick={handleFetch}
       >
         Fetch
       </Button>
+
+      <br />
+
+      <ButtonGroup className="mb-3">
+        <Button
+          variant="primary"
+          id="startWebSocket"
+          disabled={isLoading}
+          onClick={handleStartWebSocket}
+        >
+          Start WebSocket
+        </Button>
+        <Button
+          variant="primary"
+          id="stopWebSocket"
+          disabled={isLoading}
+          onClick={handleStopWebSocket}
+        >
+          Stop WebSocket
+        </Button>
+
+        <Button
+          variant="primary"
+          id="getBlockNumber"
+          disabled={isLoading}
+          onClick={handleGetBlockNumber}
+        >
+          Get Block Number
+        </Button>
+      </ButtonGroup>
+
       <Result>
         <span id="networkAccessResult">
           {JSON.stringify(data, null, 2)}

--- a/packages/test-snaps/src/features/snaps/network-access/NetworkAccess.tsx
+++ b/packages/test-snaps/src/features/snaps/network-access/NetworkAccess.tsx
@@ -44,10 +44,10 @@ export const NetworkAccess: FunctionComponent = () => {
     }).catch(logError);
   };
 
-  const handleGetBlockNumber = () => {
+  const handleGetState = () => {
     invokeSnap({
       snapId,
-      method: 'getBlockNumber',
+      method: 'getState',
     }).catch(logError);
   };
 
@@ -77,8 +77,6 @@ export const NetworkAccess: FunctionComponent = () => {
         Fetch
       </Button>
 
-      <br />
-
       <ButtonGroup className="mb-3">
         <Button
           variant="primary"
@@ -99,11 +97,11 @@ export const NetworkAccess: FunctionComponent = () => {
 
         <Button
           variant="primary"
-          id="getBlockNumber"
+          id="getWebSocketState"
           disabled={isLoading}
-          onClick={handleGetBlockNumber}
+          onClick={handleGetState}
         >
-          Get Block Number
+          Get State
         </Button>
       </ButtonGroup>
 


### PR DESCRIPTION
Expands the network access Snap to support opening a WebSocket connection and subscribing to block updates from a local Ethereum node. Additionally fixes some mistakes made in the original WebSocket PR.

Closes https://github.com/MetaMask/snaps/issues/3456