### PR TITLE
chore: Update scuttling exceptions for React Native update

### DIFF
--- a/packages/snaps-execution-environments/webpack.config.js
+++ b/packages/snaps-execution-environments/webpack.config.js
@@ -114,7 +114,13 @@ const ENTRY_POINTS = [
     inlineBundle: true,
 
     scuttleGlobalThis: true,
-    scuttleGlobalThisExceptions: ['JSON', 'ReactNativeWebView', 'String'],
+    scuttleGlobalThisExceptions: [
+      'DOMParser',
+      'JSON',
+      'ReactNativeWebView',
+      'String',
+      'XMLSerializer',
+    ],
 
     config: {
       plugins: [


### PR DESCRIPTION
`DOMParser` and `XMLSerializer` needed for the React Native upgrade: https://github.com/MetaMask/metamask-mobile/pull/29195