### PR TITLE
fix: Assert expected hooks for restricted method specifications

### DIFF
--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -10,7 +10,7 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 97.3,
+      branches: 97.29,
       functions: 98.85,
       lines: 99.14,
       statements: 98.81,

--- a/packages/snaps-rpc-methods/jest.config.js
+++ b/packages/snaps-rpc-methods/jest.config.js
@@ -10,8 +10,8 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 97.28,
-      functions: 98.84,
+      branches: 97.3,
+      functions: 98.85,
       lines: 99.14,
       statements: 98.81,
     },

--- a/packages/snaps-rpc-methods/src/permissions.test.ts
+++ b/packages/snaps-rpc-methods/src/permissions.test.ts
@@ -197,7 +197,14 @@ describe('buildSnapRestrictedMethodSpecifications', () => {
   it('returns the expected object', () => {
     const specifications = buildSnapRestrictedMethodSpecifications(
       [],
-      {},
+      {
+        getUnlockPromise: jest.fn(),
+        getClientCryptography: jest.fn(),
+        isOnPhishingList: jest.fn(),
+        maybeUpdatePhishingList: jest.fn(),
+        getSnapKeyring: jest.fn(),
+        getPreferences: jest.fn(),
+      },
       new Messenger({ namespace: 'SnapsRestrictedMethods' }),
     );
     expect(specifications).toMatchInlineSnapshot(`

--- a/packages/snaps-rpc-methods/src/permissions.test.ts
+++ b/packages/snaps-rpc-methods/src/permissions.test.ts
@@ -323,4 +323,21 @@ describe('buildSnapRestrictedMethodSpecifications', () => {
       }
     `);
   });
+
+  it('excludes the specified permissions', () => {
+    const specifications = buildSnapRestrictedMethodSpecifications(
+      ['snap_dialog'],
+      {
+        getUnlockPromise: jest.fn(),
+        getClientCryptography: jest.fn(),
+        isOnPhishingList: jest.fn(),
+        maybeUpdatePhishingList: jest.fn(),
+        getSnapKeyring: jest.fn(),
+        getPreferences: jest.fn(),
+      },
+      new Messenger({ namespace: 'SnapsRestrictedMethods' }),
+    );
+
+    expect(specifications.snap_dialog).toBeUndefined();
+  });
 });

--- a/packages/snaps-rpc-methods/src/permissions.ts
+++ b/packages/snaps-rpc-methods/src/permissions.ts
@@ -71,7 +71,9 @@ export const buildSnapRestrictedMethodSpecifications = (
   hooks: Record<string, unknown>,
   messenger: RestrictedMethodMessenger,
 ) => {
-  const permissionBuilders = Object.values(restrictedMethodPermissionBuilders);
+  const permissionBuilders = Object.values(
+    restrictedMethodPermissionBuilders,
+  ).filter((builder) => !excludedPermissions.includes(builder.targetName));
 
   const expectedHookNames = new Set(
     permissionBuilders.flatMap((builder) =>
@@ -90,18 +92,16 @@ export const buildSnapRestrictedMethodSpecifications = (
       specifications,
       { targetName, specificationBuilder, methodHooks, actionNames },
     ) => {
-      if (!excludedPermissions.includes(targetName)) {
-        specifications[targetName] = specificationBuilder({
-          methodHooks: selectHooks(hooks, methodHooks),
-          messenger: createRestrictedMethodMessenger({
-            namespace: targetName,
-            rootMessenger: messenger,
-            actionNames: actionNames as readonly [
-              RestrictedMethodActions['type'],
-            ],
-          }),
-        });
-      }
+      specifications[targetName] = specificationBuilder({
+        methodHooks: selectHooks(hooks, methodHooks),
+        messenger: createRestrictedMethodMessenger({
+          namespace: targetName,
+          rootMessenger: messenger,
+          actionNames: actionNames as readonly [
+            RestrictedMethodActions['type'],
+          ],
+        }),
+      });
       return specifications;
     },
     {},

--- a/packages/snaps-rpc-methods/src/permissions.ts
+++ b/packages/snaps-rpc-methods/src/permissions.ts
@@ -1,4 +1,4 @@
-import { selectHooks } from '@metamask/json-rpc-engine/v2';
+import { selectHooks, assertExpectedHooks } from '@metamask/json-rpc-engine/v2';
 import {
   createRestrictedMethodMessenger,
   type PermissionConstraint,
@@ -70,8 +70,20 @@ export const buildSnapRestrictedMethodSpecifications = (
   excludedPermissions: string[],
   hooks: Record<string, unknown>,
   messenger: RestrictedMethodMessenger,
-) =>
-  Object.values(restrictedMethodPermissionBuilders).reduce<
+) => {
+  const permissionBuilders = Object.values(restrictedMethodPermissionBuilders);
+
+  const expectedHookNames = new Set(
+    permissionBuilders.flatMap((builder) =>
+      builder.methodHooks
+        ? Object.getOwnPropertyNames(builder.methodHooks)
+        : [],
+    ),
+  );
+
+  assertExpectedHooks(hooks, expectedHookNames);
+
+  return permissionBuilders.reduce<
     Record<string, PermissionSpecificationConstraint>
   >(
     (
@@ -94,3 +106,4 @@ export const buildSnapRestrictedMethodSpecifications = (
     },
     {},
   );
+};

--- a/packages/snaps-simulation/src/methods/specifications.ts
+++ b/packages/snaps-simulation/src/methods/specifications.ts
@@ -73,6 +73,7 @@ export function getPermissionSpecifications({
   hooks,
   options,
 }: GetPermissionSpecificationsOptions): PermissionSpecificationMap<PermissionSpecificationConstraint> {
+  const { getClientCryptography } = hooks;
   return {
     [caip25EndowmentBuilder.targetName]:
       caip25EndowmentBuilder.specificationBuilder({}),
@@ -81,11 +82,12 @@ export function getPermissionSpecifications({
       EXCLUDED_SNAP_PERMISSIONS,
       {
         // Shared hooks.
-        ...hooks,
+        getClientCryptography,
 
         // Snaps-specific hooks.
         getPreferences: getGetPreferencesMethodImplementation(options),
         getUnlockPromise: asyncResolve(true),
+        getSnapKeyring: asyncResolve(null),
 
         // TODO: Allow the user to specify the result of this function.
         isOnPhishingList: resolve(false),


### PR DESCRIPTION
Assert the expected hooks as part of `buildSnapRestrictedMethodSpecifications` to indicate missing or extraneous hooks being passed in to the developer. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds strict hook validation in `buildSnapRestrictedMethodSpecifications`, which can cause runtime errors for callers passing missing or extra hooks, and updates simulation wiring accordingly.
> 
> **Overview**
> Adds hook contract enforcement to `buildSnapRestrictedMethodSpecifications` by computing the expected `methodHooks` from non-excluded restricted-method builders, calling `assertExpectedHooks`, and filtering excluded permissions before spec creation.
> 
> Updates tests to pass the full required hook set and adds coverage ensuring excluded permissions (e.g., `snap_dialog`) are omitted. Adjusts snaps simulation permission spec assembly to pass only the required hooks (including `getSnapKeyring`) and tweaks Jest coverage thresholds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6640a8d20269b199e4c42233826756f2c9af664d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->