### PR TITLE
chore: fix some typos in comments

### DIFF
--- a/packages/snaps-sdk/src/types/handlers/assets-market-data.ts
+++ b/packages/snaps-sdk/src/types/handlers/assets-market-data.ts
@@ -30,7 +30,7 @@ export type FungibleAssetMarketData = {
  * An asset value, which includes the asset type and the amount.
  *
  * @property asset - The CAIP-19 asset type or ID of the asset.
- * @property amount - The pice represented as a number in string format.
+ * @property amount - The price represented as a number in string format.
  */
 export type AssetValue = {
   asset: CaipAssetTypeOrId;

--- a/packages/snaps-utils/src/handlers/assets-market-data.ts
+++ b/packages/snaps-utils/src/handlers/assets-market-data.ts
@@ -53,7 +53,7 @@ export const FungibleAssetMarketDataStruct = object({
  * A struct representing an asset value, which includes the asset type and the amount.
  *
  * @property asset - The CAIP-19 asset type or ID of the asset.
- * @property amount - The pice represented as a number in string format.
+ * @property amount - The price represented as a number in string format.
  */
 export const AssetValueStruct = object({
   asset: CaipAssetTypeOrIdStruct,
@@ -64,7 +64,7 @@ export const AssetValueStruct = object({
  * A struct representing the market data for a non-fungible asset.
  *
  * @property asset - The CAIP-19 asset type or ID of the asset.
- * @property amount - The pice represented as a number in string format.
+ * @property amount - The price represented as a number in string format.
  * @property fungible - Indicates that this is a non-fungible asset.
  * This is always `false` for non-fungible assets.
  * @property lastSale - The last sale price of the asset, if available. See {@link AssetValueStruct}.


### PR DESCRIPTION
fix some typos in comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes comment typos in asset market data types/structs.
> 
> - Corrects `amount` description from "pice" to "price" in `AssetValue` and related non-fungible docs in `snaps-sdk` and `snaps-utils` handlers
> - Documentation-only change; no runtime or type behavior modifications
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ede12e56116bbfa2588f97c5d1508585c2c4562b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->