### PR TITLE
fix: Do not emit `:registryUpdated` on failure

### DIFF
--- a/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.ts
+++ b/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.ts
@@ -262,7 +262,6 @@ export class SnapRegistryController extends BaseController<
       this.update((state) => {
         state.databaseUnavailable = true;
       });
-      this.messenger.publish('SnapRegistryController:registryUpdated', false);
     }
   }
 


### PR DESCRIPTION
BugBot indicated that my previous PR had a infinite loop in case of the registry failure state: https://github.com/MetaMask/snaps/pull/3948#discussion_r3058958333

We do not need to emit `:registryUpdated` on failure, which should fix this problem.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small behavioral change to event emission that only affects failure paths, reducing the chance of update-trigger loops when the registry is unavailable.
> 
> **Overview**
> Prevents `SnapRegistryController` from publishing the `SnapRegistryController:registryUpdated` event when `#update()` fails (e.g., fetch/verify errors), while still marking `databaseUnavailable` in state.
> 
> Successful updates and no-op updates (recent fetch or unchanged signature) continue to emit `:registryUpdated` as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8af7c863c91dd3ae3eb2d782c6cad7ba04145e38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->