### PR TITLE
feat: Allow all children in `Row`

### DIFF
--- a/packages/snaps-sdk/src/jsx/components/Row.ts
+++ b/packages/snaps-sdk/src/jsx/components/Row.ts
@@ -10,8 +10,7 @@ export type RowChildren = GenericSnapElement;
  * The props of the {@link Row} component.
  *
  * @property label - The label of the row.
- * @property children - The content of the row. This can be an address, an
- * image, or text.
+ * @property children - The content of the row. This can be any component.
  * @property variant - The variant of the row.
  * @property tooltip - An optional tooltip to show for the row.
  */

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -1466,9 +1466,6 @@ describe('RowStruct', () => {
     [],
     // @ts-expect-error - Invalid props.
     <Row />,
-    <Row label="label">
-      <Bold>foo</Bold>
-    </Row>,
     // @ts-expect-error - Invalid props.
     <Row label="label" variant="foo">
       <Text>foo</Text>

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -918,10 +918,9 @@ export const BannerStruct: Describe<BannerElement> = element('Banner', {
  */
 export const RowStruct: Describe<RowElement> = element('Row', {
   label: string(),
-  children: lazy(
-    () =>
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define
-      BoxChildStruct,
+  children: lazy(() =>
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    typedUnion([ValueStruct, BoxChildStruct]),
   ) as unknown as Describe<GenericSnapElement>,
   variant: optional(
     nullUnion([literal('default'), literal('warning'), literal('critical')]),


### PR DESCRIPTION
Allow `BoxChildStruct` as child of `Row`. This enables a bunch of additional use-cases for `Row` by allowing any component as its child.