### PR TITLE
chore: fix `publish-release` error to avoid non-fast-forward pushes

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -249,7 +249,9 @@ jobs:
 
   publish-test-snaps-latest:
     name: Publish test snaps to `latest` folder
-    needs: is-test-snaps-release
+    needs:
+      - is-test-snaps-release
+      - publish-test-snaps
     if: ${{ needs.is-test-snaps-release.outputs.IS_TEST_SNAPS_RELEASE == 'true' }}
     permissions:
       contents: write


### PR DESCRIPTION
Fix publish-release error to avoid non-fast-forward pushes in the test-snap package

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit ab1de00d1eb8d5168a0ee4d5f21e8f12d2d34feb. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->