### PR TITLE
ci: Lint changelogs in CI

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -126,6 +126,8 @@ jobs:
           is-high-risk-environment: false
       - name: Lint
         run: yarn lint
+      - name: Validate changelogs
+        run: yarn changelog:validate
       - name: Require clean working directory
         shell: bash
         run: |

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -22,7 +22,6 @@
   "scripts": {
     "build": "yarn workspaces filter --include 'packages/examples/packages/**' --parallel --no-private run build",
     "build:clean": "yarn clean && yarn build",
-    "changelog:validate": "../../scripts/validate-changelog.sh @metamask/example-snaps",
     "changelog:validates": "yarn workspaces foreach --worktree --parallel --verbose run changelog:validate",
     "clean": "yarn workspaces foreach --worktree --parallel --verbose --no-private run clean",
     "lint": "yarn workspaces foreach --worktree --parallel --verbose --interlaced --no-private run lint && yarn lint:dependencies",

--- a/packages/examples/packages/invoke-snap/package.json
+++ b/packages/examples/packages/invoke-snap/package.json
@@ -22,7 +22,6 @@
   "scripts": {
     "build": "yarn workspaces foreach --worktree --parallel --verbose run build",
     "build:clean": "yarn clean && yarn build",
-    "changelog:validate": "../../../../scripts/validate-changelog.sh @metamask/invoke-snap-example-snap",
     "clean": "yarn workspaces foreach --worktree --parallel --verbose run clean",
     "lint": "yarn workspaces foreach --worktree --parallel --verbose --interlaced run lint && yarn lint:dependencies",
     "lint:ci": "yarn lint:eslint && yarn lint:misc --check",

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -148,20 +148,18 @@ module.exports = defineConfig({
 
         // All non-root package must have valid "changelog:update" and
         // "changelog:validate" scripts.
-        expectWorkspaceField(
-          workspace,
-          'scripts.changelog:validate',
-          `${getRelativePath(workspace, 'scripts/validate-changelog.sh')} ${
-            workspace.manifest.name
-          }`,
-        );
-        expectWorkspaceField(
-          workspace,
-          'scripts.changelog:validate',
-          `${getRelativePath(workspace, 'scripts/validate-changelog.sh')} ${
-            workspace.manifest.name
-          }`,
-        );
+        if (
+          workspace.cwd !== 'packages/examples' &&
+          workspace.cwd !== 'packages/examples/packages/invoke-snap'
+        ) {
+          expectWorkspaceField(
+            workspace,
+            'scripts.changelog:validate',
+            `${getRelativePath(workspace, 'scripts/validate-changelog.sh')} ${
+              workspace.manifest.name
+            }`,
+          );
+        }
 
         // All non-root packages must have a valid "since-latest-release" script.
         expectWorkspaceField(


### PR DESCRIPTION
Seems that we unintentionally stopped validating changelogs in CI at some point. This adds a step to start validating them again.