### PR TITLE
fix: Use custom state manager for cronjob controller

### DIFF
--- a/packages/snaps-controllers/src/cronjob/CronjobController.test.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.test.ts
@@ -28,7 +28,7 @@ function getMockStateManager(): CronjobControllerStateManager {
   let state: CronjobControllerState | undefined;
 
   return {
-    get: () => state,
+    getInitialState: () => state,
     set: (newState) => {
       state = newState;
     },

--- a/packages/snaps-controllers/src/cronjob/CronjobController.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.ts
@@ -95,7 +95,7 @@ export const DAILY_TIMEOUT = inMilliseconds(24, Duration.Hour);
 
 export type CronjobControllerStateManager = {
   set(state: CronjobControllerState): void;
-  get(): CronjobControllerState | undefined;
+  getInitialState(): CronjobControllerState | undefined;
 };
 
 export type CronjobControllerArgs = {
@@ -184,7 +184,7 @@ export class CronjobController extends BaseController<
       state: {
         events: {},
         ...state,
-        ...stateManager.get(),
+        ...stateManager.getInitialState(),
       },
     });
 


### PR DESCRIPTION
This updates the cronjob controller to add a custom `stateManager` property for persisting state. This is a temporary workaround for the controller persisting state too often, causing the entire client state to be written.