### PR TITLE
fix: Improve mergeStructs: Safely Combine Refiners and Prevent Runtime Errors

### DIFF
--- a/packages/snaps-utils/src/structs.ts
+++ b/packages/snaps-utils/src/structs.ts
@@ -542,7 +542,10 @@ export function mergeStructs(...structs: Struct<any>[]): Struct<any> {
     ...mergedStruct,
     *refiner(value, ctx) {
       for (const struct of structs) {
-        yield* struct.refiner(value, ctx);
+        // Only yield if the struct has a refiner function
+        if (typeof struct.refiner === 'function') {
+          yield* struct.refiner(value, ctx);
+        }
       }
     },
   });


### PR DESCRIPTION

### Description
Fix refactors the `mergeStructs` function in `packages/snaps-utils/src/structs.ts` to improve its robustness and prevent potential runtime errors. Previously, the function assumed that every struct in the merge would have a valid `refiner` function. In practice, this is not always guaranteed and could lead to errors if a struct does not implement a `refiner`.

With this update, the function now explicitly checks whether `struct.refiner` is a function before calling it. This ensures that only valid refiners are invoked, making the code more reliable and easier to maintain.

### Changes
- Updated the `mergeStructs` function to safely combine refiners from multiple structs.
- Added a type check to ensure `struct.refiner` is a function before invoking it.

#### References
[Regular expression](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS)
[WikipediaReDoS](https://en.wikipedia.org/wiki/ReDoS)
[WikipediaTime complexity](https://en.wikipedia.org/wiki/Time_complexity)
[Static Analysis for Regular Expression](https://arxiv.org/abs/1301.0849)