### PR TITLE
chore: Add LavaMoat CLI to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     allow:
       - dependency-name: '@metamask/*'
       - dependency-name: '@lavamoat/*'
+      - dependency-name: 'lavamoat'
       - dependency-name: 'ses'
     target-branch: 'main'
     versioning-strategy: 'increase'


### PR DESCRIPTION
Add the LavaMoat CLI to Dependabot, which is not in the LavaMoat NPM org.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds the 'lavamoat' package to the npm allowlist in Dependabot config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3c016cdab95df8961f5851cd4505a920024748e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->