### PR TITLE
feat: Add IOTA derivation path

### DIFF
--- a/packages/snaps-utils/src/derivation-paths.ts
+++ b/packages/snaps-utils/src/derivation-paths.ts
@@ -185,6 +185,11 @@ export const SNAPS_DERIVATION_PATHS: SnapsDerivationPath[] = [
     curve: 'ed25519',
     name: 'Massa',
   },
+  {
+    path: ['m', `44'`, `4218'`],
+    curve: 'ed25519',
+    name: 'IOTA',
+  },
 ];
 
 /**


### PR DESCRIPTION
Add IOTA derivation path since they use `ed25519`, which our default resolution logic doesn't allow for SLIP-44 defined chains.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds the IOTA ed25519 derivation path `m/44'/4218'` to the supported snaps derivation paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fbbbd81e79a6fe7912338975ad6d6fc62c4ad68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->