### PR TITLE
fix: Stop relying on account metadata for `MultichainRoutingService`

### DIFF
--- a/packages/snaps-controllers/src/multichain/MultichainRoutingService.test.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRoutingService.test.ts
@@ -38,6 +38,13 @@ describe('MultichainRoutingService', () => {
       });
 
       rootMessenger.registerActionHandler(
+        'SnapController:getRunnableSnaps',
+        () => {
+          return [getTruncatedSnap()];
+        },
+      );
+
+      rootMessenger.registerActionHandler(
         'AccountsController:listMultichainAccounts',
         () => MOCK_BTC_ACCOUNTS,
       );
@@ -91,6 +98,13 @@ describe('MultichainRoutingService', () => {
       });
 
       rootMessenger.registerActionHandler(
+        'SnapController:getRunnableSnaps',
+        () => {
+          return [getTruncatedSnap()];
+        },
+      );
+
+      rootMessenger.registerActionHandler(
         'AccountsController:listMultichainAccounts',
         () => MOCK_SOLANA_ACCOUNTS,
       );
@@ -141,6 +155,13 @@ describe('MultichainRoutingService', () => {
         messenger,
         withSnapKeyring,
       });
+
+      rootMessenger.registerActionHandler(
+        'SnapController:getRunnableSnaps',
+        () => {
+          return [getTruncatedSnap()];
+        },
+      );
 
       rootMessenger.registerActionHandler(
         'AccountsController:listMultichainAccounts',
@@ -231,7 +252,7 @@ describe('MultichainRoutingService', () => {
       });
 
       expect(messenger.call).toHaveBeenNthCalledWith(
-        5,
+        6,
         'SnapController:handleRequest',
         {
           snapId: MOCK_SNAP_ID,
@@ -303,6 +324,13 @@ describe('MultichainRoutingService', () => {
       });
 
       rootMessenger.registerActionHandler(
+        'SnapController:getRunnableSnaps',
+        () => {
+          return [getTruncatedSnap()];
+        },
+      );
+
+      rootMessenger.registerActionHandler(
         'SnapController:handleRequest',
         async ({ handler }) => {
           if (handler === HandlerType.OnKeyringRequest) {
@@ -351,6 +379,13 @@ describe('MultichainRoutingService', () => {
         messenger,
         withSnapKeyring,
       });
+
+      rootMessenger.registerActionHandler(
+        'SnapController:getRunnableSnaps',
+        () => {
+          return [getTruncatedSnap()];
+        },
+      );
 
       rootMessenger.registerActionHandler(
         'SnapController:handleRequest',
@@ -404,6 +439,13 @@ describe('MultichainRoutingService', () => {
         messenger,
         withSnapKeyring,
       });
+
+      rootMessenger.registerActionHandler(
+        'SnapController:getRunnableSnaps',
+        () => {
+          return [getTruncatedSnap()];
+        },
+      );
 
       rootMessenger.registerActionHandler(
         'SnapController:handleRequest',
@@ -575,6 +617,13 @@ describe('MultichainRoutingService', () => {
       rootMessenger.registerActionHandler(
         'AccountsController:listMultichainAccounts',
         () => MOCK_SOLANA_ACCOUNTS,
+      );
+
+      rootMessenger.registerActionHandler(
+        'SnapController:getRunnableSnaps',
+        () => {
+          return [getTruncatedSnap()];
+        },
       );
 
       expect(

--- a/packages/snaps-controllers/src/multichain/MultichainRoutingService.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRoutingService.ts
@@ -361,8 +361,7 @@ export class MultichainRoutingService {
         } =>
           account.metadata.snap?.id !== undefined &&
           runnableSnaps.includes(account.metadata.snap?.id) &&
-          ((method !== undefined && account.methods.includes(method)) ||
-            method === undefined),
+          (method === undefined || account.methods.includes(method)),
       );
   }
 

--- a/packages/snaps-controllers/src/multichain/MultichainRoutingService.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRoutingService.ts
@@ -166,17 +166,7 @@ export class MultichainRoutingService {
     scope: CaipChainId,
     request: JsonRpcRequest,
   ) {
-    const accounts = this.#messenger
-      .call('AccountsController:listMultichainAccounts', scope)
-      .filter(
-        (
-          account: InternalAccount,
-        ): account is InternalAccount & {
-          metadata: Required<InternalAccount['metadata']>;
-        } =>
-          Boolean(account.metadata.snap?.enabled) &&
-          account.methods.includes(request.method),
-      );
+    const accounts = this.#getSupportedAccountsMetadata(scope, request.method);
 
     // If no accounts can service the request, return null.
     if (accounts.length === 0) {
@@ -349,12 +339,31 @@ export class MultichainRoutingService {
    * Get a list of metadata for supported accounts for a given scope from the client.
    *
    * @param scope - The CAIP-2 scope.
+   * @param method - An optional method that the account should support.
    * @returns A list of metadata for the supported accounts.
    */
-  #getSupportedAccountsMetadata(scope: CaipChainId): InternalAccount[] {
+  #getSupportedAccountsMetadata(
+    scope: CaipChainId,
+    method?: string,
+  ): (InternalAccount & {
+    metadata: Required<InternalAccount['metadata']>;
+  })[] {
+    const runnableSnaps = this.#messenger
+      .call('SnapController:getRunnableSnaps')
+      .map((snap) => snap.id);
     return this.#messenger
       .call('AccountsController:listMultichainAccounts', scope)
-      .filter((account: InternalAccount) => account.metadata.snap?.enabled);
+      .filter(
+        (
+          account: InternalAccount,
+        ): account is InternalAccount & {
+          metadata: Required<InternalAccount['metadata']>;
+        } =>
+          account.metadata.snap?.id !== undefined &&
+          runnableSnaps.includes(account.metadata.snap?.id) &&
+          ((method !== undefined && account.methods.includes(method)) ||
+            method === undefined),
+      );
   }
 
   /**
@@ -395,10 +404,10 @@ export class MultichainRoutingService {
    * @returns True if the router can service the scope, otherwise false.
    */
   isSupportedScope(scope: CaipChainId): boolean {
-    const hasAccountSnap = this.#messenger
-      .call('AccountsController:listMultichainAccounts', scope)
-      .some((account: InternalAccount) => account.metadata.snap?.enabled);
     // We currently assume here that if one Snap exists that service the scope, we can service the scope generally.
-    return hasAccountSnap || this.#getProtocolSnaps(scope).length > 0;
+    return (
+      this.#getSupportedAccountsMetadata(scope).length > 0 ||
+      this.#getProtocolSnaps(scope).length > 0
+    );
   }
 }

--- a/packages/snaps-controllers/src/multichain/MultichainRoutingService.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRoutingService.ts
@@ -351,6 +351,7 @@ export class MultichainRoutingService {
     const runnableSnaps = this.#messenger
       .call('SnapController:getRunnableSnaps')
       .map((snap) => snap.id);
+
     return this.#messenger
       .call('AccountsController:listMultichainAccounts', scope)
       .filter(

--- a/packages/snaps-controllers/src/test-utils/multichain.ts
+++ b/packages/snaps-controllers/src/test-utils/multichain.ts
@@ -22,9 +22,7 @@ export const MOCK_BTC_ACCOUNTS = [
       lastSelected: 1729154128902,
       name: 'Bitcoin Account',
       snap: {
-        enabled: true,
         id: MOCK_SNAP_ID,
-        name: 'Bitcoin',
       },
     },
     methods: ['sendBitcoin'],
@@ -50,9 +48,7 @@ export const MOCK_SOLANA_ACCOUNTS = [
       lastSelected: 1729154128902,
       name: 'Solana Account',
       snap: {
-        enabled: true,
         id: MOCK_SNAP_ID,
-        name: 'Solana',
       },
     },
     methods: ['signAndSendTransaction'],

--- a/packages/snaps-utils/src/account.ts
+++ b/packages/snaps-utils/src/account.ts
@@ -15,7 +15,7 @@ export type InternalAccount = {
   scopes: CaipChainId[];
   metadata: {
     name: string;
-    snap?: { id: SnapId; enabled: boolean; name: string };
+    snap?: { id: SnapId };
   };
 };
 


### PR DESCRIPTION
Stop relying on `account.metadata.snap.enabled` for `MultichainRoutingService` as it is going away. Instead we can cross-check `getRunnableSnaps`.

While doing this fix I also managed to re-use `getSupportedAccountsMetadata` in more cases.

https://consensyssoftware.atlassian.net/browse/WPC-988

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes routing eligibility checks for account Snaps by cross-referencing `SnapController:getRunnableSnaps`, which could impact which accounts/methods are considered routable if Snap/account metadata is inconsistent. Touches request routing and scope support detection, so regressions would affect multichain RPC handling.
> 
> **Overview**
> Stops relying on `account.metadata.snap.enabled` (and other snap metadata fields) to decide whether an account Snap can service a request, and instead gates supported accounts by whether their `metadata.snap.id` appears in `SnapController:getRunnableSnaps`.
> 
> Refactors `MultichainRoutingService` to reuse `#getSupportedAccountsMetadata` for both request routing (`#getSnapAccountId`) and `isSupportedScope`, and extends it with an optional `method` filter.
> 
> Updates multichain test fixtures and `InternalAccount` typing to remove the deprecated `metadata.snap.enabled`/`name` fields, and adjusts tests to mock `SnapController:getRunnableSnaps` (including updated call ordering expectations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5425d0ddf0cbf768304f42511a2c3fa5458d352. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->