### PR TITLE
feat: Add `snap_trackError` method for error tracking through Sentry

### DIFF
--- a/packages/examples/packages/background-events/snap.manifest.json
+++ b/packages/examples/packages/background-events/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "wRIfHJ8IQh76ktT6bMPaQeL76aUSIfOfdusGJAvU8j0=",
+    "shasum": "HfS8W51aqGb0BK1JDliL6ksC9mWUIH1GUORb4M4YYWM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/background-events/snap.manifest.json
+++ b/packages/examples/packages/background-events/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "HfS8W51aqGb0BK1JDliL6ksC9mWUIH1GUORb4M4YYWM=",
+    "shasum": "ZeGOk81XzfozOV1K0AAOCycf35KFDewU1b7Ygx+UYq0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/background-events/snap.manifest.json
+++ b/packages/examples/packages/background-events/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZeGOk81XzfozOV1K0AAOCycf35KFDewU1b7Ygx+UYq0=",
+    "shasum": "ry7ytwwA6jLu2lyh37cu4GnxJGRWw9l4HtHqfk/YxKs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "XKnKqodXcZJA0hSvC6TNfZVhDzN6eZRHSctqpJazuF0=",
+    "shasum": "IrZRKN11QSuHCvwhtjLMKYkeQzo3dQbcnEM3h5UxMHU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "kQsI1Pe5Ds8AQM+3sbKnBpqCHbhkSlgPeuErzig1BSU=",
+    "shasum": "bjHxGGXuopVEpD/hKK+P3fn4Ax/vlCEnNxNBu7qMnY4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip32/snap.manifest.json
+++ b/packages/examples/packages/bip32/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "bjHxGGXuopVEpD/hKK+P3fn4Ax/vlCEnNxNBu7qMnY4=",
+    "shasum": "XKnKqodXcZJA0hSvC6TNfZVhDzN6eZRHSctqpJazuF0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "tTKHHOjlxd1H1xlL8/u06w5rtdwE+lAjy8huj0Xpmgc=",
+    "shasum": "fbvXCpHz9/c+J/oGwc6cfNlmo44+YzB5+KzQGjg3UrQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZpWq5pSZ2qjXZHc2awkpSbUbO10vuT8uyRcVy6xyqkg=",
+    "shasum": "GaiczDPNcZNNeZmTM1lD0Es16ol0Vc9dUnla9My0vMY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/bip44/snap.manifest.json
+++ b/packages/examples/packages/bip44/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "GaiczDPNcZNNeZmTM1lD0Es16ol0Vc9dUnla9My0vMY=",
+    "shasum": "tTKHHOjlxd1H1xlL8/u06w5rtdwE+lAjy8huj0Xpmgc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0mYu+HG0LF+zEXP0ofbO2XRnU9pEJKJ/OysJkUgXySk=",
+    "shasum": "OH3tTkb7IP7btCwvcg/aPl8KzsXTNN74U0+7mDnDbvI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "61htd1OxCgh7MrL7o8gU0/H+jSjFTdq6iYdYOt6O/lc=",
+    "shasum": "0mYu+HG0LF+zEXP0ofbO2XRnU9pEJKJ/OysJkUgXySk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/client-status/snap.manifest.json
+++ b/packages/examples/packages/client-status/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "IGEfi7rQXI0Tu98aDyGbtUAeUIE0CMZonR0leSBUl8E=",
+    "shasum": "61htd1OxCgh7MrL7o8gU0/H+jSjFTdq6iYdYOt6O/lc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjob-duration/snap.manifest.json
+++ b/packages/examples/packages/cronjob-duration/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "jV7dwnFSo1LyRdbv0Fc2kVC/HUcQHKZCqZ+obYm/KwI=",
+    "shasum": "ikxPXqPpsUrLhRdpG++xXZq+P6nUtjy63k2MNa3senk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjob-duration/snap.manifest.json
+++ b/packages/examples/packages/cronjob-duration/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3DriGiLqSVIfeZ0Pmno4wIpddgP4FSW4YyMiTJ90nsU=",
+    "shasum": "jV7dwnFSo1LyRdbv0Fc2kVC/HUcQHKZCqZ+obYm/KwI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjob-duration/snap.manifest.json
+++ b/packages/examples/packages/cronjob-duration/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "vzzpBIX/vOKbSw6x8JXHzMMeBe8lpOhaZi0KSZk9uOY=",
+    "shasum": "3DriGiLqSVIfeZ0Pmno4wIpddgP4FSW4YyMiTJ90nsU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "coE2TjDqRVzcxwAQVMPyDAbqFg+7wyqxoqw73QwRUj4=",
+    "shasum": "5IyZ0i8xZ4OXBhTpF6XO6xVBSM7UtcBhguNiE5gpNEQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5IyZ0i8xZ4OXBhTpF6XO6xVBSM7UtcBhguNiE5gpNEQ=",
+    "shasum": "OwBJvrucDv6ozRGjtbbQbxDxM47wa0PSvDyPXAbypv8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/cronjobs/snap.manifest.json
+++ b/packages/examples/packages/cronjobs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "eTktdzvPzAr/fMl6sZALdcUL2LOW3YhiUwqi28na8js=",
+    "shasum": "coE2TjDqRVzcxwAQVMPyDAbqFg+7wyqxoqw73QwRUj4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "KSJ9SgPoU6o89qv3qwFZri1nv7ysxzGPgdBAPJTb8dU=",
+    "shasum": "XRvnPWZOPTeaNuNKbWdeSg89DanFVVxy1uXssjMTgBg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "peqfxtsGBNeHO3WooTYIJK4bnujccveEwEd/FfGnItE=",
+    "shasum": "KSJ9SgPoU6o89qv3qwFZri1nv7ysxzGPgdBAPJTb8dU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/dialogs/snap.manifest.json
+++ b/packages/examples/packages/dialogs/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "XRvnPWZOPTeaNuNKbWdeSg89DanFVVxy1uXssjMTgBg=",
+    "shasum": "o/O+FW4JxMxiKE0SG0WMTeztDEGRD9OYTl38kg0gDW4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZCmChJFnAXnE/reNPQCY6XE8tCPzwnZiR96/8zbxXj8=",
+    "shasum": "6bOeXhVQofs25UbISkyigUCoRA10T7zaPP2ghzsQOIU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6bOeXhVQofs25UbISkyigUCoRA10T7zaPP2ghzsQOIU=",
+    "shasum": "1I4qm6Fj6W2wx+m5PhMqR9B+xZEvapmvEhRG+y8rrN8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethereum-provider/snap.manifest.json
+++ b/packages/examples/packages/ethereum-provider/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "TVX02bG6spSFsyki6sdzEnH/mWydCmiCBikwbTzAtUU=",
+    "shasum": "ZCmChJFnAXnE/reNPQCY6XE8tCPzwnZiR96/8zbxXj8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "i6t5+ahTZ1mHHpzwDxALp5ChS8rUoAU8vxO23TxuJoA=",
+    "shasum": "8BYNSeBmkTFOGtfAoCr40kBtyWFuphUpx1Ysrc69wxM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "fo34896eh0i/mRyFqXftntOqS1VtBPsTrh7dMfrE9/A=",
+    "shasum": "CIThpcRTDoxbtSCxJX9zu/yk27gOdnESslvjQ+38OHw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/ethers-js/snap.manifest.json
+++ b/packages/examples/packages/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "CIThpcRTDoxbtSCxJX9zu/yk27gOdnESslvjQ+38OHw=",
+    "shasum": "i6t5+ahTZ1mHHpzwDxALp5ChS8rUoAU8vxO23TxuJoA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "r0k7CpEo3WCkhWrBlo12a1TOng+NPDwFnlCFaxLqA1w=",
+    "shasum": "R1nxGhPLmZf4xnkP5S5VfAGFMJt2gUSFupys6wy/1mc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "2iuAhDEJAimbHAlgESzJfXj209w2Nu53AINf9xLClHc=",
+    "shasum": "r0k7CpEo3WCkhWrBlo12a1TOng+NPDwFnlCFaxLqA1w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/file-upload/snap.manifest.json
+++ b/packages/examples/packages/file-upload/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "R1nxGhPLmZf4xnkP5S5VfAGFMJt2gUSFupys6wy/1mc=",
+    "shasum": "6e1fd7mgrhCixaloe7WHbq31QyA9F7L1TDAOiCqo8U8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "oRHKfsSlzhEOjSmkTzIR+D4oqNDrnFubmqgNTUg5HNM=",
+    "shasum": "TeMbJ5681N2cDXzaCh6HXJuy/Cky/3O5kKrigky0gVA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "OhwhIt01d7K6C0xxURWShV35cQZN7ruR25MMzntIRQg=",
+    "shasum": "oRHKfsSlzhEOjSmkTzIR+D4oqNDrnFubmqgNTUg5HNM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-entropy/snap.manifest.json
+++ b/packages/examples/packages/get-entropy/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "DSRbnw3+N0bDFXC98mp6CRZclf9xnv02YjzbjqGhW+A=",
+    "shasum": "OhwhIt01d7K6C0xxURWShV35cQZN7ruR25MMzntIRQg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4C5vzQlMDkBCc4TFatzgPQL4wpedASQr6D0bFWaYliM=",
+    "shasum": "A97Ii0+tB1PKtVmeFcMQ4f4CJ7rKvrKQRXmDYSc0HKw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "aMp60pJJHM9TN+2CysoRjREdZmAIP0YrNJEjk1YBAeA=",
+    "shasum": "4C5vzQlMDkBCc4TFatzgPQL4wpedASQr6D0bFWaYliM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/get-file/snap.manifest.json
+++ b/packages/examples/packages/get-file/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "H06WpypSmOTGdYvW2FlWgvSJQlfbrClA6MhZQm+hCcE=",
+    "shasum": "aMp60pJJHM9TN+2CysoRjREdZmAIP0YrNJEjk1YBAeA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "imanfMg8Sxu0lxXajFyoz2ZP0yiEC2PMlQ6XFE7qd+c=",
+    "shasum": "rlsDGm7dkPQC5I5/pf5LWKL2tDYpHxPO0Xk1fDZjByM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "cOM8ZJe8trZHWqIcS3cpLHpeCSyzAwp0O4/FzOa4EBg=",
+    "shasum": "imanfMg8Sxu0lxXajFyoz2ZP0yiEC2PMlQ6XFE7qd+c=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/images/snap.manifest.json
+++ b/packages/examples/packages/images/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "iwc4kyH65BZAt2aoYie0NV8WPQOifwsE/2FM09m83Pw=",
+    "shasum": "cOM8ZJe8trZHWqIcS3cpLHpeCSyzAwp0O4/FzOa4EBg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3kmmluAHE93ugjckhw3/G2s0p1w5HxzJEiR/U2WwPqQ=",
+    "shasum": "zhytEGLjGozEwzs14OJManfGsrp+c57naE1UsMVmcEg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "zhytEGLjGozEwzs14OJManfGsrp+c57naE1UsMVmcEg=",
+    "shasum": "0FkGC2CLD9XcjEQPVzOSGIeELYNeScqCBCIZsC5Vuo0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/interactive-ui/snap.manifest.json
+++ b/packages/examples/packages/interactive-ui/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "0FkGC2CLD9XcjEQPVzOSGIeELYNeScqCBCIZsC5Vuo0=",
+    "shasum": "C4s/7pT8TurRFHtZsFKkewUmrcVl/oHEs3fthh+s32g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "BwQ6ntfFAHvq/hKlliEg97F8OE0ECPKnGh5Qxld9toM=",
+    "shasum": "8CpEf7iVZRh7Lf3OWjuuHlP5UHvUckw7Z/tlhHxedTc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "8CpEf7iVZRh7Lf3OWjuuHlP5UHvUckw7Z/tlhHxedTc=",
+    "shasum": "nWsLWABz+WKeumeIvRwVuQ5b85PaQtWNticwcprEegk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/consumer-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "nWsLWABz+WKeumeIvRwVuQ5b85PaQtWNticwcprEegk=",
+    "shasum": "sfi9zpuxLaGN+Wtjb/YNHkmzkEkfhK5mClhV83Vl598=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "GGlNYy63xQB4PJESE8J1MKD3kx7E+IQAYTtGJTPNzKQ=",
+    "shasum": "LDkje53dEOlbE5p/+faAByNWNRcs45GqM0iwQUjeOWI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "HJdfma/JNA9n42xcivbwCE6j5BJVNmTGsqx+rvTI9fs=",
+    "shasum": "ns6XW/tGsvyJkC4ZE1LLQSACTmA8VoblXxJHuzc2dxI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
+++ b/packages/examples/packages/invoke-snap/packages/core-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ns6XW/tGsvyJkC4ZE1LLQSACTmA8VoblXxJHuzc2dxI=",
+    "shasum": "GGlNYy63xQB4PJESE8J1MKD3kx7E+IQAYTtGJTPNzKQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "PzbEeF/xlc60ix7Vn8wgUTC7yQYBzl5hA6xFhIBT6FE=",
+    "shasum": "LZz10wnND4wF0cG3q+qux+PtSsSI5EzTms7KFfr5Xxg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "/dZEkO3uJdDwChCX84v/2pI8vqmlpnHjLymVI+UysJI=",
+    "shasum": "LMWJyn/sBYyJ/T3SQkWuMEqSqzXs0cVK4vhLEHHbjxc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/json-rpc/snap.manifest.json
+++ b/packages/examples/packages/json-rpc/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "LZz10wnND4wF0cG3q+qux+PtSsSI5EzTms7KFfr5Xxg=",
+    "shasum": "/dZEkO3uJdDwChCX84v/2pI8vqmlpnHjLymVI+UysJI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "I08NYz0dUay2qHMl59yV3WxxhviFD5nEvUksl8jkolQ=",
+    "shasum": "miUOTcr3HaIm+vWPvfr1mIg7tJvgnhOKxh5XMUj1+7I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "1j6zkURMjaXhrGzAZgKsk1CD4NCIkPiM9DkDlcwPEO0=",
+    "shasum": "uVcApb2nDesejqTeixPxDsjZ+5uxAiC9a74eD1EhQi0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/localization/snap.manifest.json
+++ b/packages/examples/packages/localization/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "uVcApb2nDesejqTeixPxDsjZ+5uxAiC9a74eD1EhQi0=",
+    "shasum": "I08NYz0dUay2qHMl59yV3WxxhviFD5nEvUksl8jkolQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ASqoajn7XyEjPrCjZT4E3M4aSVTvpLcY90Sm63aCwNc=",
+    "shasum": "VlXLednI2Olvz71X4CqanMhTLJuzJuGK6W06idNhRQk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "u+m8cv8KuZLOKQQIrxIWoTyxIB6GERUbrDkixdw4hAk=",
+    "shasum": "ASqoajn7XyEjPrCjZT4E3M4aSVTvpLcY90Sm63aCwNc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/manage-state/snap.manifest.json
+++ b/packages/examples/packages/manage-state/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "CnU94yCbx/U2dMUA65F3zbYhlE3gACevVU0m6QABsKY=",
+    "shasum": "u+m8cv8KuZLOKQQIrxIWoTyxIB6GERUbrDkixdw4hAk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "scw0xXWz40VXRIgwF/GbGaQRT47ydnDC/SJzT+sRKPU=",
+    "shasum": "z0u5KdZroSO+unOsboZCuKF5WjSUPWLePVKfjL0dUlM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ODMJEfnOONzwujZvZIqgTQ2HGn/TL0Ri8j5EgYyn6fw=",
+    "shasum": "InSbJNcvPggkSzQkDHEZ+VuIuQC7UpyJH05d8fGnLzw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/network-access/snap.manifest.json
+++ b/packages/examples/packages/network-access/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "z0u5KdZroSO+unOsboZCuKF5WjSUPWLePVKfjL0dUlM=",
+    "shasum": "ODMJEfnOONzwujZvZIqgTQ2HGn/TL0Ri8j5EgYyn6fw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "+HO9w8NWQNgPf7JKQ14fSocaYzMVA1ep6qyRu1nhOQ0=",
+    "shasum": "No4VRxU18XBt0a4y9pdsHhsMardJi5d4njYbBm1yW10=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "No4VRxU18XBt0a4y9pdsHhsMardJi5d4njYbBm1yW10=",
+    "shasum": "6PWp6pREX1oDwWVO8teg8Zpa7UW34vdMtUSbGuz25wU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/notifications/snap.manifest.json
+++ b/packages/examples/packages/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "I4pWz+sebUIYt8Tq2/wgcppAYrihS8mAS+Qq08/Txtg=",
+    "shasum": "+HO9w8NWQNgPf7JKQ14fSocaYzMVA1ep6qyRu1nhOQ0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/preferences/snap.manifest.json
+++ b/packages/examples/packages/preferences/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "A5uZ1kbQyC0+xWfTz4rE1TMKexi6jX0nLs+W6eFh4rY=",
+    "shasum": "UNEeF7Es5+tmJfxINloQxcnrn0znlKd0fWvnPDH3hH4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/preferences/snap.manifest.json
+++ b/packages/examples/packages/preferences/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ZS5vkAxL/NRIfymK1gnNl9B6ezbvUx/8tNlUVW18noA=",
+    "shasum": "gnBDDsEcMzymkzYqWR4cX7ck1nRv0p4RmRWPNTqsaJw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/preferences/snap.manifest.json
+++ b/packages/examples/packages/preferences/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "gnBDDsEcMzymkzYqWR4cX7ck1nRv0p4RmRWPNTqsaJw=",
+    "shasum": "A5uZ1kbQyC0+xWfTz4rE1TMKexi6jX0nLs+W6eFh4rY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/preinstalled/snap.manifest.json
+++ b/packages/examples/packages/preinstalled/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4d6rgW2HNdm61ukhh2c/v0epD9wFtijzmvcd2qJhFKQ=",
+    "shasum": "E+3HjLH4YURxmrRtZT3FnhXYll0tl5qUSvw8udM6XM0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/preinstalled/snap.manifest.json
+++ b/packages/examples/packages/preinstalled/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Juaz6N/SFU6Koza36MPD8hORE7A4qu0H/jqw8rAWGMQ=",
+    "shasum": "4v5zZEVDr3TNAeojfskCm+S0eXnEWriOIWDook4rU18=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/preinstalled/snap.manifest.json
+++ b/packages/examples/packages/preinstalled/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "4v5zZEVDr3TNAeojfskCm+S0eXnEWriOIWDook4rU18=",
+    "shasum": "4d6rgW2HNdm61ukhh2c/v0epD9wFtijzmvcd2qJhFKQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/preinstalled/snap.manifest.json
+++ b/packages/examples/packages/preinstalled/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "lHCFjLZG7ocZFA8VZOCbzMwfgVR90oqR+YjSvStoiT0=",
+    "shasum": "Juaz6N/SFU6Koza36MPD8hORE7A4qu0H/jqw8rAWGMQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/preinstalled/src/index.tsx
+++ b/packages/examples/packages/preinstalled/src/index.tsx
@@ -1,4 +1,8 @@
-import { MethodNotFoundError, UserInputEventType } from '@metamask/snaps-sdk';
+import {
+  getJsonError,
+  MethodNotFoundError,
+  UserInputEventType,
+} from '@metamask/snaps-sdk';
 import type {
   OnRpcRequestHandler,
   OnSettingsPageHandler,
@@ -46,6 +50,18 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
           encrypted: false,
         },
       });
