### PR TITLE
feat: Add `onActive` and `onInactive` lifecycle hooks

### DIFF
--- a/packages/examples/packages/lifecycle-hooks/snap.manifest.json
+++ b/packages/examples/packages/lifecycle-hooks/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "hTwghLmR+2f8zwjEcFujq/ojCDoMnQRcYBPMJ73IqGE=",
+    "shasum": "/Wc+1sY2V4NwgUxQT81/nquwTBDsw2vdNEkkYd8g+0Q=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -18,6 +18,7 @@
   },
   "initialPermissions": {
     "snap_dialog": {},
+    "snap_notify": {},
     "endowment:lifecycle-hooks": {}
   },
   "platformVersion": "9.2.0",

--- a/packages/examples/packages/lifecycle-hooks/src/index.tsx
+++ b/packages/examples/packages/lifecycle-hooks/src/index.tsx
@@ -1,4 +1,5 @@
 import type {
+  OnActiveHandler,
   OnInstallHandler,
   OnStartHandler,
   OnUpdateHandler,
@@ -82,6 +83,46 @@ export const onUpdate: OnUpdateHandler = async () => {
           </Text>
         </Box>
       ),
+    },
+  });
+};
+
+/**
+ * Handle activation of the client. This handler is called when the client is
+ * activated, and can be used to perform any initialization that is required.
+ *
+ * This handler is optional.
+ *
+ * @see https://docs.metamask.io/snaps/reference/entry-points/#onactive
+ * @returns The JSON-RPC response.
+ */
+export const onActive: OnActiveHandler = async () => {
+  return await snap.request({
+    method: 'snap_notify',
+    params: {
+      type: 'inApp',
+      message:
+        'The client was activated, and the "onActive" handler was called.',
+    },
+  });
+};
+
+/**
+ * Handle deactivation of the client. This handler is called when the client
+ * is deactivated, and can be used to perform any cleanup that is required.
+ *
+ * This handler is optional.
+ *
+ * @see https://docs.metamask.io/snaps/reference/entry-points/#oninactive
+ * @returns The JSON-RPC response.
+ */
+export const onInactive = async () => {
+  return await snap.request({
+    method: 'snap_notify',
+    params: {
+      type: 'inApp',
+      message:
+        'The client was deactivated, and the "onInactive" handler was called.',
     },
   });
 };

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -12375,7 +12375,7 @@ describe('SnapController', () => {
     });
   });
 
