### PR TITLE
perf: Reduce JSON validation during state updates

### DIFF
--- a/packages/snaps-execution-environments/lavamoat/webpack/iframe/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/webpack/iframe/policy.json
@@ -79,6 +79,7 @@
     },
     "@metamask/snaps-utils": {
       "globals": {
+        "TextEncoder": true,
         "URL": true,
         "console.error": true,
         "console.log": true,

--- a/packages/snaps-execution-environments/lavamoat/webpack/node-process/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/webpack/node-process/policy.json
@@ -85,6 +85,7 @@
     },
     "@metamask/snaps-utils": {
       "globals": {
+        "TextEncoder": true,
         "URL": true,
         "console.error": true,
         "console.log": true,

--- a/packages/snaps-execution-environments/lavamoat/webpack/node-thread/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/webpack/node-thread/policy.json
@@ -85,6 +85,7 @@
     },
     "@metamask/snaps-utils": {
       "globals": {
+        "TextEncoder": true,
         "URL": true,
         "console.error": true,
         "console.log": true,

--- a/packages/snaps-execution-environments/lavamoat/webpack/webview/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/webpack/webview/policy.json
@@ -79,6 +79,7 @@
     },
     "@metamask/snaps-utils": {
       "globals": {
+        "TextEncoder": true,
         "URL": true,
         "console.error": true,
         "console.log": true,

--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -10,10 +10,10 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 95.37,
+      branches: 95.7,
       functions: 98.75,
-      lines: 98.92,
-      statements: 98.62,
+      lines: 98.99,
+      statements: 98.69,
     },
   },
 });

--- a/packages/snaps-rpc-methods/src/permitted/setState.test.ts
+++ b/packages/snaps-rpc-methods/src/permitted/setState.test.ts
@@ -34,12 +34,14 @@ describe('snap_setState', () => {
       const updateSnapState = jest.fn().mockReturnValue(null);
       const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
       const hasPermission = jest.fn().mockReturnValue(true);
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const hooks = {
         getSnapState,
         updateSnapState,
         getUnlockPromise,
         hasPermission,
+        getSnap,
       };
 
       const engine = new JsonRpcEngine();
@@ -87,12 +89,14 @@ describe('snap_setState', () => {
       const updateSnapState = jest.fn().mockReturnValue(null);
       const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
       const hasPermission = jest.fn().mockReturnValue(true);
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const hooks = {
         getSnapState,
         updateSnapState,
         getUnlockPromise,
         hasPermission,
+        getSnap,
       };
 
       const engine = new JsonRpcEngine();
@@ -141,12 +145,14 @@ describe('snap_setState', () => {
       const updateSnapState = jest.fn().mockReturnValue(null);
       const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
       const hasPermission = jest.fn().mockReturnValue(true);
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const hooks = {
         getSnapState,
         updateSnapState,
         getUnlockPromise,
         hasPermission,
+        getSnap,
       };
 
       const engine = new JsonRpcEngine();
@@ -200,12 +206,14 @@ describe('snap_setState', () => {
       const updateSnapState = jest.fn().mockReturnValue(null);
       const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
       const hasPermission = jest.fn().mockReturnValue(false);
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const hooks = {
         getSnapState,
         updateSnapState,
         getUnlockPromise,
         hasPermission,
+        getSnap,
       };
 
       const engine = new JsonRpcEngine();
@@ -252,12 +260,14 @@ describe('snap_setState', () => {
       const updateSnapState = jest.fn().mockReturnValue(null);
       const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
       const hasPermission = jest.fn().mockReturnValue(true);
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const hooks = {
         getSnapState,
         updateSnapState,
         getUnlockPromise,
         hasPermission,
+        getSnap,
       };
 
       const engine = new JsonRpcEngine();
@@ -303,12 +313,14 @@ describe('snap_setState', () => {
       const updateSnapState = jest.fn().mockReturnValue(null);
       const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
       const hasPermission = jest.fn().mockReturnValue(true);
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const hooks = {
         getSnapState,
         updateSnapState,
         getUnlockPromise,
         hasPermission,
+        getSnap,
       };
 
       const engine = new JsonRpcEngine();
@@ -358,12 +370,14 @@ describe('snap_setState', () => {
       const updateSnapState = jest.fn().mockReturnValue(null);
       const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
       const hasPermission = jest.fn().mockReturnValue(true);
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const hooks = {
         getSnapState,
         updateSnapState,
         getUnlockPromise,
         hasPermission,
+        getSnap,
       };
 
       const engine = new JsonRpcEngine();
@@ -408,12 +422,14 @@ describe('snap_setState', () => {
       const updateSnapState = jest.fn().mockReturnValue(null);
       const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
       const hasPermission = jest.fn().mockReturnValue(true);
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const hooks = {
         getSnapState,
         updateSnapState,
         getUnlockPromise,
         hasPermission,
+        getSnap,
       };
 
       const engine = new JsonRpcEngine();
@@ -461,12 +477,14 @@ describe('snap_setState', () => {
       const updateSnapState = jest.fn().mockReturnValue(null);
       const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
       const hasPermission = jest.fn().mockReturnValue(true);
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const hooks = {
         getSnapState,
         updateSnapState,
         getUnlockPromise,
         hasPermission,
+        getSnap,
       };
 
       const engine = new JsonRpcEngine();

--- a/packages/snaps-rpc-methods/src/restricted/manageState.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/manageState.test.ts
@@ -38,8 +38,6 @@ describe('getEncryptionEntropy', () => {
 });
 
 describe('snap_manageState', () => {
-  const MOCK_SMALLER_STORAGE_SIZE_LIMIT = 10; // In bytes
-
   describe('specification', () => {
     it('builds specification', () => {
       const methodHooks = {
@@ -47,6 +45,7 @@ describe('snap_manageState', () => {
         getSnapState: jest.fn(),
         updateSnapState: jest.fn(),
         getUnlockPromise: jest.fn(),
+        getSnap: jest.fn(),
       };
 
       expect(
@@ -75,12 +74,14 @@ describe('snap_manageState', () => {
       const clearSnapState = jest.fn().mockReturnValueOnce(true);
       const getSnapState = jest.fn().mockReturnValueOnce(mockSnapState);
       const updateSnapState = jest.fn().mockReturnValueOnce(true);
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const manageStateImplementation = getManageStateImplementation({
         clearSnapState,
         getSnapState,
         updateSnapState,
         getUnlockPromise: jest.fn(),
+        getSnap,
       });
 
       const result = await manageStateImplementation({
@@ -104,12 +105,14 @@ describe('snap_manageState', () => {
       const getSnapState = jest.fn().mockReturnValueOnce(mockSnapState);
       const updateSnapState = jest.fn().mockReturnValueOnce(true);
       const getUnlockPromise = jest.fn();
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const manageStateImplementation = getManageStateImplementation({
         clearSnapState,
         getSnapState,
         updateSnapState,
         getUnlockPromise,
+        getSnap,
       });
 
       const result = await manageStateImplementation({
@@ -127,12 +130,14 @@ describe('snap_manageState', () => {
       const clearSnapState = jest.fn().mockReturnValueOnce(true);
       const getSnapState = jest.fn().mockReturnValueOnce(null);
       const updateSnapState = jest.fn().mockReturnValueOnce(true);
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const manageStateImplementation = getManageStateImplementation({
         clearSnapState,
         getSnapState,
         updateSnapState,
         getUnlockPromise: jest.fn(),
+        getSnap,
       });
 
       const result = await manageStateImplementation({
@@ -150,12 +155,14 @@ describe('snap_manageState', () => {
       const getSnapState = jest.fn().mockReturnValueOnce(true);
       const updateSnapState = jest.fn().mockReturnValueOnce(true);
       const getUnlockPromise = jest.fn();
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const manageStateImplementation = getManageStateImplementation({
         clearSnapState,
         getSnapState,
         updateSnapState,
         getUnlockPromise,
+        getSnap,
       });
 
       await manageStateImplementation({
@@ -173,12 +180,14 @@ describe('snap_manageState', () => {
       const getSnapState = jest.fn().mockReturnValueOnce(true);
       const updateSnapState = jest.fn().mockReturnValueOnce(true);
       const getUnlockPromise = jest.fn();
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const manageStateImplementation = getManageStateImplementation({
         clearSnapState,
         getSnapState,
         updateSnapState,
         getUnlockPromise,
+        getSnap,
       });
 
       await manageStateImplementation({
@@ -204,12 +213,14 @@ describe('snap_manageState', () => {
       const clearSnapState = jest.fn().mockReturnValueOnce(true);
       const getSnapState = jest.fn().mockReturnValueOnce(true);
       const updateSnapState = jest.fn().mockReturnValueOnce(true);
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const manageStateImplementation = getManageStateImplementation({
         clearSnapState,
         getSnapState,
         updateSnapState,
         getUnlockPromise: jest.fn(),
+        getSnap,
       });
 
       await manageStateImplementation({
@@ -241,12 +252,14 @@ describe('snap_manageState', () => {
         .mockReturnValueOnce(JSON.stringify(mockSnapState));
       const updateSnapState = jest.fn().mockReturnValueOnce(true);
       const getUnlockPromise = jest.fn();
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const manageStateImplementation = getManageStateImplementation({
         clearSnapState,
         getSnapState,
         updateSnapState,
         getUnlockPromise,
+        getSnap,
       });
 
       await manageStateImplementation({
@@ -277,12 +290,14 @@ describe('snap_manageState', () => {
       const clearSnapState = jest.fn().mockReturnValueOnce(true);
       const getSnapState = jest.fn().mockReturnValueOnce(true);
       const updateSnapState = jest.fn().mockReturnValueOnce(true);
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const manageStateImplementation = getManageStateImplementation({
         clearSnapState,
         getSnapState,
         updateSnapState,
         getUnlockPromise: jest.fn(),
+        getSnap,
       });
 
       expect(async () =>
@@ -301,12 +316,14 @@ describe('snap_manageState', () => {
       const clearSnapState = jest.fn().mockReturnValueOnce(true);
       const getSnapState = jest.fn().mockReturnValueOnce(true);
       const updateSnapState = jest.fn().mockReturnValueOnce(true);
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const manageStateImplementation = getManageStateImplementation({
         clearSnapState,
         getSnapState,
         updateSnapState,
         getUnlockPromise: jest.fn(),
+        getSnap,
       });
 
       const newState = (a: unknown) => {
@@ -338,12 +355,14 @@ describe('snap_manageState', () => {
       const clearSnapState = jest.fn().mockReturnValueOnce(true);
       const getSnapState = jest.fn().mockReturnValueOnce(true);
       const updateSnapState = jest.fn().mockReturnValueOnce(true);
+      const getSnap = jest.fn().mockReturnValue({ preinstalled: false });
 
       const manageStateImplementation = getManageStateImplementation({
         clearSnapState,
         getSnapState,
         updateSnapState,
         getUnlockPromise: jest.fn(),
+        getSnap,
       });
 
       const newState = {
@@ -469,28 +488,6 @@ describe('snap_manageState', () => {
         ),
       ).toThrow(
         'Invalid snap_manageState "newState" parameter: The new state must be JSON serializable.',
-      );
-    });
-
-    it('throws an error if the new state object is exceeding the JSON size limit', () => {
-      const mockInvalidNewStateObject = {
-        something: {
-          something: {
-            whatever: 'whatever',
-          },
-        },
-      };
-
-      expect(() =>
-        getValidatedParams(
-          { operation: 'update', newState: mockInvalidNewStateObject },
-          'snap_manageState',
-          MOCK_SMALLER_STORAGE_SIZE_LIMIT,
-        ),
-      ).toThrow(
-        `Invalid snap_manageState "newState" parameter: The new state must not exceed ${
-          MOCK_SMALLER_STORAGE_SIZE_LIMIT / 1_000_000
-        } MB in size.`,
       );
     });
   });

--- a/packages/snaps-rpc-methods/src/restricted/manageState.ts
+++ b/packages/snaps-rpc-methods/src/restricted/manageState.ts
@@ -234,6 +234,7 @@ export function getManageStateImplementation({
         return null;
       }
 
+      /* istanbul ignore next */
       default:
         throw rpcErrors.invalidParams(
           `Invalid ${method} operation: "${

--- a/packages/snaps-simulation/src/simulation.ts
+++ b/packages/snaps-simulation/src/simulation.ts
@@ -141,6 +141,14 @@ export type RestrictedMiddlewareHooks = {
    * @returns The cryptographic functions to use for the client.
    */
   getClientCryptography: () => CryptographicFunctions;
+
+  /**
+   * A hook that returns metadata about a given Snap.
+   *
+   * @param snapId - The ID of a Snap.
+   * @returns The metadata for the given Snap.
+   */
+  getSnap: (snapId: string) => Snap;
 };
 
 export type PermittedMiddlewareHooks = {
@@ -450,6 +458,7 @@ export function getRestrictedHooks(
     ),
     getIsLocked: () => false,
     getClientCryptography: () => ({}),
+    getSnap: getGetSnapImplementation(true),
   };
 }
 

--- a/packages/snaps-utils/src/json.test.ts
+++ b/packages/snaps-utils/src/json.test.ts
@@ -13,4 +13,9 @@ describe('getJsonSizeUnsafe', () => {
     const input = { foo: 'bar' };
     expect(getJsonSizeUnsafe(input)).toBe(13);
   });
+
+  it('calculates the size of the JSON input in bytes', () => {
+    const input = { foo: 'bar€' };
+    expect(getJsonSizeUnsafe(input, true)).toBe(16);
+  });
 });

--- a/packages/snaps-utils/src/json.ts
+++ b/packages/snaps-utils/src/json.ts
@@ -32,6 +32,6 @@ export function parseJson<Type extends Json = Json>(json: string) {
  */
 export function getJsonSizeUnsafe(value: Json, encode = false): number {
   const json = JSON.stringify(value);
-  // We intentionally don't use `TextEncoder` because of bad performance on React Native.
+  // We intentionally don't use `TextEncoder` by default because of bad performance on React Native.
   return encode ? new TextEncoder().encode(json).byteLength : json.length;
 }

--- a/packages/snaps-utils/src/json.ts
+++ b/packages/snaps-utils/src/json.ts
@@ -23,14 +23,15 @@ export function parseJson<Type extends Json = Json>(json: string) {
  *
  * This may sometimes be preferred over `getJsonSize` for performance reasons.
  *
- * Note: This function does not encode the string to bytes, thus the input may
+ * Note: By default this function does not encode the string to bytes, thus the input may
  * be about 4x larger in practice. Use this function with caution.
  *
  * @param value - The JSON value to get the size of.
+ * @param encode - Whether the value should be encoded before measuring.
  * @returns The size of the JSON value in bytes.
  */
-export function getJsonSizeUnsafe(value: Json): number {
+export function getJsonSizeUnsafe(value: Json, encode = false): number {
   const json = JSON.stringify(value);
   // We intentionally don't use `TextEncoder` because of bad performance on React Native.
-  return json.length;
+  return encode ? new TextEncoder().encode(json).byteLength : json.length;
 }


### PR DESCRIPTION
This PR makes two changes to improve performance in `snap_setState` and `snap_manageState`:
- Stop enforcing JSON sizing limits for preinstalled Snaps
- Stop double checking JSON validity in `snap_setState`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes `snap_setState`/`snap_manageState` by using `getSnap` and `getJsonSizeUnsafe` to enforce size limits only for non-preinstalled Snaps, removes redundant JSON validation, updates hooks/simulation, adds TextEncoder allowances, and adjusts tests and coverage.
> 
> - **RPC methods**:
>   - **`snap_setState` (`packages/snaps-rpc-methods/src/permitted/setState.ts`)**: Add `getSnap` hook; replace `getJsonSize` with `getJsonSizeUnsafe(..., true)`; enforce storage size only for non-`preinstalled` Snaps.
>   - **`snap_manageState` (`packages/snaps-rpc-methods/src/restricted/manageState.ts`)**: Add `getSnap` hook; move size check to method implementation using `getJsonSizeUnsafe(..., true)` (skip for `preinstalled`); validation now uses `isValidJson` and no longer checks size.
> - **Simulation**:
>   - Extend restricted hooks with `getSnap` and wire implementation (`packages/snaps-simulation/src/simulation.ts`).
> - **Utils**:
>   - Enhance `getJsonSizeUnsafe` to optionally measure byte length via `TextEncoder` and add tests (`packages/snaps-utils/src/json.ts`, `json.test.ts`).
> - **Security/Policies**:
>   - Allow `TextEncoder` in LavaMoat policies for `@metamask/snaps-utils` (iframe/node-process/node-thread/webview policies).
> - **Tests**:
>   - Update tests to use `getSnap` and cover large state error paths; remove size check from param validation (`manageState.test.ts`, `setState.test.ts`).
> - **Config**:
>   - Slightly raise Jest coverage thresholds (`packages/snaps-rpc-methods/jest.config.js`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 168610a7c182db08368ac59045652b7666007e2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->