### PR TITLE
fix: Ignore terminate calls to not executing Snaps

### DIFF
--- a/packages/snaps-controllers/src/services/AbstractExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.test.ts
@@ -141,11 +141,9 @@ describe('AbstractExecutionService', () => {
     ).rejects.toThrow(`"${MOCK_SNAP_ID}" is already running.`);
   });
 
-  it('throws an error if the Snap is not running when attempted to be terminated', async () => {
+  it('does nothing if the Snap is not running when attempted to be terminated', async () => {
     const { service } = createService(MockExecutionService);
 
-    await expect(service.terminateSnap(MOCK_SNAP_ID)).rejects.toThrow(
-      `"${MOCK_SNAP_ID}" is not currently running.`,
-    );
+    expect(await service.terminateSnap(MOCK_SNAP_ID)).toBeUndefined();
   });
 });

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.ts
@@ -157,15 +157,14 @@ export abstract class AbstractExecutionService<WorkerType>
   /**
    * Terminates the Snap with the specified ID and deletes all its associated
    * data. Any subsequent messages targeting the Snap will fail with an error.
-   * Throws an error if the specified Snap does not exist, or if termination
-   * fails unexpectedly.
+   * Throws an error if termination fails unexpectedly.
    *
    * @param snapId - The id of the Snap to be terminated.
    */
   public async terminateSnap(snapId: string): Promise<void> {
     const job = this.#jobs.get(snapId);
     if (!job) {
-      throw new Error(`"${snapId}" is not currently running.`);
+      return;
     }
 
     try {


### PR DESCRIPTION
When a Snap fails to start we call `terminateSnap` (https://github.com/MetaMask/snaps/blob/main/packages/snaps-controllers/src/snaps/SnapController.ts#L3162), but this may fail if the Snap has not fully started.

To prevent logging unnecessary errors to Sentry, this PR allows calls to `terminateSnap` even if the Snap is not currently executing, if no job is found the we just return early.