### PR TITLE
fix: Display CLI minimum version range

### DIFF
--- a/packages/snaps-cli/src/cli.test.ts
+++ b/packages/snaps-cli/src/cli.test.ts
@@ -2,6 +2,7 @@ import type yargs from 'yargs';
 
 import { checkNodeVersion, cli } from './cli';
 import commands from './commands';
+import packageJson from '@metamask/snaps-cli/package.json';
 
 jest.mock('./config');
 
@@ -26,6 +27,8 @@ const getMockArgv = (...args: string[]) => {
 // In Jest, that's sometimes "childProcess.js", sometimes other things.
 // In practice, it should always be "mm-snap".
 const HELP_TEXT_REGEX = /^\s*Usage: .+ <command> \[options\]/u;
+
+const versionRange = packageJson.engines.node;
 
 describe('checkNodeVersion', () => {
   it.each(['20.0.0', '20.1.2', '22.0.0'])(
@@ -57,7 +60,7 @@ describe('checkNodeVersion', () => {
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining(
-        `Node version ${version} is not supported. Please use Node 20.0.0 or later.`,
+        `Node version ${version} is not supported. Please use a Node version that satisfies the following range: ${versionRange}`,
       ),
     );
   });

--- a/packages/snaps-cli/src/cli.ts
+++ b/packages/snaps-cli/src/cli.ts
@@ -1,5 +1,4 @@
-import type { SemVer } from 'semver';
-import { minVersion, satisfies } from 'semver';
+import { satisfies } from 'semver';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
@@ -18,11 +17,10 @@ export function checkNodeVersion(
   nodeVersion: string = process.version.slice(1),
 ) {
   const versionRange = packageJson.engines.node;
-  const minimumVersion = (minVersion(versionRange) as SemVer).format();
 
   if (!satisfies(nodeVersion, versionRange)) {
     error(
-      `Node version ${nodeVersion} is not supported. Please use Node ${minimumVersion} or later.`,
+      `Node version ${nodeVersion} is not supported. Please use a Node version that satisfies the following range: ${versionRange}.`,
     );
     process.exit(1);
   }


### PR DESCRIPTION
Display minimum version range when the CLI is using an unsupported Node version. Previously it would recommend Node 20 or later which would be incorrect for Node 21.