+
+    case 'trackError': {
+      const error = new Error('This is a test error.');
+      error.name = 'TestError';
+
+      return await snap.request({
+        method: 'snap_trackError',
+        params: {
+          error: getJsonError(error),
+        },
+      });
+    }
 
     default:
       throw new MethodNotFoundError({ method: request.method });

--- a/packages/examples/packages/preinstalled/src/index.tsx
+++ b/packages/examples/packages/preinstalled/src/index.tsx
@@ -19,10 +19,11 @@ type SnapState = {
 
 /**
  * Handle incoming JSON-RPC requests from the dapp, sent through the
- * `wallet_invokeSnap` method. This handler handles two methods:
+ * `wallet_invokeSnap` method. This handler handles the following methods:
  *
  * - `showDialog` - Opens a dialog.
  * - `getSettings`: Get the settings state from the snap state.
+ * - `trackError`: Tracks an error and sends it to Sentry.
  *
  * @param params - The request parameters.
  * @param params.request - The JSON-RPC request object.

--- a/packages/examples/packages/protocol/snap.manifest.json
+++ b/packages/examples/packages/protocol/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "X7lSaqw58WTaT2P/Ofq57qObR3TQV06yihd1e701u3k=",
+    "shasum": "6wqhUI9DdvjwZbc6CJ/CciNttk7NiDf1px83Hvishvo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/protocol/snap.manifest.json
+++ b/packages/examples/packages/protocol/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6wqhUI9DdvjwZbc6CJ/CciNttk7NiDf1px83Hvishvo=",
+    "shasum": "/tyL0UAj8C/m+V84Mg/MatbgUiHQ8ozguqF3usBcfcs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/protocol/snap.manifest.json
+++ b/packages/examples/packages/protocol/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "/tyL0UAj8C/m+V84Mg/MatbgUiHQ8ozguqF3usBcfcs=",
+    "shasum": "+IW+fJ+V6Vtwtxe9sV0Ipox+ouiJxmK4m8T2N99Mgfo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "ML8tZErn9MkD/0HYpiaHZVBOp7WPjxXQUXlGl9MGW7M=",
+    "shasum": "7/afLZEvkMGoScchNYQDU09lxprGxiw4ONjsmW/tXx8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "3s1s+6SeR9cU74vA8YIq+sVmniB5+t2Pygc8+rK1uVM=",
+    "shasum": "ML8tZErn9MkD/0HYpiaHZVBOp7WPjxXQUXlGl9MGW7M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/rollup-plugin/snap.manifest.json
+++ b/packages/examples/packages/rollup-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "6OOqdjZEf4xrOS3UOt8nkJUupgrJUb6iWLbwg1gOwZ8=",
+    "shasum": "3s1s+6SeR9cU74vA8YIq+sVmniB5+t2Pygc8+rK1uVM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "KpgZMcMvsLnq/tD0uNvHeHet6ZbghknYyosk8shUyT0=",
+    "shasum": "Bpfpq94Ou/K12Rreg43ew/IPgdq+cQIORTnRTRYfhQ0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "Bpfpq94Ou/K12Rreg43ew/IPgdq+cQIORTnRTRYfhQ0=",
+    "shasum": "8YM0V0NUiX1UF8+g96L/5rGmr1HpAvEevt0iz+zuodg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/wasm/snap.manifest.json
+++ b/packages/examples/packages/wasm/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "PwRz4Geot00DmXDKEItFv266knJTA6drmHMTAIKuWqY=",
+    "shasum": "KpgZMcMvsLnq/tD0uNvHeHet6ZbghknYyosk8shUyT0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "VyFZXzG2zFde44i9ZqI/ikv+QA3NvRjKgi39LDbSV/I=",
+    "shasum": "lAf6BB/S5/GfX3SNy9MBrTCnDQqpNttzmfYlTIsVWI8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "pSEJrqnZG87efQOrr+8Q8SZLMgwS9pqSQuoW5hcLxuM=",
+    "shasum": "VyFZXzG2zFde44i9ZqI/ikv+QA3NvRjKgi39LDbSV/I=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/webpack-plugin/snap.manifest.json
+++ b/packages/examples/packages/webpack-plugin/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "FtPoUR6SLkCXDUaAMiTbYNcaOR0asuy9r54IXFFbCg4=",
+    "shasum": "pSEJrqnZG87efQOrr+8Q8SZLMgwS9pqSQuoW5hcLxuM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -10,10 +10,10 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 95.07,
-      functions: 98.68,
-      lines: 98.84,
-      statements: 98.53,
+      branches: 95.1,
+      functions: 98.7,
+      lines: 98.86,
+      statements: 98.55,
     },
   },
 });

--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -10,9 +10,9 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 95.13,
-      functions: 98.7,
-      lines: 98.86,
+      branches: 95.16,
+      functions: 98.71,
+      lines: 98.87,
       statements: 98.56,
     },
   },

--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -10,10 +10,10 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 95.1,
+      branches: 95.13,
       functions: 98.7,
       lines: 98.86,
-      statements: 98.55,
+      statements: 98.56,
     },
   },
 });

--- a/packages/snaps-rpc-methods/src/permitted/handlers.ts
+++ b/packages/snaps-rpc-methods/src/permitted/handlers.ts
@@ -22,6 +22,7 @@ import { resolveInterfaceHandler } from './resolveInterface';
 import { scheduleBackgroundEventHandler } from './scheduleBackgroundEvent';
 import { sendWebSocketMessageHandler } from './sendWebSocketMessage';
 import { setStateHandler } from './setState';
+import { trackErrorHandler } from './trackError';
 import { trackEventHandler } from './trackEvent';
 import { updateInterfaceHandler } from './updateInterface';
 
@@ -48,6 +49,7 @@ export const methodHandlers = {
   snap_cancelBackgroundEvent: cancelBackgroundEventHandler,
   snap_getBackgroundEvents: getBackgroundEventsHandler,
   snap_setState: setStateHandler,
+  snap_trackError: trackErrorHandler,
   snap_trackEvent: trackEventHandler,
   snap_openWebSocket: openWebSocketHandler,
   snap_closeWebSocket: closeWebSocketHandler,

--- a/packages/snaps-rpc-methods/src/permitted/index.ts
+++ b/packages/snaps-rpc-methods/src/permitted/index.ts
@@ -18,6 +18,8 @@ import type { ResolveInterfaceMethodHooks } from './resolveInterface';
 import type { ScheduleBackgroundEventMethodHooks } from './scheduleBackgroundEvent';
 import type { SendWebSocketMessageMethodHooks } from './sendWebSocketMessage';
 import type { SetStateHooks } from './setState';
+import type { TrackErrorMethodHooks } from './trackError';
+import type { TrackEventMethodHooks } from './trackEvent';
 import type { UpdateInterfaceMethodHooks } from './updateInterface';
 
 export type PermittedRpcMethodHooks = ClearStateHooks &
@@ -40,7 +42,9 @@ export type PermittedRpcMethodHooks = ClearStateHooks &
   OpenWebSocketMethodHooks &
   CloseWebSocketMethodHooks &
   SendWebSocketMessageMethodHooks &
-  GetWebSocketsMethodHooks;
+  GetWebSocketsMethodHooks &
+  TrackEventMethodHooks &
+  TrackErrorMethodHooks;
 
 export * from './handlers';
 export * from './middleware';

--- a/packages/snaps-rpc-methods/src/permitted/trackError.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/trackError.test.ts
@@ -1,0 +1,225 @@
+import { JsonRpcEngine } from '@metamask/json-rpc-engine';
+import type { TrackErrorParams, TrackErrorResult } from '@metamask/snaps-sdk';
+import { getJsonError } from '@metamask/snaps-sdk';
+import type { JsonRpcRequest, PendingJsonRpcResponse } from '@metamask/utils';
+
+import { trackErrorHandler } from './trackError';
+
+describe('snap_trackError', () => {
+  describe('trackErrorHandler', () => {
+    it('has the expected shape', () => {
+      expect(trackErrorHandler).toMatchObject({
+        methodNames: ['snap_trackError'],
+        implementation: expect.any(Function),
+        hookNames: {
+          trackError: true,
+          getSnap: true,
+        },
+      });
+    });
+  });
+
+  describe('implementation', () => {
+    it('tracks an error with a name, message, and stack', async () => {
+      const { implementation } = trackErrorHandler;
+
+      const trackError = jest.fn().mockReturnValue('test-id');
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: true });
+      const hooks = { trackError, getSnap };
+
+      const engine = new JsonRpcEngine();
+
+      engine.push((request, response, next, end) => {
+        const result = implementation(
+          request as JsonRpcRequest<TrackErrorParams>,
+          response as PendingJsonRpcResponse<TrackErrorResult>,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'snap_trackError',
+        params: {
+          error: {
+            name: 'TestError',
+            message: 'This is a test error.',
+            stack:
+              'Error: This is a test error\n    at Object.<anonymous> (test.js:1:1)',
+          },
+        },
+      });
+
+      expect(response).toStrictEqual({
+        jsonrpc: '2.0',
+        id: 1,
+        result: 'test-id',
+      });
+
+      expect(trackError).toHaveBeenCalledWith({
+        name: 'TestError',
+        message: 'This is a test error.',
+        stack:
+          'Error: This is a test error\n    at Object.<anonymous> (test.js:1:1)',
+      });
+    });
+
+    it('tracks an error with the error helper', async () => {
+      const { implementation } = trackErrorHandler;
+
+      const trackError = jest.fn().mockReturnValue('test-id');
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: true });
+      const hooks = { trackError, getSnap };
+
+      const engine = new JsonRpcEngine();
+
+      engine.push((request, response, next, end) => {
+        const result = implementation(
+          request as JsonRpcRequest<TrackErrorParams>,
+          response as PendingJsonRpcResponse<TrackErrorResult>,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const error = new Error('This is a test error.');
+      error.name = 'TestError';
+
+      const response = await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'snap_trackError',
+        params: {
+          error: getJsonError(error),
+        },
+      });
+
+      expect(response).toStrictEqual({
+        jsonrpc: '2.0',
+        id: 1,
+        result: 'test-id',
+      });
+
+      expect(trackError).toHaveBeenCalledWith({
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+      });
+    });
+
+    it('throws an error if the Snap is not preinstalled', async () => {
+      const { implementation } = trackErrorHandler;
+
+      const trackError = jest.fn();
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
+      const hooks = { trackError, getSnap };
+
+      const engine = new JsonRpcEngine();
+
+      engine.push((request, response, next, end) => {
+        const result = implementation(
+          request as JsonRpcRequest<TrackErrorParams>,
+          response as PendingJsonRpcResponse<TrackErrorResult>,
+          next,
+          end,
+          hooks,
+        );
+
+        result?.catch(end);
+      });
+
+      const response = await engine.handle({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'snap_trackError',
+        params: {
+          error: {
+            name: 'TestError',
+            message: 'This is a test error.',
+            stack:
+              'Error: This is a test error\n    at Object.<anonymous> (test.js:1:1)',
+          },
+        },
+      });
+
+      expect(trackError).not.toHaveBeenCalled();
+      expect(response).toStrictEqual({
+        jsonrpc: '2.0',
+        id: 1,
+        error: {
+          code: -32601,
+          message: 'The method does not exist / is not available.',
+          stack: expect.any(String),
+        },
+      });
+    });
+
+    it.each([
+      [
+        { foo: 'bar' },
+        'Invalid params: At path: error -- Expected an object, but received: undefined.',
+      ],
+      [
+        { error: {} },
+        'Invalid params: At path: error.name -- Expected a string, but received: undefined.',
+      ],
+      [
+        { error: { name: 'TestError' } },
+        'Invalid params: At path: error.message -- Expected a string, but received: undefined.',
+      ],
+      [
+        { error: { name: 'TestError', message: 'This is a test error.' } },
+        'Invalid params: At path: error.stack -- Expected a string, but received: undefined.',
+      ],
+    ])(
+      'throws an error if the parameters are invalid',
+      async (params, error) => {
+        const { implementation } = trackErrorHandler;
+
+        const trackError = jest.fn();
+        const getSnap = jest.fn().mockReturnValue({ preinstalled: true });
+        const hooks = { trackError, getSnap };
+
+        const engine = new JsonRpcEngine();
+
+        engine.push((request, response, next, end) => {
+          const result = implementation(
+            request as JsonRpcRequest<TrackErrorParams>,
+            response as PendingJsonRpcResponse<TrackErrorResult>,
+            next,
+            end,
+            hooks,
+          );
+
+          result?.catch(end);
+        });
+
+        const response = await engine.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'snap_trackError',
+          params,
+        });
+
+        expect(trackError).not.toHaveBeenCalled();
+        expect(response).toStrictEqual({
+          jsonrpc: '2.0',
+          id: 1,
+          error: {
+            code: -32602,
+            message: error,
+            stack: expect.any(String),
+          },
+        });
+      },
+    );
+  });
+});

--- a/packages/snaps-rpc-methods/src/permitted/trackError.ts
+++ b/packages/snaps-rpc-methods/src/permitted/trackError.ts
@@ -1,0 +1,132 @@
+import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
+import type { PermittedHandlerExport } from '@metamask/permission-controller';
+import { rpcErrors } from '@metamask/rpc-errors';
+import type {
+  JsonRpcRequest,
+  TrackableError,
+  TrackErrorParams,
+  TrackErrorResult,
+} from '@metamask/snaps-sdk';
+import type { InferMatching, Snap } from '@metamask/snaps-utils';
+import {
+  create,
+  nullable,
+  object,
+  string,
+  StructError,
+} from '@metamask/superstruct';
+import type { PendingJsonRpcResponse } from '@metamask/utils';
+
+import type { MethodHooksObject } from '../utils';
+
+const hookNames: MethodHooksObject<TrackErrorMethodHooks> = {
+  trackError: true,
+  getSnap: true,
+};
+
+export type TrackErrorMethodHooks = {
+  /**
+   * Track an error.
+   *
+   * @param error - The error object to track.
+   * @returns The ID of the tracked error, as returned by the Sentry instance
+   * in the client.
+   */
+  trackError: (error: TrackableError) => string;
+
+  /**
+   * Get Snap metadata.
+   *
+   * @param snapId - The ID of a Snap.
+   */
+  getSnap: (snapId: string) => Snap | undefined;
+};
+
+const TrackErrorParametersStruct = object({
+  error: object({
+    name: string(),
+    message: string(),
+    stack: nullable(string()),
+  }),
+});
+
+export type TrackErrorParameters = InferMatching<
+  typeof TrackErrorParametersStruct,
+  TrackErrorParams
+>;
+
+/**
+ * Handler for the `snap_trackError` method.
+ */
+export const trackErrorHandler: PermittedHandlerExport<
+  TrackErrorMethodHooks,
+  TrackErrorParameters,
+  TrackErrorResult
+> = {
+  methodNames: ['snap_trackError'],
+  implementation: getTrackErrorImplementation,
+  hookNames,
+};
+
+/**
+ * The `snap_trackError` method implementation. This method allows preinstalled
+ * Snaps to send errors to the Sentry instance in the client for tracking.
+ *
+ * @param request - The JSON-RPC request object.
+ * @param response - The JSON-RPC response object.
+ * @param _next - The `json-rpc-engine` "next" callback. Not used by this
+ * function.
+ * @param end - The `json-rpc-engine` "end" callback.
+ * @param hooks - The RPC method hooks.
+ * @param hooks.trackError - The hook function to track an error.
+ * @param hooks.getSnap - The hook function to get Snap metadata.
+ * @returns Nothing.
+ */
+function getTrackErrorImplementation(
+  request: JsonRpcRequest<TrackErrorParameters>,
+  response: PendingJsonRpcResponse<TrackErrorResult>,
+  _next: unknown,
+  end: JsonRpcEngineEndCallback,
+  { trackError, getSnap }: TrackErrorMethodHooks,
+): void {
+  const snap = getSnap(
+    (request as JsonRpcRequest<TrackErrorParams> & { origin: string }).origin,
+  );
+
+  if (!snap?.preinstalled) {
+    return end(rpcErrors.methodNotFound());
+  }
+
+  const { params } = request;
+
+  try {
+    const validatedParams = getValidatedParams(params);
+    response.result = trackError(validatedParams.error);
+  } catch (error) {
+    return end(error);
+  }
+
+  return end();
+}
+
+/**
+ * Validates the parameters for the snap_trackEvent method.
+ *
+ * @param params - Parameters to validate.
+ * @returns Validated parameters.
+ * @throws Throws RPC error if validation fails.
+ */
+function getValidatedParams(params: unknown): TrackErrorParameters {
+  try {
+    return create(params, TrackErrorParametersStruct);
+  } catch (error) {
+    if (error instanceof StructError) {
+      throw rpcErrors.invalidParams({
+        message: `Invalid params: ${error.message}.`,
+      });
+    }
+
+    /* istanbul ignore next */
+    throw rpcErrors.internal();
+  }
+}

