### PR TITLE
chore: make @metamask/test-snaps-site publishable

### DIFF
--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -32,6 +32,7 @@
     "lint:eslint": "eslint . --cache",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier --no-error-on-unmatched-pattern --log-level warn \"**/*.json\" \"**/*.md\" \"**/*.html\" \"!CHANGELOG.md\" --ignore-path ../../.gitignore",
+    "publish:preview": "yarn npm publish --tag preview",
     "since-latest-release": "../../scripts/since-latest-release.sh",
     "start": "yarn workspaces foreach --parallel --interlaced --all --include \"@metamask/test-snaps\" --include \"@metamask/example-snaps\" run start:test",
     "start:test": "cross-env NODE_ENV=development webpack serve",
@@ -122,6 +123,7 @@
     "node": "^20 || >=22"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -109,7 +109,8 @@ module.exports = defineConfig({
         if (
           !isPrivate &&
           !isExample &&
-          workspace.cwd !== 'packages/snaps-sandbox'
+          workspace.cwd !== 'packages/snaps-sandbox' &&
+          workspace.cwd !== 'packages/test-snaps'
         ) {
           // All non-root, non-example packages must set up ESM- and
           // CommonJS-compatible exports correctly.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make `@metamask/test-snaps` publishable and adjust Yarn constraints accordingly.
> 
> - **packages/test-snaps/package.json**:
>   - Make package public by removing `private` and adding `publishConfig` (`access: public`, npm registry).
>   - Restrict published files to `dist` via `files` array.
>   - Add `scripts.publish:preview`.
> - **yarn.config.cjs**:
>   - Exempt `packages/test-snaps` from ESM/CJS exports enforcement (same as `snaps-sandbox`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6efe9dd6bd41b95bd4e3abfe248b078ab1ccc183. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->