### PR TITLE
fix: Improve a couple of error messages for UI components

### DIFF
--- a/packages/snaps-sdk/src/internals/structs.test.ts
+++ b/packages/snaps-sdk/src/internals/structs.test.ts
@@ -69,14 +69,6 @@ describe('typedUnion', () => {
     BoxStruct,
     typedUnion([TextStruct, FieldStruct]),
   ]);
-  const stringUnion = nullUnion([
-    string(),
-    typedUnion([TextStruct, BoldStruct]),
-  ]);
-  const nonTypedObjectUnion = nullUnion([
-    typedUnion([TextStruct, BoldStruct]),
-    object({ type: literal('bar') }),
-  ]);
 
   it('validates strictly the part of the union that matches the type', () => {
     // @ts-expect-error Invalid props.
@@ -97,6 +89,11 @@ describe('typedUnion', () => {
   });
 
   it('validates when nested in a union including primitives', () => {
+    const stringUnion = nullUnion([
+      string(),
+      typedUnion([TextStruct, BoldStruct]),
+    ]);
+
     // @ts-expect-error Invalid props.
     const result = validate(Text({}), stringUnion);
 
@@ -106,6 +103,11 @@ describe('typedUnion', () => {
   });
 
   it('validates when nested in a union including non-typed objects', () => {
+    const nonTypedObjectUnion = nullUnion([
+      typedUnion([TextStruct, BoldStruct]),
+      object({ type: literal('bar') }),
+    ]);
+
     const result = validate({ type: 'abc' }, nonTypedObjectUnion);
 
     expect(result[0]?.message).toBe(

--- a/packages/snaps-sdk/src/internals/structs.test.ts
+++ b/packages/snaps-sdk/src/internals/structs.test.ts
@@ -8,6 +8,7 @@ import {
   any,
 } from '@metamask/superstruct';
 
+import { nullUnion } from './jsx';
 import {
   enumValue,
   literal,
@@ -18,6 +19,7 @@ import {
 import type { BoxElement } from '../jsx';
 import { Footer, Icon, Text, Button, Box } from '../jsx';
 import {
+  BoldStruct,
   BoxStruct,
   FieldStruct,
   FooterStruct,
@@ -67,6 +69,14 @@ describe('typedUnion', () => {
     BoxStruct,
     typedUnion([TextStruct, FieldStruct]),
   ]);
+  const stringUnion = nullUnion([
+    string(),
+    typedUnion([TextStruct, BoldStruct]),
+  ]);
+  const nonTypedObjectUnion = nullUnion([
+    typedUnion([TextStruct, BoldStruct]),
+    object({ type: literal('bar') }),
+  ]);
 
   it('validates strictly the part of the union that matches the type', () => {
     // @ts-expect-error Invalid props.
@@ -83,6 +93,23 @@ describe('typedUnion', () => {
 
     expect(result[0]?.message).toBe(
       'At path: props.children -- Expected type to be one of: "Bold", "Italic", "Link", "Icon", "Skeleton", but received: undefined',
+    );
+  });
+
+  it('validates when nested in a union including primitives', () => {
+    // @ts-expect-error Invalid props.
+    const result = validate(Text({}), stringUnion);
+
+    expect(result[0]?.message).toBe(
+      'Expected the value to satisfy a union of `string | union`, but received: [object Object]',
+    );
+  });
+
+  it('validates when nested in a union including non-typed objects', () => {
+    const result = validate({ type: 'abc' }, nonTypedObjectUnion);
+
+    expect(result[0]?.message).toBe(
+      'Expected the value to satisfy a union of `union | object`, but received: [object Object]',
     );
   });
 

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -620,7 +620,7 @@ export const BoldStruct: Describe<BoldElement> = element('Bold', {
         return string();
       }
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
-      return lazy(() => ItalicStruct) as unknown as Struct<
+      return ItalicStruct as unknown as Struct<
         SnapElement<JsonObject, 'Italic'>
       >;
     }),
@@ -637,9 +637,7 @@ export const ItalicStruct: Describe<ItalicElement> = element('Italic', {
         return string();
       }
 
-      return lazy(() => BoldStruct) as unknown as Struct<
-        SnapElement<JsonObject, 'Bold'>
-      >;
+      return BoldStruct as unknown as Struct<SnapElement<JsonObject, 'Bold'>>;
     }),
   ]),
 });

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -615,11 +615,15 @@ export const FieldStruct: Describe<FieldElement> = element('Field', {
  */
 export const BoldStruct: Describe<BoldElement> = element('Bold', {
   children: children([
-    string(),
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    lazy(() => ItalicStruct) as unknown as Struct<
-      SnapElement<JsonObject, 'Italic'>
-    >,
+    selectiveUnion((value) => {
+      if (typeof value === 'string') {
+        return string();
+      }
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      return lazy(() => ItalicStruct) as unknown as Struct<
+        SnapElement<JsonObject, 'Italic'>
+      >;
+    }),
   ]),
 });
 
@@ -628,10 +632,15 @@ export const BoldStruct: Describe<BoldElement> = element('Bold', {
  */
 export const ItalicStruct: Describe<ItalicElement> = element('Italic', {
   children: children([
-    string(),
-    lazy(() => BoldStruct) as unknown as Struct<
-      SnapElement<JsonObject, 'Bold'>
-    >,
+    selectiveUnion((value) => {
+      if (typeof value === 'string') {
+        return string();
+      }
+
+      return lazy(() => BoldStruct) as unknown as Struct<
+        SnapElement<JsonObject, 'Bold'>
+      >;
+    }),
   ]),
 });
 
@@ -774,11 +783,18 @@ export const HeadingStruct: Describe<HeadingElement> = element('Heading', {
 export const LinkStruct: Describe<LinkElement> = element('Link', {
   href: string(),
   children: children([
-    FormattingStruct,
-    string(),
-    IconStruct,
-    ImageStruct,
-    AddressStruct,
+    selectiveUnion((value) => {
+      if (typeof value === 'string') {
+        return string();
+      }
+
+      return typedUnion([
+        FormattingStruct,
+        IconStruct,
+        ImageStruct,
+        AddressStruct,
+      ]);
+    }),
   ]),
 });
 
@@ -896,13 +912,15 @@ export const TooltipStruct: Describe<TooltipElement> = element('Tooltip', {
  */
 export const BannerStruct: Describe<BannerElement> = element('Banner', {
   children: children([
-    TextStruct,
-    LinkStruct,
-    IconStruct,
-    ButtonStruct,
-    BoldStruct,
-    ItalicStruct,
-    SkeletonStruct,
+    typedUnion([
+      TextStruct,
+      LinkStruct,
+      IconStruct,
+      ButtonStruct,
+      BoldStruct,
+      ItalicStruct,
+      SkeletonStruct,
+    ]),
   ]),
   title: string(),
   severity: union([


### PR DESCRIPTION
Improve a couple of error messages when validating UI components that use the `children` utility method.