### PR TITLE
fix: Prevent double scheduling events and ensure long-running events work correctly

### DIFF
--- a/packages/snaps-controllers/src/cronjob/CronjobController.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.ts
@@ -621,13 +621,13 @@ export class CronjobController extends BaseController<
       // immediately.
       if (event.recurring && eventDate <= now) {
         this.#execute(event);
-        return;
+        continue;
       }
 
       // If the existing event has not passed, start the timer.
       if (eventDate >= now) {
         this.#startTimer(event);
-        return;
+        continue;
       }
 
       this.#schedule(event);

--- a/packages/snaps-controllers/src/cronjob/CronjobController.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.ts
@@ -621,6 +621,13 @@ export class CronjobController extends BaseController<
       // immediately.
       if (event.recurring && eventDate <= now) {
         this.#execute(event);
+        return;
+      }
+
+      // If the existing event has not passed, start the timer.
+      if (eventDate >= now) {
+        this.#startTimer(event);
+        return;
       }
 
       this.#schedule(event);

--- a/packages/snaps-controllers/src/cronjob/CronjobController.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.ts
@@ -406,8 +406,15 @@ export class CronjobController extends BaseController<
    * Get the next execution date for a given event and start a timer for it.
    *
    * @param event - The event to schedule.
+   * @param next - Whether to schedule to the next date, otherwise will
+   * schedule for existing date.
    */
-  #schedule(event: InternalBackgroundEvent) {
+  #schedule(event: InternalBackgroundEvent, next = true) {
+    if (!next) {
+      this.#startTimer(event);
+      return;
+    }
+
     const date = getExecutionDate(event.schedule);
     const { nextState } = this.update((state) => {
       state.events[event.id].date = date;
@@ -624,13 +631,7 @@ export class CronjobController extends BaseController<
         continue;
       }
 
-      // If the existing event has not passed, start the timer.
-      if (eventDate >= now) {
-        this.#startTimer(event);
-        continue;
-      }
-
-      this.#schedule(event);
+      this.#schedule(event, false);
     }
   }
 


### PR DESCRIPTION
Fixes two issues with the `CronjobController`. We were double scheduling events that had not run since last boot since `#execute` also schedules the next call. Additionally we were not correctly scheduling events that run for longer than 24 hours, since the daily timer would re-calculate the execution date every day.