### PR TITLE
feat: Add feature flag to treat local Snaps as preinstalled

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -187,6 +187,7 @@ import {
   throttleTracking,
   withTimeout,
   isTrackableHandler,
+  isLocalSnapId,
 } from '../utils';
 
 export const controllerName = 'SnapController';
@@ -700,6 +701,14 @@ type FeatureFlags = {
   disableSnapInstallation?: boolean;
   rejectInvalidPlatformVersion?: boolean;
   useCaip25Permission?: boolean;
+
+  /**
+   * Force any local Snap to be treated as a preinstalled Snap.
+   *
+   * This should only be used for local testing, and should not be enabled in
+   * any production builds (including beta and Flask).
+   */
+  forcePreinstalledSnaps?: boolean;
 };
 
 type DynamicFeatureFlags = {
@@ -2987,11 +2996,21 @@ export class SnapController extends BaseController<
 
       this.#transition(snapId, SnapStatusEvents.Update);
 
+      const preinstalledArgs =
+        this.#featureFlags.forcePreinstalledSnaps && isLocalSnapId(snapId)
+          ? {
+              preinstalled: true,
+              hideSnapBranding: false,
+              hidden: false,
+            }
+          : {};
+
       this.#set({
         origin,
         id: snapId,
         files: newSnap,
         isUpdate: true,
+        ...preinstalledArgs,
       });
 
       this.#updatePermissions({
@@ -3117,10 +3136,20 @@ export class SnapController extends BaseController<
           platformVersion: manifest.platformVersion,
         });
 
+        const preinstalledArgs =
+          this.#featureFlags.forcePreinstalledSnaps && isLocalSnapId(snapId)
+            ? {
+                preinstalled: true,
+                hideSnapBranding: false,
+                hidden: false,
+              }
+            : {};
+
         return this.#set({
           ...args,
           files: fetchedSnap,
           id: snapId,
+          ...preinstalledArgs,
         });
       })();
     }

--- a/packages/snaps-controllers/src/utils.ts
+++ b/packages/snaps-controllers/src/utils.ts
@@ -470,3 +470,14 @@ export function isTrackableHandler(
 ): handler is TrackableHandler {
   return TRACKABLE_HANDLERS.includes(handler as TrackableHandler);
 }
+
+/**
+ * Checks if the given Snap ID is a local Snap ID. This assumes the Snap ID is
+ * validated before calling this function, as it only checks the prefix.
+ *
+ * @param snapId - The Snap ID to check.
+ * @returns True if the Snap ID is a local Snap ID, false otherwise.
+ */
+export function isLocalSnapId(snapId: SnapId): boolean {
+  return snapId.startsWith('local:');
+}


### PR DESCRIPTION
This adds a new feature flag `forcePreinstalledSnaps`, which makes the `SnapController` treat any local Snaps as preinstalled Snaps.

It's intended to only be enabled in local Flask builds, and should not be enabled in any production builds. It can be used to simplify the development of preinstalled Snaps by using a local Snap instead.

Related extension PR: MetaMask/metamask-extension#34022.