### PR TITLE
fix: Omit installing Snaps from `getAllSnaps` and `getRunnableSnaps`

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2566,7 +2566,9 @@ export class SnapController extends BaseController<
    * @returns All installed snaps in their truncated format.
    */
   getAllSnaps(): TruncatedSnap[] {
-    return Object.values(this.state.snaps).map(truncateSnap);
+    return Object.values(this.state.snaps)
+      .filter((snap) => snap.status !== SnapStatus.Installing)
+      .map(truncateSnap);
   }
 
   /**
@@ -2575,11 +2577,7 @@ export class SnapController extends BaseController<
    * @returns All runnable snaps.
    */
   getRunnableSnaps(): TruncatedSnap[] {
-    return getRunnableSnaps(
-      Object.values(this.state.snaps)
-        .filter((snap) => snap.status !== SnapStatus.Installing)
-        .map(truncateSnap),
-    );
+    return getRunnableSnaps(this.getAllSnaps());
   }
 
   /**

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2575,7 +2575,11 @@ export class SnapController extends BaseController<
    * @returns All runnable snaps.
    */
   getRunnableSnaps(): TruncatedSnap[] {
-    return getRunnableSnaps(this.getAllSnaps());
+    return getRunnableSnaps(
+      Object.values(this.state.snaps)
+        .filter((snap) => snap.status !== SnapStatus.Installing)
+        .map(truncateSnap),
+    );
   }
 
   /**


### PR DESCRIPTION
Omit Snaps in the `installing` state from being returned by `getAllSnaps` and `getRunnableSnaps`. Since they aren't actually runnable.

In the clients this caused a bug where consumers of Snaps would fail to get valid permissions from `PermissionController` because the installation had not completed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only filters out `SnapStatus.Installing` entries from `getAllSnaps`, narrowing what downstream callers (including `getRunnableSnaps`) can see; main risk is any consumer that expected installing snaps to be listed.
> 
> **Overview**
> `SnapController.getAllSnaps()` now **omits Snaps in `SnapStatus.Installing`**, so they are no longer returned in the truncated Snap list.
> 
> Because `getRunnableSnaps()` is derived from `getAllSnaps()`, installing Snaps will also no longer be considered runnable, avoiding clients interacting with Snaps before installation (and permissions) are complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba0faa05f338fb6114b1e989526966c6854e8ec7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->