### PR TITLE
fix: Prevent race condition in preinstalled example Snap

### DIFF
--- a/packages/examples/packages/preinstalled/snap.manifest.json
+++ b/packages/examples/packages/preinstalled/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "5GjC5OYTtXLw1aHztViZ2Xf1dZIgvqP4xCgw4gPT1JY=",
+    "shasum": "BHcDBSLqllDgqbTjvlpoZLw5M13p4mK+d8b/yMMeHoU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/packages/preinstalled/src/index.tsx
+++ b/packages/examples/packages/preinstalled/src/index.tsx
@@ -190,23 +190,12 @@ export const onUserInput: OnUserInputHandler = async ({
       event.name === 'setting2' ||
       event.name === 'setting3')
   ) {
-    const state = await snap.request({
-      method: 'snap_manageState',
-      params: {
-        operation: 'get',
-        encrypted: false,
-      },
-    });
-
     await snap.request({
-      method: 'snap_manageState',
+      method: 'snap_setState',
       params: {
-        operation: 'update',
         encrypted: false,
-        newState: {
-          ...state,
-          [event.name]: event.value,
-        },
+        key: event.name,
+        value: event.value,
       },
     });
   }


### PR DESCRIPTION
Prevent a race condition in the preinstalled example Snap by using `snap_setState`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use snap_setState for settings updates in the preinstalled example snap and update the manifest shasum.
> 
> - **Preinstalled example snap**:
>   - Replace settings input change flow to use `snap_setState` with `key`/`value`, removing prior `snap_manageState` get+update sequence.
> - **Manifest**:
>   - Update `source.shasum` in `packages/examples/packages/preinstalled/snap.manifest.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 807ef4c5d4a86b64d462dd1487d688a2ffebc845. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->