### PR TITLE
fix: Show different error message for cancelled requests when Snap is stopped

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -1947,7 +1947,7 @@ describe('SnapController', () => {
     expect(results[0].status).toBe('fulfilled');
     expect(results[1].status).toBe('rejected');
     expect((results[1] as PromiseRejectedResult).reason.message).toBe(
-      `${snap.id} failed to respond to the request in time.`,
+      `${snap.id} has been stopped and the request was cancelled.`,
     );
 
     snapController.destroy();

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -1947,7 +1947,7 @@ describe('SnapController', () => {
     expect(results[0].status).toBe('fulfilled');
     expect(results[1].status).toBe('rejected');
     expect((results[1] as PromiseRejectedResult).reason.message).toBe(
-      `${snap.id} has been stopped and the request was cancelled.`,
+      `${snap.id} was stopped and the request was cancelled. This is likely because the Snap crashed.`,
     );
 
     snapController.destroy();

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -3642,7 +3642,13 @@ export class SnapController extends BaseController<
       const result = await withTimeout(handleRpcRequestPromise, timer);
 
       if (result === hasTimedOut) {
-        throw new Error(`${snapId} failed to respond to the request in time.`);
+        const stopping =
+          runtime.stopPromise !== null || !this.isRunning(snapId);
+        throw new Error(
+          stopping
+            ? `${snapId} has been stopped and the request was cancelled.`
+            : `${snapId} failed to respond to the request in time.`,
+        );
       }
 
       await this.#assertSnapRpcResponse(snapId, handlerType, result);

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -3646,7 +3646,7 @@ export class SnapController extends BaseController<
           runtime.stopPromise !== null || !this.isRunning(snapId);
         throw new Error(
           stopping
-            ? `${snapId} has been stopped and the request was cancelled.`
+            ? `${snapId} was stopped and the request was cancelled. This is likely because the Snap crashed.`
             : `${snapId} failed to respond to the request in time.`,
         );
       }


### PR DESCRIPTION
Show a different error message for cancelled requests when the Snap is stopped. Right now, we show the generic "failed to respond in time" message, which is very confusing.