### PR TITLE
chore: Revert "release: 128.0.0 (#3685)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "128.0.0",
+  "version": "127.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/test-snaps/CHANGELOG.md
+++ b/packages/test-snaps/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.0]
-
-### Changed
-
-- Make `@metamask/test-snaps` publishable ([#3679](https://github.com/MetaMask/snaps/pull/3679))
-
 ## [2.28.1]
 
 ### Fixed
@@ -394,8 +388,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix NPM package name of the network access snap ([#1621](https://github.com/MetaMask/snaps/pull/1621))
 
-[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@3.0.0...HEAD
-[3.0.0]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@2.28.1...@metamask/test-snaps@3.0.0
+[Unreleased]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@2.28.1...HEAD
 [2.28.1]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@2.28.0...@metamask/test-snaps@2.28.1
 [2.28.0]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@2.27.0...@metamask/test-snaps@2.28.0
 [2.27.0]: https://github.com/MetaMask/snaps/compare/@metamask/test-snaps@2.26.0...@metamask/test-snaps@2.27.0

--- a/packages/test-snaps/package.json
+++ b/packages/test-snaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-snaps",
-  "version": "3.0.0",
+  "version": "2.28.1",
   "description": "The test snaps website for MetaMask Snaps, used for end-to-end testing",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
This reverts commit e246ad7e074766f49d40fb079cf6aa43770f1e58.

The release failed because `test-snaps` isn't built in the publish NPM workflow. Will need further investigation.