### PR TITLE
chore: add prototype pollution guards to setState and SnapController

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -3943,17 +3943,26 @@ export class SnapController extends BaseController<
     const { conversions: requestedConversions } = requestedParams;
 
     const filteredConversionRates = requestedConversions.reduce<
-      Record<CaipAssetType, Record<CaipAssetType, AssetConversion>>
+      Map<CaipAssetType, Map<CaipAssetType, AssetConversion>>
     >((accumulator, conversion) => {
       const rate = conversionRates[conversion.from]?.[conversion.to];
       // Only include rates that were actually requested.
       if (rate) {
-        accumulator[conversion.from] ??= {};
-        accumulator[conversion.from][conversion.to] = rate;
+        if (!accumulator.has(conversion.from)) {
+          accumulator.set(conversion.from, new Map());
+        }
+        accumulator.get(conversion.from).set(conversion.to, rate);
       }
       return accumulator;
-    }, {});
-    return { conversionRates: filteredConversionRates };
+    }, new Map());
+    // Convert nested Maps into plain objects for return value compatibility.
+    const conversionRatesObj = Object.fromEntries(
+      Array.from(filteredConversionRates.entries()).map(([fromKey, toMap]) => [
+        fromKey,
+        Object.fromEntries(toMap.entries()),
+      ]),
+    );
+    return { conversionRates: conversionRatesObj };
   }
 
   /**
@@ -3980,11 +3989,13 @@ export class SnapController extends BaseController<
       const result = marketData[assets.asset]?.[assets.unit];
       // Only include rates that were actually requested.
       if (result) {
-        accumulator[assets.asset] ??= {};
+        if (!accumulator[assets.asset]) {
+          accumulator[assets.asset] = Object.create(null);
+        }
         accumulator[assets.asset][assets.unit] = result;
       }
       return accumulator;
-    }, {});
+    }, Object.create(null));
     return { marketData: filteredMarketData };
   }
 

--- a/packages/snaps-rpc-methods/src/permitted/setState.ts
+++ b/packages/snaps-rpc-methods/src/permitted/setState.ts
@@ -260,9 +260,15 @@ export function set(
 
   for (let i = 0; i < keys.length; i++) {
     const currentKey = keys[i];
-    if (FORBIDDEN_KEYS.includes(currentKey)) {
+    // Explicitly block prototype pollution keys
+    if (
+      FORBIDDEN_KEYS.includes(currentKey) ||
+      currentKey === '__proto__' ||
+      currentKey === 'constructor' ||
+      currentKey === 'prototype'
+    ) {
       throw rpcErrors.invalidParams(
-        'Invalid params: Key contains forbidden characters.',
+        'Invalid params: Key contains forbidden characters or is potentially prototype polluting.',
       );
     }
 


### PR DESCRIPTION

request strengthens security across multiple components of the MetaMask Snaps codebase by addressing potential **prototype pollution vulnerabilities** in recursive state assignment and object accumulation logic.
 these fixes prevent malicious user input from mutating JavaScript object prototypes or altering inherited behavior, thereby improving the overall safety and robustness of Snaps runtime operations.


**Issue:** #3718

**Mitigate Prototype Pollution in `setState` (packages/snaps-rpc-methods/src/permitted/setState.ts)**
The recursive assignment function used in `setState` could inadvertently allow prototype pollution if untrusted keys such as `__proto__`, `constructor`, or `prototype` were used as property names during state updates.
This issue could enable malicious payloads to modify global object prototypes, leading to unpredictable behavior or security compromises.



**Secure Object Construction in `SnapController` Conversion Logic (packages/snaps-controllers/src/snaps/SnapController.ts#L3946)**

Within the logic that constructs `filteredConversionRates` from `requestedConversions`, plain JavaScript objects were being used to store user-derived keys (`conversion.from` and `conversion.to`).
Since object property keys can interact with the prototype chain, this pattern risked prototype pollution if untrusted input was introduced.



 **Prevent Pollution in Market Data Transformation (`#transformOnAssetsMarketDataResult`)**

In the private method `#transformOnAssetsMarketDataResult`, user-derived `asset` and `unit` strings were used as keys during reduction to construct `filteredMarketData`.
 As with the previous issue, this pattern risked prototype pollution via implicit property inheritance.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit prototype pollution guards in setState and switches SnapController asset transform reducers to safe accumulators, preserving output shape.
> 
> - **Security hardening**
>   - **`packages/snaps-rpc-methods/src/permitted/setState.ts`**:
>     - `set(...)`: Rejects keys `__proto__`, `constructor`, `prototype` (in addition to existing forbidden keys); updates error message.
>   - **`packages/snaps-controllers/src/snaps/SnapController.ts`**:
>     - `#transformOnAssetsConversionResult(...)`: Uses `Map`→`Map` accumulator during reduction; converts nested `Map`s back to plain objects for return.
>     - `#transformOnAssetsMarketDataResult(...)`: Uses `Object.create(null)` for nested objects to avoid prototype inheritance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 700c6b66ab71b08eb968cd11564f41dc7d72dae4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->