### PR TITLE
fix: Fix broken test file link in README

### DIFF
--- a/packages/examples/packages/lifecycle-hooks/README.md
+++ b/packages/examples/packages/lifecycle-hooks/README.md
@@ -27,4 +27,4 @@ These hooks are called when the client is started, when the Snap is installed,
 or the Snap is updated, respectively, and cannot be called manually.
 
 For more information, you can refer to
-[the end-to-end tests](./src/index.test.ts).
+[the end-to-end tests](./src/index.test.tsx).


### PR DESCRIPTION
Replaced the outdated reference to ./src/index.test.ts with the correct file path ./src/index.test.tsx in the README. This ensures the documentation points to the actual end-to-end test file and prevents confusion or broken links for users.