### PR TITLE
Update MetaMask Permissionless Snaps Registry link to the current repository

### DIFF
--- a/docs/internals/platform/snaps-registry.md
+++ b/docs/internals/platform/snaps-registry.md
@@ -44,4 +44,4 @@ in the [Permissionless Snaps Registry] repository.
 [snap controller]: ./snap-controller.md
 [jsonsnapsregistry]: ../../../packages/snaps-controllers/src/snaps/registry/json.ts
 [snaps registry]: https://github.com/MetaMask/snaps-registry
-[permissionless snaps registry]: https://github.com/MetaMask/permissionless-snaps-registry
+[permissionless snaps registry]: https://github.com/MetaMask/snaps-registry


### PR DESCRIPTION
Replaced the outdated GitHub link to the MetaMask Permissionless Snaps Registry (https://github.com/MetaMask/permissionless-snaps-registry) with the current and correct repository URL (https://github.com/MetaMask/snaps-registry) in the documentation. This ensures users are directed to the latest and maintained source for the Snaps Registry.