### PR TITLE
feat: Add non-fungible assets support to `endowment:assets`

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -4118,7 +4118,7 @@ describe('SnapController', () => {
           },
         }),
       ).rejects.toThrow(
-        `Assertion failed: At path: assets.foo -- Expected a value of type \`CaipAssetType\`, but received: \`"foo"\`.`,
+        `Assertion failed: At path: assets.foo -- Expected a value of type \`CaipAssetTypeOrId\`, but received: \`"foo"\`.`,
       );
 
       snapController.destroy();
@@ -4200,7 +4200,7 @@ describe('SnapController', () => {
       snapController.destroy();
     });
 
-    it('returns the value when `onAssetsLookup` returns a valid response', async () => {
+    it('returns the value when `onAssetsLookup` returns a valid response for fungible assets', async () => {
       const rootMessenger = getControllerMessenger();
       const messenger = getSnapControllerMessenger(rootMessenger);
       const snapController = getSnapController(
@@ -4286,6 +4286,126 @@ describe('SnapController', () => {
               },
             ],
           },
+        },
+      });
+
+      snapController.destroy();
+    });
+
+    it('returns the value when `onAssetsLookup` returns a valid response for non-fungible assets', async () => {
+      const rootMessenger = getControllerMessenger();
+      const messenger = getSnapControllerMessenger(rootMessenger);
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(),
+          },
+        }),
+      );
+
+      rootMessenger.registerActionHandler(
+        'PermissionController:getPermissions',
+        () => ({
+          [SnapEndowments.Assets]: {
+            caveats: [
+              {
+                type: SnapCaveatType.ChainIds,
+                value: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+              },
+            ],
+            date: 1664187844588,
+            id: 'izn0WGUO8cvq_jqvLQuQP',
+            invoker: MOCK_SNAP_ID,
+            parentCapability: SnapEndowments.Assets,
+          },
+        }),
+      );
+
+      rootMessenger.registerActionHandler(
+        'SubjectMetadataController:getSubjectMetadata',
+        () => MOCK_SNAP_SUBJECT_METADATA,
+      );
+
+      rootMessenger.registerActionHandler(
+        'ExecutionService:handleRpcRequest',
+        async () =>
+          Promise.resolve({
+            assets: {
+              'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:Fz6LxeUg5qjesYX3BdmtTwyyzBtMxk644XiTqU5W3w9w':
+                {
+                  fungible: false,
+                  name: 'Persky Penguins #398',
+                  symbol: 'PENGUIN',
+                  imageUrl: `https://metamask.io/pinguin.svg`,
+                  description:
+                    'A nice penguin from the Persky Penguins collection.',
+                  acquiredAt: 1750941834,
+                  isPossibleSpam: false,
+                  attributes: {
+                    type: 'Alien',
+                    accessories: 'Headband',
+                    age: 32,
+                  },
+                  collection: {
+                    name: 'Persky Penguins',
+                    address:
+                      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvd:Fz6LxeUg5qjesYX3BdmtTwyyzBtMxk644XiTqU5W3w9w',
+                    symbol: 'PENGUIN',
+                    tokenCount: 10000,
+                    creator:
+                      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvd:Fz6LxeUg5qjesYX3BdmtTwyyzBtMxk644XiTqU5W3w9w',
+                    imageUrl: `https://metamask.io/pinguin.svg`,
+                  },
+                },
+            },
+          }),
+      );
+
+      expect(
+        await snapController.handleRequest({
+          snapId: MOCK_SNAP_ID,
+          origin: METAMASK_ORIGIN,
+          handler: HandlerType.OnAssetsLookup,
+          request: {
+            jsonrpc: '2.0',
+            method: ' ',
+            params: {
+              assets: [
+                'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:Fz6LxeUg5qjesYX3BdmtTwyyzBtMxk644XiTqU5W3w9w',
+              ],
+            },
+            id: 1,
+          },
+        }),
+      ).toStrictEqual({
+        assets: {
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:Fz6LxeUg5qjesYX3BdmtTwyyzBtMxk644XiTqU5W3w9w':
+            {
+              fungible: false,
+              name: 'Persky Penguins #398',
+              symbol: 'PENGUIN',
+              imageUrl: `https://metamask.io/pinguin.svg`,
+              description:
+                'A nice penguin from the Persky Penguins collection.',
+              acquiredAt: 1750941834,
+              isPossibleSpam: false,
+              attributes: {
+                type: 'Alien',
+                accessories: 'Headband',
+                age: 32,
+              },
+              collection: {
+                name: 'Persky Penguins',
+                address:
+                  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvd:Fz6LxeUg5qjesYX3BdmtTwyyzBtMxk644XiTqU5W3w9w',
+                symbol: 'PENGUIN',
+                tokenCount: 10000,
+                creator:
+                  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvd:Fz6LxeUg5qjesYX3BdmtTwyyzBtMxk644XiTqU5W3w9w',
+                imageUrl: `https://metamask.io/pinguin.svg`,
+              },
+            },
         },
       });
 
@@ -4571,7 +4691,7 @@ describe('SnapController', () => {
           },
         }),
       ).rejects.toThrow(
-        `Assertion failed: At path: marketData.foo -- Expected a value of type \`CaipAssetType\`, but received: \`"foo"\`.`,
+        `Assertion failed: At path: marketData.foo -- Expected a value of type \`CaipAssetTypeOrId\`, but received: \`"foo"\`.`,
       );
 
       snapController.destroy();
@@ -4650,7 +4770,7 @@ describe('SnapController', () => {
       snapController.destroy();
     });
 
