### PR TITLE
chore: Bump `@metamask/permission-controller` to `^13.0.0`

### DIFF
--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -88,7 +88,7 @@
     "@metamask/key-tree": "^10.1.1",
     "@metamask/messenger": "^1.2.0",
     "@metamask/object-multiplex": "^2.1.0",
-    "@metamask/permission-controller": "^12.3.0",
+    "@metamask/permission-controller": "^13.0.0",
     "@metamask/post-message-stream": "^10.0.0",
     "@metamask/rpc-errors": "^7.0.3",
     "@metamask/snaps-registry": "^4.0.0",

--- a/packages/snaps-rpc-methods/package.json
+++ b/packages/snaps-rpc-methods/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@metamask/key-tree": "^10.1.1",
-    "@metamask/permission-controller": "^12.3.0",
+    "@metamask/permission-controller": "^13.0.0",
     "@metamask/rpc-errors": "^7.0.3",
     "@metamask/snaps-sdk": "workspace:^",
     "@metamask/snaps-utils": "workspace:^",

--- a/packages/snaps-rpc-methods/src/permitted/cancelBackgroundEvent.ts
+++ b/packages/snaps-rpc-methods/src/permitted/cancelBackgroundEvent.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type {
   JsonRpcRequest,
@@ -11,6 +10,7 @@ import { StructError, create, object, string } from '@metamask/superstruct';
 import { type PendingJsonRpcResponse } from '@metamask/utils';
 
 import { SnapEndowments } from '../endowments';
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'snap_cancelBackgroundEvent';

--- a/packages/snaps-rpc-methods/src/permitted/clearState.ts
+++ b/packages/snaps-rpc-methods/src/permitted/clearState.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type { ClearStateParams, ClearStateResult } from '@metamask/snaps-sdk';
 import { type InferMatching } from '@metamask/snaps-utils';
@@ -13,6 +12,7 @@ import {
 import type { PendingJsonRpcResponse, JsonRpcRequest } from '@metamask/utils';
 
 import { manageStateBuilder } from '../restricted/manageState';
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'snap_clearState';

--- a/packages/snaps-rpc-methods/src/permitted/closeWebSocket.ts
+++ b/packages/snaps-rpc-methods/src/permitted/closeWebSocket.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type {
   JsonRpcRequest,
@@ -11,6 +10,7 @@ import { create, object, string, StructError } from '@metamask/superstruct';
 import type { PendingJsonRpcResponse } from '@metamask/utils';
 
 import { SnapEndowments } from '../endowments';
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'snap_closeWebSocket';

--- a/packages/snaps-rpc-methods/src/permitted/createInterface.ts
+++ b/packages/snaps-rpc-methods/src/permitted/createInterface.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type {
   CreateInterfaceParams,
@@ -17,6 +16,7 @@ import { type InferMatching } from '@metamask/snaps-utils';
 import { StructError, create, object, optional } from '@metamask/superstruct';
 import type { PendingJsonRpcResponse } from '@metamask/utils';
 
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 import { UI_PERMISSIONS } from '../utils';
 

--- a/packages/snaps-rpc-methods/src/permitted/endTrace.ts
+++ b/packages/snaps-rpc-methods/src/permitted/endTrace.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
 import type {
   JsonRpcRequest,
@@ -18,6 +17,7 @@ import {
 } from '@metamask/superstruct';
 import type { PendingJsonRpcResponse } from '@metamask/utils';
 
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'snap_endTrace';

--- a/packages/snaps-rpc-methods/src/permitted/getAllSnaps.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getAllSnaps.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
 import type { GetSnapsResult } from '@metamask/snaps-sdk';
 import type {
@@ -8,6 +7,7 @@ import type {
   PendingJsonRpcResponse,
 } from '@metamask/utils';
 
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'wallet_getAllSnaps';

--- a/packages/snaps-rpc-methods/src/permitted/getBackgroundEvents.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getBackgroundEvents.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors } from '@metamask/rpc-errors';
 import type {
   BackgroundEvent,
@@ -10,6 +9,7 @@ import type {
 import { type PendingJsonRpcResponse } from '@metamask/utils';
 
 import { SnapEndowments } from '../endowments';
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'snap_getBackgroundEvents';

--- a/packages/snaps-rpc-methods/src/permitted/getClientStatus.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getClientStatus.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import type { GetClientStatusResult } from '@metamask/snaps-sdk';
 import { getPlatformVersion } from '@metamask/snaps-utils';
 import type {
@@ -8,6 +7,7 @@ import type {
   PendingJsonRpcResponse,
 } from '@metamask/utils';
 
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'snap_getClientStatus';

--- a/packages/snaps-rpc-methods/src/permitted/getFile.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getFile.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
 import type { GetFileParams, GetFileResult } from '@metamask/snaps-sdk';
 import { AuxiliaryFileEncoding, enumValue } from '@metamask/snaps-sdk';
@@ -8,6 +7,7 @@ import { object, optional, string, union } from '@metamask/superstruct';
 import type { PendingJsonRpcResponse, JsonRpcRequest } from '@metamask/utils';
 import { assertStruct } from '@metamask/utils';
 
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 export const GetFileArgsStruct = object({

--- a/packages/snaps-rpc-methods/src/permitted/getInterfaceContext.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getInterfaceContext.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type {
   GetInterfaceContextParams,
@@ -11,6 +10,7 @@ import { type InferMatching } from '@metamask/snaps-utils';
 import { StructError, create, object, string } from '@metamask/superstruct';
 import type { PendingJsonRpcResponse } from '@metamask/utils';
 
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 import { UI_PERMISSIONS } from '../utils';
 

--- a/packages/snaps-rpc-methods/src/permitted/getInterfaceState.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getInterfaceState.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type {
   GetInterfaceStateParams,
@@ -11,6 +10,7 @@ import { type InferMatching } from '@metamask/snaps-utils';
 import { StructError, create, object, string } from '@metamask/superstruct';
 import type { PendingJsonRpcResponse } from '@metamask/utils';
 
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 import { UI_PERMISSIONS } from '../utils';
 

--- a/packages/snaps-rpc-methods/src/permitted/getSnaps.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getSnaps.ts
@@ -1,8 +1,8 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import type { GetSnapsResult } from '@metamask/snaps-sdk';
 import type { JsonRpcParams, PendingJsonRpcResponse } from '@metamask/utils';
 
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'wallet_getSnaps';

--- a/packages/snaps-rpc-methods/src/permitted/getState.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getState.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type { GetStateParams, GetStateResult } from '@metamask/snaps-sdk';
 import { type InferMatching } from '@metamask/snaps-utils';
@@ -18,6 +17,7 @@ import type {
 import { hasProperty, isObject } from '@metamask/utils';
 
 import { manageStateBuilder } from '../restricted/manageState';
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 import { FORBIDDEN_KEYS, StateKeyStruct } from '../utils';
 

--- a/packages/snaps-rpc-methods/src/permitted/getWebSockets.ts
+++ b/packages/snaps-rpc-methods/src/permitted/getWebSockets.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors } from '@metamask/rpc-errors';
 import type {
   GetWebSocketsParams,
@@ -9,6 +8,7 @@ import type {
 import type { PendingJsonRpcResponse } from '@metamask/utils';
 
 import { SnapEndowments } from '../endowments';
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'snap_getWebSockets';

--- a/packages/snaps-rpc-methods/src/permitted/invokeKeyring.ts
+++ b/packages/snaps-rpc-methods/src/permitted/invokeKeyring.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
 import type {
   InvokeKeyringParams,
@@ -16,6 +15,7 @@ import type {
 import { hasProperty } from '@metamask/utils';
 
 import { getValidatedParams } from './invokeSnapSugar';
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'wallet_invokeKeyring';

--- a/packages/snaps-rpc-methods/src/permitted/invokeSnapSugar.ts
+++ b/packages/snaps-rpc-methods/src/permitted/invokeSnapSugar.ts
@@ -2,11 +2,12 @@ import type {
   JsonRpcEngineEndCallback,
   JsonRpcEngineNextCallback,
 } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
 import type { InvokeSnapParams, InvokeSnapResult } from '@metamask/snaps-sdk';
 import type { JsonRpcRequest, PendingJsonRpcResponse } from '@metamask/utils';
 import { isObject } from '@metamask/utils';
+
+import type { PermittedHandlerExport } from '../types';
 
 const methodName = 'wallet_invokeSnap';
 

--- a/packages/snaps-rpc-methods/src/permitted/listEntropySources.ts
+++ b/packages/snaps-rpc-methods/src/permitted/listEntropySources.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors } from '@metamask/rpc-errors';
 import type {
   EntropySource,
@@ -13,6 +12,7 @@ import { getBip32EntropyBuilder } from '../restricted/getBip32Entropy';
 import { getBip32PublicKeyBuilder } from '../restricted/getBip32PublicKey';
 import { getBip44EntropyBuilder } from '../restricted/getBip44Entropy';
 import { getEntropyBuilder } from '../restricted/getEntropy';
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 /**

--- a/packages/snaps-rpc-methods/src/permitted/openWebSocket.ts
+++ b/packages/snaps-rpc-methods/src/permitted/openWebSocket.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import {
   literal,
@@ -20,6 +19,7 @@ import {
 import type { PendingJsonRpcResponse } from '@metamask/utils';
 
 import { SnapEndowments } from '../endowments';
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'snap_openWebSocket';

--- a/packages/snaps-rpc-methods/src/permitted/requestSnaps.ts
+++ b/packages/snaps-rpc-methods/src/permitted/requestSnaps.ts
@@ -3,7 +3,6 @@ import type {
   PermissionConstraint,
   RequestedPermissions,
   Caveat,
-  PermittedHandlerExport,
 } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
 import type {
@@ -24,6 +23,7 @@ import { hasProperty, isObject } from '@metamask/utils';
 import { Mutex } from 'async-mutex';
 
 import { WALLET_SNAP_PERMISSION_KEY } from '../restricted/invokeSnap';
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'wallet_requestSnaps';

--- a/packages/snaps-rpc-methods/src/permitted/resolveInterface.ts
+++ b/packages/snaps-rpc-methods/src/permitted/resolveInterface.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type {
   JsonRpcRequest,
@@ -11,6 +10,7 @@ import { StructError, create, object, string } from '@metamask/superstruct';
 import type { Json, PendingJsonRpcResponse } from '@metamask/utils';
 import { JsonStruct } from '@metamask/utils';
 
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 import { UI_PERMISSIONS } from '../utils';
 

--- a/packages/snaps-rpc-methods/src/permitted/scheduleBackgroundEvent.ts
+++ b/packages/snaps-rpc-methods/src/permitted/scheduleBackgroundEvent.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import {
   selectiveUnion,
@@ -17,6 +16,7 @@ import { StructError, create, object } from '@metamask/superstruct';
 import { hasProperty, type PendingJsonRpcResponse } from '@metamask/utils';
 
 import { SnapEndowments } from '../endowments';
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'snap_scheduleBackgroundEvent';

--- a/packages/snaps-rpc-methods/src/permitted/sendWebSocketMessage.ts
+++ b/packages/snaps-rpc-methods/src/permitted/sendWebSocketMessage.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type {
   JsonRpcRequest,
@@ -19,6 +18,7 @@ import {
 import type { PendingJsonRpcResponse } from '@metamask/utils';
 
 import { SnapEndowments } from '../endowments';
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'snap_sendWebSocketMessage';

--- a/packages/snaps-rpc-methods/src/permitted/setState.ts
+++ b/packages/snaps-rpc-methods/src/permitted/setState.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type {
   SetStateParams,
@@ -31,6 +30,7 @@ import {
   manageStateBuilder,
   STORAGE_SIZE_LIMIT,
 } from '../restricted/manageState';
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 import { FORBIDDEN_KEYS, StateKeyStruct } from '../utils';
 

--- a/packages/snaps-rpc-methods/src/permitted/startTrace.ts
+++ b/packages/snaps-rpc-methods/src/permitted/startTrace.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
 import type {
   JsonRpcRequest,
@@ -23,6 +22,7 @@ import {
 import type { PendingJsonRpcResponse } from '@metamask/utils';
 import { JsonStruct } from '@metamask/utils';
 
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'snap_startTrace';

--- a/packages/snaps-rpc-methods/src/permitted/trackError.ts
+++ b/packages/snaps-rpc-methods/src/permitted/trackError.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
 import type {
   JsonRpcRequest,
@@ -12,6 +11,7 @@ import { TrackableErrorStruct } from '@metamask/snaps-utils';
 import { create, object, StructError } from '@metamask/superstruct';
 import type { PendingJsonRpcResponse } from '@metamask/utils';
 
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'snap_trackError';

--- a/packages/snaps-rpc-methods/src/permitted/trackEvent.ts
+++ b/packages/snaps-rpc-methods/src/permitted/trackEvent.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
 import type {
   JsonRpcRequest,
@@ -19,6 +18,7 @@ import {
 import type { Json, PendingJsonRpcResponse } from '@metamask/utils';
 import { JsonStruct } from '@metamask/utils';
 
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 
 const methodName = 'snap_trackEvent';

--- a/packages/snaps-rpc-methods/src/permitted/updateInterface.ts
+++ b/packages/snaps-rpc-methods/src/permitted/updateInterface.ts
@@ -1,5 +1,4 @@
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
-import type { PermittedHandlerExport } from '@metamask/permission-controller';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type {
   UpdateInterfaceParams,
@@ -22,6 +21,7 @@ import {
 } from '@metamask/superstruct';
 import type { PendingJsonRpcResponse } from '@metamask/utils';
 
+import type { PermittedHandlerExport } from '../types';
 import type { MethodHooksObject } from '../utils';
 import { UI_PERMISSIONS } from '../utils';
 

--- a/packages/snaps-rpc-methods/src/types.ts
+++ b/packages/snaps-rpc-methods/src/types.ts
@@ -1,0 +1,50 @@
+import type {
+  JsonRpcEngineEndCallback,
+  JsonRpcEngineNextCallback,
+} from '@metamask/json-rpc-engine';
+import type {
+  Json,
+  JsonRpcParams,
+  JsonRpcRequest,
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
+
+// The types below are temporarily copied to this repo until we can migrate away from `PermittedHandlerExport`.
+
+/**
+ * A middleware function for handling a permitted method.
+ */
+type HandlerMiddlewareFunction<
+  Hooks,
+  Params extends JsonRpcParams,
+  Result extends Json,
+> = (
+  req: JsonRpcRequest<Params>,
+  res: PendingJsonRpcResponse<Result>,
+  next: JsonRpcEngineNextCallback,
+  end: JsonRpcEngineEndCallback,
+  hooks: Hooks,
+) => void | Promise<void>;
+
+/**
+ * We use a mapped object type in order to create a type that requires the
+ * presence of the names of all hooks for the given handler.
+ * This can then be used to select only the necessary hooks whenever a method
+ * is called for purposes of POLA.
+ */
+type HookNames<HookMap> = {
+  [Property in keyof HookMap]: true;
+};
+
+/**
+ * A handler for a permitted method.
+ */
+export type PermittedHandlerExport<
+  Hooks,
+  Params extends JsonRpcParams,
+  Result extends Json,
+> = {
+  implementation: HandlerMiddlewareFunction<Hooks, Params, Result>;
+  hookNames: HookNames<Hooks>;
+  methodNames: string[];
+};

--- a/packages/snaps-simulation/package.json
+++ b/packages/snaps-simulation/package.json
@@ -60,7 +60,7 @@
     "@metamask/json-rpc-middleware-stream": "^8.0.8",
     "@metamask/key-tree": "^10.1.1",
     "@metamask/messenger": "^1.2.0",
-    "@metamask/permission-controller": "^12.3.0",
+    "@metamask/permission-controller": "^13.0.0",
     "@metamask/rpc-errors": "^7.0.3",
     "@metamask/snaps-controllers": "workspace:^",
     "@metamask/snaps-execution-environments": "workspace:^",

--- a/packages/snaps-simulation/src/methods/specifications.ts
+++ b/packages/snaps-simulation/src/methods/specifications.ts
@@ -1,5 +1,9 @@
 import { caip25EndowmentBuilder } from '@metamask/chain-agnostic-permission';
-import type { GenericPermissionController } from '@metamask/permission-controller';
+import type {
+  GenericPermissionController,
+  PermissionSpecificationConstraint,
+  PermissionSpecificationMap,
+} from '@metamask/permission-controller';
 import {
   endowmentPermissionBuilders,
   buildSnapEndowmentSpecifications,
@@ -81,7 +85,7 @@ export function getPermissionSpecifications({
   hooks,
   runSaga,
   options,
-}: GetPermissionSpecificationsOptions) {
+}: GetPermissionSpecificationsOptions): PermissionSpecificationMap<PermissionSpecificationConstraint> {
   return {
     [caip25EndowmentBuilder.targetName]:
       caip25EndowmentBuilder.specificationBuilder({}),

--- a/packages/snaps-simulation/src/simulation.ts
+++ b/packages/snaps-simulation/src/simulation.ts
@@ -11,6 +11,7 @@ import {
   PermissionDoesNotExistError,
   type Caveat,
   type RequestedPermissions,
+  createPermissionMiddleware,
 } from '@metamask/permission-controller';
 import type { ExecutionService } from '@metamask/snaps-controllers';
 import {
@@ -454,8 +455,9 @@ export async function installSnap<
     options,
   });
 
-  const permissionMiddleware = permissionController.createPermissionMiddleware({
+  const permissionMiddleware = createPermissionMiddleware({
     origin: snapId,
+    messenger: controllerMessenger,
   });
 
   const engine = createJsonRpcEngine({

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -82,7 +82,7 @@
     "@babel/types": "^7.23.0",
     "@metamask/key-tree": "^10.1.1",
     "@metamask/messenger": "^1.2.0",
-    "@metamask/permission-controller": "^12.3.0",
+    "@metamask/permission-controller": "^13.0.0",
     "@metamask/rpc-errors": "^7.0.3",
     "@metamask/slip44": "^4.4.0",
     "@metamask/snaps-registry": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3038,7 +3038,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/controller-utils@npm:^11.19.0":
+"@metamask/controller-utils@npm:^11.19.0, @metamask/controller-utils@npm:^11.20.0":
   version: 11.20.0
   resolution: "@metamask/controller-utils@npm:11.20.0"
   dependencies:
@@ -3920,7 +3920,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/permission-controller@npm:^12.2.1, @metamask/permission-controller@npm:^12.3.0":
+"@metamask/permission-controller@npm:^12.2.1":
   version: 12.3.0
   resolution: "@metamask/permission-controller@npm:12.3.0"
   dependencies:
@@ -3936,6 +3936,25 @@ __metadata:
     immer: "npm:^9.0.6"
     nanoid: "npm:^3.3.8"
   checksum: 10/a5fe9f2bab8c2d41cd829cd6c1af970e71da97eac42de17071c10f90d975e9135a4e6987ed6b2f3ea2209b1c6c51b822508f800225fda2207cdc598c16ea77dd
+  languageName: node
+  linkType: hard
+
+"@metamask/permission-controller@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "@metamask/permission-controller@npm:13.0.0"
+  dependencies:
+    "@metamask/approval-controller": "npm:^9.0.1"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^11.20.0"
+    "@metamask/json-rpc-engine": "npm:^10.3.0"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.9.0"
+    "@types/deep-freeze-strict": "npm:^1.1.0"
+    deep-freeze-strict: "npm:^1.1.1"
+    immer: "npm:^9.0.6"
+    nanoid: "npm:^3.3.8"
+  checksum: 10/e4062076f7dd7da7acf890f66ee7df1a0309bbb9d9adb221f28eefb203318c2675707754b884a0d4f49892608a8771443a97e743c2c68f7c75f123ec7fafbf49
   languageName: node
   linkType: hard
 
@@ -4249,7 +4268,7 @@ __metadata:
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/messenger-cli": "npm:^0.2.0"
     "@metamask/object-multiplex": "npm:^2.1.0"
-    "@metamask/permission-controller": "npm:^12.3.0"
+    "@metamask/permission-controller": "npm:^13.0.0"
     "@metamask/post-message-stream": "npm:^10.0.0"
     "@metamask/rpc-errors": "npm:^7.0.3"
     "@metamask/snaps-registry": "npm:^4.0.0"
@@ -4506,7 +4525,7 @@ __metadata:
     "@metamask/json-rpc-engine": "npm:^10.3.0"
     "@metamask/key-tree": "npm:^10.1.1"
     "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/permission-controller": "npm:^12.3.0"
+    "@metamask/permission-controller": "npm:^13.0.0"
     "@metamask/rpc-errors": "npm:^7.0.3"
     "@metamask/snaps-sdk": "workspace:^"
     "@metamask/snaps-utils": "workspace:^"
@@ -4606,7 +4625,7 @@ __metadata:
     "@metamask/json-rpc-middleware-stream": "npm:^8.0.8"
     "@metamask/key-tree": "npm:^10.1.1"
     "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/permission-controller": "npm:^12.3.0"
+    "@metamask/permission-controller": "npm:^13.0.0"
     "@metamask/rpc-errors": "npm:^7.0.3"
     "@metamask/snaps-controllers": "workspace:^"
     "@metamask/snaps-execution-environments": "workspace:^"
@@ -4650,7 +4669,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/key-tree": "npm:^10.1.1"
     "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/permission-controller": "npm:^12.3.0"
+    "@metamask/permission-controller": "npm:^13.0.0"
     "@metamask/post-message-stream": "npm:^10.0.0"
     "@metamask/rpc-errors": "npm:^7.0.3"
     "@metamask/slip44": "npm:^4.4.0"


### PR DESCRIPTION
Bump `permission-controller` to the latest version and resolve most breaking changes. Dealing with the removal of `PermittedHandlerExport` is a larger refactor, that we will solve in follow-up PRs, thus we copy the type into `snaps-rpc-methods` temporarily.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades a core permissions dependency and adjusts middleware/type integration points; runtime behavior should be mostly unchanged but mismatches with the new `permission-controller` APIs could break permission enforcement or simulations.
> 
> **Overview**
> Updates multiple packages to use `@metamask/permission-controller@^13.0.0` and refreshes the lockfile accordingly.
> 
> Adapts to breaking API changes by switching `snaps-simulation` to the new top-level `createPermissionMiddleware` helper and tightening the return type of `getPermissionSpecifications`.
> 
> To avoid a larger refactor from the upstream removal of `PermittedHandlerExport`, `snaps-rpc-methods` temporarily vendors that type in `src/types.ts` and rewires permitted-method handlers to import it locally instead of from `permission-controller`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1775e8b8fa859cbbbe8159ee8e2a07c6bacc063e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->