-  describe('SnapController:setActive', () => {
+  describe('SnapController:setClientActive', () => {
     it('calls the `onActive` lifecycle hook for all Snaps when called with `true`', async () => {
       const rootMessenger = getControllerMessenger();
       const messenger = getSnapControllerMessenger(rootMessenger);
@@ -12415,7 +12415,7 @@ describe('SnapController', () => {
         }),
       );
 
-      messenger.call('SnapController:setActive', true);
+      messenger.call('SnapController:setClientActive', true);
       await sleep(10);
 
       expect(messenger.call).toHaveBeenNthCalledWith(
@@ -12501,7 +12501,7 @@ describe('SnapController', () => {
         }),
       );
 
-      messenger.call('SnapController:setActive', false);
+      messenger.call('SnapController:setClientActive', false);
       await sleep(10);
 
       expect(messenger.call).toHaveBeenNthCalledWith(

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -10,6 +10,7 @@ import type {
   Caveat,
   SubjectPermissions,
   ValidPermission,
+  CaveatConstraint,
 } from '@metamask/permission-controller';
 import { SubjectType } from '@metamask/permission-controller';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
@@ -10336,7 +10337,11 @@ describe('SnapController', () => {
 
         rootMessenger.registerActionHandler(
           'PermissionController:getPermissions',
-          (origin) => {
+          (
+            origin,
+          ): SubjectPermissions<
+            ValidPermission<TargetName, CaveatConstraint>
+          > => {
             if (origin === MOCK_SNAP_ID) {
               return {
                 [SnapEndowments.LifecycleHooks]:
@@ -10443,7 +10448,7 @@ describe('SnapController', () => {
         await sleep(10);
 
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-          `Error when calling \`onStart\` lifecycle hook for Snap "npm:@metamask/example-snap": Test error in lifecycle hook.`,
+          `Error calling lifecycle hook "onStart" for Snap "npm:@metamask/example-snap": Test error in lifecycle hook.`,
         );
 
         snapController.destroy();
@@ -12365,6 +12370,180 @@ describe('SnapController', () => {
           '999.0.0' as SemVerVersion,
         ),
       ).toBe(false);
+
+      snapController.destroy();
+    });
+  });
+
+  describe('SnapController:setActive', () => {
+    it('calls the `onActive` lifecycle hook for all Snaps when called with `true`', async () => {
+      const rootMessenger = getControllerMessenger();
+      const messenger = getSnapControllerMessenger(rootMessenger);
+
+      rootMessenger.registerActionHandler(
+        'PermissionController:hasPermission',
+        () => true,
+      );
+
+      rootMessenger.registerActionHandler(
+        'PermissionController:getPermissions',
+        (
+          origin,
+        ): SubjectPermissions<ValidPermission<string, CaveatConstraint>> => {
+          if (origin === MOCK_SNAP_ID) {
+            return {
+              [SnapEndowments.LifecycleHooks]: MOCK_LIFECYCLE_HOOKS_PERMISSION,
+            };
+          }
+
+          return {};
+        },
+      );
+
+      const manifest = getSnapManifest({
+        initialPermissions: {
+          [SnapEndowments.LifecycleHooks]: {},
+        },
+      });
+
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(getPersistedSnapObject({ manifest })),
+          },
+        }),
+      );
+
+      messenger.call('SnapController:setActive', true);
+      await sleep(10);
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        2,
+        'PermissionController:hasPermission',
+        MOCK_SNAP_ID,
+        SnapEndowments.LifecycleHooks,
+      );
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        3,
+        'PermissionController:hasPermission',
+        MOCK_SNAP_ID,
+        SnapEndowments.LifecycleHooks,
+      );
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        4,
+        'PermissionController:getPermissions',
+        MOCK_SNAP_ID,
+      );
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        5,
+        'ExecutionService:executeSnap',
+        expect.any(Object),
+      );
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        6,
+        'ExecutionService:handleRpcRequest',
+        MOCK_SNAP_ID,
+        {
+          handler: HandlerType.OnActive,
+          origin: METAMASK_ORIGIN,
+          request: {
+            jsonrpc: '2.0',
+            id: expect.any(String),
+            method: HandlerType.OnActive,
+          },
+        },
+      );
+
+      snapController.destroy();
+    });
+
+    it('calls the `onInactive` lifecycle hook for all Snaps when called with `false`', async () => {
+      const rootMessenger = getControllerMessenger();
+      const messenger = getSnapControllerMessenger(rootMessenger);
+
+      rootMessenger.registerActionHandler(
+        'PermissionController:hasPermission',
+        () => true,
+      );
+
+      rootMessenger.registerActionHandler(
+        'PermissionController:getPermissions',
+        (
+          origin,
+        ): SubjectPermissions<ValidPermission<string, CaveatConstraint>> => {
+          if (origin === MOCK_SNAP_ID) {
+            return {
+              [SnapEndowments.LifecycleHooks]: MOCK_LIFECYCLE_HOOKS_PERMISSION,
+            };
+          }
+
+          return {};
+        },
+      );
+
+      const manifest = getSnapManifest({
+        initialPermissions: {
+          [SnapEndowments.LifecycleHooks]: {},
+        },
+      });
+
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(getPersistedSnapObject({ manifest })),
+          },
+        }),
+      );
+
+      messenger.call('SnapController:setActive', false);
+      await sleep(10);
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        2,
+        'PermissionController:hasPermission',
+        MOCK_SNAP_ID,
+        SnapEndowments.LifecycleHooks,
+      );
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        3,
+        'PermissionController:hasPermission',
+        MOCK_SNAP_ID,
+        SnapEndowments.LifecycleHooks,
+      );
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        4,
+        'PermissionController:getPermissions',
+        MOCK_SNAP_ID,
+      );
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        5,
+        'ExecutionService:executeSnap',
+        expect.any(Object),
+      );
+
+      expect(messenger.call).toHaveBeenNthCalledWith(
+        6,
+        'ExecutionService:handleRpcRequest',
+        MOCK_SNAP_ID,
+        {
+          handler: HandlerType.OnInactive,
+          origin: METAMASK_ORIGIN,
+          request: {
+            jsonrpc: '2.0',
+            id: expect.any(String),
+            method: HandlerType.OnInactive,
+          },
+        },
+      );
 
       snapController.destroy();
     });

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -479,9 +479,9 @@ export type IsMinimumPlatformVersion = {
   handler: SnapController['isMinimumPlatformVersion'];
 };
 