-    it('returns the value when `onAssetsMarketData` returns a valid response', async () => {
+    it('returns the value when `onAssetsMarketData` returns a valid response for fungible assets', async () => {
       const rootMessenger = getControllerMessenger();
       const messenger = getSnapControllerMessenger(rootMessenger);
       const snapController = getSnapController(
@@ -4729,6 +4849,128 @@ describe('SnapController', () => {
               totalVolume: '100000000',
             },
           },
+        },
+      });
+
+      snapController.destroy();
+    });
+
+    it('returns the value when `onAssetsMarketData` returns a valid response for non-fungible assets', async () => {
+      const rootMessenger = getControllerMessenger();
+      const messenger = getSnapControllerMessenger(rootMessenger);
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(),
+          },
+        }),
+      );
+
+      rootMessenger.registerActionHandler(
+        'PermissionController:getPermissions',
+        () => ({
+          [SnapEndowments.Assets]: {
+            caveats: [
+              {
+                type: SnapCaveatType.ChainIds,
+                value: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+              },
+            ],
+            date: 1664187844588,
+            id: 'izn0WGUO8cvq_jqvLQuQP',
+            invoker: MOCK_SNAP_ID,
+            parentCapability: SnapEndowments.Assets,
+          },
+        }),
+      );
+
+      rootMessenger.registerActionHandler(
+        'SubjectMetadataController:getSubjectMetadata',
+        () => MOCK_SNAP_SUBJECT_METADATA,
+      );
+
+      rootMessenger.registerActionHandler(
+        'ExecutionService:handleRpcRequest',
+        async () =>
+          Promise.resolve({
+            marketData: {
+              'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:Fz6LxeUg5qjesYX3BdmtTwyyzBtMxk644XiTqU5W3w9w':
+                {
+                  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501': {
+                    fungible: false,
+                    lastSale: {
+                      asset:
+                        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                      amount: '123',
+                    },
+                    topBid: {
+                      asset:
+                        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                      amount: '123',
+                    },
+                    floorPrice: {
+                      asset:
+                        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                      amount: '123',
+                    },
+                    rarity: {
+                      ranking: { source: 'source', rank: 1 },
+                      metadata: { attribute1: 1, attribute2: 2 },
+                    },
+                  },
+                },
+            },
+          }),
+      );
+
+      expect(
+        await snapController.handleRequest({
+          snapId: MOCK_SNAP_ID,
+          origin: METAMASK_ORIGIN,
+          handler: HandlerType.OnAssetsMarketData,
+          request: {
+            jsonrpc: '2.0',
+            method: ' ',
+            params: {
+              assets: [
+                {
+                  asset:
+                    'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:Fz6LxeUg5qjesYX3BdmtTwyyzBtMxk644XiTqU5W3w9w',
+                  unit: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+                },
+              ],
+            },
+            id: 1,
+          },
+        }),
+      ).toStrictEqual({
+        marketData: {
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:Fz6LxeUg5qjesYX3BdmtTwyyzBtMxk644XiTqU5W3w9w':
+            {
+              'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501': {
+                fungible: false,
+                lastSale: {
+                  asset:
+                    'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                  amount: '123',
+                },
+                topBid: {
+                  asset:
+                    'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                  amount: '123',
+                },
+                floorPrice: {
+                  asset:
+                    'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                  amount: '123',
+                },
+                rarity: {
+                  ranking: { source: 'source', rank: 1 },
+                  metadata: { attribute1: 1, attribute2: 2 },
+                },
+              },
+            },
         },
       });
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -50,14 +50,14 @@ import type {
   ComponentOrElement,
   ContentType,
   OnAssetsLookupResponse,
-  FungibleAssetMetadata,
   OnAssetsConversionResponse,
   OnAssetsConversionArguments,
   AssetConversion,
   OnAssetsLookupArguments,
   OnAssetsMarketDataArguments,
-  FungibleAssetMarketData,
   OnAssetsMarketDataResponse,
+  AssetMarketData,
+  AssetMetadata,
 } from '@metamask/snaps-sdk';
 import {
   AuxiliaryFileEncoding,
@@ -118,6 +118,7 @@ import type {
   JsonRpcRequest,
   Hex,
   SemVerVersion,
+  CaipAssetTypeOrId,
 } from '@metamask/utils';
 import {
   hexToNumber,
@@ -3854,9 +3855,9 @@ export class SnapController extends BaseController<
     const { assets: requestedAssets } = requestedParams;
 
     const filteredAssets = Object.keys(assets).reduce<
-      Record<CaipAssetType, FungibleAssetMetadata | null>
+      Record<CaipAssetType, AssetMetadata | null>
     >((accumulator, assetType) => {
-      const castAssetType = assetType as CaipAssetType;
+      const castAssetType = assetType as CaipAssetTypeOrId;
       const isValid =
         scopes.some((scope) => castAssetType.startsWith(scope)) &&
         requestedAssets.includes(castAssetType);
@@ -3920,7 +3921,7 @@ export class SnapController extends BaseController<
     const { assets: requestedAssets } = requestedParams;
 
     const filteredMarketData = requestedAssets.reduce<
-      Record<CaipAssetType, Record<CaipAssetType, FungibleAssetMarketData>>
+      Record<CaipAssetTypeOrId, Record<CaipAssetType, AssetMarketData | null>>
     >((accumulator, assets) => {
       const result = marketData[assets.asset]?.[assets.unit];
       // Only include rates that were actually requested.

--- a/packages/snaps-execution-environments/src/common/validation.test.ts
+++ b/packages/snaps-execution-environments/src/common/validation.test.ts
@@ -247,6 +247,12 @@ describe('assertIsOnAssetsLookupRequestArguments', () => {
         'bip122:000000000019d6689c085ae165831e93/slip44:0',
       ],
     },
+    {
+      assets: [
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+        'hedera:mainnet/nft:0.0.55492/12',
+      ],
+    },
   ])('does not throw for a valid assets lookup param object', (value) => {
     expect(() => assertIsOnAssetsLookupRequestArguments(value)).not.toThrow();
   });
@@ -322,6 +328,14 @@ describe('assertIsOnAssetsMarketDataRequestArguments', () => {
       assets: [
         {
           asset: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+          unit: 'swift:0/iso4217:USD',
+        },
+      ],
+    },
+    {
+      assets: [
+        {
+          asset: 'hedera:mainnet/nft:0.0.55492/12',
           unit: 'swift:0/iso4217:USD',
         },
       ],

--- a/packages/snaps-execution-environments/src/common/validation.ts
+++ b/packages/snaps-execution-environments/src/common/validation.ts
@@ -32,6 +32,7 @@ import type {
 } from '@metamask/utils';
 import {
   assertStruct,
+  CaipAssetTypeOrIdStruct,
   CaipAssetTypeStruct,
   CaipChainIdStruct,
   JsonRpcIdStruct,
@@ -259,7 +260,7 @@ export const OnAssetsMarketDataRequestArgumentsStruct = object({
   assets: size(
     array(
       object({
-        asset: CaipAssetTypeStruct,
+        asset: CaipAssetTypeOrIdStruct,
         unit: CaipAssetTypeStruct,
       }),
     ),
@@ -287,7 +288,7 @@ export function assertIsOnAssetsMarketDataRequestArguments(
 }
 
 export const OnAssetsLookupRequestArgumentsStruct = object({
-  assets: size(array(CaipAssetTypeStruct), 1, Infinity),
+  assets: size(array(CaipAssetTypeOrIdStruct), 1, Infinity),
 });
 
 export type OnAssetsLookupRequestArguments = Infer<

--- a/packages/snaps-sdk/src/types/handlers/assets-lookup.test.ts
+++ b/packages/snaps-sdk/src/types/handlers/assets-lookup.test.ts
@@ -1,6 +1,7 @@
 import { is } from '@metamask/superstruct';
 
 import {
+  AssetMetadataStruct,
   FungibleAssetMetadataStruct,
   NonFungibleAssetMetadataStruct,
 } from './assets-lookup';
@@ -176,5 +177,75 @@ describe('NonFungibleAssetMetadataStruct', () => {
     },
   ])('does not validate "%p"', (value) => {
     expect(is(value, NonFungibleAssetMetadataStruct)).toBe(false);
+  });
+});
+
+describe('AssetMetadataStruct', () => {
+  it.each([
+    {
+      fungible: false,
+      name: 'CryptoPunk #3100',
+      symbol: 'PUNK',
+      imageUrl: `data:image/svg+xml;base64,${BTC_ICON_BASE64}`,
+      description: 'A rare CryptoPunk',
+      acquiredAt: 1750941834,
+      isPossibleSpam: false,
+      attributes: {
+        type: 'Alien',
+        accessories: 'Headband',
+        age: 32,
+      },
+      collection: {
+        name: 'CryptoPunks',
+        address: 'eip155:1:0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb',
+        symbol: 'PUNK',
+        tokenCount: 10000,
+        creator: 'eip155:1:0x8c5be1e5e09f6a7b3c0d8f5b4c1e2f5b4c1e2f5',
+        imageUrl: `data:image/svg+xml;base64,${BTC_ICON_BASE64}`,
+      },
+    },
+    {
+      name: 'Bitcoin',
+      symbol: 'BTC',
+      fungible: true,
+      iconUrl: `data:image/svg+xml;base64,${BTC_ICON_BASE64}`,
+      units: [
+        {
+          name: 'Bitcoin',
+          symbol: 'BTC',
+          decimals: 8,
+        },
+      ],
+    },
+  ])('validates an object %p', (value) => {
+    expect(is(value, AssetMetadataStruct)).toBe(true);
+  });
+
+  it.each([
+    'foo',
+    42,
+    null,
+    undefined,
+    {},
+    [],
+    {
+      fungible: false,
+      name: 'CryptoPunk #3100',
+      symbol: 'PUNK',
+      imageUrl: 'https://metamask.io/cryptopunk.svg',
+      description: 'A rare CryptoPunk',
+      acquiredAt: 1750941834,
+      isPossibleSpam: false,
+      collection: {},
+    },
+    {
+      fungible: true,
+      name: 'Bitcoin',
+      symbol: 'BTC',
+      iconUrl: 'https://metamask.io/btc.svg',
+      units: [],
+    },
+  ])('does not validate "%p"', (value) => {
+    expect(is(value, AssetMetadataStruct)).toBe(false);
   });
 });

--- a/packages/snaps-sdk/src/types/handlers/assets-lookup.test.ts
+++ b/packages/snaps-sdk/src/types/handlers/assets-lookup.test.ts
@@ -1,6 +1,9 @@
 import { is } from '@metamask/superstruct';
 
-import { FungibleAssetMetadataStruct } from './assets-lookup';
+import {
+  FungibleAssetMetadataStruct,
+  NonFungibleAssetMetadataStruct,
+} from './assets-lookup';
 
 const BTC_ICON_BASE64 =
   'PHN2ZyB3aWR0aD0iNDAiIGhlaWdodD0iNDAiIHZpZXdCb3g9IjAgMCA0MCA0MCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMjAiIGN5PSIyMC4wMDAyIiByPSIxOC44ODg5IiBmaWxsPSJ1cmwoI3BhaW50MF9saW5lYXJfNjlfODQxKSIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI0LjgxNTIgMTIuMTcxNkMyNy40MzQyIDEzLjEzMjUgMjkuMzIwNiAxNC41NTYxIDI4Ljg4ODIgMTcuMjg3OUMyOC41NjA5IDE5LjI3NjUgMjcuNTE4OCAyMC4yNDg1IDI2LjExMDYgMjAuNTkxNUMyNy45ODQ1IDIxLjY0MDQgMjguODg2NSAyMy4yMzI1IDI3LjkyMTYgMjYuMDI1MkMyNi43MjE3IDI5LjUyNzggMjQuMDM1OSAyOS44NDU1IDIwLjQ3ODQgMjkuMTY3TDE5LjU2MjUgMzIuODYzNkwxNy40OTU1IDMyLjM1MTNMMTguNDExMyAyOC42NTQ4QzE4LjE4NjQgMjguNTk0OSAxNy45NDk0IDI4LjUzOTcgMTcuNzA2MyAyOC40ODMxQzE3LjM4MTUgMjguNDA3NSAxNy4wNDU4IDI4LjMyOTMgMTYuNzEzNiAyOC4yMzM5TDE1Ljc5NzcgMzEuOTMwN0wxMy43MzQ1IDMxLjQxOTNMMTQuNjUwMyAyNy43MjI2TDEwLjU0MDMgMjYuNjAzMkwxMS41NjE5IDIzLjk4OTRDMTEuNTYxOSAyMy45ODk0IDEzLjExMzIgMjQuNDE2MSAxMy4wODkxIDI0LjM4OTNDMTMuNjY0NSAyNC41MjkyIDEzLjk0NTkgMjQuMTI3MyAxNC4wNjExIDIzLjg0NThMMTUuNTI3OCAxNy45MTk3TDE2LjU5NTEgMTMuNzA3N0MxNi42NDEzIDEzLjI1MjQgMTYuNDk4NyAxMi42NTY4IDE1LjY1OCAxMi40MzAyQzE1LjcxNTIgMTIuMzk2NiAxNC4xNDQ1IDEyLjA1NTEgMTQuMTQ0NSAxMi4wNTUxTDE0Ljc1NjYgOS41Nzc5N0wxOC45OTI2IDEwLjYyNzhMMTkuODg5NyA3LjAwNjg0TDIyLjAyMzcgNy41MzU3M0wyMS4xMjY2IDExLjE1NjdDMjEuNTQxNSAxMS4yNDY5IDIxLjk0NyAxMS4zNTE4IDIyLjM1NjggMTEuNDU3OEwyMi4zNTcgMTEuNDU3OEMyMi40OTE1IDExLjQ5MjYgMjIuNjI2NSAxMS41Mjc1IDIyLjc2MjQgMTEuNTYyMUwyMy42NTk1IDcuOTQxMTJMMjUuNzM1OSA4LjQ1NTcxTDI0LjgxNTIgMTIuMTcxNlpNMTkuMTUyNSAxNy45OTRDMTkuMTg0OCAxOC4wMDM2IDE5LjIxOTQgMTguMDE0IDE5LjI1NjEgMTguMDI1QzIwLjQ5NyAxOC4zOTggMjQuMTc2NiAxOS41MDM3IDI0Ljc5NjQgMTcuMDQxN0MyNS4zNzM1IDE0LjcwMTQgMjIuMTg1NyAxMy45ODY2IDIwLjcwNDUgMTMuNjU0NEMyMC41Mjk2IDEzLjYxNTIgMjAuMzc4NCAxMy41ODEzIDIwLjI2MDEgMTMuNTUwN0wxOS4xNTI1IDE3Ljk5NFpNMTcuNTE5NiAyNS4yOTM5QzE3LjQ1NDQgMjUuMjc0NCAxNy4zOTQzIDI1LjI1NjcgMTcuMzM5OCAyNS4yNDA2TDE4LjQ0NzQgMjAuNzk3NEMxOC41NzgzIDIwLjgzMTQgMTguNzQzOCAyMC44NzAzIDE4LjkzNTIgMjAuOTE1MkMyMC42ODEzIDIxLjMyNTUgMjQuNTgxMyAyMi4yNDIgMjMuOTc1MSAyNC41OTU0QzIzLjM4NjggMjcuMDM5IDE5LjA0ODQgMjUuNzQ4NyAxNy41MTk2IDI1LjI5MzlaIiBmaWxsPSJ3aGl0ZSIvPgo8ZGVmcz4KPGxpbmVhckdyYWRpZW50IGlkPSJwYWludDBfbGluZWFyXzY5Xzg0MSIgeDE9IjIwIiB5MT0iMS4xMTEzMyIgeDI9IjIwIiB5Mj0iMzguODg5MSIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPgo8c3RvcCBzdG9wLWNvbG9yPSIjRkZCNjBBIi8+CjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iI0Y1ODMwMCIvPgo8L2xpbmVhckdyYWRpZW50Pgo8L2RlZnM+Cjwvc3ZnPgo=';
@@ -104,5 +107,74 @@ describe('FungibleAssetMetadataStruct', () => {
     },
   ])('does not validate "%p"', (value) => {
     expect(is(value, FungibleAssetMetadataStruct)).toBe(false);
+  });
+});
+
+describe('NonFungibleAssetMetadataStruct', () => {
+  it.each([
+    {
+      fungible: false,
+      name: 'CryptoPunk #3100',
+      symbol: 'PUNK',
+      imageUrl: `data:image/svg+xml;base64,${BTC_ICON_BASE64}`,
+      description: 'A rare CryptoPunk',
+      acquiredAt: 1750941834,
+      isPossibleSpam: false,
+      attributes: {
+        type: 'Alien',
+        accessories: 'Headband',
+        age: 32,
+      },
+      collection: {
+        name: 'CryptoPunks',
+        address: 'eip155:1:0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb',
+        symbol: 'PUNK',
+        tokenCount: 10000,
+        creator: 'eip155:1:0x8c5be1e5e09f6a7b3c0d8f5b4c1e2f5b4c1e2f5',
+        imageUrl: `data:image/svg+xml;base64,${BTC_ICON_BASE64}`,
+      },
+    },
+    {
+      fungible: false,
+    },
+  ])('validates an object %p', (value) => {
+    expect(is(value, NonFungibleAssetMetadataStruct)).toBe(true);
+  });
+
+  it.each([
+    'foo',
+    42,
+    null,
+    undefined,
+    {},
+    [],
+    {
+      fungible: false,
+      name: 'CryptoPunk #3100',
+      symbol: 'PUNK',
+      imageUrl: 'https://metamask.io/cryptopunk.svg',
+      description: 'A rare CryptoPunk',
+      acquiredAt: 1750941834,
+      isPossibleSpam: false,
+      collection: {},
+    },
+    {
+      fungible: false,
+      name: 'CryptoPunk #3100',
+      symbol: 'PUNK',
+      imageUrl: 'data:image/png;base64,',
+      description: 'A rare CryptoPunk',
+      acquiredAt: 1750941834,
+      isPossibleSpam: false,
+      collection: {
+        name: 'CryptoPunks',
+        address: 'eip155:1:0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb',
+        symbol: 'PUNK',
+        tokenCount: 10000,
+        creator: 'eip155:1:0x8c5be1e5e09f6a7b3c0d8f5b4c1e2f5b4c1e2f5',
+      },
+    },
+  ])('does not validate "%p"', (value) => {
+    expect(is(value, NonFungibleAssetMetadataStruct)).toBe(false);
   });
 });

--- a/packages/snaps-sdk/src/types/handlers/assets-lookup.ts
+++ b/packages/snaps-sdk/src/types/handlers/assets-lookup.ts
@@ -17,6 +17,8 @@ import {
   CaipAccountIdStruct,
   CaipAssetTypeOrIdStruct,
   assert,
+  hasProperty,
+  isObject,
 } from '@metamask/utils';
 import type { CaipAssetTypeOrId } from '@metamask/utils';
 
@@ -78,6 +80,10 @@ export const NonFungibleAssetMetadataStruct = object({
 });
 
 export const AssetMetadataStruct = selectiveUnion((metadata) => {
+  if (!isObject(metadata) || !hasProperty(metadata, 'fungible')) {
+    return union([FungibleAssetMetadataStruct, NonFungibleAssetMetadataStruct]);
+  }
+
   if (metadata.fungible) {
     return FungibleAssetMetadataStruct;
   }

--- a/packages/snaps-sdk/src/types/handlers/assets-lookup.ts
+++ b/packages/snaps-sdk/src/types/handlers/assets-lookup.ts
@@ -17,7 +17,6 @@ import {
   CaipAccountIdStruct,
   CaipAssetTypeOrIdStruct,
   assert,
-  hasProperty,
   isObject,
 } from '@metamask/utils';
 import type { CaipAssetTypeOrId } from '@metamask/utils';
@@ -80,11 +79,7 @@ export const NonFungibleAssetMetadataStruct = object({
 });
 
 export const AssetMetadataStruct = selectiveUnion((metadata) => {
-  if (!isObject(metadata) || !hasProperty(metadata, 'fungible')) {
-    return union([FungibleAssetMetadataStruct, NonFungibleAssetMetadataStruct]);
-  }
-
-  if (metadata.fungible) {
+  if (isObject(metadata) && metadata.fungible) {
     return FungibleAssetMetadataStruct;
   }
 

--- a/packages/snaps-sdk/src/types/handlers/assets-lookup.ts
+++ b/packages/snaps-sdk/src/types/handlers/assets-lookup.ts
@@ -29,6 +29,14 @@ export const FungibleAssetUnitStruct = object({
   decimals: number(),
 });
 
+/**
+ * A unit of a fungible asset, which can be used to represent
+ * different denominations of the asset.
+ *
+ * @property name - The name of the unit, if available.
+ * @property symbol - The symbol of the unit, if available.
+ * @property decimals - The number of decimal places for the unit.
+ */
 export type FungibleAssetUnit = Infer<typeof FungibleAssetUnitStruct>;
 
 export const AssetIconUrlStruct = refine(string(), 'Asset URL', (value) => {
@@ -45,6 +53,16 @@ export const AssetIconUrlStruct = refine(string(), 'Asset URL', (value) => {
   }
 });
 
+/**
+ * A struct representing the metadata for a fungible asset.
+ *
+ * @property name - The name of the asset, if available.
+ * @property symbol - The symbol of the asset, if available.
+ * @property fungible - Indicates that this is a fungible asset. This is always `
+ * true` for fungible assets.
+ * @property iconUrl - The URL of the asset's icon, which can be a base64 SVG or a remote HTTPS URL.
+ * @property units - An array of units for the asset, each represented by {@link FungibleAssetUnitStruct}.
+ */
 export const FungibleAssetMetadataStruct = object({
   name: optional(string()),
   symbol: optional(string()),
@@ -53,6 +71,18 @@ export const FungibleAssetMetadataStruct = object({
   units: size(array(FungibleAssetUnitStruct), 1, Infinity),
 });
 
+/**
+ * A collection of non-fungible assets, which can be used to group
+ * assets that share a common theme or creator.
+ *
+ * @property name - The name of the collection.
+ * @property address - The CAIP-10 account ID of the collection's creator.
+ * @property symbol - The symbol of the collection.
+ * @property tokenCount - The number of tokens in the collection, if available.
+ * @property creator - The CAIP-10 account ID of the collection's creator, if
+ * available.
+ * @property imageUrl - The URL of the collection's image.
+ */
 export const NonFungibleAssetCollectionStruct = object({
   name: string(),
   address: CaipAccountIdStruct,
@@ -62,10 +92,37 @@ export const NonFungibleAssetCollectionStruct = object({
   imageUrl: optional(AssetIconUrlStruct),
 });
 
+/**
+ * A collection of non-fungible assets, which can be used to group
+ * assets that share a common theme or creator.
+ *
+ * @property name - The name of the collection.
+ * @property address - The CAIP-10 account ID of the collection's creator.
+ * @property symbol - The symbol of the collection.
+ * @property tokenCount - The number of tokens in the collection, if available.
+ * @property creator - The CAIP-10 account ID of the collection's creator, if
+ * available.
+ * @property imageUrl - The URL of the collection's image.
+ */
 export type NonFungibleAssetCollection = Infer<
   typeof NonFungibleAssetCollectionStruct
 >;
 
+/**
+ * A struct representing the metadata for a non-fungible asset.
+ *
+ * @property fungible - Indicates that this is a non-fungible asset.
+ * This is always `false` for non-fungible assets.
+ * @property name - The name of the asset, if available.
+ * @property symbol - The symbol of the asset, if available.
+ * @property imageUrl - The URL of the asset's image, which can be a base64 SVG or a remote HTTPS URL.
+ * @property description - A description of the asset, if available.
+ * @property acquiredAt - The timestamp when the asset was acquired, if available.
+ * @property isPossibleSpam - Indicates if the asset is possibly spam, if available.
+ * @property attributes - Additional attributes of the asset, represented as a record of string keys and
+ * string or number values.
+ * @property collection - The collection the asset belongs to, if available. See {@link NonFungibleAssetCollectionStruct}.
+ */
 export const NonFungibleAssetMetadataStruct = object({
   fungible: literal(false),
   name: optional(string()),
@@ -78,6 +135,10 @@ export const NonFungibleAssetMetadataStruct = object({
   collection: optional(NonFungibleAssetCollectionStruct),
 });
 
+/**
+ * A struct representing the metadata for an asset, which can be either
+ * {@link FungibleAssetMetadataStruct} or {@link NonFungibleAssetMetadataStruct}.
+ */
 export const AssetMetadataStruct = selectiveUnion((metadata) => {
   if (isObject(metadata) && metadata.fungible) {
     return FungibleAssetMetadataStruct;
@@ -86,22 +147,47 @@ export const AssetMetadataStruct = selectiveUnion((metadata) => {
   return NonFungibleAssetMetadataStruct;
 });
 
+/**
+ * A struct representing the response of the `onAssetsLookup` method.
+ *
+ * @property assets - An object containing a mapping between the CAIP-19 key and a metadata object or null.
+ */
 export const OnAssetsLookupResponseStruct = object({
   assets: record(CaipAssetTypeOrIdStruct, nullable(AssetMetadataStruct)),
 });
 
 /**
  * The metadata for an asset, which can be either fungible or non-fungible.
+ *
  */
 export type AssetMetadata = Infer<typeof AssetMetadataStruct>;
 
 /**
  * The metadata for a fungible asset.
+ *
+ * @property fungible - Indicates that this is a fungible asset.
+ * This is always `true` for fungible assets.
+ * @property name - The name of the asset.
+ * @property symbol - The symbol of the asset.
+ * @property iconUrl - The URL of the asset's icon.
+ * @property units - An array of units for the asset, each represented by {@link FungibleAssetUnit}.
  */
 export type FungibleAssetMetadata = Infer<typeof FungibleAssetMetadataStruct>;
 
 /**
  * The metadata for a non-fungible asset.
+ *
+ * @property fungible - Indicates that this is a non-fungible asset.
+ * This is always `false` for non-fungible assets.
+ * @property name - The name of the asset.
+ * @property symbol - The symbol of the asset.
+ * @property imageUrl - The URL of the asset's image.
+ * @property description - A description of the asset.
+ * @property acquiredAt - The timestamp when the asset was acquired, if available.
+ * @property isPossibleSpam - Indicates if the asset is possibly spam, if available.
+ * @property attributes - Additional attributes of the asset, represented as a record of string keys and
+ * string or number values.
+ * @property collection - The collection the asset belongs to, if available. See {@link NonFungibleAssetCollection}.
  */
 export type NonFungibleAssetMetadata = Infer<
   typeof NonFungibleAssetMetadataStruct

--- a/packages/snaps-sdk/src/types/handlers/assets-lookup.ts
+++ b/packages/snaps-sdk/src/types/handlers/assets-lookup.ts
@@ -15,10 +15,10 @@ import {
 } from '@metamask/superstruct';
 import {
   CaipAccountIdStruct,
-  CaipAssetTypeStruct,
+  CaipAssetTypeOrIdStruct,
   assert,
 } from '@metamask/utils';
-import type { CaipAssetTypeOrId, CaipAssetType } from '@metamask/utils';
+import type { CaipAssetTypeOrId } from '@metamask/utils';
 
 export const FungibleAssetUnitStruct = object({
   name: optional(string()),
@@ -81,7 +81,7 @@ export const AssetMetadataStruct = union([
 ]);
 
 export const OnAssetsLookupResponseStruct = object({
-  assets: record(CaipAssetTypeStruct, nullable(AssetMetadataStruct)),
+  assets: record(CaipAssetTypeOrIdStruct, nullable(AssetMetadataStruct)),
 });
 
 /**
@@ -126,5 +126,5 @@ export type OnAssetsLookupHandler = (
  * @property assets - An object containing a mapping between the CAIP-19 key and a metadata object or null.
  */
 export type OnAssetsLookupResponse = {
-  assets: Record<CaipAssetType, AssetMetadata | null>;
+  assets: Record<CaipAssetTypeOrId, AssetMetadata | null>;
 };

--- a/packages/snaps-sdk/src/types/handlers/assets-lookup.ts
+++ b/packages/snaps-sdk/src/types/handlers/assets-lookup.ts
@@ -20,6 +20,8 @@ import {
 } from '@metamask/utils';
 import type { CaipAssetTypeOrId } from '@metamask/utils';
 
+import { selectiveUnion } from '../../internals';
+
 export const FungibleAssetUnitStruct = object({
   name: optional(string()),
   symbol: optional(string()),
@@ -75,10 +77,13 @@ export const NonFungibleAssetMetadataStruct = object({
   collection: optional(NonFungibleAssetCollectionStruct),
 });
 
-export const AssetMetadataStruct = union([
-  FungibleAssetMetadataStruct,
-  NonFungibleAssetMetadataStruct,
-]);
+export const AssetMetadataStruct = selectiveUnion((metadata) => {
+  if (metadata.fungible) {
+    return FungibleAssetMetadataStruct;
+  }
+
+  return NonFungibleAssetMetadataStruct;
+});
 
 export const OnAssetsLookupResponseStruct = object({
   assets: record(CaipAssetTypeOrIdStruct, nullable(AssetMetadataStruct)),

--- a/packages/snaps-sdk/src/types/handlers/assets-market-data.ts
+++ b/packages/snaps-sdk/src/types/handlers/assets-market-data.ts
@@ -1,4 +1,4 @@
-import type { CaipAssetType } from '@metamask/utils';
+import type { CaipAssetType, CaipAssetTypeOrId } from '@metamask/utils';
 
 /**
  * The market data for a fungible asset.
@@ -27,15 +27,62 @@ export type FungibleAssetMarketData = {
 };
 
 /**
+ * An asset value, which includes the asset type and the amount.
+ *
+ * @property asset - The CAIP-19 asset type or ID of the asset.
+ * @property amount - The pice represented as a number in string format.
+ */
+export type AssetValue = {
+  asset: CaipAssetTypeOrId;
+  amount: string;
+};
+
+/**
+ * The market data for a non-fungible asset.
+ *
+ * @property fungible - Indicates that this is a non-fungible asset.
+ * This is always `false` for non-fungible assets.
+ * @property lastSale - The last sale price of the asset, if available. See {@link AssetValue}.
+ * @property topBid - The top bid price for the asset, if available. See {@link AssetValue}.
+ * @property floorPrice - The floor price of the asset, if available. See {@link AssetValue}.
+ * @property rarity - The rarity information for the asset, if available.
+ * @property rarity.ranking - The ranking of the asset's rarity, if available.
+ * @property rarity.ranking.source - The source of the rarity ranking.
+ * @property rarity.ranking.rank - The rank of the asset in the rarity ranking.
+ * @property rarity.metadata - Additional metadata about the asset's rarity, if available.
+ * This is a record of string keys and number values.
+ */
+export type NonFungibleAssetMarketData = {
+  fungible: false;
+  lastSale?: AssetValue;
+  topBid?: AssetValue;
+  floorPrice?: AssetValue;
+  rarity?: {
+    ranking?: {
+      source: string;
+      rank: number;
+    };
+    metadata?: Record<string, number>;
+  };
+};
+
+/**
+ * The market data for an asset, which can be either fungible or non-fungible.
+ */
+export type AssetMarketData =
+  | FungibleAssetMarketData
+  | NonFungibleAssetMarketData;
+
+/**
  * The arguments for the `onAssetsMarketData` handler.
  *
  * @property assets - An array of objects containing the asset and unit types.
- * @property assets.asset - The CAIP-19 asset type of the asset.
+ * @property assets.asset - The CAIP-19 asset type or ID of the asset.
  * @property assets.unit - The CAIP-19 asset type of the unit to use.
  */
 export type OnAssetsMarketDataArguments = {
   assets: {
-    asset: CaipAssetType;
+    asset: CaipAssetTypeOrId;
     unit: CaipAssetType;
   }[];
 };
@@ -54,11 +101,11 @@ export type OnAssetsMarketDataHandler = (
 /**
  * The response from the market data query, containing market data for the requested assets.
  *
- * @property marketData - A nested object with two CAIP-19 keys that contains a {@link FungibleAssetMarketData} object or null between the two keys.
+ * @property marketData - A nested object with two CAIP-19 keys that contains a {@link AssetMarketData} object or null between the two keys.
  */
 export type OnAssetsMarketDataResponse = {
   marketData: Record<
-    CaipAssetType,
-    Record<CaipAssetType, FungibleAssetMarketData | null>
+    CaipAssetTypeOrId,
+    Record<CaipAssetType, AssetMarketData | null>
   >;
 };

--- a/packages/snaps-sdk/src/types/handlers/assets-market-data.ts
+++ b/packages/snaps-sdk/src/types/handlers/assets-market-data.ts
@@ -101,7 +101,7 @@ export type OnAssetsMarketDataHandler = (
 /**
  * The response from the market data query, containing market data for the requested assets.
  *
- * @property marketData - A nested object with two CAIP-19 keys that contains a {@link AssetMarketData} object or null between the two keys.
+ * @property marketData - A nested object with two CAIP-19 keys that contains a {@link AssetMarketData} object or null.
  */
 export type OnAssetsMarketDataResponse = {
   marketData: Record<

--- a/packages/snaps-sdk/src/types/handlers/assets-market-data.ts
+++ b/packages/snaps-sdk/src/types/handlers/assets-market-data.ts
@@ -67,7 +67,7 @@ export type NonFungibleAssetMarketData = {
 };
 
 /**
- * The market data for an asset, which can be either fungible or non-fungible.
+ * The market data for an asset, which can be either {@link FungibleAssetMarketData} or {@link NonFungibleAssetMarketData}.
  */
 export type AssetMarketData =
   | FungibleAssetMarketData

--- a/packages/snaps-utils/src/handlers/assets-market-data.test.ts
+++ b/packages/snaps-utils/src/handlers/assets-market-data.test.ts
@@ -1,7 +1,10 @@
 import { is } from '@metamask/superstruct';
 
 import {
+  AssetMarketDataStruct,
+  AssetValueStruct,
   FungibleAssetMarketDataStruct,
+  NonFungibleAssetMarketDataStruct,
   OnAssetsMarketDataResponseStruct,
   PricePercentChangeStruct,
 } from './assets-market-data';
@@ -70,6 +73,130 @@ describe('FungibleAssetMarketDataStruct', () => {
   });
 });
 
+describe('AssetValueStruct', () => {
+  it.each([
+    {
+      asset:
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      amount: '123',
+    },
+    {
+      asset:
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      amount: '123',
+    },
+  ])('validates "%p"', (value) => {
+    expect(is(value, AssetValueStruct)).toBe(true);
+  });
+  it.each(['foo', 42, null, undefined, {}, [], { asset: 'foo' }])(
+    'does not validate "%p"',
+    (value) => {
+      expect(is(value, AssetValueStruct)).toBe(false);
+    },
+  );
+});
+
+describe('NonFungibleAssetMarketDataStruct', () => {
+  it.each([
+    {
+      fungible: false,
+      lastSale: {
+        asset:
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        amount: '123',
+      },
+      topBid: {
+        asset:
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        amount: '123',
+      },
+      floorPrice: {
+        asset:
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        amount: '123',
+      },
+      rarity: {
+        ranking: { source: 'source', rank: 1 },
+        metadata: { attribute1: 1, attribute2: 2 },
+      },
+    },
+    {
+      fungible: false,
+    },
+  ])('validates "%p"', (value) => {
+    expect(is(value, NonFungibleAssetMarketDataStruct)).toBe(true);
+  });
+  it.each([
+    'foo',
+    42,
+    null,
+    undefined,
+    {},
+    [],
+    { fungible: true },
+    {
+      lastSale: {
+        asset:
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        amount: 123,
+      },
+    },
+  ])('does not validate "%p"', (value) => {
+    expect(is(value, NonFungibleAssetMarketDataStruct)).toBe(false);
+  });
+});
+
+describe('AssetMarketDataStruct', () => {
+  it.each([
+    {
+      fungible: false,
+      lastSale: {
+        asset:
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        amount: '123',
+      },
+      topBid: {
+        asset:
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        amount: '123',
+      },
+      floorPrice: {
+        asset:
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        amount: '123',
+      },
+      rarity: {
+        ranking: { source: 'source', rank: 1 },
+        metadata: { attribute1: 1, attribute2: 2 },
+      },
+    },
+    {
+      fungible: true,
+      marketCap: '123',
+      totalVolume: '123',
+      circulatingSupply: '123',
+      allTimeHigh: '123',
+      allTimeLow: '123',
+      pricePercentChange: { all: 1.23 },
+    },
+  ])('validates "%p"', (value) => {
+    expect(is(value, AssetMarketDataStruct)).toBe(true);
+  });
+
+  it.each([
+    'foo',
+    42,
+    null,
+    undefined,
+    {},
+    [],
+    { fungible: true, lastSale: {} },
+    { fungible: false, marketCap: '123' },
+  ])('does not validate "%p"', (value) => {
+    expect(is(value, AssetMarketDataStruct)).toBe(false);
+  });
+});
+
 describe('OnAssetsMarketDataResponseStruct', () => {
   it.each([
     {
@@ -84,6 +211,76 @@ describe('OnAssetsMarketDataResponseStruct', () => {
               allTimeHigh: '123',
               allTimeLow: '123',
               pricePercentChange: { all: 1.23 },
+            },
+          },
+      },
+    },
+    {
+      marketData: {
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v':
+          {
+            'swift:0/iso4217:USD': {
+              fungible: false,
+              lastSale: {
+                asset:
+                  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                amount: '123',
+              },
+              topBid: {
+                asset:
+                  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                amount: '123',
+              },
+              floorPrice: {
+                asset:
+                  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                amount: '123',
+              },
+              rarity: {
+                ranking: { source: 'source', rank: 1 },
+                metadata: { attribute1: 1, attribute2: 2 },
+              },
+            },
+          },
+      },
+    },
+    {
+      marketData: {
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v':
+          {
+            'swift:0/iso4217:USD': {
+              fungible: true,
+              marketCap: '123',
+              totalVolume: '123',
+              circulatingSupply: '123',
+              allTimeHigh: '123',
+              allTimeLow: '123',
+              pricePercentChange: { all: 1.23 },
+            },
+          },
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/nft:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v':
+          {
+            'swift:0/iso4217:USD': {
+              fungible: false,
+              lastSale: {
+                asset:
+                  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                amount: '123',
+              },
+              topBid: {
+                asset:
+                  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                amount: '123',
+              },
+              floorPrice: {
+                asset:
+                  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                amount: '123',
+              },
+              rarity: {
+                ranking: { source: 'source', rank: 1 },
+                metadata: { attribute1: 1, attribute2: 2 },
+              },
             },
           },
       },

--- a/packages/snaps-utils/src/handlers/assets-market-data.ts
+++ b/packages/snaps-utils/src/handlers/assets-market-data.ts
@@ -9,7 +9,7 @@ import {
   string,
   union,
 } from '@metamask/superstruct';
-import { CaipAssetTypeStruct } from '@metamask/utils';
+import { CaipAssetTypeOrIdStruct, CaipAssetTypeStruct } from '@metamask/utils';
 
 import { ISO8601DurationStruct } from '../time';
 
@@ -35,11 +35,48 @@ export const FungibleAssetMarketDataStruct = object({
 });
 
 /**
+ * A struct representing the metadata for a fungible asset.
+ */
+export const AssetValueStruct = object({
+  asset: CaipAssetTypeOrIdStruct,
+  amount: string(),
+});
+
+/**
+ * A struct representing the market data for a non-fungible asset.
+ */
+export const NonFungibleAssetMarketDataStruct = object({
+  fungible: literal(false),
+  lastSale: optional(AssetValueStruct),
+  topBid: optional(AssetValueStruct),
+  floorPrice: optional(AssetValueStruct),
+  rarity: optional(
+    object({
+      ranking: optional(
+        object({
+          source: string(),
+          rank: number(),
+        }),
+      ),
+      metadata: optional(record(string(), number())),
+    }),
+  ),
+});
+
+/**
+ * A struct representing the market data for an asset, which can be either fungible or non-fungible.
+ */
+export const AssetMarketDataStruct = union([
+  FungibleAssetMarketDataStruct,
+  NonFungibleAssetMarketDataStruct,
+]);
+
+/**
  * A struct representing the response of the `onAssetsMarketData` method.
  */
 export const OnAssetsMarketDataResponseStruct = object({
   marketData: record(
     CaipAssetTypeStruct,
-    record(CaipAssetTypeStruct, nullable(FungibleAssetMarketDataStruct)),
+    record(CaipAssetTypeStruct, nullable(AssetMarketDataStruct)),
   ),
 });

--- a/packages/snaps-utils/src/handlers/assets-market-data.ts
+++ b/packages/snaps-utils/src/handlers/assets-market-data.ts
@@ -9,7 +9,12 @@ import {
   string,
   union,
 } from '@metamask/superstruct';
-import { CaipAssetTypeOrIdStruct, CaipAssetTypeStruct } from '@metamask/utils';
+import {
+  CaipAssetTypeOrIdStruct,
+  CaipAssetTypeStruct,
+  hasProperty,
+  isObject,
+} from '@metamask/utils';
 
 import { ISO8601DurationStruct } from '../time';
 
@@ -67,6 +72,13 @@ export const NonFungibleAssetMarketDataStruct = object({
  * A struct representing the market data for an asset, which can be either fungible or non-fungible.
  */
 export const AssetMarketDataStruct = selectiveUnion((marketData) => {
+  if (!isObject(marketData) || !hasProperty(marketData, 'fungible')) {
+    return union([
+      FungibleAssetMarketDataStruct,
+      NonFungibleAssetMarketDataStruct,
+    ]);
+  }
+
   if (marketData.fungible) {
     return FungibleAssetMarketDataStruct;
   }

--- a/packages/snaps-utils/src/handlers/assets-market-data.ts
+++ b/packages/snaps-utils/src/handlers/assets-market-data.ts
@@ -26,7 +26,18 @@ export const PricePercentChangeStruct = nonEmptyRecord(
 );
 
 /**
- * A struct representing the market data for an asset.
+ * A struct representing the market data for a fungible asset.
+ *
+ * @property fungible - Indicates that this is a fungible asset.
+ * This is always `true` for fungible assets.
+ * @property marketCap - The market capitalization of the asset.
+ * @property totalVolume - The total volume of the asset.
+ * @property circulatingSupply - The circulating supply of the asset.
+ * @property allTimeHigh - The all-time high price of the asset.
+ * @property allTimeLow - The all-time low price of the asset.
+ * @property pricePercentChange - The percentage change in price over different intervals.
+ * @property pricePercentChange.interval - The time interval for the price change as a ISO 8601 duration
+ * or the string "all" to represent the all-time change.
  */
 export const FungibleAssetMarketDataStruct = object({
   fungible: literal(true),
@@ -40,6 +51,9 @@ export const FungibleAssetMarketDataStruct = object({
 
 /**
  * A struct representing the metadata for a fungible asset.
+ *
+ * @property asset - The CAIP-19 asset type or ID of the asset.
+ * @property amount - The pice represented as a number in string format.
  */
 export const AssetValueStruct = object({
   asset: CaipAssetTypeOrIdStruct,
@@ -48,6 +62,20 @@ export const AssetValueStruct = object({
 
 /**
  * A struct representing the market data for a non-fungible asset.
+ *
+ * @property asset - The CAIP-19 asset type or ID of the asset.
+ * @property amount - The pice represented as a number in string format.
+ * @property fungible - Indicates that this is a non-fungible asset.
+ * This is always `false` for non-fungible assets.
+ * @property lastSale - The last sale price of the asset, if available. See {@link AssetValueStruct}.
+ * @property topBid - The top bid price for the asset, if available. See {@link AssetValueStruct}.
+ * @property floorPrice - The floor price of the asset, if available. See {@link AssetValueStruct}.
+ * @property rarity - The rarity information for the asset, if available.
+ * @property rarity.ranking - The ranking of the asset's rarity, if available.
+ * @property rarity.ranking.source - The source of the rarity ranking.
+ * @property rarity.ranking.rank - The rank of the asset in the rarity ranking.
+ * @property rarity.metadata - Additional metadata about the asset's rarity, if available.
+ * This is a record of string keys and number values.
  */
 export const NonFungibleAssetMarketDataStruct = object({
   fungible: literal(false),
@@ -68,7 +96,7 @@ export const NonFungibleAssetMarketDataStruct = object({
 });
 
 /**
- * A struct representing the market data for an asset, which can be either fungible or non-fungible.
+ * A struct representing the market data for an asset, which can be either {@link FungibleAssetMarketDataStruct} or {@link NonFungibleAssetMarketDataStruct}.
  */
 export const AssetMarketDataStruct = selectiveUnion((marketData) => {
   if (isObject(marketData) && marketData.fungible) {
@@ -80,6 +108,8 @@ export const AssetMarketDataStruct = selectiveUnion((marketData) => {
 
 /**
  * A struct representing the response of the `onAssetsMarketData` method.
+ *
+ * @property marketData - A nested object with two CAIP-19 keys that contains a {@link AssetMarketDataStruct} object or null between the two keys.
  */
 export const OnAssetsMarketDataResponseStruct = object({
   marketData: record(

--- a/packages/snaps-utils/src/handlers/assets-market-data.ts
+++ b/packages/snaps-utils/src/handlers/assets-market-data.ts
@@ -12,7 +12,6 @@ import {
 import {
   CaipAssetTypeOrIdStruct,
   CaipAssetTypeStruct,
-  hasProperty,
   isObject,
 } from '@metamask/utils';
 
@@ -72,14 +71,7 @@ export const NonFungibleAssetMarketDataStruct = object({
  * A struct representing the market data for an asset, which can be either fungible or non-fungible.
  */
 export const AssetMarketDataStruct = selectiveUnion((marketData) => {
-  if (!isObject(marketData) || !hasProperty(marketData, 'fungible')) {
-    return union([
-      FungibleAssetMarketDataStruct,
-      NonFungibleAssetMarketDataStruct,
-    ]);
-  }
-
-  if (marketData.fungible) {
+  if (isObject(marketData) && marketData.fungible) {
     return FungibleAssetMarketDataStruct;
   }
 

--- a/packages/snaps-utils/src/handlers/assets-market-data.ts
+++ b/packages/snaps-utils/src/handlers/assets-market-data.ts
@@ -1,4 +1,4 @@
-import { nonEmptyRecord } from '@metamask/snaps-sdk';
+import { nonEmptyRecord, selectiveUnion } from '@metamask/snaps-sdk';
 import {
   literal,
   nullable,
@@ -66,10 +66,13 @@ export const NonFungibleAssetMarketDataStruct = object({
 /**
  * A struct representing the market data for an asset, which can be either fungible or non-fungible.
  */
-export const AssetMarketDataStruct = union([
-  FungibleAssetMarketDataStruct,
-  NonFungibleAssetMarketDataStruct,
-]);
+export const AssetMarketDataStruct = selectiveUnion((marketData) => {
+  if (marketData.fungible) {
+    return FungibleAssetMarketDataStruct;
+  }
+
+  return NonFungibleAssetMarketDataStruct;
+});
 
 /**
  * A struct representing the response of the `onAssetsMarketData` method.

--- a/packages/snaps-utils/src/handlers/assets-market-data.ts
+++ b/packages/snaps-utils/src/handlers/assets-market-data.ts
@@ -50,7 +50,7 @@ export const FungibleAssetMarketDataStruct = object({
 });
 
 /**
- * A struct representing the metadata for a fungible asset.
+ * A struct representing an asset value, which includes the asset type and the amount.
  *
  * @property asset - The CAIP-19 asset type or ID of the asset.
  * @property amount - The pice represented as a number in string format.

--- a/packages/snaps-utils/src/handlers/assets-market-data.ts
+++ b/packages/snaps-utils/src/handlers/assets-market-data.ts
@@ -109,7 +109,7 @@ export const AssetMarketDataStruct = selectiveUnion((marketData) => {
 /**
  * A struct representing the response of the `onAssetsMarketData` method.
  *
- * @property marketData - A nested object with two CAIP-19 keys that contains a {@link AssetMarketDataStruct} object or null between the two keys.
+ * @property marketData - A nested object with two CAIP-19 keys that contains a {@link AssetMarketData} object or null.
  */
 export const OnAssetsMarketDataResponseStruct = object({
   marketData: record(

--- a/packages/snaps-utils/src/handlers/assets-market-data.ts
+++ b/packages/snaps-utils/src/handlers/assets-market-data.ts
@@ -76,7 +76,7 @@ export const AssetMarketDataStruct = union([
  */
 export const OnAssetsMarketDataResponseStruct = object({
   marketData: record(
-    CaipAssetTypeStruct,
+    CaipAssetTypeOrIdStruct,
     record(CaipAssetTypeStruct, nullable(AssetMarketDataStruct)),
   ),
 });


### PR DESCRIPTION
This PR adds the support for non-fungible assets (NFTs) to `onAssetsLookup` and `onAssetsMarketData` handlers of `endowment:assets`

fixes: #3314 