### PR TITLE
feat: Add `CollapsibleSection`

### DIFF
--- a/packages/snaps-rpc-methods/src/permitted/createInterface.test.tsx
+++ b/packages/snaps-rpc-methods/src/permitted/createInterface.test.tsx
@@ -195,7 +195,7 @@ describe('snap_createInterface', () => {
       error: {
         code: -32602,
         message:
-          'Invalid params: At path: ui -- Expected type to be one of: "AccountSelector", "Address", "AssetSelector", "AddressInput", "Bold", "Box", "Button", "Copyable", "DateTimePicker", "Divider", "Dropdown", "RadioGroup", "Field", "FileInput", "Form", "Heading", "Input", "Image", "Italic", "Link", "Row", "Spinner", "Text", "Tooltip", "Checkbox", "Card", "Icon", "Selector", "Section", "Avatar", "Banner", "Skeleton", "Container", but received: undefined.',
+          'Invalid params: At path: ui -- Expected type to be one of: "AccountSelector", "Address", "AssetSelector", "AddressInput", "Bold", "Box", "Button", "Copyable", "DateTimePicker", "Divider", "Dropdown", "RadioGroup", "Field", "FileInput", "Form", "Heading", "Input", "Image", "Italic", "Link", "Row", "Spinner", "Text", "Tooltip", "Checkbox", "Card", "Icon", "Selector", "Section", "Avatar", "Banner", "Skeleton", "CollapsibleSection", "Container", but received: undefined.',
         stack: expect.any(String),
       },
       id: 1,

--- a/packages/snaps-sdk/src/jsx/components/CollapsibleSection.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/CollapsibleSection.test.tsx
@@ -1,0 +1,125 @@
+import { Address } from './Address';
+import { CollapsibleSection } from './CollapsibleSection';
+import { Row } from './Row';
+import { Text } from './Text';
+
+describe('CollapsibleSection', () => {
+  it('renders a collapsible section', () => {
+    const result = (
+      <CollapsibleSection label="Details">
+        <Text>Hello</Text>
+      </CollapsibleSection>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'CollapsibleSection',
+      key: null,
+      props: {
+        label: 'Details',
+        children: {
+          type: 'Text',
+          key: null,
+          props: {
+            children: 'Hello',
+          },
+        },
+      },
+    });
+  });
+
+  it('renders a collapsible section with multiple children', () => {
+    const result = (
+      <CollapsibleSection label="Transaction details">
+        <Row label="From">
+          <Address address="0x1234567890123456789012345678901234567890" />
+        </Row>
+        <Row
+          label="To"
+          variant="warning"
+          tooltip="This address has been deemed dangerous."
+        >
+          <Address address="0x0000000000000000000000000000000000000000" />
+        </Row>
+      </CollapsibleSection>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'CollapsibleSection',
+      key: null,
+      props: {
+        label: 'Transaction details',
+        children: [
+          {
+            type: 'Row',
+            key: null,
+            props: {
+              label: 'From',
+              children: {
+                type: 'Address',
+                key: null,
+                props: {
+                  address: '0x1234567890123456789012345678901234567890',
+                },
+              },
+            },
+          },
+          {
+            type: 'Row',
+            key: null,
+            props: {
+              label: 'To',
+              tooltip: 'This address has been deemed dangerous.',
+              variant: 'warning',
+              children: {
+                type: 'Address',
+                key: null,
+                props: {
+                  address: '0x0000000000000000000000000000000000000000',
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('renders a collapsible section with props', () => {
+    const result = (
+      <CollapsibleSection
+        label="Details"
+        direction="horizontal"
+        alignment="space-between"
+      >
+        <Text>Hello</Text>
+        <Text>World</Text>
+      </CollapsibleSection>
+    );
+
+    expect(result).toStrictEqual({
+      type: 'CollapsibleSection',
+      key: null,
+      props: {
+        label: 'Details',
+        direction: 'horizontal',
+        alignment: 'space-between',
+        children: [
+          {
+            type: 'Text',
+            key: null,
+            props: {
+              children: 'Hello',
+            },
+          },
+          {
+            type: 'Text',
+            key: null,
+            props: {
+              children: 'World',
+            },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/snaps-sdk/src/jsx/components/CollapsibleSection.test.tsx
+++ b/packages/snaps-sdk/src/jsx/components/CollapsibleSection.test.tsx
@@ -90,6 +90,8 @@ describe('CollapsibleSection', () => {
         label="Details"
         direction="horizontal"
         alignment="space-between"
+        isLoading={false}
+        isExpanded={true}
       >
         <Text>Hello</Text>
         <Text>World</Text>
@@ -103,6 +105,8 @@ describe('CollapsibleSection', () => {
         label: 'Details',
         direction: 'horizontal',
         alignment: 'space-between',
+        isExpanded: true,
+        isLoading: false,
         children: [
           {
             type: 'Text',

--- a/packages/snaps-sdk/src/jsx/components/CollapsibleSection.ts
+++ b/packages/snaps-sdk/src/jsx/components/CollapsibleSection.ts
@@ -6,6 +6,8 @@ import { createSnapComponent } from '../component';
  *
  * @property children - The children of the collapsible section.
  * @property label - The label of the collapsible section.
+ * @property isLoading - Whether the section is still loading.
+ * @property isExpanded - Whether the section should start expanded.
  * @property direction - The direction to stack the components within the section. Defaults to `vertical`.
  * @property alignment - The alignment mode to use within the section. Defaults to `start`.
  * @category Component Props
@@ -14,6 +16,8 @@ export type CollapsibleSectionProps = {
   // We can't use `JSXElement` because it causes a circular reference.
   children: SnapsChildren<GenericSnapElement>;
   label: string;
+  isLoading?: boolean;
+  isExpanded?: boolean;
   direction?: 'vertical' | 'horizontal' | undefined;
   alignment?:
     | 'start'

--- a/packages/snaps-sdk/src/jsx/components/CollapsibleSection.ts
+++ b/packages/snaps-sdk/src/jsx/components/CollapsibleSection.ts
@@ -2,16 +2,18 @@ import type { GenericSnapElement, SnapsChildren } from '../component';
 import { createSnapComponent } from '../component';
 
 /**
- * The props of the {@link Section} component.
+ * The props of the {@link CollapsibleSection} component.
  *
- * @property children - The children of the section.
+ * @property children - The children of the collapsible section.
+ * @property label - The label of the collapsible section.
  * @property direction - The direction to stack the components within the section. Defaults to `vertical`.
  * @property alignment - The alignment mode to use within the section. Defaults to `start`.
  * @category Component Props
  */
-export type SectionProps = {
+export type CollapsibleSectionProps = {
   // We can't use `JSXElement` because it causes a circular reference.
   children: SnapsChildren<GenericSnapElement>;
+  label: string;
   direction?: 'vertical' | 'horizontal' | undefined;
   alignment?:
     | 'start'
@@ -22,34 +24,38 @@ export type SectionProps = {
     | undefined;
 };
 
-const TYPE = 'Section';
+const TYPE = 'CollapsibleSection';
 
 /**
- * A section component, which is used to group multiple components together.
- * The component itself is 16px padded with a default background and a border radius of 8px.
+ * A collapsible section component, which is used to group multiple components
+ * together with a label. The section can be expanded or collapsed by the user.
  *
  * @param props - The props of the component.
- * @param props.children - The children of the section.
+ * @param props.children - The children of the collapsible section.
+ * @param props.label - The label of the collapsible section.
  * @param props.direction - The direction that the children are aligned.
  * @param props.alignment - The alignment of the children (a justify-content value).
- * @returns A section element.
+ * @returns A collapsible section element.
  * @example
- * <Section>
+ * <CollapsibleSection label="Transaction details">
  *   <Row label="From">
  *     <Address address="0x1234567890123456789012345678901234567890" />
  *   </Row>
  *   <Row label="To" variant="warning" tooltip="This address has been deemed dangerous.">
  *     <Address address="0x0000000000000000000000000000000000000000" />
  *   </Row>
- * </Section>
+ * </CollapsibleSection>
  * @category Components
  */
-export const Section = createSnapComponent<SectionProps, typeof TYPE>(TYPE);
+export const CollapsibleSection = createSnapComponent<
+  CollapsibleSectionProps,
+  typeof TYPE
+>(TYPE);
 
 /**
- * A section element.
+ * A collapsible section element.
  *
- * @see {@link Section}
+ * @see {@link CollapsibleSection}
  * @category Elements
  */
-export type SectionElement = ReturnType<typeof Section>;
+export type CollapsibleSectionElement = ReturnType<typeof CollapsibleSection>;

--- a/packages/snaps-sdk/src/jsx/components/index.ts
+++ b/packages/snaps-sdk/src/jsx/components/index.ts
@@ -3,6 +3,7 @@ import type { AvatarElement } from './Avatar';
 import type { BannerElement } from './Banner';
 import type { BoxElement } from './Box';
 import type { CardElement } from './Card';
+import type { CollapsibleSectionElement } from './CollapsibleSection';
 import type { ContainerElement } from './Container';
 import type { CopyableElement } from './Copyable';
 import type { DividerElement } from './Divider';
@@ -27,6 +28,7 @@ export * from './Address';
 export * from './Avatar';
 export * from './Box';
 export * from './Card';
+export * from './CollapsibleSection';
 export * from './Copyable';
 export * from './Divider';
 export * from './Value';
@@ -66,6 +68,7 @@ export type JSXElement =
   | LinkElement
   | RowElement
   | SectionElement
+  | CollapsibleSectionElement
   | SpinnerElement
   | TextElement
   | TooltipElement

--- a/packages/snaps-sdk/src/jsx/validation.test.tsx
+++ b/packages/snaps-sdk/src/jsx/validation.test.tsx
@@ -39,6 +39,7 @@ import {
   AddressInput,
   AccountSelector,
   DateTimePicker,
+  CollapsibleSection,
 } from './components';
 import {
   AddressStruct,
@@ -82,6 +83,7 @@ import {
   AddressInputStruct,
   AccountSelectorStruct,
   DateTimePickerStruct,
+  CollapsibleSectionStruct,
 } from './validation';
 
 describe('KeyStruct', () => {
@@ -1663,6 +1665,77 @@ describe('SectionStruct', () => {
     </Section>,
   ])('does not validate "%p"', (value) => {
     expect(is(value, SectionStruct)).toBe(false);
+  });
+});
+
+describe('CollapsibleSectionStruct', () => {
+  it.each([
+    <CollapsibleSection label="Details">
+      <Box>
+        <Text>Hello world!</Text>
+      </Box>
+    </CollapsibleSection>,
+    <CollapsibleSection label="Transaction details">
+      <Row label="From">
+        <Address address="0x1234567890123456789012345678901234567890" />
+      </Row>
+      <Row
+        label="To"
+        variant="warning"
+        tooltip="This address has been deemed dangerous."
+      >
+        <Address address="0x0000000000000000000000000000000000000000" />
+      </Row>
+    </CollapsibleSection>,
+    <CollapsibleSection
+      label="Details"
+      direction="horizontal"
+      alignment="space-between"
+    >
+      <Text>foo</Text>
+      <Row label="label">
+        <Image src="<svg />" alt="alt" />
+      </Row>
+    </CollapsibleSection>,
+    <CollapsibleSection label="Details" direction="horizontal">
+      <Text>foo</Text>
+      <Row label="label">
+        <Image src="<svg />" alt="alt" />
+      </Row>
+    </CollapsibleSection>,
+  ])('validates a collapsible section element', (value) => {
+    expect(is(value, CollapsibleSectionStruct)).toBe(true);
+  });
+
+  it.each([
+    'foo',
+    42,
+    null,
+    undefined,
+    {},
+    [],
+    // @ts-expect-error - Invalid props.
+    <CollapsibleSection />,
+    // @ts-expect-error - Invalid props.
+    <CollapsibleSection label="Details" />,
+    // @ts-expect-error - Invalid props.
+    <CollapsibleSection label="Details"></CollapsibleSection>,
+    // @ts-expect-error - Missing label.
+    <CollapsibleSection>
+      <Text>foo</Text>
+    </CollapsibleSection>,
+    <Text>foo</Text>,
+    <Box>
+      <Text>foo</Text>
+    </Box>,
+    // @ts-expect-error - Invalid props.
+    <CollapsibleSection label="Details" direction="diagonal">
+      <Box>
+        <Text>Hello world!</Text>
+      </Box>
+    </CollapsibleSection>,
+  ])('does not validate "%p"', (value) => {
+    expect(is(value, CollapsibleSectionStruct)).toBe(false);
   });
 });
 

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -776,6 +776,8 @@ export const CollapsibleSectionStruct: Describe<CollapsibleSectionElement> =
   element('CollapsibleSection', {
     children: BoxChildrenStruct,
     label: string(),
+    isLoading: optional(boolean()),
+    isExpanded: optional(boolean()),
     direction: optional(
       nullUnion([literal('horizontal'), literal('vertical')]),
     ),

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -1039,10 +1039,10 @@ export const BoxChildStruct = typedUnion([
   IconStruct,
   SelectorStruct,
   SectionStruct,
-  CollapsibleSectionStruct,
   AvatarStruct,
   BannerStruct,
   SkeletonStruct,
+  CollapsibleSectionStruct,
 ]);
 
 /**
@@ -1114,10 +1114,10 @@ export const JSXElementStruct: Describe<JSXElement> = typedUnion([
   SelectorStruct,
   SelectorOptionStruct,
   SectionStruct,
-  CollapsibleSectionStruct,
   AvatarStruct,
   BannerStruct,
   SkeletonStruct,
+  CollapsibleSectionStruct,
 ]);
 
 /**

--- a/packages/snaps-sdk/src/jsx/validation.ts
+++ b/packages/snaps-sdk/src/jsx/validation.ts
@@ -81,6 +81,7 @@ import type {
   SelectorOptionElement,
   BannerElement,
   DateTimePickerElement,
+  CollapsibleSectionElement,
 } from './components';
 import { IconName } from './components';
 import type { Describe } from '../internals';
@@ -769,6 +770,27 @@ export const SectionStruct: Describe<SectionElement> = element('Section', {
 });
 
 /**
+ * A struct for the {@link CollapsibleSectionElement} type.
+ */
+export const CollapsibleSectionStruct: Describe<CollapsibleSectionElement> =
+  element('CollapsibleSection', {
+    children: BoxChildrenStruct,
+    label: string(),
+    direction: optional(
+      nullUnion([literal('horizontal'), literal('vertical')]),
+    ),
+    alignment: optional(
+      nullUnion([
+        literal('start'),
+        literal('center'),
+        literal('end'),
+        literal('space-between'),
+        literal('space-around'),
+      ]),
+    ),
+  });
+
+/**
  * A subset of JSX elements that are allowed as children of the Footer component.
  * This set should include a single button or a tuple of two buttons.
  */
@@ -1017,6 +1039,7 @@ export const BoxChildStruct = typedUnion([
   IconStruct,
   SelectorStruct,
   SectionStruct,
+  CollapsibleSectionStruct,
   AvatarStruct,
   BannerStruct,
   SkeletonStruct,
@@ -1091,6 +1114,7 @@ export const JSXElementStruct: Describe<JSXElement> = typedUnion([
   SelectorStruct,
   SelectorOptionStruct,
   SectionStruct,
+  CollapsibleSectionStruct,
   AvatarStruct,
   BannerStruct,
   SkeletonStruct,


### PR DESCRIPTION
Add `CollapsibleSection` component, including structs, types etc.

https://consensyssoftware.atlassian.net/browse/WPC-959

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new JSX element and wires it into core UI validation/allowed-element unions, which could affect interface creation/validation behavior and error messaging across Snaps UIs.
> 
> **Overview**
> Adds a new `CollapsibleSection` JSX component (with `label`, optional `isLoading`/`isExpanded`, and layout props) and exports it as a first-class Snaps UI element.
> 
> Updates JSX validation to recognize and validate `CollapsibleSection` (including adding it to root/box child unions), adds component/struct test coverage, and adjusts the `snap_createInterface` invalid-param test expectation to include the new allowed UI type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7097d3e7a26e1006d5af0aceda829b0f5e31d39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->