### PR TITLE
feat!: Allow updating preinstalled Snaps via the registry

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -70,11 +70,12 @@ import {
 import { hmac } from '@noble/hashes/hmac';
 import { sha512 } from '@noble/hashes/sha512';
 import { File } from 'buffer';
+import { createReadStream } from 'fs';
 import fetchMock from 'jest-fetch-mock';
+import path from 'path';
 import { pipeline } from 'readable-stream';
 import type { Duplex } from 'readable-stream';
 import { inc } from 'semver';
-import path from 'path';
 import { Readable } from 'stream';
 
 import {
@@ -123,7 +124,6 @@ import {
   waitForStateChange,
 } from '../test-utils';
 import { delay } from '../utils';
-import { createReadStream } from 'fs';
 
 globalThis.crypto.getRandomValues = <Type extends ArrayBufferView | null>(
   array: Type,
@@ -10234,32 +10234,34 @@ describe('SnapController', () => {
       snapController.destroy();
     });
 
-    it.only('updates preinstalled Snaps', async () => {
+    it('updates preinstalled Snaps', async () => {
       const registry = new MockSnapsRegistry();
       const rootMessenger = getControllerMessenger(registry);
       const messenger = getSnapControllerMessenger(rootMessenger);
 
       const snapId = 'npm:@metamask/jsx-example-snap' as SnapId;
 
-      const mockSnap = getPersistedSnapObject({ id: snapId, preinstalled: true });
+      const mockSnap = getPersistedSnapObject({
+        id: snapId,
+        preinstalled: true,
+      });
 
       const updateVersion = '1.2.1';
-      
+
       registry.resolveVersion.mockResolvedValue(updateVersion);
-          const fetchFunction = jest.fn()
-            .mockResolvedValueOnce({
-              // eslint-disable-next-line no-restricted-globals
-              headers: new Headers({ 'content-length': '5477' }),
-              ok: true,
-              body: Readable.toWeb(
-                createReadStream(
-                  path.resolve(
-                    __dirname,
-                    `../../test/fixtures/metamask-jsx-example-snap-${updateVersion}.tgz`,
-                  ),
-                ),
-              ),
-            } as any);
+      const fetchFunction = jest.fn().mockResolvedValueOnce({
+        // eslint-disable-next-line no-restricted-globals
+        headers: new Headers({ 'content-length': '5477' }),
+        ok: true,
+        body: Readable.toWeb(
+          createReadStream(
+            path.resolve(
+              __dirname,
+              `../../test/fixtures/metamask-jsx-example-snap-${updateVersion}.tgz`,
+            ),
+          ),
+        ),
+      } as any);
 
       const snapController = getSnapController(
         getSnapControllerOptions({

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -10319,6 +10319,45 @@ describe('SnapController', () => {
 
       snapController.destroy();
     });
+
+    it('does not update preinstalled Snaps when the feature flag is off', async () => {
+      const registry = new MockSnapsRegistry();
+      const rootMessenger = getControllerMessenger(registry);
+      const messenger = getSnapControllerMessenger(rootMessenger);
+
+      const snapId = 'npm:@metamask/jsx-example-snap' as SnapId;
+
+      const mockSnap = getPersistedSnapObject({
+        id: snapId,
+        preinstalled: true,
+      });
+
+      const updateVersion = '1.2.1';
+
+      registry.resolveVersion.mockResolvedValue(updateVersion);
+
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(mockSnap),
+          },
+          featureFlags: {
+            autoUpdatePreinstalledSnaps: false,
+          },
+        }),
+      );
+
+      await snapController.updateRegistry();
+
+      const snap = snapController.get(snapId);
+      assert(snap);
+
+      expect(snap.version).toStrictEqual(mockSnap.version);
+      expect(registry.resolveVersion).not.toHaveBeenCalled();
+
+      snapController.destroy();
+    });
   });
 
   describe('clearState', () => {

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -10272,7 +10272,7 @@ describe('SnapController', () => {
             ),
           ),
         ),
-      } as any);
+      });
 
       const snapController = getSnapController(
         getSnapControllerOptions({

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -9956,7 +9956,7 @@ describe('SnapController', () => {
     });
   });
 
-  describe('updateBlockedSnaps', () => {
+  describe('updateRegistry', () => {
     it('updates the registry database', async () => {
       const registry = new MockSnapsRegistry();
       const rootMessenger = getControllerMessenger(registry);
@@ -9970,7 +9970,7 @@ describe('SnapController', () => {
           },
         }),
       );
-      await snapController.updateBlockedSnaps();
+      await snapController.updateRegistry();
 
       expect(registry.update).toHaveBeenCalled();
 
@@ -10014,7 +10014,7 @@ describe('SnapController', () => {
           reason: { explanation, infoUrl },
         },
       });
-      await snapController.updateBlockedSnaps();
+      await snapController.updateRegistry();
 
       // Ensure that CheckSnapBlockListArg is correct
       expect(registry.get).toHaveBeenCalledWith({
@@ -10073,7 +10073,7 @@ describe('SnapController', () => {
       registry.get.mockResolvedValueOnce({
         [mockSnap.id]: { status: SnapsRegistryStatus.Blocked },
       });
-      await snapController.updateBlockedSnaps();
+      await snapController.updateRegistry();
 
       // The snap is blocked, disabled, and stopped
       expect(snapController.get(mockSnap.id)?.blocked).toBe(true);
@@ -10127,7 +10127,7 @@ describe('SnapController', () => {
         [mockSnapA.id]: { status: SnapsRegistryStatus.Unverified },
         [mockSnapB.id]: { status: SnapsRegistryStatus.Unverified },
       });
-      await snapController.updateBlockedSnaps();
+      await snapController.updateRegistry();
 
       // A is unblocked, but still disabled
       expect(snapController.get(mockSnapA.id)?.blocked).toBe(false);
@@ -10171,7 +10171,7 @@ describe('SnapController', () => {
         new Promise<unknown>((resolve) => (resolveBlockListPromise = resolve)),
       );
 
-      const updateBlockList = snapController.updateBlockedSnaps();
+      const updateBlockList = snapController.updateRegistry();
 
       // Remove the snap while waiting for the blocklist
       await snapController.removeSnap(mockSnap.id);
@@ -10219,7 +10219,7 @@ describe('SnapController', () => {
       registry.get.mockResolvedValueOnce({
         [mockSnap.id]: { status: SnapsRegistryStatus.Blocked },
       });
-      await snapController.updateBlockedSnaps();
+      await snapController.updateRegistry();
 
       // A is blocked and disabled
       expect(snapController.get(mockSnap.id)?.blocked).toBe(true);
@@ -10273,7 +10273,7 @@ describe('SnapController', () => {
         }),
       );
 
-      await snapController.updateBlockedSnaps();
+      await snapController.updateRegistry();
 
       expect(snapController.get(snapId)?.version).toStrictEqual(updateVersion);
 
@@ -11570,8 +11570,8 @@ describe('SnapController', () => {
     });
   });
 
-  describe('SnapController:updateBlockedSnaps', () => {
-    it('calls SnapController.updateBlockedSnaps()', async () => {
+  describe('SnapController:updateRegistry', () => {
+    it('calls SnapController.updateRegistry()', async () => {
       const messenger = getSnapControllerMessenger();
       const snapController = getSnapController(
         getSnapControllerOptions({
@@ -11579,12 +11579,12 @@ describe('SnapController', () => {
         }),
       );
 
-      const updateBlockedSnapsSpy = jest
-        .spyOn(snapController, 'updateBlockedSnaps')
+      const updateRegistrySpy = jest
+        .spyOn(snapController, 'updateRegistry')
         .mockImplementation();
 
-      await messenger.call('SnapController:updateBlockedSnaps');
-      expect(updateBlockedSnapsSpy).toHaveBeenCalledTimes(1);
+      await messenger.call('SnapController:updateRegistry');
+      expect(updateRegistrySpy).toHaveBeenCalledTimes(1);
 
       snapController.destroy();
     });

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -10281,6 +10281,9 @@ describe('SnapController', () => {
             snaps: getPersistedSnapsState(mockSnap),
           },
           fetchFunction,
+          featureFlags: {
+            autoUpdatePreinstalledSnaps: true,
+          },
         }),
       );
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1495,26 +1495,27 @@ export class SnapController extends BaseController<
       Object.values(this.state.snaps)
         .filter((snap) => snap.preinstalled)
         .map(async (snap) => {
-          const resolvedVersion = (await this.#resolveAllowlistVersion(
+          const resolvedVersion = await this.#resolveAllowlistVersion(
             snap.id,
             '*' as SemVerRange,
-          )) as unknown as SemVerVersion;
+          );
 
-          if (gtVersion(resolvedVersion, snap.version)) {
+          if (
+            gtVersion(resolvedVersion as unknown as SemVerVersion, snap.version)
+          ) {
             const location = this.#detectSnapLocation(snap.id, {
-              versionRange: resolvedVersion as unknown as SemVerRange,
+              versionRange: resolvedVersion,
               fetch: this.#fetchFunction,
               allowLocal: false,
             });
 
-            await this.updateSnap(
-              ORIGIN_METAMASK,
-              snap.id,
+            await this.#updateSnap({
+              origin: ORIGIN_METAMASK,
+              snapId: snap.id,
               location,
-              resolvedVersion,
-              true,
-              true,
-            );
+              versionRange: resolvedVersion,
+              automaticUpdate: true,
+            });
           }
         }),
     );
@@ -2910,7 +2911,7 @@ export class SnapController extends BaseController<
     snapId: SnapId;
     location: SnapLocation;
     versionRange: SemVerRange;
-    automaticUpdate: boolean;
+    automaticUpdate?: boolean;
   }): Promise<TruncatedSnap> {
     this.#assertCanInstallSnaps();
     this.#assertCanUsePlatform();

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2921,7 +2921,9 @@ export class SnapController extends BaseController<
 
     const snap = this.getExpect(snapId);
 
-    if (snap.preinstalled && !automaticUpdate) {
+    const { preinstalled, removable, hidden, hideSnapBranding } = snap;
+
+    if (preinstalled && !automaticUpdate) {
       throw new Error('Preinstalled Snaps cannot be manually updated.');
     }
 
@@ -3026,6 +3028,10 @@ export class SnapController extends BaseController<
         origin,
         id: snapId,
         files: newSnap,
+        removable,
+        preinstalled,
+        hidden,
+        hideSnapBranding,
         isUpdate: true,
       });
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -405,9 +405,9 @@ export type ClearSnapState = {
 /**
  * Checks all installed snaps against the blocklist.
  */
-export type UpdateBlockedSnaps = {
-  type: `${typeof controllerName}:updateBlockedSnaps`;
-  handler: SnapController['updateBlockedSnaps'];
+export type UpdateRegistry = {
+  type: `${typeof controllerName}:updateRegistry`;
+  handler: SnapController['updateRegistry'];
 };
 
 export type EnableSnap = {
@@ -497,7 +497,7 @@ export type SnapControllerActions =
   | GetSnapState
   | HandleSnapRequest
   | HasSnap
-  | UpdateBlockedSnaps
+  | UpdateRegistry
   | UpdateSnapState
   | EnableSnap
   | DisableSnap
@@ -1221,8 +1221,8 @@ export class SnapController extends BaseController<
     );
 
     this.messagingSystem.registerActionHandler(
-      `${controllerName}:updateBlockedSnaps`,
-      async () => this.updateBlockedSnaps(),
+      `${controllerName}:updateRegistry`,
+      async () => this.updateRegistry(),
     );
 
     this.messagingSystem.registerActionHandler(
@@ -1463,7 +1463,7 @@ export class SnapController extends BaseController<
    *
    * Also updates any preinstalled Snaps to the latest allowlisted version.
    */
-  async updateBlockedSnaps(): Promise<void> {
+  async updateRegistry(): Promise<void> {
     this.#assertCanUsePlatform();
     await this.messagingSystem.call('SnapsRegistry:update');
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2895,6 +2895,8 @@ export class SnapController extends BaseController<
    * @param options.snapId - The id of the Snap to be updated.
    * @param options.location - The location implementation of the snap.
    * @param options.versionRange - A semver version range in which the maximum version will be chosen.
+   * @param options.automaticUpdate - An optional boolean flag to indicate whether this update should be done
+   * automatically.
    * @returns The snap metadata if updated, `null` otherwise.
    */
   async #updateSnap({
@@ -2984,7 +2986,6 @@ export class SnapController extends BaseController<
       let requestData;
 
       if (automaticUpdate) {
-        // TODO: This probably doesn't work as it doesn't account for initialConnections.
         approvedNewPermissions = newPermissions;
       } else {
         assert(pendingApproval);
@@ -3000,8 +3001,11 @@ export class SnapController extends BaseController<
           loading: false,
         });
 
-        const { permissions: approvedNewPermissions, ...requestData } =
+        const { permissions, ...rest } =
           (await pendingApproval.promise) as PermissionsRequest;
+
+        approvedNewPermissions = permissions;
+        requestData = rest;
 
         pendingApproval = this.#createApproval({
           origin,

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1491,16 +1491,19 @@ export class SnapController extends BaseController<
       }),
     );
 
+    const preinstalledVersionRange = '*' as SemVerRange;
+
     await Promise.all(
       Object.values(this.state.snaps)
         .filter((snap) => snap.preinstalled)
         .map(async (snap) => {
           const resolvedVersion = await this.#resolveAllowlistVersion(
             snap.id,
-            '*' as SemVerRange,
+            preinstalledVersionRange,
           );
 
           if (
+            resolvedVersion !== preinstalledVersionRange &&
             gtVersion(resolvedVersion as unknown as SemVerVersion, snap.version)
           ) {
             const location = this.#detectSnapLocation(snap.id, {

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -716,6 +716,12 @@ type FeatureFlags = {
    * any production builds (including beta and Flask).
    */
   forcePreinstalledSnaps?: boolean;
+
+  /**
+   * Automatically update preinstalled Snaps "over the air",
+   * when a new version of the Snap is added to the registry.
+   */
+  autoUpdatePreinstalledSnaps?: boolean;
 };
 
 type DynamicFeatureFlags = {
@@ -1490,6 +1496,10 @@ export class SnapController extends BaseController<
         return this.#unblockSnap(snapId as SnapId);
       }),
     );
+
+    if (!this.#featureFlags.autoUpdatePreinstalledSnaps) {
+      return;
+    }
 
     const preinstalledVersionRange = '*' as SemVerRange;
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1493,7 +1493,7 @@ export class SnapController extends BaseController<
 
     const preinstalledVersionRange = '*' as SemVerRange;
 
-    await Promise.all(
+    await Promise.allSettled(
       Object.values(this.state.snaps)
         .filter((snap) => snap.preinstalled)
         .map(async (snap) => {


### PR DESCRIPTION
Allow updating preinstalled Snaps by updating their entry in the registry. This is accomplished by searching the registry for updates whenever `updateRegistry` is called and triggering `#updateSnap`. As part of this PR the previously named `updateBlockedSnaps` has been renamed to `updateRegistry` and a flag to allow automatic updates has been added to `#updateSnap`.

When an update is automatic, the permissions requested by the Snap are applied automatically similarly to how a preinstalled Snap is initialized. Preinstalled Snaps can still be installed and updated via the constructor. In case of any errors applying the update, the Snap is rolled back to its previous state.

This behavior is put behind a feature flag that we can decide to enable at a later date.

Closes https://github.com/MetaMask/snaps/issues/3593