### PR TITLE
chore: update configuration section anchor in snaps-cli/README

### DIFF
--- a/packages/snaps-cli/README.md
+++ b/packages/snaps-cli/README.md
@@ -116,7 +116,7 @@ snap-project/
 
 Source files other than `index.js` are located through its imports. The
 defaults can be overwritten using the `snap.config.js` or (`snap.config.ts`)
-[config file](#configuration-file).
+[config file](#configuration).
 
 ## Configuration
 


### PR DESCRIPTION
This PR fixes a in-page navigation for the configuration file reference.
Updated the internal anchor link for the configuration section in snaps-cli/README to match the new heading introduced in [#1521](https://github.com/MetaMask/snaps/pull/1521).  
