### PR TITLE
docs: Exclude test-snaps from README graph

### DIFF
--- a/scripts/update-readme-content.mts
+++ b/scripts/update-readme-content.mts
@@ -61,7 +61,9 @@ async function retrieveWorkspaces(): Promise<Workspace[]> {
     .split('\n')
     .map((line) => JSON.parse(line))
     .filter(
-      (workspace) => !workspace.location.startsWith('packages/examples/'),
+      (workspace) =>
+        !workspace.location.startsWith('packages/examples/') &&
+        !workspace.location.startsWith('packages/test-snaps'),
     );
 }
 


### PR DESCRIPTION
This excludes `test-snaps` from the graph in the README.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exclude `packages/test-snaps` from README’s generated dependency graph and package list.
> 
> - **README generation script (`scripts/update-readme-content.mts`)**:
>   - Update `retrieveWorkspaces` filter to also exclude `packages/test-snaps`, in addition to `packages/examples/`, from workspace processing.
>   - Effectively removes `test-snaps` from the generated dependency graph and package list in the README.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78943f020937728045a1f8e7a35a11a156a77c44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->