### PR TITLE
fix: Handle scheduled events close to current time gracefully

### DIFF
--- a/packages/snaps-controllers/src/cronjob/CronjobController.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.ts
@@ -415,6 +415,13 @@ export class CronjobController extends BaseController<
       return;
     }
 
+    // When an event is supposed to be scheduled close to the current time
+    // we may end up needing to execute immediately instead.
+    if (ms < 0) {
+      this.#execute(event);
+      return;
+    }
+
     const timer = new Timer(ms);
     timer.start(() => {
       this.#execute(event);


### PR DESCRIPTION
When an event is supposed to be scheduled immediately there is a chance that by the time we get to schedule it the time left is less than 0 milliseconds. In that case we should just execute immediately. This is most likely to happen during initialization.