### PR TITLE
fix: Add `prettier` as a regular dependency for `snaps-webpack-plugin`

### DIFF
--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -62,6 +62,7 @@
     "@metamask/snaps-utils": "workspace:^",
     "@metamask/utils": "^11.4.2",
     "chalk": "^4.1.2",
+    "prettier": "^3.3.3",
     "webpack-sources": "^3.2.3"
   },
   "devDependencies": {
@@ -79,7 +80,6 @@
     "jest-it-up": "^2.0.0",
     "jest-silent-reporter": "^0.6.0",
     "memfs": "^3.4.13",
-    "prettier": "^3.3.3",
     "typescript": "~5.3.3",
     "webpack": "^5.97.1"
   },


### PR DESCRIPTION
Our Webpack plugin uses Prettier at runtime but does not specify it as a dependency. This breaks in repositories that do not have the expected version of Prettier already in the dependency tree.