### PR TITLE
fix: Increase iframe unload timeout

### DIFF
--- a/packages/snaps-controllers/src/services/iframe/IframeExecutionService.ts
+++ b/packages/snaps-controllers/src/services/iframe/IframeExecutionService.ts
@@ -48,7 +48,7 @@ export class IframeExecutionService extends ExecutionService<Window> {
         iframe.addEventListener('load', () => resolve(), { once: true });
         iframe.src = 'about:blank';
       }),
-      10,
+      1_000,
     );
 
     iframe.remove();


### PR DESCRIPTION
Increase the iframe unload timeout significantly to prevent issues where the timeout would be too low and thus the workaround wouldn't be effective.

When testing this I've seen spikes up to 200ms, but mostly in the 10-50ms range. Though, we've decided to bump to a full second, since we don't expect to hit this often (if at all).

https://consensyssoftware.atlassian.net/browse/WPC-987

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single timeout constant is increased to reduce flaky iframe teardown; the main behavioral change is waiting longer before removing the iframe in edge cases.
> 
> **Overview**
> Increases the `withTimeout` duration used during `IframeExecutionService.terminateJob` teardown (waiting for the `about:blank` load) from `10`ms to `1_000`ms before removing the iframe, making unload/cleanup more reliable under slower load events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 747ccabf9236d3ebe189a62633b50a21318206ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->