### PR TITLE
perf: Stop creating error before needing to throw

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1952,7 +1952,7 @@ export class SnapController extends BaseController<
    */
   getExpect(snapId: SnapId): Snap {
     const snap = this.get(snapId);
-    assert(snap !== undefined, new Error(`Snap "${snapId}" not found.`));
+    assert(snap !== undefined, `Snap "${snapId}" not found.`);
     return snap;
   }
 
@@ -4169,7 +4169,7 @@ export class SnapController extends BaseController<
   #createRollbackSnapshot(snapId: SnapId): RollbackSnapshot {
     assert(
       this.#rollbackSnapshots.get(snapId) === undefined,
-      new Error(`Snap "${snapId}" rollback snapshot already exists.`),
+      `Snap "${snapId}" rollback snapshot already exists.`,
     );
 
     this.#rollbackSnapshots.set(snapId, {
@@ -4182,7 +4182,7 @@ export class SnapController extends BaseController<
 
     assert(
       newRollbackSnapshot !== undefined,
-      new Error(`Snapshot creation failed for ${snapId}.`),
+      `Snapshot creation failed for ${snapId}.`,
     );
     return newRollbackSnapshot;
   }
@@ -4272,10 +4272,7 @@ export class SnapController extends BaseController<
 
   #getRuntimeExpect(snapId: SnapId): SnapRuntimeData {
     const runtime = this.#getRuntime(snapId);
-    assert(
-      runtime !== undefined,
-      new Error(`Snap "${snapId}" runtime data not found`),
-    );
+    assert(runtime !== undefined, `Snap "${snapId}" runtime data not found`);
     return runtime;
   }
 

--- a/packages/snaps-controllers/src/snaps/Timer.ts
+++ b/packages/snaps-controllers/src/snaps/Timer.ts
@@ -54,7 +54,7 @@ export class Timer {
   cancel() {
     assert(
       this.status === 'paused' || this.status === 'running',
-      new Error('Tried to cancel a not running Timer'),
+      'Tried to cancel a not running Timer',
     );
     this.onFinish(false);
   }
@@ -65,10 +65,7 @@ export class Timer {
    * @throws {@link Error}. If it wasn't running or paused.
    */
   finish() {
-    assert(
-      this.status !== 'finished',
-      new Error('Tried to finish a finished Timer.'),
-    );
+    assert(this.status !== 'finished', 'Tried to finish a finished Timer.');
     this.onFinish(true);
   }
 
@@ -80,7 +77,7 @@ export class Timer {
   pause() {
     assert(
       this.state.value === 'running',
-      new Error('Tried to pause a not running Timer'),
+      'Tried to pause a not running Timer',
     );
 
     const { callback, start, timeout, remaining } = this.state;
@@ -102,7 +99,7 @@ export class Timer {
   start(callback: () => void) {
     assert(
       this.state.value === 'stopped',
-      new Error('Tried to start an already running Timer'),
+      'Tried to start an already running Timer',
     );
 
     const { remaining } = this.state;
@@ -116,10 +113,7 @@ export class Timer {
    * @throws {@link Error}. If it wasn't paused.
    */
   resume() {
-    assert(
-      this.state.value === 'paused',
-      new Error('Tried to resume not paused Timer'),
-    );
+    assert(this.state.value === 'paused', 'Tried to resume not paused Timer');
     const { remaining, callback } = this.state;
     const start = Date.now();
 


### PR DESCRIPTION
Stop creating `Error` and passing into `assert`, especially in hot paths as it takes a significant amount of time on mobile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `assert(..., new Error(...))` with string messages in `SnapController` and `Timer` to avoid unnecessary Error construction.
> 
> - **Performance refactor**
>   - `packages/snaps-controllers/src/snaps/SnapController.ts`
>     - Use `assert(condition, "message")` instead of creating `Error` in `getExpect`, `#createRollbackSnapshot` (2 sites), and `#getRuntimeExpect`.
>   - `packages/snaps-controllers/src/snaps/Timer.ts`
>     - Same change in `cancel`, `finish`, `pause`, `start`, and `resume`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c151966bedeb3ad7d1ddc8071e1f88ac3c513fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->