### PR TITLE
fix: Add missing WS types and allow local URLs

### DIFF
--- a/packages/snaps-rpc-methods/src/permitted/openWebSocket.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/openWebSocket.test.ts
@@ -88,7 +88,7 @@ describe('snap_openWebSocket', () => {
         id: 1,
         method: 'snap_openWebSocket',
         params: {
-          url: 'ws://metamask.io',
+          url: 'http://metamask.io',
         },
       });
 
@@ -96,7 +96,7 @@ describe('snap_openWebSocket', () => {
         error: {
           code: -32602,
           message:
-            'Invalid params: At path: url -- Expected URL, got "ws://metamask.io"..',
+            'Invalid params: At path: url -- Expected URL, got "http://metamask.io"..',
           stack: expect.any(String),
         },
         id: 1,

--- a/packages/snaps-rpc-methods/src/permitted/openWebSocket.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/openWebSocket.test.ts
@@ -96,7 +96,7 @@ describe('snap_openWebSocket', () => {
         error: {
           code: -32602,
           message:
-            'Invalid params: At path: url -- Expected URL, got "http://metamask.io"..',
+            'Invalid params: At path: url -- At path: protocol -- Expected the value to satisfy a union of `"wss:" | "ws:"`, but received: "http:"..',
           stack: expect.any(String),
         },
         id: 1,

--- a/packages/snaps-rpc-methods/src/permitted/openWebSocket.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/openWebSocket.test.ts
@@ -96,7 +96,7 @@ describe('snap_openWebSocket', () => {
         error: {
           code: -32602,
           message:
-            'Invalid params: At path: url -- At path: protocol -- Expected the value to satisfy a union of `"wss:" | "ws:"`, but received: "http:"..',
+            'Invalid params: At path: url -- At path: protocol -- Expected the value to satisfy a union of `"wss:" | "ws:"`, but received: "http:".',
           stack: expect.any(String),
         },
         id: 1,

--- a/packages/snaps-rpc-methods/src/permitted/openWebSocket.ts
+++ b/packages/snaps-rpc-methods/src/permitted/openWebSocket.ts
@@ -3,6 +3,7 @@ import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import {
   literal,
+  union,
   type JsonRpcRequest,
   type OpenWebSocketParams,
   type OpenWebSocketResult,
@@ -32,7 +33,7 @@ export type OpenWebSocketMethodHooks = {
 };
 
 const OpenWebSocketParametersStruct = object({
-  url: uri({ protocol: literal('wss:') }),
+  url: uri({ protocol: union([literal('wss:'), literal('ws:')]) }),
   protocols: optional(array(string())),
 });
 

--- a/packages/snaps-sdk/src/types/methods/methods.ts
+++ b/packages/snaps-sdk/src/types/methods/methods.ts
@@ -4,6 +4,10 @@ import type {
 } from './cancel-background-event';
 import type { ClearStateParams, ClearStateResult } from './clear-state';
 import type {
+  CloseWebSocketParams,
+  CloseWebSocketResult,
+} from './close-web-socket';
+import type {
   CreateInterfaceParams,
   CreateInterfaceResult,
 } from './create-interface';
@@ -50,6 +54,10 @@ import type {
 import type { GetSnapsParams, GetSnapsResult } from './get-snaps';
 import type { GetStateParams, GetStateResult } from './get-state';
 import type {
+  GetWebSocketsParams,
+  GetWebSocketsResult,
+} from './get-web-sockets';
+import type {
   InvokeKeyringParams,
   InvokeKeyringResult,
 } from './invoke-keyring';
@@ -64,6 +72,10 @@ import type {
 } from './manage-accounts';
 import type { ManageStateParams, ManageStateResult } from './manage-state';
 import type { NotifyParams, NotifyResult } from './notify';
+import type {
+  OpenWebSocketParams,
+  OpenWebSocketResult,
+} from './open-web-socket';
 import type { RequestSnapsParams, RequestSnapsResult } from './request-snaps';
 import type {
   ResolveInterfaceParams,
@@ -73,6 +85,10 @@ import type {
   ScheduleBackgroundEventParams,
   ScheduleBackgroundEventResult,
 } from './schedule-background-event';
+import type {
+  SendWebSocketMessageParams,
+  SendWebSocketMessageResult,
+} from './send-web-socket-message';
 import type { SetStateParams, SetStateResult } from './set-state';
 import type { TrackEventParams, TrackEventResult } from './track-event';
 import type {
@@ -125,6 +141,13 @@ export type SnapMethods = {
   snap_resolveInterface: [ResolveInterfaceParams, ResolveInterfaceResult];
   snap_setState: [SetStateParams, SetStateResult];
   snap_trackEvent: [TrackEventParams, TrackEventResult];
+  snap_openWebSocket: [OpenWebSocketParams, OpenWebSocketResult];
+  snap_closeWebSocket: [CloseWebSocketParams, CloseWebSocketResult];
+  snap_getWebSockets: [GetWebSocketsParams, GetWebSocketsResult];
+  snap_sendWebSocketMessage: [
+    SendWebSocketMessageParams,
+    SendWebSocketMessageResult,
+  ];
   wallet_getSnaps: [GetSnapsParams, GetSnapsResult];
   wallet_invokeKeyring: [InvokeKeyringParams, InvokeKeyringResult];
   wallet_invokeSnap: [InvokeSnapParams, InvokeSnapResult];

--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 99.76,
   "functions": 99,
-  "lines": 98.68,
-  "statements": 97.28
+  "lines": 98.69,
+  "statements": 97.29
 }

--- a/packages/snaps-utils/src/types.ts
+++ b/packages/snaps-utils/src/types.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from '@metamask/snaps-sdk';
 import {
   is,
   optional,
@@ -6,6 +7,7 @@ import {
   string,
   type,
   assert as assertSuperstruct,
+  StructError,
 } from '@metamask/superstruct';
 import type { Infer, Struct } from '@metamask/superstruct';
 import type { Json } from '@metamask/utils';
@@ -124,8 +126,11 @@ export const uri = (opts: UriOptions<any> = {}) =>
       const UrlStruct = type(opts);
       assertSuperstruct(url, UrlStruct);
       return true;
-    } catch {
-      return `Expected URL, got "${value.toString()}".`;
+    } catch (error) {
+      if (error instanceof StructError) {
+        return getErrorMessage(error);
+      }
+      return `Expected URL, got "${value.toString()}"`;
     }
   });
 


### PR DESCRIPTION
Fixes a couple of issues after the merge of the WebSockets PR. Adds the proper types for the RPC methods and allows local WebSocket URLs in `snap_openWebSocket`.

Also fixes the formatting for Uri validation errors.

Closes https://github.com/MetaMask/snaps/issues/3457