### PR TITLE
fix: Await `sendWebSocketMessage` promise

### DIFF
--- a/packages/snaps-rpc-methods/src/permitted/sendWebSocketMessage.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/sendWebSocketMessage.test.ts
@@ -23,7 +23,7 @@ describe('snap_sendWebSocketMessage', () => {
     it('throws if the origin does not have permission', async () => {
       const { implementation } = sendWebSocketMessageHandler;
 
-      const sendWebSocketMessage = jest.fn();
+      const sendWebSocketMessage = jest.fn().mockResolvedValue(undefined);
       const hasPermission = jest.fn().mockReturnValue(false);
       const hooks = { hasPermission, sendWebSocketMessage };
 
@@ -63,7 +63,7 @@ describe('snap_sendWebSocketMessage', () => {
     it('throws if invalid parameters are passed', async () => {
       const { implementation } = sendWebSocketMessageHandler;
 
-      const sendWebSocketMessage = jest.fn();
+      const sendWebSocketMessage = jest.fn().mockResolvedValue(undefined);
       const hasPermission = jest.fn().mockReturnValue(true);
       const hooks = { hasPermission, sendWebSocketMessage };
 
@@ -103,7 +103,7 @@ describe('snap_sendWebSocketMessage', () => {
     it('sends a WebSocket message and returns null', async () => {
       const { implementation } = sendWebSocketMessageHandler;
 
-      const sendWebSocketMessage = jest.fn();
+      const sendWebSocketMessage = jest.fn().mockResolvedValue(undefined);
       const hasPermission = jest.fn().mockReturnValue(true);
       const hooks = { hasPermission, sendWebSocketMessage };
 

--- a/packages/snaps-rpc-methods/src/permitted/sendWebSocketMessage.ts
+++ b/packages/snaps-rpc-methods/src/permitted/sendWebSocketMessage.ts
@@ -28,7 +28,7 @@ const hookNames: MethodHooksObject<SendWebSocketMessageMethodHooks> = {
 
 export type SendWebSocketMessageMethodHooks = {
   hasPermission: (permissionName: string) => boolean;
-  sendWebSocketMessage: (id: string, data: string | number[]) => void;
+  sendWebSocketMessage: (id: string, data: string | number[]) => Promise<void>;
 };
 
 const SendWebSocketMessageParametersStruct = object({
@@ -66,13 +66,13 @@ export const sendWebSocketMessageHandler: PermittedHandlerExport<
  * @param hooks.sendWebSocketMessage - The function to send a WebSocket message.
  * @returns Nothing.
  */
-function sendWebSocketMessageImplementation(
+async function sendWebSocketMessageImplementation(
   req: JsonRpcRequest<SendWebSocketMessageParameters>,
   res: PendingJsonRpcResponse<SendWebSocketMessageResult>,
   _next: unknown,
   end: JsonRpcEngineEndCallback,
   { hasPermission, sendWebSocketMessage }: SendWebSocketMessageMethodHooks,
-): void {
+): Promise<void> {
   if (!hasPermission(SnapEndowments.NetworkAccess)) {
     return end(providerErrors.unauthorized());
   }
@@ -81,7 +81,7 @@ function sendWebSocketMessageImplementation(
 
   try {
     const { id, message } = getValidatedParams(params);
-    sendWebSocketMessage(id, message);
+    await sendWebSocketMessage(id, message);
     res.result = null;
   } catch (error) {
     return end(error);


### PR DESCRIPTION
The type for the `sendWebSocketMessage` hook was wrong. The function returns a promise and must be awaited, previously this would result in unhandled rejections.