### PR TITLE
fix: Merge manifest validation reports to include latest validation errors and warnings

### DIFF
--- a/packages/snaps-cli/src/commands/build/implementation.test.ts
+++ b/packages/snaps-cli/src/commands/build/implementation.test.ts
@@ -6,7 +6,6 @@ import {
   getPackageJson,
   getSnapManifest,
 } from '@metamask/snaps-utils/test-utils';
-import type { SemVerVersion } from '@metamask/utils';
 import normalFs from 'fs';
 import { dirname } from 'path';
 import type { Configuration } from 'webpack';
@@ -58,7 +57,7 @@ describe('build', () => {
   beforeEach(async () => {
     const { manifest } = await getMockSnapFilesWithUpdatedChecksum({
       manifest: getSnapManifest({
-        platformVersion: getPlatformVersion() as SemVerVersion,
+        platformVersion: getPlatformVersion(),
       }),
     });
 

--- a/packages/snaps-utils/src/manifest/manifest.test.ts
+++ b/packages/snaps-utils/src/manifest/manifest.test.ts
@@ -188,8 +188,34 @@ describe('checkManifest', () => {
 
     expect(files?.manifest.result).toStrictEqual(defaultManifest);
     expect(updated).toBe(true);
+
     expect(unfixed).toHaveLength(1);
+    expect(unfixed).toContainEqual({
+      id: 'production-platform-version',
+      severity: 'warning',
+      message: expect.stringContaining(
+        'The current maximum supported version is "1.0.0". To resolve this, downgrade `@metamask/snaps-sdk` to a compatible version.',
+      ),
+    });
+
     expect(fixed).toHaveLength(2);
+    expect(fixed).toContainEqual({
+      id: 'platform-version-missing',
+      severity: 'error',
+      message: expect.stringContaining(
+        'The "platformVersion" field is missing from the manifest.',
+      ),
+      wasFixed: true,
+    });
+
+    expect(fixed).toContainEqual({
+      id: 'checksum',
+      severity: 'error',
+      message: expect.stringContaining(
+        '"snap.manifest.json" "shasum" field does not match computed shasum.',
+      ),
+      wasFixed: true,
+    });
 
     const file = await readJsonFile<SnapManifest>(MANIFEST_PATH);
     const { source, version } = file.result;

--- a/packages/snaps-utils/src/manifest/manifest.ts
+++ b/packages/snaps-utils/src/manifest/manifest.ts
@@ -265,7 +265,7 @@ export async function runFixes(
     mergedReports.push(
       ...fixResults.reports.filter(
         (report) =>
-          !mergedReports.find((mergedReport) => mergedReport.id === report.id),
+          !mergedReports.some((mergedReport) => mergedReport.id === report.id),
       ),
     );
   }

--- a/packages/snaps-utils/src/manifest/manifest.ts
+++ b/packages/snaps-utils/src/manifest/manifest.ts
@@ -262,12 +262,12 @@ export async function runFixes(
     fixResults = await runValidators(fixResults.files, rules);
     shouldRunFixes = hasFixes(fixResults, errorsOnly);
 
-    mergedReports.push(
-      ...fixResults.reports.filter(
+    fixResults.reports
+      .filter(
         (report) =>
           !mergedReports.some((mergedReport) => mergedReport.id === report.id),
-      ),
-    );
+      )
+      .forEach((report) => mergedReports.push(report));
   }
 
   const allReports: (CheckManifestReport & ValidatorReport)[] =

--- a/packages/snaps-utils/src/manifest/validator-types.ts
+++ b/packages/snaps-utils/src/manifest/validator-types.ts
@@ -27,11 +27,12 @@ export type ValidatorContextOptions = {
 export type ValidatorSeverity = 'error' | 'warning';
 
 export type ValidatorContext = {
-  readonly report: (message: string, fix?: ValidatorFix) => void;
+  readonly report: (id: string, message: string, fix?: ValidatorFix) => void;
   readonly options?: ValidatorContextOptions;
 };
 
 export type ValidatorReport = {
+  id: string;
   severity: ValidatorSeverity;
   message: string;
   fix?: ValidatorFix;
@@ -41,7 +42,8 @@ export type ValidatorMeta = {
   severity: ValidatorSeverity;
 
   /**
-   * 1. Run the validator on unverified files to ensure that the files are structurally sound.
+   * 1. Run the validator on unverified files to ensure that the files are
+   * structurally sound.
    *
    * @param files - Files to be verified
    * @param context - Validator context to report errors

--- a/packages/snaps-utils/src/manifest/validator.ts
+++ b/packages/snaps-utils/src/manifest/validator.ts
@@ -33,12 +33,22 @@ class Context implements ValidatorContext {
     this.#options = options;
   }
 
-  report(message: string, fix?: ValidatorFix): void {
+  /**
+   * Report a validation error or warning.
+   *
+   * @param id - The unique identifier for the report.
+   * @param message - The message describing the validation issue.
+   * @param fix - An optional fix function that can be used to automatically
+   * resolve the issue.
+   */
+  report(id: string, message: string, fix?: ValidatorFix): void {
     assert(this.#nextSeverity !== undefined);
+
     this.reports.push({
-      severity: this.#nextSeverity,
+      id,
       message,
       fix,
+      severity: this.#nextSeverity,
     });
   }
 
@@ -80,6 +90,7 @@ export async function runValidators(
     context.prepareForValidator({
       severity: rule.severity,
     });
+
     await rule.structureCheck?.(files, context);
   }
 
@@ -93,6 +104,7 @@ export async function runValidators(
     context.prepareForValidator({
       severity: rule.severity,
     });
+
     await rule.semanticCheck?.(files as SnapFiles, context);
   }
 

--- a/packages/snaps-utils/src/manifest/validators/checksum.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/checksum.test.ts
@@ -27,6 +27,7 @@ describe('checksum', () => {
 
     expect(report).toHaveBeenCalledTimes(1);
     expect(report).toHaveBeenCalledWith(
+      'checksum',
       expect.stringContaining(
         '"snap.manifest.json" "shasum" field does not match computed shasum.',
       ),
@@ -38,7 +39,7 @@ describe('checksum', () => {
     const manifest = getSnapManifest({ shasum: 'foobar' });
 
     let fix: ValidatorFix | undefined;
-    const report = (_: any, fixer?: ValidatorFix) => {
+    const report = (_id: string, _message: string, fixer?: ValidatorFix) => {
       assert(fixer !== undefined);
       fix = fixer;
     };

--- a/packages/snaps-utils/src/manifest/validators/checksum.ts
+++ b/packages/snaps-utils/src/manifest/validators/checksum.ts
@@ -14,6 +14,7 @@ export const checksum: ValidatorMeta = {
     const expectedChecksum = await getSnapChecksum(fetchedFiles);
     if (gotChecksum !== expectedChecksum) {
       context.report(
+        'checksum',
         `"${NpmSnapFileNames.Manifest}" "shasum" field does not match computed shasum. Got "${gotChecksum}", expected "${expectedChecksum}".`,
         async ({ manifest }) => {
           manifest.source.shasum = expectedChecksum;

--- a/packages/snaps-utils/src/manifest/validators/expected-files.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/expected-files.test.ts
@@ -25,7 +25,7 @@ describe('expectedFiles', () => {
 
       expect(report).toHaveBeenCalledTimes(1);
       expect(report).toHaveBeenCalledWith(
-        'expected-files',
+        `expected-files-${missingFile}`,
         expect.stringContaining('Missing file'),
       );
     },

--- a/packages/snaps-utils/src/manifest/validators/expected-files.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/expected-files.test.ts
@@ -25,6 +25,7 @@ describe('expectedFiles', () => {
 
       expect(report).toHaveBeenCalledTimes(1);
       expect(report).toHaveBeenCalledWith(
+        'expected-files',
         expect.stringContaining('Missing file'),
       );
     },

--- a/packages/snaps-utils/src/manifest/validators/expected-files.ts
+++ b/packages/snaps-utils/src/manifest/validators/expected-files.ts
@@ -17,7 +17,10 @@ export const expectedFiles: ValidatorMeta = {
   structureCheck(files, context) {
     for (const expectedFile of EXPECTED_SNAP_FILES) {
       if (!files[expectedFile]) {
-        context.report(`Missing file "${SnapFileNameFromKey[expectedFile]}".`);
+        context.report(
+          'expected-files',
+          `Missing file "${SnapFileNameFromKey[expectedFile]}".`,
+        );
       }
     }
   },

--- a/packages/snaps-utils/src/manifest/validators/expected-files.ts
+++ b/packages/snaps-utils/src/manifest/validators/expected-files.ts
@@ -18,7 +18,7 @@ export const expectedFiles: ValidatorMeta = {
     for (const expectedFile of EXPECTED_SNAP_FILES) {
       if (!files[expectedFile]) {
         context.report(
-          'expected-files',
+          `expected-files-${expectedFile}`,
           `Missing file "${SnapFileNameFromKey[expectedFile]}".`,
         );
       }

--- a/packages/snaps-utils/src/manifest/validators/icon-declared.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/icon-declared.test.ts
@@ -23,6 +23,7 @@ describe('iconDeclared', () => {
     });
 
     expect(report).toHaveBeenCalledWith(
+      'icon-declared',
       'No icon found in the Snap manifest. It is recommended to include an icon for the Snap. See https://docs.metamask.io/snaps/how-to/design-a-snap/#guidelines-at-a-glance for more information.',
     );
   });

--- a/packages/snaps-utils/src/manifest/validators/icon-declared.ts
+++ b/packages/snaps-utils/src/manifest/validators/icon-declared.ts
@@ -8,6 +8,7 @@ export const iconDeclared: ValidatorMeta = {
   semanticCheck(files, context) {
     if (!files.manifest.result.source.location.npm.iconPath) {
       context.report(
+        'icon-declared',
         'No icon found in the Snap manifest. It is recommended to include an icon for the Snap. See https://docs.metamask.io/snaps/how-to/design-a-snap/#guidelines-at-a-glance for more information.',
       );
     }

--- a/packages/snaps-utils/src/manifest/validators/icon-dimensions.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/icon-dimensions.test.ts
@@ -28,6 +28,7 @@ describe('iconDimensions', () => {
     });
 
     expect(report).toHaveBeenCalledWith(
+      'icon-dimensions',
       'The icon in the Snap manifest is not square. It is recommended to use a square icon for the Snap.',
     );
   });

--- a/packages/snaps-utils/src/manifest/validators/icon-dimensions.ts
+++ b/packages/snaps-utils/src/manifest/validators/icon-dimensions.ts
@@ -14,6 +14,7 @@ export const iconDimensions: ValidatorMeta = {
     const dimensions = getSvgDimensions(files.svgIcon.toString());
     if (dimensions && dimensions?.height !== dimensions.width) {
       context.report(
+        'icon-dimensions',
         'The icon in the Snap manifest is not square. It is recommended to use a square icon for the Snap.',
       );
     }

--- a/packages/snaps-utils/src/manifest/validators/icon-missing.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/icon-missing.test.ts
@@ -23,6 +23,7 @@ describe('iconMissing', () => {
     await iconMissing.semanticCheck(files, { report });
 
     expect(report).toHaveBeenCalledWith(
+      'icon-missing',
       'Could not find icon "images/icon.svg".',
     );
   });

--- a/packages/snaps-utils/src/manifest/validators/icon-missing.ts
+++ b/packages/snaps-utils/src/manifest/validators/icon-missing.ts
@@ -8,7 +8,7 @@ export const iconMissing: ValidatorMeta = {
   semanticCheck(files, context) {
     const { iconPath } = files.manifest.result.source.location.npm;
     if (iconPath && !files.svgIcon) {
-      context.report(`Could not find icon "${iconPath}".`);
+      context.report('icon-missing', `Could not find icon "${iconPath}".`);
     }
   },
 };

--- a/packages/snaps-utils/src/manifest/validators/is-localization-file.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/is-localization-file.test.ts
@@ -52,6 +52,7 @@ describe('isLocalizationFile', () => {
     );
 
     expect(report).toHaveBeenCalledWith(
+      'is-localization-file',
       'Failed to validate localization file "/foo": At path: messages — Expected a value of type record, but received: "foo".',
     );
   });

--- a/packages/snaps-utils/src/manifest/validators/is-localization-file.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/is-localization-file.test.ts
@@ -52,7 +52,7 @@ describe('isLocalizationFile', () => {
     );
 
     expect(report).toHaveBeenCalledWith(
-      `is-localization-file-${localizationFile.path}`,
+      `is-localization-file-${localizationFile.path}-record-messages`,
       'Failed to validate localization file "/foo": At path: messages — Expected a value of type record, but received: "foo".',
     );
   });

--- a/packages/snaps-utils/src/manifest/validators/is-localization-file.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/is-localization-file.test.ts
@@ -52,7 +52,7 @@ describe('isLocalizationFile', () => {
     );
 
     expect(report).toHaveBeenCalledWith(
-      'is-localization-file',
+      `is-localization-file-${localizationFile.path}`,
       'Failed to validate localization file "/foo": At path: messages — Expected a value of type record, but received: "foo".',
     );
   });

--- a/packages/snaps-utils/src/manifest/validators/is-localization-file.ts
+++ b/packages/snaps-utils/src/manifest/validators/is-localization-file.ts
@@ -16,6 +16,7 @@ export const isLocalizationFile: ValidatorMeta = {
       if (error) {
         for (const failure of error.failures()) {
           context.report(
+            'is-localization-file',
             `Failed to validate localization file "${
               file.path
             }": ${getStructFailureMessage(

--- a/packages/snaps-utils/src/manifest/validators/is-localization-file.ts
+++ b/packages/snaps-utils/src/manifest/validators/is-localization-file.ts
@@ -16,7 +16,7 @@ export const isLocalizationFile: ValidatorMeta = {
       if (error) {
         for (const failure of error.failures()) {
           context.report(
-            'is-localization-file',
+            `is-localization-file-${file.path}`,
             `Failed to validate localization file "${
               file.path
             }": ${getStructFailureMessage(

--- a/packages/snaps-utils/src/manifest/validators/is-localization-file.ts
+++ b/packages/snaps-utils/src/manifest/validators/is-localization-file.ts
@@ -16,7 +16,7 @@ export const isLocalizationFile: ValidatorMeta = {
       if (error) {
         for (const failure of error.failures()) {
           context.report(
-            `is-localization-file-${file.path}`,
+            `is-localization-file-${file.path}-${failure.type}-${failure.path.join('-')}`,
             `Failed to validate localization file "${
               file.path
             }": ${getStructFailureMessage(

--- a/packages/snaps-utils/src/manifest/validators/is-package-json.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/is-package-json.test.ts
@@ -64,7 +64,7 @@ describe('isPackageJson', () => {
     );
 
     expect(report).toHaveBeenCalledWith(
-      'is-package-json',
+      'is-package-json-string-version',
       '"package.json" is invalid: At path: version — Expected SemVer version, got "foo".',
     );
   });

--- a/packages/snaps-utils/src/manifest/validators/is-package-json.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/is-package-json.test.ts
@@ -64,6 +64,7 @@ describe('isPackageJson', () => {
     );
 
     expect(report).toHaveBeenCalledWith(
+      'is-package-json',
       '"package.json" is invalid: At path: version — Expected SemVer version, got "foo".',
     );
   });

--- a/packages/snaps-utils/src/manifest/validators/is-package-json.ts
+++ b/packages/snaps-utils/src/manifest/validators/is-package-json.ts
@@ -20,7 +20,7 @@ export const isPackageJson: ValidatorMeta = {
     if (error) {
       for (const failure of error.failures()) {
         context.report(
-          'is-package-json',
+          `is-package-json-${failure.type}-${failure.path.join('-')}`,
           `"${
             NpmSnapFileNames.PackageJson
           }" is invalid: ${getStructFailureMessage(

--- a/packages/snaps-utils/src/manifest/validators/is-package-json.ts
+++ b/packages/snaps-utils/src/manifest/validators/is-package-json.ts
@@ -20,6 +20,7 @@ export const isPackageJson: ValidatorMeta = {
     if (error) {
       for (const failure of error.failures()) {
         context.report(
+          'is-package-json',
           `"${
             NpmSnapFileNames.PackageJson
           }" is invalid: ${getStructFailureMessage(

--- a/packages/snaps-utils/src/manifest/validators/is-snap-icon.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/is-snap-icon.test.ts
@@ -32,6 +32,9 @@ describe('isSnapIcon', () => {
       { report },
     );
 
-    expect(report).toHaveBeenCalledWith('Snap icon must be a valid SVG.');
+    expect(report).toHaveBeenCalledWith(
+      'is-snap-icon',
+      'Snap icon must be a valid SVG.',
+    );
   });
 });

--- a/packages/snaps-utils/src/manifest/validators/is-snap-icon.ts
+++ b/packages/snaps-utils/src/manifest/validators/is-snap-icon.ts
@@ -17,7 +17,7 @@ export const isSnapIcon: ValidatorMeta = {
       assertIsSnapIcon(files.svgIcon);
     } catch (error) {
       assert(error instanceof Error);
-      context.report(error.message);
+      context.report('is-snap-icon', error.message);
     }
   },
 };

--- a/packages/snaps-utils/src/manifest/validators/is-snap-manifest.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/is-snap-manifest.test.ts
@@ -42,6 +42,7 @@ describe('isSnapManifest', () => {
     );
 
     expect(report).toHaveBeenCalledWith(
+      'is-snap-manifest',
       '"snap.manifest.json" is invalid: Expected a value of type object, but received: "foo".',
     );
   });

--- a/packages/snaps-utils/src/manifest/validators/is-snap-manifest.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/is-snap-manifest.test.ts
@@ -42,7 +42,7 @@ describe('isSnapManifest', () => {
     );
 
     expect(report).toHaveBeenCalledWith(
-      'is-snap-manifest',
+      'is-snap-manifest-object-',
       '"snap.manifest.json" is invalid: Expected a value of type object, but received: "foo".',
     );
   });

--- a/packages/snaps-utils/src/manifest/validators/is-snap-manifest.ts
+++ b/packages/snaps-utils/src/manifest/validators/is-snap-manifest.ts
@@ -18,6 +18,7 @@ export const isSnapManifest: ValidatorMeta = {
     if (error) {
       for (const failure of error.failures()) {
         context.report(
+          'is-snap-manifest',
           `"${NpmSnapFileNames.Manifest}" is invalid: ${getStructFailureMessage(
             SnapManifestStruct,
             failure,

--- a/packages/snaps-utils/src/manifest/validators/is-snap-manifest.ts
+++ b/packages/snaps-utils/src/manifest/validators/is-snap-manifest.ts
@@ -18,7 +18,7 @@ export const isSnapManifest: ValidatorMeta = {
     if (error) {
       for (const failure of error.failures()) {
         context.report(
-          'is-snap-manifest',
+          `is-snap-manifest-${failure.type}-${failure.path.join('-')}`,
           `"${NpmSnapFileNames.Manifest}" is invalid: ${getStructFailureMessage(
             SnapManifestStruct,
             failure,

--- a/packages/snaps-utils/src/manifest/validators/manifest-localization.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/manifest-localization.test.ts
@@ -43,6 +43,7 @@ describe('manifestLocalization', () => {
     await manifestLocalization.semanticCheck(files, { report });
 
     expect(report).toHaveBeenCalledWith(
+      'manifest-localization',
       'Failed to localize Snap manifest: Failed to translate "{{ name }}": No translation found for "name" in "en" file.',
     );
   });

--- a/packages/snaps-utils/src/manifest/validators/manifest-localization.ts
+++ b/packages/snaps-utils/src/manifest/validators/manifest-localization.ts
@@ -26,6 +26,7 @@ export const manifestLocalization: ValidatorMeta = {
         getLocalizedSnapManifest(manifest, locale, localizations);
       } catch (error) {
         context.report(
+          'manifest-localization',
           `Failed to localize Snap manifest: ${getErrorMessage(error)}`,
         );
       }

--- a/packages/snaps-utils/src/manifest/validators/package-json-recommended-fields.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/package-json-recommended-fields.test.ts
@@ -26,6 +26,7 @@ describe('packageJsonRecommendedFields', () => {
     await packageJsonRecommendedFields.semanticCheck(files, { report });
 
     expect(report).toHaveBeenCalledWith(
+      'package-json-recommended-fields',
       'Missing recommended package.json property: "repository".',
     );
   });

--- a/packages/snaps-utils/src/manifest/validators/package-json-recommended-fields.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/package-json-recommended-fields.test.ts
@@ -26,7 +26,7 @@ describe('packageJsonRecommendedFields', () => {
     await packageJsonRecommendedFields.semanticCheck(files, { report });
 
     expect(report).toHaveBeenCalledWith(
-      'package-json-recommended-fields',
+      'package-json-recommended-fields-repository',
       'Missing recommended package.json property: "repository".',
     );
   });

--- a/packages/snaps-utils/src/manifest/validators/package-json-recommended-fields.ts
+++ b/packages/snaps-utils/src/manifest/validators/package-json-recommended-fields.ts
@@ -11,7 +11,7 @@ export const packageJsonRecommendedFields: ValidatorMeta = {
     for (const recommendedField of RECOMMENDED_FIELDS) {
       if (!files.packageJson.result[recommendedField]) {
         context.report(
-          'package-json-recommended-fields',
+          `package-json-recommended-fields-${recommendedField}`,
           `Missing recommended package.json property: "${recommendedField}".`,
         );
       }

--- a/packages/snaps-utils/src/manifest/validators/package-json-recommended-fields.ts
+++ b/packages/snaps-utils/src/manifest/validators/package-json-recommended-fields.ts
@@ -11,6 +11,7 @@ export const packageJsonRecommendedFields: ValidatorMeta = {
     for (const recommendedField of RECOMMENDED_FIELDS) {
       if (!files.packageJson.result[recommendedField]) {
         context.report(
+          'package-json-recommended-fields',
           `Missing recommended package.json property: "${recommendedField}".`,
         );
       }

--- a/packages/snaps-utils/src/manifest/validators/package-name-match.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/package-name-match.test.ts
@@ -26,11 +26,12 @@ describe('packageNameMatch', () => {
     await packageNameMatch.semanticCheck(files, { report });
 
     expect(report).toHaveBeenCalledWith(
+      'package-name-match',
       '"snap.manifest.json" npm package name ("foobar") does not match the "package.json" "name" field ("@metamask/example-snap").',
       expect.any(Function),
     );
 
-    const { manifest: newManifest } = await report.mock.calls[0][1]({
+    const { manifest: newManifest } = await report.mock.calls[0][2]({
       manifest: deepClone(manifest),
     });
     expect(manifest.source.location.npm.packageName).toBe('foobar');

--- a/packages/snaps-utils/src/manifest/validators/package-name-match.ts
+++ b/packages/snaps-utils/src/manifest/validators/package-name-match.ts
@@ -12,6 +12,7 @@ export const packageNameMatch: ValidatorMeta = {
       files.manifest.result.source.location.npm.packageName;
     if (packageJsonName !== manifestPackageName) {
       context.report(
+        'package-name-match',
         `"${NpmSnapFileNames.Manifest}" npm package name ("${manifestPackageName}") does not match the "${NpmSnapFileNames.PackageJson}" "name" field ("${packageJsonName}").`,
         ({ manifest }) => {
           manifest.source.location.npm.packageName = packageJsonName;

--- a/packages/snaps-utils/src/manifest/validators/platform-version.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/platform-version.test.ts
@@ -42,13 +42,14 @@ describe('platformVersion', () => {
 
     expect(report).toHaveBeenCalledTimes(1);
     expect(report).toHaveBeenCalledWith(
+      'platform-version-missing',
       expect.stringContaining(
         `The "platformVersion" field is missing from the manifest.`,
       ),
       expect.any(Function),
     );
 
-    const fix = report.mock.calls[0][1];
+    const fix = report.mock.calls[0][2];
     expect(fix).toBeInstanceOf(Function);
     assert(fix);
 
@@ -71,13 +72,14 @@ describe('platformVersion', () => {
 
     expect(report).toHaveBeenCalledTimes(1);
     expect(report).toHaveBeenCalledWith(
+      'platform-version-mismatch',
       expect.stringContaining(
         `The "platformVersion" field in the manifest must match the version of the Snaps SDK. Got "1.2.3", expected "${sdkVersion}".`,
       ),
       expect.any(Function),
     );
 
-    const fix = report.mock.calls[0][1];
+    const fix = report.mock.calls[0][2];
     expect(fix).toBeInstanceOf(Function);
     assert(fix);
 

--- a/packages/snaps-utils/src/manifest/validators/platform-version.ts
+++ b/packages/snaps-utils/src/manifest/validators/platform-version.ts
@@ -21,6 +21,7 @@ export const platformVersion: ValidatorMeta = {
 
     if (!manifestPlatformVersion) {
       context.report(
+        'platform-version-missing',
         'The "platformVersion" field is missing from the manifest.',
         ({ manifest }) => {
           manifest.platformVersion = actualVersion;
@@ -33,6 +34,7 @@ export const platformVersion: ValidatorMeta = {
 
     if (manifestPlatformVersion !== actualVersion) {
       context.report(
+        'platform-version-mismatch',
         `The "platformVersion" field in the manifest must match the version of the Snaps SDK. Got "${manifestPlatformVersion}", expected "${actualVersion}".`,
         async ({ manifest }) => {
           manifest.platformVersion = actualVersion;

--- a/packages/snaps-utils/src/manifest/validators/production-platform-version.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/production-platform-version.test.ts
@@ -54,6 +54,7 @@ describe('productionPlatformVersion', () => {
 
     expect(report).toHaveBeenCalledTimes(1);
     expect(report).toHaveBeenCalledWith(
+      'production-platform-version',
       expect.stringContaining(
         'The specified platform version "6.5.0" is not supported in the production version of MetaMask. The current maximum supported version is "6.1.0". To resolve this, downgrade `@metamask/snaps-sdk` to a compatible version.',
       ),

--- a/packages/snaps-utils/src/manifest/validators/production-platform-version.ts
+++ b/packages/snaps-utils/src/manifest/validators/production-platform-version.ts
@@ -60,6 +60,7 @@ export const productionPlatformVersion: ValidatorMeta = {
 
     if (gt(manifestPlatformVersion, maximumVersion)) {
       context.report(
+        'production-platform-version',
         `The specified platform version "${manifestPlatformVersion}" is not supported in the production version of MetaMask. The current maximum supported version is "${maximumVersion}". To resolve this, downgrade \`@metamask/snaps-sdk\` to a compatible version.`,
       );
     }

--- a/packages/snaps-utils/src/manifest/validators/repository-match.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/repository-match.test.ts
@@ -27,11 +27,12 @@ describe('repositoryMatch', () => {
     await repositoryMatch.semanticCheck(files, { report });
 
     expect(report).toHaveBeenLastCalledWith(
+      'repository-match',
       '"snap.manifest.json" "repository" field does not match the "package.json" "repository" field.',
       expect.any(Function),
     );
 
-    const { manifest: newManifest } = await report.mock.calls[0][1]({
+    const { manifest: newManifest } = await report.mock.calls[0][2]({
       manifest: deepClone(manifest),
     });
     expect(manifest.repository).toBeUndefined();

--- a/packages/snaps-utils/src/manifest/validators/repository-match.ts
+++ b/packages/snaps-utils/src/manifest/validators/repository-match.ts
@@ -17,6 +17,7 @@ export const repositoryMatch: ValidatorMeta = {
       !deepEqual(packageJsonRepository, manifestRepository)
     ) {
       context.report(
+        'repository-match',
         `"${NpmSnapFileNames.Manifest}" "repository" field does not match the "${NpmSnapFileNames.PackageJson}" "repository" field.`,
         ({ manifest }) => {
           manifest.repository = packageJsonRepository

--- a/packages/snaps-utils/src/manifest/validators/unused-exports.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/unused-exports.test.ts
@@ -46,13 +46,14 @@ describe('unusedExports', () => {
 
     expect(report).toHaveBeenCalledTimes(1);
     expect(report).toHaveBeenCalledWith(
+      'unused-endowments',
       expect.stringContaining(
         `The Snap requests permission for the following handlers, but does not export them: onHomePage (endowment:page-home).`,
       ),
       expect.any(Function),
     );
 
-    const fix = report.mock.calls[0][1];
+    const fix = report.mock.calls[0][2];
     assert(fix);
 
     const { manifest } = await fix({ manifest: files.manifest.result });
@@ -86,6 +87,7 @@ describe('unusedExports', () => {
 
     expect(report).toHaveBeenCalledTimes(1);
     expect(report).toHaveBeenCalledWith(
+      'unused-exports',
       expect.stringContaining(
         'The Snap exports the following handlers, but does not request permission for them: onRpcRequest (endowment:rpc).',
       ),

--- a/packages/snaps-utils/src/manifest/validators/unused-exports.ts
+++ b/packages/snaps-utils/src/manifest/validators/unused-exports.ts
@@ -68,6 +68,7 @@ export const unusedExports: ValidatorMeta = {
       // 2. Adding the permission to the manifest is not always possible, as it
       //    may require additional configuration in the manifest.
       context.report(
+        `unused-exports`,
         `The Snap exports the following handlers, but does not request permission for them: ${unusedHandlers.join(
           ', ',
         )}.`,
@@ -80,6 +81,7 @@ export const unusedExports: ValidatorMeta = {
         .join(', ');
 
       context.report(
+        `unused-endowments`,
         `The Snap requests permission for the following handlers, but does not export them: ${formattedEndowments}.`,
         ({ manifest }) => {
           unusedEndowments.forEach(([, endowment]) => {

--- a/packages/snaps-utils/src/manifest/validators/version-match.test.ts
+++ b/packages/snaps-utils/src/manifest/validators/version-match.test.ts
@@ -28,11 +28,12 @@ describe('versionMatch', () => {
     await versionMatch.semanticCheck(files, { report });
 
     expect(report).toHaveBeenCalledWith(
+      'version-match',
       '"snap.manifest.json" npm package version ("foo") does not match the "package.json" "version" field ("1.0.0").',
       expect.any(Function),
     );
 
-    const { manifest: newManifest } = await report.mock.calls[0][1]({
+    const { manifest: newManifest } = await report.mock.calls[0][2]({
       manifest: deepClone(manifest),
     });
     expect(manifest.version).toBe('foo');

--- a/packages/snaps-utils/src/manifest/validators/version-match.ts
+++ b/packages/snaps-utils/src/manifest/validators/version-match.ts
@@ -11,6 +11,7 @@ export const versionMatch: ValidatorMeta = {
     const manifestPackageVersion = files.manifest.result.version;
     if (packageJsonVersion !== manifestPackageVersion) {
       context.report(
+        'version-match',
         `"${NpmSnapFileNames.Manifest}" npm package version ("${manifestPackageVersion}") does not match the "${NpmSnapFileNames.PackageJson}" "version" field ("${packageJsonVersion}").`,
         ({ manifest }) => {
           manifest.version = packageJsonVersion;

--- a/packages/snaps-utils/src/platform-version.ts
+++ b/packages/snaps-utils/src/platform-version.ts
@@ -1,4 +1,5 @@
 import packageJson from '@metamask/snaps-sdk/package.json';
+import type { SemVerVersion } from '@metamask/utils';
 
 /**
  * Get the current supported platform version.
@@ -10,5 +11,5 @@ import packageJson from '@metamask/snaps-sdk/package.json';
  * @returns The platform version.
  */
 export function getPlatformVersion() {
-  return packageJson.version;
+  return packageJson.version as SemVerVersion;
 }


### PR DESCRIPTION
This updates the manifest validation to merge new reports after the initial validation. We run the validation logic in a loop to address any newly found issues, but previously, newly found errors or warnings were never actually surfaced: Only the reports found in the initial validation were used.

After this change, each report has an ID based on the name of the report, and for validators with multiple potential errors (e.g., unused exports/endowments), a different ID is used as well. This ensures we can merge reports without duplicating them (causing two shasum warnings for example).

Closes #3505.