-export type SetActive = {
-  type: `${typeof controllerName}:setActive`;
-  handler: SnapController['setActive'];
+export type SetClientActive = {
+  type: `${typeof controllerName}:setClientActive`;
+  handler: SnapController['setClientActive'];
 };
 
 export type SnapControllerGetStateAction = ControllerGetStateAction<
@@ -513,7 +513,7 @@ export type SnapControllerActions =
   | SnapControllerGetStateAction
   | StopAllSnaps
   | IsMinimumPlatformVersion
-  | SetActive;
+  | SetClientActive;
 
 // Controller Messenger Events
 
@@ -1301,8 +1301,8 @@ export class SnapController extends BaseController<
     );
 
     this.messagingSystem.registerActionHandler(
-      `${controllerName}:setActive`,
-      (...args) => this.setActive(...args),
+      `${controllerName}:setClientActive`,
+      (...args) => this.setClientActive(...args),
     );
   }
 
@@ -3709,7 +3709,7 @@ export class SnapController extends BaseController<
    *
    * @param active - A boolean indicating whether the client is active or not.
    */
-  setActive(active: boolean) {
+  setClientActive(active: boolean) {
     if (active) {
       this.#callLifecycleHooks(METAMASK_ORIGIN, HandlerType.OnActive);
     } else {

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1899,6 +1899,8 @@ describe('BaseSnapExecutor', () => {
       HandlerType.OnInstall,
       HandlerType.OnUpdate,
       HandlerType.OnStart,
+      HandlerType.OnActive,
+      HandlerType.OnInactive,
     ];
 
     for (const handler of LIFECYCLE_HOOKS) {

--- a/packages/snaps-execution-environments/src/common/commands.ts
+++ b/packages/snaps-execution-environments/src/common/commands.ts
@@ -129,6 +129,8 @@ export function getHandlerArguments(
     case HandlerType.OnInstall:
     case HandlerType.OnUpdate:
     case HandlerType.OnStart:
+    case HandlerType.OnActive:
+    case HandlerType.OnInactive:
       return { origin };
 
     case HandlerType.OnHomePage:

--- a/packages/snaps-rpc-methods/src/endowments/index.ts
+++ b/packages/snaps-rpc-methods/src/endowments/index.ts
@@ -122,6 +122,8 @@ export const handlerEndowments: Record<HandlerType, string | null> = {
   [HandlerType.OnInstall]: lifecycleHooksEndowmentBuilder.targetName,
   [HandlerType.OnUpdate]: lifecycleHooksEndowmentBuilder.targetName,
   [HandlerType.OnStart]: lifecycleHooksEndowmentBuilder.targetName,
+  [HandlerType.OnActive]: lifecycleHooksEndowmentBuilder.targetName,
+  [HandlerType.OnInactive]: lifecycleHooksEndowmentBuilder.targetName,
   [HandlerType.OnKeyringRequest]: keyringEndowmentBuilder.targetName,
   [HandlerType.OnHomePage]: homePageEndowmentBuilder.targetName,
   [HandlerType.OnSettingsPage]: settingsPageEndowmentBuilder.targetName,

--- a/packages/snaps-sdk/src/types/handlers/lifecycle.ts
+++ b/packages/snaps-sdk/src/types/handlers/lifecycle.ts
@@ -52,7 +52,7 @@ export type OnUpdateHandler = LifecycleEventHandler;
 export type OnStartHandler = LifecycleEventHandler;
 
 /**
- * The `onActive` handler. This is called when the Snap becomes active.
+ * The `onActive` handler. This is called when the client becomes active.
  *
  * Note that using this handler requires the `endowment:lifecycle-hooks`
  * permission.

--- a/packages/snaps-sdk/src/types/handlers/lifecycle.ts
+++ b/packages/snaps-sdk/src/types/handlers/lifecycle.ts
@@ -50,3 +50,29 @@ export type OnUpdateHandler = LifecycleEventHandler;
  * @param args.origin - The origin that triggered the lifecycle event hook.
  */
 export type OnStartHandler = LifecycleEventHandler;
+
+/**
+ * The `onActive` handler. This is called when the Snap becomes active.
+ *
+ * Note that using this handler requires the `endowment:lifecycle-hooks`
+ * permission.
+ *
+ * This type is an alias for {@link LifecycleEventHandler}.
+ *
+ * @param args - The request arguments.
+ * @param args.origin - The origin that triggered the lifecycle event hook.
+ */
+export type OnActiveHandler = LifecycleEventHandler;
+
+/**
+ * The `onInactive` handler. This is called when the Snap becomes inactive.
+ *
+ * Note that using this handler requires the `endowment:lifecycle-hooks`
+ * permission.
+ *
+ * This type is an alias for {@link LifecycleEventHandler}.
+ *
+ * @param args - The request arguments.
+ * @param args.origin - The origin that triggered the lifecycle event hook.
+ */
+export type OnInactiveHandler = LifecycleEventHandler;

--- a/packages/snaps-sdk/src/types/handlers/lifecycle.ts
+++ b/packages/snaps-sdk/src/types/handlers/lifecycle.ts
@@ -65,7 +65,7 @@ export type OnStartHandler = LifecycleEventHandler;
 export type OnActiveHandler = LifecycleEventHandler;
 
 /**
- * The `onInactive` handler. This is called when the Snap becomes inactive.
+ * The `onInactive` handler. This is called when the client becomes inactive.
  *
  * Note that using this handler requires the `endowment:lifecycle-hooks`
  * permission.

--- a/packages/snaps-utils/src/handlers/exports.test.ts
+++ b/packages/snaps-utils/src/handlers/exports.test.ts
@@ -22,6 +22,8 @@ describe('SNAP_EXPORT_NAMES', () => {
       'onInstall',
       'onUpdate',
       'onStart',
+      'onActive',
+      'onInactive',
       'onNameLookup',
       'onKeyringRequest',
       'onHomePage',

--- a/packages/snaps-utils/src/handlers/exports.ts
+++ b/packages/snaps-utils/src/handlers/exports.ts
@@ -1,4 +1,5 @@
 import type {
+  OnActiveHandler,
   OnAssetHistoricalPriceHandler,
   OnAssetsConversionHandler,
   OnAssetsLookupHandler,
@@ -6,6 +7,7 @@ import type {
   OnClientRequestHandler,
   OnCronjobHandler,
   OnHomePageHandler,
+  OnInactiveHandler,
   OnInstallHandler,
   OnKeyringRequestHandler,
   OnNameLookupHandler,
@@ -75,14 +77,14 @@ export const SNAP_EXPORTS = {
   [HandlerType.OnActive]: {
     type: HandlerType.OnActive,
     required: false,
-    validator: (snapExport: unknown): snapExport is OnStartHandler => {
+    validator: (snapExport: unknown): snapExport is OnActiveHandler => {
       return typeof snapExport === 'function';
     },
   },
   [HandlerType.OnInactive]: {
     type: HandlerType.OnInactive,
     required: false,
-    validator: (snapExport: unknown): snapExport is OnStartHandler => {
+    validator: (snapExport: unknown): snapExport is OnInactiveHandler => {
       return typeof snapExport === 'function';
     },
   },

--- a/packages/snaps-utils/src/handlers/exports.ts
+++ b/packages/snaps-utils/src/handlers/exports.ts
@@ -72,6 +72,20 @@ export const SNAP_EXPORTS = {
       return typeof snapExport === 'function';
     },
   },
+  [HandlerType.OnActive]: {
+    type: HandlerType.OnActive,
+    required: false,
+    validator: (snapExport: unknown): snapExport is OnStartHandler => {
+      return typeof snapExport === 'function';
+    },
+  },
+  [HandlerType.OnInactive]: {
+    type: HandlerType.OnInactive,
+    required: false,
+    validator: (snapExport: unknown): snapExport is OnStartHandler => {
+      return typeof snapExport === 'function';
+    },
+  },
   [HandlerType.OnKeyringRequest]: {
     type: HandlerType.OnKeyringRequest,
     required: true,

--- a/packages/snaps-utils/src/handlers/types.ts
+++ b/packages/snaps-utils/src/handlers/types.ts
@@ -48,6 +48,8 @@ export enum HandlerType {
   OnProtocolRequest = 'onProtocolRequest',
   OnClientRequest = 'onClientRequest',
   OnWebSocketEvent = 'onWebSocketEvent',
+  OnActive = 'onActive',
+  OnInactive = 'onInactive',
 }
 
 export type SnapHandler = {

--- a/packages/snaps-utils/src/handlers/types.ts
+++ b/packages/snaps-utils/src/handlers/types.ts
@@ -36,6 +36,8 @@ export enum HandlerType {
   OnInstall = 'onInstall',
   OnUpdate = 'onUpdate',
   OnStart = 'onStart',
+  OnActive = 'onActive',
+  OnInactive = 'onInactive',
   OnNameLookup = 'onNameLookup',
   OnKeyringRequest = 'onKeyringRequest',
   OnHomePage = 'onHomePage',
@@ -48,8 +50,6 @@ export enum HandlerType {
   OnProtocolRequest = 'onProtocolRequest',
   OnClientRequest = 'onClientRequest',
   OnWebSocketEvent = 'onWebSocketEvent',
-  OnActive = 'onActive',
-  OnInactive = 'onInactive',
 }
 
 export type SnapHandler = {


### PR DESCRIPTION
This adds support for the `onActive` and `onInactive` lifecycle hooks. It's accomplished by exposing a new `setActive` action in the Snap controller, which should be called by the clients when the active status changes.

Related to #3541.