### PR TITLE
fix: Allow name-lookup example to resolve on multiple chains

### DIFF
--- a/packages/examples/packages/name-lookup/snap.manifest.json
+++ b/packages/examples/packages/name-lookup/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps.git"
   },
   "source": {
-    "shasum": "eNNeBNRqhKFwcAgxdkh4mFheK12KAxGm6dAoZbbnIdg=",
+    "shasum": "kn9PU2TBgBl7A4Glo7QKDtjOm7avOJ9RBNSDPjNWdog=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -18,7 +18,7 @@
   },
   "initialPermissions": {
     "endowment:name-lookup": {
-      "chains": ["eip155:1"]
+      "chains": ["eip155:1", "eip155:1337", "eip155:11155111"]
     }
   },
   "platformVersion": "11.0.0",


### PR DESCRIPTION
Allow name-lookup example Snap to resolve on Sepolia and the `1337` local chain used for E2E. This eases testing with it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only change that expands the allowed `endowment:name-lookup` chain IDs for an example Snap; low risk aside from potentially affecting which networks the snap can resolve names on.
> 
> **Overview**
> Updates the name-lookup example Snap manifest to allow `endowment:name-lookup` resolution on additional chains by expanding `chains` from mainnet-only to include *local E2E (`eip155:1337`)* and *Sepolia (`eip155:11155111`)*.
> 
> Also updates the snap `source.shasum` to match the new bundled output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 129a18bd05bdaa123e25d1eff4123d4cc3e398c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->