### PR TITLE
chore: bump `@metamask/phishing-controller` from `^13.1.0` to `^15.0.0`

### DIFF
--- a/packages/snaps-controllers/CHANGELOG.md
+++ b/packages/snaps-controllers/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@metamask/phishing-controller` from `^13.1.0` to `^15.0.0`(([#3705](https://github.com/MetaMask/snaps/pull/3705))
+
 ## [16.0.0]
 
 ### Changed

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -87,7 +87,7 @@
     "@metamask/messenger": "^0.3.0",
     "@metamask/object-multiplex": "^2.1.0",
     "@metamask/permission-controller": "^12.0.0",
-    "@metamask/phishing-controller": "^13.1.0",
+    "@metamask/phishing-controller": "^15.0.0",
     "@metamask/post-message-stream": "^10.0.0",
     "@metamask/rpc-errors": "^7.0.3",
     "@metamask/snaps-registry": "^3.2.3",

--- a/packages/snaps-jest/CHANGELOG.md
+++ b/packages/snaps-jest/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@metamask/phishing-controller` from `^13.1.0` to `^15.0.0`(([#3705](https://github.com/MetaMask/snaps/pull/3705))
+
 ## [9.5.1]
 
 ### Changed

--- a/packages/snaps-jest/package.json
+++ b/packages/snaps-jest/package.json
@@ -74,7 +74,7 @@
     "@jest/types": "^29.6.3",
     "@lavamoat/allow-scripts": "^3.4.0",
     "@metamask/auto-changelog": "^5.0.2",
-    "@metamask/phishing-controller": "^13.1.0",
+    "@metamask/phishing-controller": "^15.0.0",
     "@metamask/snaps-utils": "workspace:^",
     "@swc/core": "1.11.31",
     "@swc/jest": "^0.2.38",

--- a/packages/snaps-simulation/CHANGELOG.md
+++ b/packages/snaps-simulation/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@metamask/phishing-controller` from `^13.1.0` to `^15.0.0`(([#3705](https://github.com/MetaMask/snaps/pull/3705))
+
 ## [3.5.1]
 
 ### Changed

--- a/packages/snaps-simulation/package.json
+++ b/packages/snaps-simulation/package.json
@@ -61,7 +61,7 @@
     "@metamask/key-tree": "^10.1.1",
     "@metamask/messenger": "^0.3.0",
     "@metamask/permission-controller": "^12.0.0",
-    "@metamask/phishing-controller": "^13.1.0",
+    "@metamask/phishing-controller": "^15.0.0",
     "@metamask/snaps-controllers": "workspace:^",
     "@metamask/snaps-execution-environments": "workspace:^",
     "@metamask/snaps-rpc-methods": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2885,17 +2885,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/base-controller@npm:^8.0.1":
-  version: 8.4.1
-  resolution: "@metamask/base-controller@npm:8.4.1"
-  dependencies:
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/utils": "npm:^11.8.1"
-    immer: "npm:^9.0.6"
-  checksum: 10/d720638b6a640f43e06b37bd77b7291be20df2f3cc89ab571ee47c895313ba2521cd49e6dede02dd7e06971c351f88eec2c39b65d8f46ba09492d89131d640b9
-  languageName: node
-  linkType: hard
-
 "@metamask/base-controller@npm:^9.0.0":
   version: 9.0.0
   resolution: "@metamask/base-controller@npm:9.0.0"
@@ -3024,7 +3013,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/controller-utils@npm:^11.11.0, @metamask/controller-utils@npm:^11.14.1":
+"@metamask/controller-utils@npm:^11.14.1":
   version: 11.14.1
   resolution: "@metamask/controller-utils@npm:11.14.1"
   dependencies:
@@ -3937,18 +3926,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/phishing-controller@npm:^13.1.0":
-  version: 13.1.0
-  resolution: "@metamask/phishing-controller@npm:13.1.0"
+"@metamask/phishing-controller@npm:^15.0.0":
+  version: 15.0.0
+  resolution: "@metamask/phishing-controller@npm:15.0.0"
   dependencies:
-    "@metamask/base-controller": "npm:^8.0.1"
-    "@metamask/controller-utils": "npm:^11.11.0"
-    "@noble/hashes": "npm:^1.4.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.14.1"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@noble/hashes": "npm:^1.8.0"
     "@types/punycode": "npm:^2.1.0"
     ethereum-cryptography: "npm:^2.1.2"
     fastest-levenshtein: "npm:^1.0.16"
     punycode: "npm:^2.1.1"
-  checksum: 10/c62f71291736dfd635cc69b2d422687d8d610591a5e1cd9a6b4806cdc19221a72fe7699c0cabe0a2a108b49c3cc4dcb88a5b283fba374fe13e54d5813fb77902
+  peerDependencies:
+    "@metamask/transaction-controller": ^61.0.0
+  checksum: 10/84e10ddcba9bb1351538c2de1105863dda030ad5f6dfa54bb17d731e436e948e6bcc4630fa914162046bda1b925514de37224f34cc00145e102b2f7f3f83059e
   languageName: node
   linkType: hard
 
@@ -4266,7 +4258,7 @@ __metadata:
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/object-multiplex": "npm:^2.1.0"
     "@metamask/permission-controller": "npm:^12.0.0"
-    "@metamask/phishing-controller": "npm:^13.1.0"
+    "@metamask/phishing-controller": "npm:^15.0.0"
     "@metamask/post-message-stream": "npm:^10.0.0"
     "@metamask/rpc-errors": "npm:^7.0.3"
     "@metamask/snaps-registry": "npm:^3.2.3"
@@ -4393,7 +4385,7 @@ __metadata:
     "@jest/types": "npm:^29.6.3"
     "@lavamoat/allow-scripts": "npm:^3.4.0"
     "@metamask/auto-changelog": "npm:^5.0.2"
-    "@metamask/phishing-controller": "npm:^13.1.0"
+    "@metamask/phishing-controller": "npm:^15.0.0"
     "@metamask/snaps-controllers": "workspace:^"
     "@metamask/snaps-sdk": "workspace:^"
     "@metamask/snaps-simulation": "workspace:^"
@@ -4560,7 +4552,7 @@ __metadata:
     "@metamask/key-tree": "npm:^10.1.1"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/permission-controller": "npm:^12.0.0"
-    "@metamask/phishing-controller": "npm:^13.1.0"
+    "@metamask/phishing-controller": "npm:^15.0.0"
     "@metamask/snaps-controllers": "workspace:^"
     "@metamask/snaps-execution-environments": "workspace:^"
     "@metamask/snaps-rpc-methods": "workspace:^"
@@ -4936,10 +4928,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.7.1, @noble/hashes@npm:^1.1.2, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2, @noble/hashes@npm:^1.4.0, @noble/hashes@npm:^1.7.1":
+"@noble/hashes@npm:1.7.1":
   version: 1.7.1
   resolution: "@noble/hashes@npm:1.7.1"
   checksum: 10/ca3120da0c3e7881d6a481e9667465cc9ebbee1329124fb0de442e56d63fef9870f8cc96f264ebdb18096e0e36cebc0e6e979a872d545deb0a6fed9353f17e05
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:^1.1.2, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2, @noble/hashes@npm:^1.7.1, @noble/hashes@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "@noble/hashes@npm:1.8.0"
+  checksum: 10/474b7f56bc6fb2d5b3a42132561e221b0ea4f91e590f4655312ca13667840896b34195e2b53b7f097ec080a1fdd3b58d902c2a8d0fbdf51d2e238b53808a177e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR bumps @metamask/phishing-controller from `^13.1.0` to `^15.0.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `@metamask/phishing-controller` to `^15.0.0` in controllers, jest, and simulation packages with corresponding changelog and lockfile updates.
> 
> - **Dependencies**:
>   - **`packages/snaps-controllers`**: Update `@metamask/phishing-controller` from `^13.1.0` to `^15.0.0` in `package.json`; add entry to `CHANGELOG.md`.
>   - **`packages/snaps-jest`**: Update devDependency `@metamask/phishing-controller` to `^15.0.0`; add entry to `CHANGELOG.md`.
>   - **`packages/snaps-simulation`**: Update `@metamask/phishing-controller` to `^15.0.0`; add entry to `CHANGELOG.md`.
> - **Lockfile**:
>   - Refresh `yarn.lock` to resolve `@metamask/phishing-controller@15.0.0` and its updated transitive/peer requirements (e.g., `@metamask/base-controller@^9`, `@metamask/controller-utils@^11.14.1`, `@metamask/messenger@^0.3.0`, `@noble/hashes@^1.8.0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca642a4399018649f230b9990f7a6cceadc74f53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->