### PR TITLE
fix: Only log error that originally caused the crash

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -3684,11 +3684,15 @@ export class SnapController extends BaseController<
 
       const [jsonRpcError, handled] = unwrapError(error);
 
+      const stopping = runtime.stopPromise !== null || !this.isRunning(snapId);
+
       if (!handled) {
-        logError(
-          `"${snapId}" crashed due to an unhandled error:`,
-          jsonRpcError,
-        );
+        if (!stopping) {
+          logError(
+            `"${snapId}" crashed due to an unhandled error:`,
+            jsonRpcError,
+          );
+        }
         await this.stopSnap(snapId, SnapStatusEvents.Crash);
       }
 


### PR DESCRIPTION
The crash logging that we recently added would trigger for any unhandled error, including cancelled requests during a crash. This PR only logs the original crash error.