### PR TITLE
fix: Override `disableSnapInstallation` feature flag when using automatic updates

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2913,7 +2913,9 @@ export class SnapController extends BaseController<
     versionRange: SemVerRange;
     automaticUpdate?: boolean;
   }): Promise<TruncatedSnap> {
-    this.#assertCanInstallSnaps();
+    if (!automaticUpdate) {
+      this.#assertCanInstallSnaps();
+    }
     this.#assertCanUsePlatform();
 
     const snap = this.getExpect(snapId);


### PR DESCRIPTION
Allow updates of Snaps even when the `disableSnapInstallation` feature flag is enabled as long as the update is an automatic one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Permits automatic Snap updates to bypass the `disableSnapInstallation` check while preserving manual update restrictions for preinstalled Snaps.
> 
> - **Snaps Controller** (`SnapController.ts`):
>   - Modify `#updateSnap(...)` to only call `#assertCanInstallSnaps()` when `automaticUpdate` is false, allowing automatic updates even if `disableSnapInstallation` is enabled.
>   - Retain restriction preventing manual updates of preinstalled Snaps (`preinstalled && !automaticUpdate`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c35eb46372fee102b6222887bd756ef3d924b15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->