### PR TITLE
fix!: Always consume latest registry in `updateRegistry`

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController-method-action-types.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController-method-action-types.ts
@@ -21,7 +21,7 @@ export type SnapControllerInitAction = {
 /**
  * Trigger an update of the registry.
  *
- * As a side-effect of this, preinstalled Snaps may be updated and Snaps may be blocked/unblocked.
+ * This will _always_ check if preinstalled Snaps can be updated and whether any Snaps need to beblocked/unblocked.
  */
 export type SnapControllerUpdateRegistryAction = {
   type: `SnapController:updateRegistry`;

--- a/packages/snaps-controllers/src/snaps/SnapController-method-action-types.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController-method-action-types.ts
@@ -21,7 +21,7 @@ export type SnapControllerInitAction = {
 /**
  * Trigger an update of the registry.
  *
- * This will _always_ check if preinstalled Snaps can be updated and whether any Snaps need to beblocked/unblocked.
+ * As a side-effect, this will _always_ check if preinstalled Snaps can be updated and whether any Snaps need to be blocked/unblocked.
  */
 export type SnapControllerUpdateRegistryAction = {
   type: `SnapController:updateRegistry`;

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -10848,8 +10848,10 @@ describe('SnapController', () => {
         preinstalled: true,
       });
 
-      // Indicate no registry update performed
-      registry.requestUpdate.mockResolvedValue(false);
+      // Indicate no database update performed
+      registry.requestUpdate.mockImplementation(() => {
+        rootMessenger.publish('SnapRegistryController:registryUpdated', false);
+      });
 
       const updateVersion = '1.2.1';
 
@@ -10882,6 +10884,8 @@ describe('SnapController', () => {
       const snapController = await getSnapController(options);
 
       await snapController.updateRegistry();
+      await waitForStateChange(options.messenger);
+      await sleep(100);
 
       const updatedSnap = snapController.getSnap(snapId);
       assert(updatedSnap);

--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -10826,6 +10826,103 @@ describe('SnapController', () => {
       snapController.destroy();
     });
 
+    it('retries updating preinstalled Snaps', async () => {
+      const rootMessenger = getRootMessenger();
+      const registry = new MockSnapRegistryController(rootMessenger);
+
+      // Simulate previous permissions, some of which will be removed
+      rootMessenger.registerActionHandler(
+        'PermissionController:getPermissions',
+        () => {
+          return {
+            [SnapEndowments.Rpc]: MOCK_RPC_ORIGINS_PERMISSION,
+            [SnapEndowments.LifecycleHooks]: MOCK_LIFECYCLE_HOOKS_PERMISSION,
+          };
+        },
+      );
+
+      const snapId = 'npm:@metamask/jsx-example-snap' as SnapId;
+
+      const mockSnap = getPersistedSnapObject({
+        id: snapId,
+        preinstalled: true,
+      });
+
+      // Indicate no registry update performed
+      registry.requestUpdate.mockResolvedValue(false);
+
+      const updateVersion = '1.2.1';
+
+      registry.resolveVersion.mockResolvedValue(updateVersion);
+      const fetchFunction = jest.fn().mockResolvedValueOnce({
+        // eslint-disable-next-line no-restricted-globals
+        headers: new Headers({ 'content-length': '5477' }),
+        ok: true,
+        body: Readable.toWeb(
+          createReadStream(
+            path.resolve(
+              __dirname,
+              `../../test/fixtures/metamask-jsx-example-snap-${updateVersion}.tgz`,
+            ),
+          ),
+        ),
+      });
+
+      const options = getSnapControllerOptions({
+        rootMessenger,
+        state: {
+          snaps: getPersistedSnapsState(mockSnap),
+        },
+        fetchFunction,
+        featureFlags: {
+          autoUpdatePreinstalledSnaps: true,
+        },
+      });
+
+      const snapController = await getSnapController(options);
+
+      await snapController.updateRegistry();
+
+      const updatedSnap = snapController.getSnap(snapId);
+      assert(updatedSnap);
+
+      expect(updatedSnap.version).toStrictEqual(updateVersion);
+      expect(updatedSnap.preinstalled).toBe(true);
+
+      expect(options.messenger.call).toHaveBeenNthCalledWith(
+        7,
+        'StorageService:setItem',
+        controllerName,
+        snapId,
+        { sourceCode: expect.any(String) },
+      );
+
+      expect(options.messenger.call).toHaveBeenNthCalledWith(
+        9,
+        'PermissionController:revokePermissions',
+        { [snapId]: [SnapEndowments.Rpc, SnapEndowments.LifecycleHooks] },
+      );
+
+      expect(options.messenger.call).toHaveBeenNthCalledWith(
+        10,
+        'PermissionController:grantPermissions',
+        {
+          approvedPermissions: {
+            'endowment:rpc': {
+              caveats: [{ type: 'rpcOrigin', value: { dapps: true } }],
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            snap_dialog: {},
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            snap_manageState: {},
+          },
+          subject: { origin: snapId },
+        },
+      );
+
+      snapController.destroy();
+    });
+
     it('does not update preinstalled Snaps when the feature flag is off', async () => {
       const rootMessenger = getRootMessenger();
       const registry = new MockSnapRegistryController(rootMessenger);

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1444,7 +1444,7 @@ export class SnapController extends BaseController<
   /**
    * Trigger an update of the registry.
    *
-   * This will _always_ check if preinstalled Snaps can be updated and whether any Snaps need to beblocked/unblocked.
+   * As a side-effect, this will _always_ check if preinstalled Snaps can be updated and whether any Snaps need to be blocked/unblocked.
    */
   async updateRegistry(): Promise<void> {
     await this.#ensureCanUsePlatform();

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -167,7 +167,7 @@ import type {
   SnapRegistryControllerRequestUpdateAction,
   SnapRegistryInfo,
   SnapRegistryRequest,
-  SnapRegistryControllerStateChangeEvent,
+  SnapRegistryControllerRegistryUpdatedEvent,
 } from './registry';
 import { SnapRegistryStatus } from './registry';
 import { getRunnableSnaps } from './selectors';
@@ -547,7 +547,7 @@ type AllowedEvents =
   | SnapControllerSnapInstalledEvent
   | SnapControllerSnapUpdatedEvent
   | KeyringControllerLockEvent
-  | SnapRegistryControllerStateChangeEvent;
+  | SnapRegistryControllerRegistryUpdatedEvent;
 
 export type SnapControllerMessenger = Messenger<
   typeof controllerName,
@@ -974,19 +974,15 @@ export class SnapController extends BaseController<
       this.#handleLock.bind(this),
     );
 
-    this.messenger.subscribe(
-      'SnapRegistryController:stateChange',
-      () => {
-        this.#handleRegistryUpdate().catch((error) => {
-          logError(
-            `Error when processing Snaps registry update: ${getErrorMessage(
-              error,
-            )}`,
-          );
-        });
-      },
-      ({ database }) => database,
-    );
+    this.messenger.subscribe('SnapRegistryController:registryUpdated', () => {
+      this.#handleRegistryUpdate().catch((error) => {
+        logError(
+          `Error when processing Snaps registry update: ${getErrorMessage(
+            error,
+          )}`,
+        );
+      });
+    });
 
     this.#initializeStateMachine();
     this.#registerMessageHandlers();
@@ -1452,15 +1448,7 @@ export class SnapController extends BaseController<
    */
   async updateRegistry(): Promise<void> {
     await this.#ensureCanUsePlatform();
-    const updated = await this.messenger.call(
-      'SnapRegistryController:requestUpdate',
-    );
-
-    // When returning false, the `:stateChange` event is not emitted, so we force update.
-    // We do this to enable mainly to provide a path to retry OTA updates.
-    if (!updated) {
-      await this.#handleRegistryUpdate();
-    }
+    await this.messenger.call('SnapRegistryController:requestUpdate');
   }
 
   /**

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1448,11 +1448,19 @@ export class SnapController extends BaseController<
   /**
    * Trigger an update of the registry.
    *
-   * As a side-effect of this, preinstalled Snaps may be updated and Snaps may be blocked/unblocked.
+   * This will _always_ check if preinstalled Snaps can be updated and whether any Snaps need to beblocked/unblocked.
    */
   async updateRegistry(): Promise<void> {
     await this.#ensureCanUsePlatform();
-    await this.messenger.call('SnapRegistryController:requestUpdate');
+    const updated = await this.messenger.call(
+      'SnapRegistryController:requestUpdate',
+    );
+
+    // When returning false, the `:stateChange` event is not emitted, so we force update.
+    // We do this to enable mainly to provide a path to retry OTA updates.
+    if (!updated) {
+      await this.#handleRegistryUpdate();
+    }
   }
 
   /**

--- a/packages/snaps-controllers/src/snaps/registry/SnapRegistryController-method-action-types.ts
+++ b/packages/snaps-controllers/src/snaps/registry/SnapRegistryController-method-action-types.ts
@@ -9,8 +9,6 @@ import type { SnapRegistryController } from './SnapRegistryController';
  * Triggers an update of the registry database.
  *
  * If an existing update is in progress this function will await that update.
- *
- * @returns True if an update was performed, otherwise false.
  */
 export type SnapRegistryControllerRequestUpdateAction = {
   type: `SnapRegistryController:requestUpdate`;

--- a/packages/snaps-controllers/src/snaps/registry/SnapRegistryController-method-action-types.ts
+++ b/packages/snaps-controllers/src/snaps/registry/SnapRegistryController-method-action-types.ts
@@ -9,6 +9,8 @@ import type { SnapRegistryController } from './SnapRegistryController';
  * Triggers an update of the registry database.
  *
  * If an existing update is in progress this function will await that update.
+ *
+ * @returns True if an update was performed, otherwise false.
  */
 export type SnapRegistryControllerRequestUpdateAction = {
   type: `SnapRegistryController:requestUpdate`;

--- a/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.ts
+++ b/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.ts
@@ -122,7 +122,7 @@ export class SnapRegistryController extends BaseController<
 
   readonly #refetchOnAllowlistMiss: boolean;
 
-  #currentUpdate: Promise<void> | null;
+  #currentUpdate: Promise<boolean> | null;
 
   constructor({
     messenger,
@@ -196,30 +196,34 @@ export class SnapRegistryController extends BaseController<
    * Triggers an update of the registry database.
    *
    * If an existing update is in progress this function will await that update.
+   *
+   * @returns True if an update was performed, otherwise false.
    */
-  async requestUpdate() {
+  async requestUpdate(): Promise<boolean> {
     // If an update is ongoing, wait for that.
     if (this.#currentUpdate) {
-      await this.#currentUpdate;
-      return;
+      return await this.#currentUpdate;
     }
     // If no update exists, create promise and store globally.
     if (this.#currentUpdate === null) {
       this.#currentUpdate = this.#update();
     }
-    await this.#currentUpdate;
+    const result = await this.#currentUpdate;
     this.#currentUpdate = null;
+    return result;
   }
 
   /**
    * Updates the registry database if the registry hasn't been updated recently.
    *
    * NOTE: SHOULD NOT be called directly, instead `triggerUpdate` should be used.
+   *
+   * @returns True if an update was performed, otherwise false.
    */
-  async #update() {
+  async #update(): Promise<boolean> {
     // No-op if we recently fetched the registry.
     if (this.#wasRecentlyFetched()) {
-      return;
+      return false;
     }
 
     try {
@@ -236,7 +240,7 @@ export class SnapRegistryController extends BaseController<
           state.lastUpdated = Date.now();
           state.databaseUnavailable = false;
         });
-        return;
+        return false;
       }
 
       await this.#verifySignature(database, signatureJson);
@@ -247,11 +251,14 @@ export class SnapRegistryController extends BaseController<
         state.databaseUnavailable = false;
         state.signature = signatureJson.signature;
       });
+
+      return true;
     } catch {
       // Ignore
       this.update((state) => {
         state.databaseUnavailable = true;
       });
+      return false;
     }
   }
 

--- a/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.ts
+++ b/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.ts
@@ -73,8 +73,14 @@ export type SnapRegistryControllerStateChangeEvent = ControllerStateChangeEvent<
   SnapRegistryControllerState
 >;
 
+export type SnapRegistryControllerRegistryUpdatedEvent = {
+  type: `${typeof controllerName}:registryUpdated`;
+  payload: [databaseUpdated: boolean];
+};
+
 export type SnapRegistryControllerEvents =
-  SnapRegistryControllerStateChangeEvent;
+  | SnapRegistryControllerStateChangeEvent
+  | SnapRegistryControllerRegistryUpdatedEvent;
 
 export type SnapRegistryControllerMessenger = Messenger<
   typeof controllerName,
@@ -122,7 +128,7 @@ export class SnapRegistryController extends BaseController<
 
   readonly #refetchOnAllowlistMiss: boolean;
 
-  #currentUpdate: Promise<boolean> | null;
+  #currentUpdate: Promise<void> | null;
 
   constructor({
     messenger,
@@ -196,34 +202,31 @@ export class SnapRegistryController extends BaseController<
    * Triggers an update of the registry database.
    *
    * If an existing update is in progress this function will await that update.
-   *
-   * @returns True if an update was performed, otherwise false.
    */
-  async requestUpdate(): Promise<boolean> {
+  async requestUpdate() {
     // If an update is ongoing, wait for that.
     if (this.#currentUpdate) {
-      return await this.#currentUpdate;
+      await this.#currentUpdate;
+      return;
     }
     // If no update exists, create promise and store globally.
     if (this.#currentUpdate === null) {
       this.#currentUpdate = this.#update();
     }
-    const result = await this.#currentUpdate;
+    await this.#currentUpdate;
     this.#currentUpdate = null;
-    return result;
   }
 
   /**
    * Updates the registry database if the registry hasn't been updated recently.
    *
    * NOTE: SHOULD NOT be called directly, instead `triggerUpdate` should be used.
-   *
-   * @returns True if an update was performed, otherwise false.
    */
-  async #update(): Promise<boolean> {
+  async #update() {
     // No-op if we recently fetched the registry.
     if (this.#wasRecentlyFetched()) {
-      return false;
+      this.messenger.publish('SnapRegistryController:registryUpdated', false);
+      return;
     }
 
     try {
@@ -240,7 +243,8 @@ export class SnapRegistryController extends BaseController<
           state.lastUpdated = Date.now();
           state.databaseUnavailable = false;
         });
-        return false;
+        this.messenger.publish('SnapRegistryController:registryUpdated', false);
+        return;
       }
 
       await this.#verifySignature(database, signatureJson);
@@ -252,13 +256,13 @@ export class SnapRegistryController extends BaseController<
         state.signature = signatureJson.signature;
       });
 
-      return true;
+      this.messenger.publish('SnapRegistryController:registryUpdated', true);
     } catch {
       // Ignore
       this.update((state) => {
         state.databaseUnavailable = true;
       });
-      return false;
+      this.messenger.publish('SnapRegistryController:registryUpdated', false);
     }
   }
 

--- a/packages/snaps-controllers/src/snaps/registry/index.ts
+++ b/packages/snaps-controllers/src/snaps/registry/index.ts
@@ -6,6 +6,7 @@ export type {
   SnapRegistryControllerMessenger,
   SnapRegistryControllerState,
   SnapRegistryControllerStateChangeEvent,
+  SnapRegistryControllerRegistryUpdatedEvent,
 } from './SnapRegistryController';
 export { SnapRegistryController } from './SnapRegistryController';
 export type {

--- a/packages/snaps-controllers/src/test-utils/controller.tsx
+++ b/packages/snaps-controllers/src/test-utils/controller.tsx
@@ -509,7 +509,7 @@ export const getSnapControllerMessenger = (
       'ExecutionService:outboundRequest',
       'ExecutionService:outboundResponse',
       'KeyringController:lock',
-      'SnapRegistryController:stateChange',
+      'SnapRegistryController:registryUpdated',
     ],
     messenger: snapControllerMessenger,
   });

