### PR TITLE
chore: Add SES to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     allow:
       - dependency-name: '@metamask/*'
       - dependency-name: '@lavamoat/*'
+      - dependency-name: 'ses'
     target-branch: 'main'
     versioning-strategy: 'increase'
     open-pull-requests-limit: 10


### PR DESCRIPTION
Add SES to Dependabot to ensure we stay on the latest version preventing issues with new/old versions of browsers.