### PR TITLE
chore: Fix broken coverage script

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 95.22,
-  "functions": 98.49,
+  "branches": 95.63,
+  "functions": 98.99,
   "lines": 98.88,
   "statements": 98.71
 }

--- a/scripts/update-coverage.mts
+++ b/scripts/update-coverage.mts
@@ -154,7 +154,7 @@ async function main() {
       return target;
     },
     {
-      percentages: currentCoverage,
+      percentages: { ...currentCoverage },
       errors: [],
     },
   );


### PR DESCRIPTION
Our coverage script would overwrite the current values with the new ones and thus never report increases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a mutation bug in the coverage update script and updates coverage.json with increased branches/functions percentages.
> 
> - **Scripts**:
>   - Fix mutation bug in `scripts/update-coverage.mts` by initializing reducer with `percentages: { ...currentCoverage }` to prevent overwriting values.
> - **Coverage**:
>   - Update `packages/snaps-controllers/coverage.json` with increased `branches` and `functions` percentages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2f60cd52bb52de8c11a76a369f6a841e301aeef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->