### PR TITLE
fix: Clear cronjobs when installing a Snap

### DIFF
--- a/packages/snaps-controllers/src/cronjob/CronjobController.test.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.test.ts
@@ -549,6 +549,8 @@ describe('CronjobController', () => {
       },
     );
 
+    expect(rootMessenger.call).toHaveBeenCalledTimes(2);
+
     cronjobController.destroy();
   });
 

--- a/packages/snaps-controllers/src/cronjob/CronjobController.test.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.test.ts
@@ -498,6 +498,22 @@ describe('CronjobController', () => {
 
     const cronjobController = new CronjobController({
       messenger: controllerMessenger,
+      state: {
+        events: {
+          [`cronjob-${MOCK_SNAP_ID}-0`]: {
+            id: `cronjob-${MOCK_SNAP_ID}-0`,
+            recurring: true,
+            date: '2022-01-01T00:01:00.000Z',
+            schedule: '* * * * *',
+            scheduledAt: '2022-01-01T00:00:00.000Z',
+            snapId: MOCK_SNAP_ID,
+            request: {
+              method: 'exampleMethodTwo',
+              params: ['p1'],
+            },
+          },
+        },
+      },
     });
 
     cronjobController.init();

--- a/packages/snaps-controllers/src/cronjob/CronjobController.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.ts
@@ -521,6 +521,8 @@ export class CronjobController extends BaseController<
    * @param snap - Basic Snap information.
    */
   readonly #handleSnapInstalledEvent = (snap: TruncatedSnap) => {
+    // In case of local Snaps, they may already have cronjobs that should be cleared.
+    this.unregister(snap.id);
     this.register(snap.id);
   };
 


### PR DESCRIPTION
Clear cronjobs when installing Snaps, this fixes an issue with local Snaps.

Fixes #3513 