### PR TITLE
fix: Make `KeyringOrigin` caveat explicitly optional

### DIFF
--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -10,7 +10,7 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 96.66,
+      branches: 96.68,
       functions: 99.2,
       lines: 99.06,
       statements: 98.78,

--- a/packages/snaps-rpc-methods/src/endowments/keyring.test.ts
+++ b/packages/snaps-rpc-methods/src/endowments/keyring.test.ts
@@ -30,15 +30,8 @@ describe('endowment:keyring', () => {
   });
 
   describe('validator', () => {
-    it('throws if the caveat is not a single "keyringOrigin"', () => {
+    it('throws if the caveats are invalid', () => {
       const specification = keyringEndowmentBuilder.specificationBuilder({});
-
-      expect(() =>
-        specification.validator({
-          // @ts-expect-error Missing other required permission types.
-          caveats: undefined,
-        }),
-      ).toThrow('Expected the following caveats: "keyringOrigin".');
 
       expect(() =>
         // @ts-expect-error Missing other required permission types.
@@ -147,13 +140,13 @@ describe('getKeyringCaveatOrigins', () => {
     ).toStrictEqual({ allowedOrigins: ['foo.com'] });
   });
 
-  it('throws if there is no "keyringOrigin" caveat', () => {
-    expect(() =>
+  it('returns an empty array when no origins are provided', () => {
+    expect(
       // @ts-expect-error Missing other required permission types.
       getKeyringCaveatOrigins({
-        caveats: [{ type: 'foo', value: 'bar' }],
+        caveats: null,
       }),
-    ).toThrow('Assertion failed.');
+    ).toStrictEqual({ allowedOrigins: [] });
   });
 });
 

--- a/packages/snaps-rpc-methods/src/endowments/keyring.ts
+++ b/packages/snaps-rpc-methods/src/endowments/keyring.ts
@@ -145,8 +145,6 @@ export function getKeyringCaveatMapper(
  *
  * @param permission - The permission to get the caveat value from.
  * @returns The caveat value.
- * @throws If the permission does not have a valid {@link KeyringOrigins}
- * caveat.
  */
 export function getKeyringCaveatOrigins(
   permission?: PermissionConstraint,

--- a/packages/snaps-rpc-methods/src/endowments/keyring.ts
+++ b/packages/snaps-rpc-methods/src/endowments/keyring.ts
@@ -20,7 +20,7 @@ import {
   SnapCaveatType,
 } from '@metamask/snaps-utils';
 import type { Json, NonEmptyArray } from '@metamask/utils';
-import { assert, hasProperty, isObject, isPlainObject } from '@metamask/utils';
+import { hasProperty, isObject, isPlainObject } from '@metamask/utils';
 
 import { createGenericPermissionValidator } from './caveats';
 import { SnapEndowments } from './enum';
@@ -58,7 +58,7 @@ const specificationBuilder: PermissionSpecificationBuilder<
     ],
     endowmentGetter: (_getterOptions?: EndowmentGetterParams) => null,
     validator: createGenericPermissionValidator([
-      { type: SnapCaveatType.KeyringOrigin },
+      { type: SnapCaveatType.KeyringOrigin, optional: true },
       { type: SnapCaveatType.KeyringCapabilities, optional: true },
       { type: SnapCaveatType.MaxRequestTime, optional: true },
     ]),
@@ -155,8 +155,7 @@ export function getKeyringCaveatOrigins(
     (permCaveat) => permCaveat.type === SnapCaveatType.KeyringOrigin,
   ) as Caveat<string, KeyringOrigins> | undefined;
 
-  assert(caveat);
-  return caveat.value;
+  return caveat?.value ?? { allowedOrigins: [] };
 }
 
 /**


### PR DESCRIPTION
Unintentional or not, `endowment:keyring` has since its implementation allowed no caveats to be passed until https://github.com/MetaMask/snaps/commit/79e8b90ee704f50382d991d78b7ec2fd6f6944e6. This was caused by the caveat mapper constructing the caveat with an empty object as the `value`, which is valid according to our validation: https://github.com/MetaMask/snaps-skunkworks/blob/fb/keyring-origins-optional/packages/snaps-utils/src/json-rpc.ts#L77

The Bitcoin Snap used in production specifies `endowment:keyring: {}` in its manifest.

This PR makes the permission validation explicit in making `KeyringOrigin` optional, including adding a fallback in `getKeyringCaveatOrigins`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts permission validation and defaults for the security-adjacent `endowment:keyring` caveats; incorrect optionality or fallback behavior could inadvertently widen allowed origins if downstream assumes the caveat is always present.
> 
> **Overview**
> Makes `endowment:keyring` permission validation explicitly treat the `keyringOrigin` caveat as *optional* (matching other keyring caveats), rather than requiring it to be present.
> 
> Updates `getKeyringCaveatOrigins` to **gracefully default** to `{ allowedOrigins: [] }` when the caveat (or caveats list) is missing, and aligns tests/coverage thresholds with the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ca964e4160dc040d69bf159d7a3f857f084da92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->