--- a/packages/snaps-controllers/src/test-utils/registry.ts
+++ b/packages/snaps-controllers/src/test-utils/registry.ts
@@ -57,5 +57,6 @@ export class MockSnapRegistryController {
       },
       [],
     );
+    return true;
   });
 }

--- a/packages/snaps-controllers/src/test-utils/registry.ts
+++ b/packages/snaps-controllers/src/test-utils/registry.ts
@@ -57,6 +57,6 @@ export class MockSnapRegistryController {
       },
       [],
     );
-    return true;
+    this.#messenger.publish('SnapRegistryController:registryUpdated', true);
   });
 }


### PR DESCRIPTION
Always consume latest registry in `updateRegistry` in an effort to provide a way to retry failed OTA updates without requiring a registry update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the event contract between `SnapRegistryController` and `SnapController`, which affects when preinstalled Snap auto-updates and block/unblock checks run. Risk is moderate because it can alter update frequency/behavior even when the registry database is unchanged or fetch is skipped.
> 
> **Overview**
> `SnapController` now reacts to a new `SnapRegistryController:registryUpdated` event instead of `stateChange`-filtering on `database`, ensuring `#handleRegistryUpdate` runs even when the registry fetch is skipped (recently fetched), the signature is unchanged, or an update fails.
> 
> `SnapRegistryController` publishes `registryUpdated` with a `databaseUpdated` boolean on all update paths, and tests/tooling are updated accordingly, including a new test that verifies preinstalled Snap OTA updates can be retried when the registry database itself did not update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 621a01af918b98f0753a236c438948e8916bd925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->