### PR TITLE
feat: Add cronjob duration example

### DIFF
--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -27,7 +27,10 @@ The following is a list of the snaps in this directory.
   executing the snap.
 - [**`packages/cronjobs`**](./packages/cronjobs): This snap demonstrates how to
   use the `endowment:cronjob` permission to schedule a function to be called at
-  a later time.
+  a later time, using cron expressions.
+- [**`packages/cronjob-duration`**](./packages/cronjobs): This snap demonstrates how to
+  use the `endowment:cronjob` permission to schedule a function to be called at
+  a later time, using ISO 8601 durations instead of cron expressions.
 - [**`packages/dialogs`**](./packages/dialogs): This snap demonstrates how to
   use the `snap_dialog` method to display different types of dialogs to the
   user.

--- a/packages/examples/packages/cronjob-duration/.depcheckrc.json
+++ b/packages/examples/packages/cronjob-duration/.depcheckrc.json
@@ -1,0 +1,18 @@
+{
+  "ignore-patterns": ["dist", "coverage"],
+  "ignores": [
+    "@lavamoat/allow-scripts",
+    "@lavamoat/preinstall-always-fail",
+    "@metamask/auto-changelog",
+    "@metamask/eslint-*",
+    "@types/*",
+    "@typescript-eslint/*",
+    "eslint-config-*",
+    "eslint-plugin-*",
+    "jest-silent-reporter",
+    "prettier-plugin-packagejson",
+    "ts-node",
+    "typedoc",
+    "typescript"
+  ]
+}

--- a/packages/examples/packages/cronjob-duration/CHANGELOG.md
+++ b/packages/examples/packages/cronjob-duration/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/snaps/

--- a/packages/examples/packages/cronjob-duration/LICENSE.APACHE2
+++ b/packages/examples/packages/cronjob-duration/LICENSE.APACHE2
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 Consensys Software Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/examples/packages/cronjob-duration/LICENSE.MIT0
+++ b/packages/examples/packages/cronjob-duration/LICENSE.MIT0
@@ -1,0 +1,16 @@
+MIT No Attribution
+
+Copyright 2025 Consensys Software Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/examples/packages/cronjob-duration/README.md
+++ b/packages/examples/packages/cronjob-duration/README.md
@@ -1,7 +1,7 @@
-# `@metamask/cronjob-example-snap`
+# `@metamask/cronjob-duration-example-snap`
 
-This snap demonstrates the use of the `endowment:cronjob` permission to
-periodically execute a function.
+This Snap demonstrates the use of the `endowment:cronjob` permission to
+periodically execute a function, using ISO 8601 durations.
 
 ## Snap manifest
 