--- a/packages/snaps-sdk/src/errors.test.ts
+++ b/packages/snaps-sdk/src/errors.test.ts
@@ -295,6 +295,7 @@ describe('getJsonError', () => {
         name: 'Error',
         message: 'Test error string.',
         stack: null,
+        cause: null,
       },
     ],
     [
@@ -303,6 +304,7 @@ describe('getJsonError', () => {
         name: 'Error',
         message: 'Test error object.',
         stack: expect.stringContaining('Error: Test error object.'),
+        cause: null,
       },
     ],
     [
@@ -311,6 +313,7 @@ describe('getJsonError', () => {
         name: 'Error',
         message: 'Test error object with message property.',
         stack: null,
+        cause: null,
       },
     ],
     [
@@ -319,6 +322,7 @@ describe('getJsonError', () => {
         name: 'JsonRpcError',
         message: 'Test error object with code.',
         stack: null,
+        cause: null,
       },
     ],
     [
@@ -329,6 +333,7 @@ describe('getJsonError', () => {
         stack: expect.stringContaining(
           'ReferenceError: Test error object with custom name.',
         ),
+        cause: null,
       },
     ],
     [
@@ -337,9 +342,30 @@ describe('getJsonError', () => {
         name: 'JsonRpcError',
         message: 'Invalid parameters.',
         stack: expect.stringContaining('Error: Invalid parameters.'),
+        cause: null,
       },
     ],
   ])('returns an object with a message and stack from %p', (error, result) => {
     expect(getJsonError(error)).toStrictEqual(result);
+  });
+
+  it('returns an object with a cause if the error has a cause', () => {
+    const cause = new Error('Original error.');
+    cause.name = 'CauseError';
+
+    const error = new Error('Test error.', { cause });
+    error.name = 'TestError';
+
+    expect(getJsonError(error)).toStrictEqual({
+      name: 'TestError',
+      message: 'Test error.',
+      stack: expect.stringContaining('TestError: Test error.'),
+      cause: {
+        name: 'CauseError',
+        message: 'Original error.',
+        stack: expect.stringContaining('CauseError: Original error.'),
+        cause: null,
+      },
+    });
   });
 });

--- a/packages/snaps-sdk/src/errors.test.ts
+++ b/packages/snaps-sdk/src/errors.test.ts
@@ -1,6 +1,6 @@
 import { rpcErrors } from '@metamask/rpc-errors';
 
-import { SnapError } from './errors';
+import { getJsonError, SnapError } from './errors';
 
 describe('SnapError', () => {
   it('creates an error from a message', () => {
@@ -284,5 +284,62 @@ describe('SnapError', () => {
     const error = new SnapError('foo');
 
     expect(error.serialize()).toStrictEqual(error.toJSON());
+  });
+});
+
+describe('getJsonError', () => {
+  it.each([
+    [
+      'Test error string.',
+      {
+        name: 'Error',
+        message: 'Test error string.',
+        stack: null,
+      },
+    ],
+    [
+      new Error('Test error object.'),
+      {
+        name: 'Error',
+        message: 'Test error object.',
+        stack: expect.stringContaining('Error: Test error object.'),
+      },
+    ],
+    [
+      { message: 'Test error object with message property.' },
+      {
+        name: 'Error',
+        message: 'Test error object with message property.',
+        stack: null,
+      },
+    ],
+    [
+      { code: 123, message: 'Test error object with code.' },
+      {
+        name: 'JsonRpcError',
+        message: 'Test error object with code.',
+        stack: null,
+      },
+    ],
+    [
+      new ReferenceError('Test error object with custom name.'),
+      {
+        name: 'ReferenceError',
+        message: 'Test error object with custom name.',
+        stack: expect.stringContaining(
+          'ReferenceError: Test error object with custom name.',
+        ),
+      },
+    ],
+    [
+      rpcErrors.invalidParams('Invalid parameters.'),
+      {
+        name: 'JsonRpcError',
+        message: 'Invalid parameters.',
+        stack: expect.stringContaining('Error: Invalid parameters.'),
+      },
+    ],
+  ])('returns an object with a message and stack from %p', (error, result) => {
+    expect(getJsonError(error)).toStrictEqual(result);
   });
 });

--- a/packages/snaps-sdk/src/errors.ts
+++ b/packages/snaps-sdk/src/errors.ts
@@ -2,6 +2,7 @@ import type { Json, JsonRpcError } from '@metamask/utils';
 import { isJsonRpcError } from '@metamask/utils';
 
 import {
+  getErrorCause,
   getErrorCode,
   getErrorData,
   getErrorMessage,
@@ -189,6 +190,7 @@ export function getJsonError(
       name: 'Error',
       message: error,
       stack: null,
+      cause: null,
     };
   }
 
@@ -197,12 +199,16 @@ export function getJsonError(
       name: 'JsonRpcError',
       message: getErrorMessage(error),
       stack: getErrorStack(error) ?? getErrorStack(error.data) ?? null,
+      cause: null,
     };
   }
+
+  const cause = getErrorCause(error);
 
   return {
     name: getErrorName(error),
     message: getErrorMessage(error),
     stack: getErrorStack(error) ?? null,
+    cause: cause === null ? null : getJsonError(cause),
   };
 }

--- a/packages/snaps-sdk/src/errors.ts
+++ b/packages/snaps-sdk/src/errors.ts
@@ -1,12 +1,16 @@
 import type { Json, JsonRpcError } from '@metamask/utils';
+import { isJsonRpcError } from '@metamask/utils';
 
 import {
   getErrorCode,
   getErrorData,
   getErrorMessage,
+  getErrorName,
+  getErrorStack,
   SNAP_ERROR_CODE,
   SNAP_ERROR_MESSAGE,
 } from './internals';
+import type { TrackableError } from './types';
 
 /**
  * A generic error which can be thrown by a Snap, without it causing the Snap to
@@ -152,3 +156,53 @@ export type SerializedSnapError = {
     cause: JsonRpcError;
   };
 };
+
+/**
+ * Get a serialised JSON error from a given error. This is intended to be used
+ * with `snap_trackError` to convert an error to a JSON object that can be
+ * tracked by the Sentry instance in the client.
+ *
+ * @param error - The error to convert to a JSON error. This can be a string, an
+ * `Error`, a `JsonRpcError`, or any other type. If it is not a string or an
+ * `Error`, it will be converted to a string using its `toString()` method.
+ * @returns A JSON object containing the error message and stack trace, if
+ * available.
+ * @example
+ * try {
+ *   // Some code that may throw an error
+ * } catch (error) {
+ *   await snap.request({
+ *     method: 'snap_trackError',
+ *     params: {
+ *       error: getJsonError(error),
+ *     },
+ *   });
+ * }
+ */
+export function getJsonError(
+  // TypeScript will narrow this to `unknown`, but we specify all the types for
+  // clarity.
+  error: string | Error | JsonRpcError | unknown,
+): TrackableError {
+  if (typeof error === 'string') {
+    return {
+      name: 'Error',
+      message: error,
+      stack: null,
+    };
+  }
+
+  if (isJsonRpcError(error)) {
+    return {
+      name: 'JsonRpcError',
+      message: getErrorMessage(error),
+      stack: getErrorStack(error) ?? getErrorStack(error.data) ?? null,
+    };
+  }
+
+  return {
+    name: getErrorName(error),
+    message: getErrorMessage(error),
+    stack: getErrorStack(error) ?? null,
+  };
+}

--- a/packages/snaps-sdk/src/internals/errors.test.ts
+++ b/packages/snaps-sdk/src/internals/errors.test.ts
@@ -4,6 +4,7 @@ import {
   getErrorCode,
   getErrorData,
   getErrorMessage,
+  getErrorName,
   getErrorStack,
 } from './errors';
 
@@ -33,13 +34,31 @@ describe('getErrorStack', () => {
     expect(getErrorStack(rpcErrors.invalidParams('foo'))).toBeDefined();
   });
 
-  it('returns undefined if the error does not have a stack property', () => {
-    expect(getErrorStack('foo')).toBeUndefined();
-    expect(getErrorStack(123)).toBeUndefined();
-    expect(getErrorStack(true)).toBeUndefined();
-    expect(getErrorStack(null)).toBeUndefined();
-    expect(getErrorStack(undefined)).toBeUndefined();
-    expect(getErrorStack({ foo: 'bar' })).toBeUndefined();
+  it('returns null if the error does not have a stack property', () => {
+    expect(getErrorStack('foo')).toBeNull();
+    expect(getErrorStack(123)).toBeNull();
+    expect(getErrorStack(true)).toBeNull();
+    expect(getErrorStack(null)).toBeNull();
+    expect(getErrorStack(undefined)).toBeNull();
+    expect(getErrorStack({ foo: 'bar' })).toBeNull();
+  });
+});
+
+describe('getErrorName', () => {
+  it('returns the error name if the error is an object with a name property', () => {
+    expect(getErrorName(new Error('foo'))).toBe('Error');
+    expect(getErrorName({ name: 'foo' })).toBe('foo');
+    expect(getErrorName(rpcErrors.invalidParams('foo'))).toBe('Error');
+    expect(getErrorName(new TypeError('foo'))).toBe('TypeError');
+  });
+
+  it('returns "Error" if the error does not have a name property', () => {
+    expect(getErrorName('foo')).toBe('Error');
+    expect(getErrorName(123)).toBe('Error');
+    expect(getErrorName(true)).toBe('Error');
+    expect(getErrorName(null)).toBe('Error');
+    expect(getErrorName(undefined)).toBe('Error');
+    expect(getErrorName({ foo: 'bar' })).toBe('Error');
   });
 });
 

--- a/packages/snaps-sdk/src/internals/errors.ts
+++ b/packages/snaps-sdk/src/internals/errors.ts
@@ -4,6 +4,32 @@ export const SNAP_ERROR_CODE = -31002;
 export const SNAP_ERROR_MESSAGE = 'Snap Error';
 
 /**
+ * Get a string property from an object, or convert the object to a string
+ * if the property does not exist or is not a string.
+ *
+ * @param object - The object to get the property from.
+ * @param property - The property to get from the object.
+ * @param fallback - The fallback value to return if the property does not exist
+ * or is not a string. Defaults to the string representation of the object.
+ * @returns The value of the property if it exists and is a string, or the
+ * fallback value if it does not exist or is not a string.
+ */
+function getObjectStringProperty<Fallback = string>(
+  object: unknown,
+  property: string,
+  fallback: Fallback = String(object) as Fallback,
+): string | Fallback {
+  if (isObject(object) && hasProperty(object, property)) {
+    const value = object[property];
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+
+  return fallback;
+}
+
+/**
  * Get the error message from an unknown error type.
  *
  * - If the error is an object with a `message` property, return the message.
@@ -14,15 +40,7 @@ export const SNAP_ERROR_MESSAGE = 'Snap Error';
  * @internal
  */
 export function getErrorMessage(error: unknown) {
-  if (
-    isObject(error) &&
-    hasProperty(error, 'message') &&
-    typeof error.message === 'string'
-  ) {
-    return error.message;
-  }
-
-  return String(error);
+  return getObjectStringProperty(error, 'message');
 }
 
 /**
@@ -34,15 +52,19 @@ export function getErrorMessage(error: unknown) {
  * @internal
  */
 export function getErrorStack(error: unknown) {
-  if (
-    isObject(error) &&
-    hasProperty(error, 'stack') &&
-    typeof error.stack === 'string'
-  ) {
-    return error.stack;
-  }
+  return getObjectStringProperty(error, 'stack', null);
+}
 
-  return undefined;
+/**
+ * Get the error name from an unknown error type.
+ *
+ * @param error - The error to get the name from.
+ * @returns The error name, or `'Error'` if the error does not have a valid
+ * name.
+ */
+export function getErrorName(error: unknown) {
+  const fallbackName = error instanceof Error ? error.name : 'Error';
+  return getObjectStringProperty(error, 'name', fallbackName);
 }
 
 /**

--- a/packages/snaps-sdk/src/internals/errors.ts
+++ b/packages/snaps-sdk/src/internals/errors.ts
@@ -98,7 +98,7 @@ export function getErrorName(error: unknown) {
  */
 export function getErrorCode(error: unknown) {
   const value = getObjectProperty(error, 'code');
-  if (typeof value === 'number') {
+  if (typeof value === 'number' && Number.isInteger(value)) {
     return value;
   }
 

--- a/packages/snaps-sdk/src/types/methods/index.ts
+++ b/packages/snaps-sdk/src/types/methods/index.ts
@@ -29,6 +29,7 @@ export type * from './schedule-background-event';
 export type * from './cancel-background-event';
 export type * from './get-background-events';
 export type * from './set-state';
+export type * from './track-error';
 export type * from './track-event';
 export type * from './open-web-socket';
 export type * from './close-web-socket';

--- a/packages/snaps-sdk/src/types/methods/methods.ts
+++ b/packages/snaps-sdk/src/types/methods/methods.ts
@@ -90,13 +90,13 @@ import type {
   SendWebSocketMessageResult,
 } from './send-web-socket-message';
 import type { SetStateParams, SetStateResult } from './set-state';
+import type { TrackErrorParams, TrackErrorResult } from './track-error';
 import type { TrackEventParams, TrackEventResult } from './track-event';
 import type {
   UpdateInterfaceParams,
   UpdateInterfaceResult,
 } from './update-interface';
 import type { Method } from '../../internals';
-import type { TrackErrorParams, TrackErrorResult } from '@metamask/snaps-sdk';
 
 /**
  * The methods that are available to the Snap. Each method is a tuple of the

--- a/packages/snaps-sdk/src/types/methods/methods.ts
+++ b/packages/snaps-sdk/src/types/methods/methods.ts
@@ -96,6 +96,7 @@ import type {
   UpdateInterfaceResult,
 } from './update-interface';
 import type { Method } from '../../internals';
+import type { TrackErrorParams, TrackErrorResult } from '@metamask/snaps-sdk';
 
 /**
  * The methods that are available to the Snap. Each method is a tuple of the
@@ -141,6 +142,7 @@ export type SnapMethods = {
   snap_resolveInterface: [ResolveInterfaceParams, ResolveInterfaceResult];
   snap_setState: [SetStateParams, SetStateResult];
   snap_trackEvent: [TrackEventParams, TrackEventResult];
+  snap_trackError: [TrackErrorParams, TrackErrorResult];
   snap_openWebSocket: [OpenWebSocketParams, OpenWebSocketResult];
   snap_closeWebSocket: [CloseWebSocketParams, CloseWebSocketResult];
   snap_getWebSockets: [GetWebSocketsParams, GetWebSocketsResult];

--- a/packages/snaps-sdk/src/types/methods/track-error.ts
+++ b/packages/snaps-sdk/src/types/methods/track-error.ts
@@ -1,0 +1,39 @@
+/**
+ * An error that can be tracked by the `snap_trackError` method.
+ */
+export type TrackableError = {
+  /**
+   * The name of the error. This is typically the constructor name of the
+   * error, such as `TypeError`, `ReferenceError`, or a custom error name.
+   */
+  name: string;
+
+  /**
+   * The error message.
+   */
+  message: string;
+
+  /**
+   * The error stack, if available. If the error does not have a stack, this
+   * will be `null`.
+   */
+  stack: string | null;
+};
+
+/**
+ * The parameters for the `snap_trackError` method.
+ *
+ * Note that this method is only available to preinstalled Snaps.
+ */
+export type TrackErrorParams = {
+  /**
+   * The error object to track.
+   */
+  error: TrackableError;
+};
+
+/**
+ * The result returned by the `snap_trackEvent` method. This is the ID of the
+ * tracked error, as returned by the Sentry instance in the client.
+ */
+export type TrackErrorResult = string;

--- a/packages/snaps-sdk/src/types/methods/track-error.ts
+++ b/packages/snaps-sdk/src/types/methods/track-error.ts
@@ -18,6 +18,12 @@ export type TrackableError = {
    * will be `null`.
    */
   stack: string | null;
+
+  /**
+   * The cause of the error, if available. This can be another error object or
+   * `null` if there is no cause.
+   */
+  cause: TrackableError | null;
 };
 
 /**

--- a/packages/snaps-utils/src/errors.test.ts
+++ b/packages/snaps-utils/src/errors.test.ts
@@ -37,6 +37,28 @@ describe('WrappedSnapError', () => {
     });
   });
 
+  it('wraps an error without a stack', () => {
+    const error = new Error('foo');
+    delete error.stack;
+
+    const wrapped = new WrappedSnapError(error);
+
+    expect(wrapped).toBeInstanceOf(Error);
+    expect(wrapped).toBeInstanceOf(WrappedSnapError);
+    expect(wrapped.name).toBe('WrappedSnapError');
+    expect(wrapped.message).toBe('foo');
+    expect(wrapped.stack).toBeDefined();
+    expect(wrapped.toJSON()).toStrictEqual({
+      code: SNAP_ERROR_WRAPPER_CODE,
+      message: SNAP_ERROR_WRAPPER_MESSAGE,
+      data: {
+        cause: {
+          message: 'foo',
+        },
+      },
+    });
+  });
+
   it('wraps a JSON-RPC error', () => {
     const error = new JsonRpcError(-1, 'foo');
     const wrapped = new WrappedSnapError(error);
@@ -275,6 +297,19 @@ describe('unwrapError', () => {
     expect(unwrappedError.code).toBe(errorCodes.rpc.internal);
     expect(unwrappedError.message).toBe('foo');
     expect(unwrappedError.stack).toBeDefined();
+    expect(handled).toBe(false);
+  });
+
+  it('unwraps an error without a stack', () => {
+    const error = new Error('foo');
+    delete error.stack;
+
+    const [unwrappedError, handled] = unwrapError(error);
+
+    expect(unwrappedError).toBeInstanceOf(Error);
+    expect(unwrappedError.code).toBe(errorCodes.rpc.internal);
+    expect(unwrappedError.message).toBe('foo');
+    expect(unwrappedError.stack).toBeUndefined();
     expect(handled).toBe(false);
   });
 

--- a/packages/snaps-utils/src/errors.ts
+++ b/packages/snaps-utils/src/errors.ts
@@ -43,7 +43,7 @@ export class WrappedSnapError extends Error {
 
     this.#error = error;
     this.#message = message;
-    this.#stack = getErrorStack(error);
+    this.#stack = getErrorStack(error) ?? undefined;
   }
 
   /**
@@ -162,11 +162,11 @@ export function isWrappedSnapError(
 function getJsonRpcError(
   code: number,
   message: string,
-  stack?: string,
+  stack?: string | null,
   data?: Json,
 ) {
   const error = new RpcError(code, message, data);
-  error.stack = stack;
+  error.stack = stack ?? undefined;
 
   return error;
 }

--- a/packages/test-snaps/src/features/snaps/preinstalled/Preinstalled.tsx
+++ b/packages/test-snaps/src/features/snaps/preinstalled/Preinstalled.tsx
@@ -23,6 +23,13 @@ export const Preinstalled: FunctionComponent = () => {
     }).catch(logError);
   };
 
+  const handleSubmitTrackError = () => {
+    invokeSnap({
+      snapId: PREINSTALLED_SNAP_ID,
+      method: 'trackError',
+    }).catch(logError);
+  };
+
   return (
     <Snap
       name="Preinstalled Snap"
@@ -46,6 +53,14 @@ export const Preinstalled: FunctionComponent = () => {
           onClick={handleSubmitSettings}
         >
           Get settings state
+        </Button>
+        <Button
+          variant="primary"
+          id="trackError"
+          disabled={isLoading}
+          onClick={handleSubmitTrackError}
+        >
+          Track error
         </Button>
       </ButtonGroup>
       <Result>


### PR DESCRIPTION
This adds a new RPC method `snap_trackError`, which can be used to track errors in Sentry. It accepts a `name`, `message`, and `stack`, which should be turned into a proper `Error` class again on the client end before sending it to Sentry with `Sentry.captureException`.

To make the API a bit easier to use, I've added a `getJsonError` helper function which takes an error (string, `Error` class, or other value) and turns it into the properties expected by `snap_trackError`:

```ts
import { getJsonError } from '@metamask/snaps-sdk';

try {
  // ...
} catch (error) {
  await snap.request({
    method: 'snap_trackError',
    params: {
      error: getJsonError(error),
    },
  });
}
```