### PR TITLE
chore: Add `@metamask-previews/*` to NPM age gate exceptions

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -28,4 +28,5 @@ npmMinimalAgeGate: 4320 # 3 days (in minutes)
 # regardless of their publish age.
 npmPreapprovedPackages:
   - '@metamask/*'
+  - '@metamask-previews/*'
   - '@lavamoat/*'


### PR DESCRIPTION
We sometimes use `@metamask-previews/*` to use preview builds for testing certain features. These will usually not be 3 days old, so can't be installed without an exception.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `@metamask-previews/*` to `npmPreapprovedPackages` in `.yarnrc.yml` to bypass the 3-day NPM minimal age gate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 571c0687b3ec771ac1720bd9f37653b250988e76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->