### PR TITLE
ci: Error if no files found when uploading source artifacts

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           name: snaps-execution-environments-build-${{ runner.os }}-${{ matrix.node-version }}-${{ github.sha }}
           retention-days: 1
+          if-no-files-found: error
           path: |
             .nvmrc
             packages/snaps-execution-environments/dist/webpack
@@ -63,6 +64,7 @@ jobs:
         with:
           name: build-source-${{ runner.os }}-${{ github.sha }}
           retention-days: 1
+          if-no-files-found: error
           path: |
             .nvmrc
             packages/*/dist

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -74,6 +74,7 @@ jobs:
           name: publish-release-artifacts-${{ github.sha }}
           include-hidden-files: true
           retention-days: 4
+          if-no-files-found: error
           path: |
             ./packages/**/dist
             ./node_modules/.yarn-state.yml


### PR DESCRIPTION
We don't want to proceed with the next CI tasks if we cannot upload the artifacts required for them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens CI/release behavior by failing jobs when expected artifacts aren’t produced, which could surface previously hidden build issues and block downstream steps.
> 
> **Overview**
> Ensures CI stops early if required build outputs aren’t present by setting `if-no-files-found: error` on key `actions/upload-artifact` steps.
> 
> This makes the `build-lint-test` workflow fail when it can’t upload the `snaps-execution-environments` build or overall `build-source` artifacts, and makes `publish-release` fail if release build artifacts aren’t generated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b68b382624bf49a4fa8e3832d0912f6924c7326. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->