@@ -19,7 +19,7 @@ Along with other permissions, the manifest of this snap includes the
     "endowment:cronjob": {
       "jobs": [
         {
-          "expression": "* * * * *",
+          "duration": "PT10S",
           "request": {
             "method": "execute"
           }
@@ -30,16 +30,16 @@ Along with other permissions, the manifest of this snap includes the
 }
 ```
 
-A snap can schedule one or more cronjobs by specifying an array of `jobs` in
-the `endowment:cronjob` permission. Each job is defined by an `expression` and
-a `request` object. The `expression` is a cron expression that defines the
-schedule of the job. The `request` object defines the JSON-RPC request that
+A Snap can schedule one or more cronjobs by specifying an array of `jobs` in
+the `endowment:cronjob` permission. Each job is defined by a `duration` and
+a `request` object. The `duration` is an ISO 8601 duration that defines the
+interval of the job. The `request` object defines the JSON-RPC request that
 will be sent to the snap's `onCronjob` handler when the job is executed.
 
 > [!TIP]
-> You can also schedule jobs using ISO 8601 durations by using the `duration`
-> field instead of `expression`. For more information, refer to the
-> [cronjob duration example](../cronjob-duration/README.md).
+> You can also schedule jobs using cron expressions by using the `expression`
+> field instead of `duration`. For more information, refer to the
+> [cronjob example](../cronjobs/README.md).
 
 In this example, we schedule a job that executes every minute. When the job is
 executed, the snap's `onCronjob` handler is called with the following JSON-RPC

--- a/packages/examples/packages/cronjob-duration/jest.config.js
+++ b/packages/examples/packages/cronjob-duration/jest.config.js
@@ -1,0 +1,36 @@
+const deepmerge = require('deepmerge');
+
+const baseConfig = require('../../../../jest.config.base');
+
+module.exports = deepmerge(baseConfig, {
+  preset: '@metamask/snaps-jest',
+
+  // Since `@metamask/snaps-jest` runs in the browser, we can't collect
+  // coverage information.
+  collectCoverage: false,
+
+  // This is required for the tests to run inside the `MetaMask/snaps`
+  // repository. You don't need this in your own project.
+  moduleNameMapper: {
+    '^@metamask/(.+)/production/jsx-runtime': [
+      '<rootDir>/../../../$1/src/jsx/production/jsx-runtime',
+      '<rootDir>/../../../../node_modules/@metamask/$1/jsx/production/jsx-runtime',
+      '<rootDir>/node_modules/@metamask/$1/jsx/production/jsx-runtime',
+    ],
+    '^@metamask/(.+)/jsx': [
+      '<rootDir>/../../../$1/src/jsx',
+      '<rootDir>/../../../../node_modules/@metamask/$1/jsx',
+      '<rootDir>/node_modules/@metamask/$1/jsx',
+    ],
+    '^@metamask/(.+)/node$': [
+      '<rootDir>/../../../$1/src/node',
+      '<rootDir>/../../../../node_modules/@metamask/$1/node',
+      '<rootDir>/node_modules/@metamask/$1/node',
+    ],
+    '^@metamask/(.+)$': [
+      '<rootDir>/../../../$1/src',
+      '<rootDir>/../../../../node_modules/@metamask/$1',
+      '<rootDir>/node_modules/@metamask/$1',
+    ],
+  },
+});

--- a/packages/examples/packages/cronjob-duration/package.json
+++ b/packages/examples/packages/cronjob-duration/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@metamask/cronjob-duration-example-snap",
+  "version": "0.0.0",
+  "description": "MetaMask example Snap demonstrating the use of cronjobs with ISO 8601 durations in Snaps",
+  "keywords": [
+    "MetaMask",
+    "Snaps",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/snaps/tree/main/packages/examples/packages/cronjob-duration#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/snaps/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/snaps.git"
+  },
+  "license": "(MIT-0 OR Apache-2.0)",
+  "sideEffects": false,
+  "main": "./dist/bundle.js",
+  "files": [
+    "dist",
+    "snap.manifest.json"
+  ],
+  "scripts": {
+    "build": "mm-snap build",
+    "build:clean": "yarn clean && yarn build",
+    "changelog:update": "../../../../scripts/update-changelog.sh @metamask/cronjob-duration-example-snap",
+    "changelog:validate": "../../../../scripts/validate-changelog.sh @metamask/cronjob-duration-example-snap",
+    "clean": "rimraf \"dist\"",
+    "lint": "yarn lint:eslint && yarn lint:misc --check && yarn changelog:validate && yarn lint:dependencies",
+    "lint:ci": "yarn lint",
+    "lint:dependencies": "depcheck",
+    "lint:eslint": "eslint . --cache",
+    "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
+    "lint:misc": "prettier --no-error-on-unmatched-pattern --log-level warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" \"!snap.manifest.json\" --ignore-path ../../../../.gitignore",
+    "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../../../scripts/since-latest-release.sh",
+    "start": "mm-snap watch",
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch"
+  },
+  "dependencies": {
+    "@metamask/snaps-sdk": "workspace:^"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.5.0",
+    "@lavamoat/allow-scripts": "^3.3.3",
+    "@metamask/auto-changelog": "^5.0.2",
+    "@metamask/snaps-cli": "workspace:^",
+    "@metamask/snaps-jest": "workspace:^",
+    "@swc/core": "1.11.31",
+    "@swc/jest": "^0.2.38",
+    "@types/node": "18.14.2",
+    "deepmerge": "^4.2.2",
+    "depcheck": "^1.4.7",
+    "eslint": "^9.11.0",
+    "jest": "^29.0.2",
+    "jest-silent-reporter": "^0.6.0",
+    "prettier": "^3.3.3",
+    "rimraf": "^4.1.2",
+    "ts-node": "^10.9.1",
+    "typescript": "~5.3.3"
+  },
+  "engines": {
+    "node": "^20 || >=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/examples/packages/cronjob-duration/snap.config.ts
+++ b/packages/examples/packages/cronjob-duration/snap.config.ts
@@ -1,0 +1,17 @@
+import type { SnapConfig } from '@metamask/snaps-cli';
+import { resolve } from 'path';
+
+const config: SnapConfig = {
+  input: resolve(__dirname, 'src/index.ts'),
+  server: {
+    port: 8035,
+  },
+  typescript: {
+    enabled: true,
+  },
+  stats: {
+    buffer: false,
+  },
+};
+
+export default config;

--- a/packages/examples/packages/cronjob-duration/snap.manifest.json
+++ b/packages/examples/packages/cronjob-duration/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "872nV9BcXrKcq9KtxvYWwoPFXqUl9kKxbvqRoI+FaiQ=",
+    "shasum": "i/YSeO2E9gHo3ovjTjj4iYfEEkP8yEr5sU5O8TgzS7g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -27,7 +27,7 @@
         }
       ]
     },
-    "snap_dialog": {}
+    "snap_notify": {}
   },
   "platformVersion": "8.0.0",
   "manifestVersion": "0.1"

--- a/packages/examples/packages/cronjob-duration/snap.manifest.json
+++ b/packages/examples/packages/cronjob-duration/snap.manifest.json
@@ -1,0 +1,34 @@
+{
+  "version": "0.0.0",
+  "description": "MetaMask example Snap demonstrating the use of cronjobs with ISO 8601 durations in Snaps.",
+  "proposedName": "Cronjob Duration Example Snap",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/snaps.git"
+  },
+  "source": {
+    "shasum": "872nV9BcXrKcq9KtxvYWwoPFXqUl9kKxbvqRoI+FaiQ=",
+    "location": {
+      "npm": {
+        "filePath": "dist/bundle.js",
+        "packageName": "@metamask/cronjob-duration-example-snap",
+        "registry": "https://registry.npmjs.org/"
+      }
+    }
+  },
+  "initialPermissions": {
+    "endowment:cronjob": {
+      "jobs": [
+        {
+          "duration": "PT10S",
+          "request": {
+            "method": "execute"
+          }
+        }
+      ]
+    },
+    "snap_dialog": {}
+  },
+  "platformVersion": "8.0.0",
+  "manifestVersion": "0.1"
+}

--- a/packages/examples/packages/cronjob-duration/src/index.test.ts
+++ b/packages/examples/packages/cronjob-duration/src/index.test.ts
@@ -1,0 +1,34 @@
+import { expect } from '@jest/globals';
+import { installSnap } from '@metamask/snaps-jest';
+import { heading, panel, text } from '@metamask/snaps-sdk';
+
+describe('onCronjob', () => {
+  describe('execute', () => {
+    it('shows a dialog', async () => {
+      const { onCronjob } = await installSnap();
+
+      const request = onCronjob({
+        // This would normally be called by the MetaMask extension, but to make
+        // this testable, `@metamask/snaps-jest` exposes a `runCronjob` method.
+        method: 'execute',
+      });
+
+      const ui = await request.getInterface();
+
+      expect(ui).toRender(
+        panel([
+          heading('Cronjob'),
+          text(
+            'This dialog was triggered by a cronjob using an ISO 8601 duration.',
+          ),
+        ]),
+      );
+
+      // TODO(ritave): Fix types in SnapInterface
+      await (ui as any).ok();
+
+      const response = await request;
+      expect(response).toRespondWith(null);
+    });
+  });
+});

--- a/packages/examples/packages/cronjob-duration/src/index.test.ts
+++ b/packages/examples/packages/cronjob-duration/src/index.test.ts
@@ -1,33 +1,23 @@
 import { expect } from '@jest/globals';
 import { installSnap } from '@metamask/snaps-jest';
-import { heading, panel, text } from '@metamask/snaps-sdk';
+import { NotificationType } from '@metamask/snaps-sdk';
 
 describe('onCronjob', () => {
   describe('execute', () => {
-    it('shows a dialog', async () => {
+    it('shows a notification', async () => {
       const { onCronjob } = await installSnap();
 
-      const request = onCronjob({
+      const response = await onCronjob({
         // This would normally be called by the MetaMask extension, but to make
-        // this testable, `@metamask/snaps-jest` exposes a `runCronjob` method.
+        // this testable, `@metamask/snaps-jest` exposes a `onCronjob` method.
         method: 'execute',
       });
 
-      const ui = await request.getInterface();
-
-      expect(ui).toRender(
-        panel([
-          heading('Cronjob'),
-          text(
-            'This dialog was triggered by a cronjob using an ISO 8601 duration.',
-          ),
-        ]),
+      expect(response).toSendNotification(
+        'This notification was triggered by a cronjob using an ISO 8601 duration.',
+        NotificationType.InApp,
       );
 
-      // TODO(ritave): Fix types in SnapInterface
-      await (ui as any).ok();
-
-      const response = await request;
       expect(response).toRespondWith(null);
     });
   });

--- a/packages/examples/packages/cronjob-duration/src/index.ts
+++ b/packages/examples/packages/cronjob-duration/src/index.ts
@@ -1,5 +1,5 @@
 import type { OnCronjobHandler } from '@metamask/snaps-sdk';
-import { panel, text, heading, MethodNotFoundError } from '@metamask/snaps-sdk';
+import { NotificationType, MethodNotFoundError } from '@metamask/snaps-sdk';
 
 /**
  * Handle cronjob execution requests from MetaMask. This handler handles one
@@ -19,16 +19,14 @@ export const onCronjob: OnCronjobHandler = async ({ request }) => {
   switch (request.method) {
     case 'execute':
       // Cronjobs can execute any method that is available to the Snap.
-      return snap.request({
-        method: 'snap_dialog',
+      return await snap.request({
+        method: 'snap_notify',
         params: {
-          type: 'alert',
-          content: panel([
-            heading('Cronjob'),
-            text(
-              'This dialog was triggered by a cronjob using an ISO 8601 duration.',
-            ),
-          ]),
+          // We're using the `NotificationType` enum here, but you can also use
+          // the string values directly, e.g. `type: 'inApp'`.
+          type: NotificationType.InApp,
+          message:
+            'This notification was triggered by a cronjob using an ISO 8601 duration.',
         },
       });
     default:

--- a/packages/examples/packages/cronjob-duration/src/index.ts
+++ b/packages/examples/packages/cronjob-duration/src/index.ts
@@ -1,0 +1,37 @@
+import type { OnCronjobHandler } from '@metamask/snaps-sdk';
+import { panel, text, heading, MethodNotFoundError } from '@metamask/snaps-sdk';
+
+/**
+ * Handle cronjob execution requests from MetaMask. This handler handles one
+ * method:
+ *
+ * - `execute`: The JSON-RPC method that is called by MetaMask when the cronjob
+ * is triggered. This method is specified in the Snap manifest under the
+ * `endowment:cronjob` permission. If you want to support more methods (e.g.,
+ * with different times), you can add them to the manifest there.
+ *
+ * @param params - The request parameters.
+ * @param params.request - The JSON-RPC request object.
+ * @returns The JSON-RPC response.
+ * @see https://docs.metamask.io/snaps/reference/exports/#oncronjob
+ */
+export const onCronjob: OnCronjobHandler = async ({ request }) => {
+  switch (request.method) {
+    case 'execute':
+      // Cronjobs can execute any method that is available to the Snap.
+      return snap.request({
+        method: 'snap_dialog',
+        params: {
+          type: 'alert',
+          content: panel([
+            heading('Cronjob'),
+            text(
+              'This dialog was triggered by a cronjob using an ISO 8601 duration.',
+            ),
+          ]),
+        },
+      });
+    default:
+      throw new MethodNotFoundError({ method: request.method });
+  }
+};

--- a/packages/examples/packages/cronjob-duration/tsconfig.json
+++ b/packages/examples/packages/cronjob-duration/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "baseUrl": "./"
+  },
+  "include": ["src", "snap.config.ts"]
+}

--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -45,6 +45,7 @@
     "@metamask/bip32-example-snap": "workspace:^",
     "@metamask/bip44-example-snap": "workspace:^",
     "@metamask/client-status-example-snap": "workspace:^",
+    "@metamask/cronjob-duration-example-snap": "workspace:^",
     "@metamask/cronjob-example-snap": "workspace:^",
     "@metamask/dialog-example-snap": "workspace:^",
     "@metamask/error-example-snap": "workspace:^",

--- a/packages/test-snaps/src/features/snaps/cronjob-duration/CronjobDuration.tsx
+++ b/packages/test-snaps/src/features/snaps/cronjob-duration/CronjobDuration.tsx
@@ -1,0 +1,20 @@
+import type { FunctionComponent } from 'react';
+
+import {
+  CRONJOB_DURATION_SNAP_ID,
+  CRONJOB_DURATION_SNAP_PORT,
+  CRONJOB_DURATION_VERSION,
+} from './constants';
+import { Snap } from '../../../components';
+
+export const CronjobDuration: FunctionComponent = () => {
+  return (
+    <Snap
+      name="Cronjob Duration Snap"
+      snapId={CRONJOB_DURATION_SNAP_ID}
+      port={CRONJOB_DURATION_SNAP_PORT}
+      version={CRONJOB_DURATION_VERSION}
+      testId="cronjob-duration"
+    />
+  );
+};

--- a/packages/test-snaps/src/features/snaps/cronjob-duration/constants.ts
+++ b/packages/test-snaps/src/features/snaps/cronjob-duration/constants.ts
@@ -1,0 +1,6 @@
+import packageJson from '@metamask/cronjob-duration-example-snap/package.json';
+
+export const CRONJOB_DURATION_SNAP_ID =
+  'npm:@metamask/cronjob-duration-example-snap';
+export const CRONJOB_DURATION_SNAP_PORT = 8035;
+export const CRONJOB_DURATION_VERSION = packageJson.version;

--- a/packages/test-snaps/src/features/snaps/cronjob-duration/index.ts
+++ b/packages/test-snaps/src/features/snaps/cronjob-duration/index.ts
@@ -1,0 +1,1 @@
+export * from './CronjobDuration';

--- a/packages/test-snaps/src/features/snaps/index.ts
+++ b/packages/test-snaps/src/features/snaps/index.ts
@@ -1,6 +1,7 @@
 export * from './bip32';
 export * from './bip44';
 export * from './client-status';
+export * from './cronjob-duration';
 export * from './cronjobs';
 export * from './dialogs';
 export * from './errors';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3128,7 +3128,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/cronjob-duration-example-snap@workspace:packages/examples/packages/cronjob-duration":
+"@metamask/cronjob-duration-example-snap@workspace:^, @metamask/cronjob-duration-example-snap@workspace:packages/examples/packages/cronjob-duration":
   version: 0.0.0-use.local
   resolution: "@metamask/cronjob-duration-example-snap@workspace:packages/examples/packages/cronjob-duration"
   dependencies:
@@ -4686,6 +4686,7 @@ __metadata:
     "@metamask/bip32-example-snap": "workspace:^"
     "@metamask/bip44-example-snap": "workspace:^"
     "@metamask/client-status-example-snap": "workspace:^"
+    "@metamask/cronjob-duration-example-snap": "workspace:^"
     "@metamask/cronjob-example-snap": "workspace:^"
     "@metamask/dialog-example-snap": "workspace:^"
     "@metamask/error-example-snap": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3128,6 +3128,31 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@metamask/cronjob-duration-example-snap@workspace:packages/examples/packages/cronjob-duration":
+  version: 0.0.0-use.local
+  resolution: "@metamask/cronjob-duration-example-snap@workspace:packages/examples/packages/cronjob-duration"
+  dependencies:
+    "@jest/globals": "npm:^29.5.0"
+    "@lavamoat/allow-scripts": "npm:^3.3.3"
+    "@metamask/auto-changelog": "npm:^5.0.2"
+    "@metamask/snaps-cli": "workspace:^"
+    "@metamask/snaps-jest": "workspace:^"
+    "@metamask/snaps-sdk": "workspace:^"
+    "@swc/core": "npm:1.11.31"
+    "@swc/jest": "npm:^0.2.38"
+    "@types/node": "npm:18.14.2"
+    deepmerge: "npm:^4.2.2"
+    depcheck: "npm:^1.4.7"
+    eslint: "npm:^9.11.0"
+    jest: "npm:^29.0.2"
+    jest-silent-reporter: "npm:^0.6.0"
+    prettier: "npm:^3.3.3"
+    rimraf: "npm:^4.1.2"
+    ts-node: "npm:^10.9.1"
+    typescript: "npm:~5.3.3"
+  languageName: unknown
+  linkType: soft
+
 "@metamask/cronjob-example-snap@workspace:^, @metamask/cronjob-example-snap@workspace:packages/examples/packages/cronjobs":
   version: 0.0.0-use.local
   resolution: "@metamask/cronjob-example-snap@workspace:packages/examples/packages/cronjobs"


### PR DESCRIPTION
This adds a new example Snap demonstrating cronjobs with ISO 8601 durations instead of cron expressions.