### PR TITLE
ci: Use platform specific caching for compatibility tests

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -267,6 +267,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: false
+          platform-specific-caching: true
       - name: Build dependencies
         run: yarn build:ci
       - name: Run tests


### PR DESCRIPTION
Enable platform specific caching for compatibility tests that run on Mac OS and Windows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables platform-specific caching in the platform compatibility CI job (macOS and Windows).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b92f666fd2e178a04147335dbda4579deb5f93c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->