### PR TITLE
fix: Move WebSocket controls to new line

### DIFF
--- a/packages/test-snaps/src/features/snaps/network-access/NetworkAccess.tsx
+++ b/packages/test-snaps/src/features/snaps/network-access/NetworkAccess.tsx
@@ -77,7 +77,7 @@ export const NetworkAccess: FunctionComponent = () => {
         Fetch
       </Button>
 
-      <ButtonGroup className="mb-3">
+      <ButtonGroup className="d-block mb-3">
         <Button
           variant="primary"
           id="startWebSocket"


### PR DESCRIPTION
Use `display: block` instead of `display: inline-flex`.