### PR TITLE
ci: Build `test-snaps` in `publish-release` job to include it in NPM publishing

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -62,10 +62,12 @@ jobs:
           npm-tag: ${{ needs.get-release-tag.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        run: yarn install --immutable
       - name: Build
-        run: |
-          yarn install --immutable
-          yarn build
+        run: yarn build
+      - name: Build test-snaps
+        run: yarn workspace @metamask/test-snaps build
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Following #3679, we want `test-snaps` to be publishable to NPM. Currently only TypeScript packages are built, so `test-snaps` wouldn't be published properly. I've added an extra step to build `test-snaps` before running the NPM publish job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the publish-release workflow to install dependencies in a dedicated step and build `@metamask/test-snaps` so it’s included in release artifacts/NPM publish.
> 
> - **CI (GitHub Actions)**:
>   - **`publish-release` job**:
>     - Add dedicated `Install dependencies` step (`yarn install --immutable`).
>     - Build all packages with `yarn build`.
>     - New step to build `@metamask/test-snaps` (`yarn workspace @metamask/test-snaps build`) so artifacts include it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ffbc256114df4c0059e4eb0b6ee53d83e5bb75b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->