### PR TITLE
fix: Skip refetching the registry in `handleRegistryUpdate`

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.tsx
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.tsx
@@ -10515,16 +10515,19 @@ describe('SnapController', () => {
       await snapController.updateRegistry();
 
       // Ensure that CheckSnapBlockListArg is correct
-      expect(registry.get).toHaveBeenCalledWith({
-        [mockSnapA.id]: {
-          version: mockSnapA.manifest.version,
-          checksum: mockSnapA.manifest.source.shasum,
+      expect(registry.get).toHaveBeenCalledWith(
+        {
+          [mockSnapA.id]: {
+            version: mockSnapA.manifest.version,
+            checksum: mockSnapA.manifest.source.shasum,
+          },
+          [mockSnapB.id]: {
+            version: mockSnapB.manifest.version,
+            checksum: mockSnapB.manifest.source.shasum,
+          },
         },
-        [mockSnapB.id]: {
-          version: mockSnapB.manifest.version,
-          checksum: mockSnapB.manifest.source.shasum,
-        },
-      });
+        true,
+      );
 
       // A is blocked and disabled
       expect(snapController.getSnap(mockSnapA.id)?.blocked).toBe(true);

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1496,6 +1496,7 @@ export class SnapController extends BaseController<
           const resolvedVersion = await this.#resolveAllowlistVersion(
             snap.id,
             preinstalledVersionRange,
+            true,
           );
 
           if (
@@ -3100,11 +3101,13 @@ export class SnapController extends BaseController<
   async #resolveAllowlistVersion(
     snapId: SnapId,
     versionRange: SemVerRange,
+    refetch = false,
   ): Promise<SemVerRange> {
     return await this.messenger.call(
       'SnapRegistryController:resolveVersion',
       snapId,
       versionRange,
+      refetch,
     );
   }
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -3101,13 +3101,13 @@ export class SnapController extends BaseController<
   async #resolveAllowlistVersion(
     snapId: SnapId,
     versionRange: SemVerRange,
-    refetch = false,
+    skipRefetch = false,
   ): Promise<SemVerRange> {
     return await this.messenger.call(
       'SnapRegistryController:resolveVersion',
       snapId,
       versionRange,
-      refetch,
+      skipRefetch,
     );
   }
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1471,6 +1471,7 @@ export class SnapController extends BaseController<
         },
         {},
       ),
+      true,
     );
 
     await Promise.all(

--- a/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.ts
+++ b/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.ts
@@ -321,11 +321,12 @@ export class SnapRegistryController extends BaseController<
 
   async get(
     snaps: SnapRegistryRequest,
+    skipRefetch = false,
   ): Promise<Record<string, SnapRegistryResult>> {
     return Object.entries(snaps).reduce<
       Promise<Record<string, SnapRegistryResult>>
     >(async (previousPromise, [snapId, snapInfo]) => {
-      const result = await this.#getSingle(snapId, snapInfo);
+      const result = await this.#getSingle(snapId, snapInfo, skipRefetch);
       const acc = await previousPromise;
       acc[snapId] = result;
       return acc;


### PR DESCRIPTION
Our tests didn't catch this, but in production, triggering `SnapRegistryController:registryUpdated` triggers `handleRegistryUpdate` which may try to refetch the registry and cause an infinite loop. We can fix this by passing a flag to not refetch the registry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes registry verification/version-resolution calls to optionally skip refetching, which could alter behavior on allowlist misses and impact snap blocking/auto-update flows if misused.
> 
> **Overview**
> Prevents an infinite update loop when handling `SnapRegistryController:registryUpdated` by ensuring `SnapController#handleRegistryUpdate` does not trigger a registry refetch during blocklist checks and preinstalled allowlist version resolution.
> 
> This adds a `skipRefetch` flag plumbed through `SnapRegistryController:get` and `SnapController#resolveAllowlistVersion` (forwarded to `SnapRegistryController:resolveVersion`), and updates the corresponding `SnapController` test to assert the new `get(..., true)` call signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0401daf9ea631f45acbc9b6ab4d098848dccca0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->