### PR TITLE
fix: Validate email addresses

### DIFF
--- a/packages/snaps-utils/src/ui.test.tsx
+++ b/packages/snaps-utils/src/ui.test.tsx
@@ -750,6 +750,19 @@ describe('validateLink', () => {
     expect(fn).toHaveBeenCalledWith('https://test.metamask-phishing.io');
   });
 
+  it('throws an error for an email containing more than one "@" symbol', () => {
+    const fn = jest.fn().mockReturnValue(false);
+    const getSnap = jest.fn();
+
+    expect(() =>
+      validateLink('mailto:foo@bar.com@baz.com', fn, getSnap),
+    ).toThrow(
+      'Invalid URL: Unable to parse email address "foo@bar.com@baz.com".',
+    );
+
+    expect(fn).not.toHaveBeenCalled();
+  });
+
   it('throws an error for a phishing email when using parameters', () => {
     const fn = jest.fn().mockImplementation((email) => {
       if (email === 'https://test.metamask-phishing.io') {

--- a/packages/snaps-utils/src/ui.tsx
+++ b/packages/snaps-utils/src/ui.tsx
@@ -366,6 +366,11 @@ export function validateLink(
     } else if (url.protocol === 'mailto:') {
       const emails = url.pathname.split(',');
       for (const email of emails) {
+        assert(
+          email.split('@').length === 2,
+          `Unable to parse email address "${email}".`,
+        );
+
         const hostname = email.split('@')[1];
         assert(!hostname.includes(':'));
         const href = `https://${hostname}`;

--- a/packages/snaps-utils/src/ui.tsx
+++ b/packages/snaps-utils/src/ui.tsx
@@ -366,12 +366,10 @@ export function validateLink(
     } else if (url.protocol === 'mailto:') {
       const emails = url.pathname.split(',');
       for (const email of emails) {
-        assert(
-          email.split('@').length === 2,
-          `Unable to parse email address "${email}".`,
-        );
+        const parts = email.split('@');
+        assert(parts.length === 2, `Unable to parse email address "${email}".`);
 
-        const hostname = email.split('@')[1];
+        const hostname = parts[1];
         assert(!hostname.includes(':'));
         const href = `https://${hostname}`;
         assert(!isOnPhishingList(href), 'The specified URL is not allowed.');


### PR DESCRIPTION
Some basic validation for email addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates `validateLink` mailto handling to fail fast on malformed email strings (e.g., multiple `@`), which may change which links are accepted and how phishing checks are applied.
> 
> **Overview**
> Tightens `mailto:` link validation in `validateLink` by requiring each email recipient to contain **exactly one** `@` before extracting the domain for phishing-list checks.
> 
> Adds a unit test to ensure malformed emails like `mailto:foo@bar.com@baz.com` throw a clear parse error and do not invoke the phishing-list checker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d178d8add3933ac45b9df6ea140995d5b61fa94c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->