### PR TITLE
fix: Ensure Snap gets half of allocated init time

### DIFF
--- a/packages/snaps-controllers/src/services/AbstractExecutionService.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.ts
@@ -358,7 +358,9 @@ export abstract class AbstractExecutionService<WorkerType>
 
     this.#setupSnapProvider(snapId, rpcStream);
 
-    const remainingTime = timer.remaining;
+    // Use the remaining time as the timer, but ensure that the
+    // Snap gets at least half the init timeout.
+    const remainingTime = Math.max(timer.remaining, this.#initTimeout / 2);
 
     const request = {
       jsonrpc: '2.0',


### PR DESCRIPTION
Ensure that the Snap gets at least half the allocated time for initialization, preventing a potential problem where a slowly loading execution environment would cause error messages that indicate that the Snap is slow.