### PR TITLE
feat(snaps-rpc-methods)!: update usage of `withKeyring` to `withKeyringV2Unsafe`

### DIFF
--- a/packages/snaps-controllers/src/multichain/MultichainRoutingService.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRoutingService.ts
@@ -38,7 +38,7 @@ type SnapKeyring = {
   }) => Promise<Json>;
 };
 
-// Expecting a bound function that calls KeyringController.withKeyringV2 selecting the Snap keyring
+// Expecting a bound function that calls KeyringController.withKeyringV2Unsafe selecting the Snap keyring
 export type WithSnapKeyringFunction = <ReturnType>(
   operation: ({ keyring }: { keyring: SnapKeyring }) => Promise<ReturnType>,
 ) => Promise<ReturnType>;

--- a/packages/snaps-controllers/src/multichain/MultichainRoutingService.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRoutingService.ts
@@ -38,7 +38,7 @@ type SnapKeyring = {
   }) => Promise<Json>;
 };
 
-// Expecting a bound function that calls KeyringController.withKeyring selecting the Snap keyring
+// Expecting a bound function that calls KeyringController.withKeyringV2 selecting the Snap keyring
 export type WithSnapKeyringFunction = <ReturnType>(
   operation: ({ keyring }: { keyring: SnapKeyring }) => Promise<ReturnType>,
 ) => Promise<ReturnType>;

--- a/packages/snaps-controllers/src/multichain/MultichainRoutingService.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRoutingService.ts
@@ -38,7 +38,7 @@ type SnapKeyring = {
   }) => Promise<Json>;
 };
 
-// Expecting a bound function that calls KeyringController.withKeyringV2Unsafe selecting the Snap keyring
+// Expecting a bound function that calls KeyringController.withKeyring selecting the Snap keyring
 export type WithSnapKeyringFunction = <ReturnType>(
   operation: ({ keyring }: { keyring: SnapKeyring }) => Promise<ReturnType>,
 ) => Promise<ReturnType>;

--- a/packages/snaps-rpc-methods/CHANGELOG.md
+++ b/packages/snaps-rpc-methods/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `withKeyring` to `withKeyringV2` ([#xxx](https://github.com/MetaMask/snaps/pull/xxxx))
+
 ## [16.0.0]
 
 ### Changed

--- a/packages/snaps-rpc-methods/CHANGELOG.md
+++ b/packages/snaps-rpc-methods/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `withKeyring` to `withKeyringV2` ([#4009](https://github.com/MetaMask/snaps/pull/4009))
+- Update `withKeyring` to `withKeyringV2Unsafe` ([#4009](https://github.com/MetaMask/snaps/pull/4009))
 
 ## [16.0.0]
 

--- a/packages/snaps-rpc-methods/CHANGELOG.md
+++ b/packages/snaps-rpc-methods/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `withKeyring` to `withKeyringV2` ([#xxx](https://github.com/MetaMask/snaps/pull/xxxx))
+- Update `withKeyring` to `withKeyringV2` ([#4009](https://github.com/MetaMask/snaps/pull/4009))
 
 ## [16.0.0]
 

--- a/packages/snaps-rpc-methods/CHANGELOG.md
+++ b/packages/snaps-rpc-methods/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `withKeyring` to `withKeyringV2Unsafe` ([#4009](https://github.com/MetaMask/snaps/pull/4009))
+- **BREAKING:** Use `withKeyringV2Unsafe` for accessing entropy ([#4009](https://github.com/MetaMask/snaps/pull/4009))
 
 ## [16.0.0]
 

--- a/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.test.ts
@@ -79,7 +79,7 @@ describe('getBip32EntropyImplementation', () => {
       async (_selector, operation) =>
         operation({
           keyring: {
-            type: 'HD Key Tree',
+            type: 'hd',
             mnemonic: TEST_SECRET_RECOVERY_PHRASE_BYTES,
             seed: TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES,
           },
@@ -345,7 +345,7 @@ describe('getBip32EntropyImplementation', () => {
         async (_selector, operation) =>
           operation({
             keyring: {
-              type: 'HD Key Tree',
+              type: 'hd',
             },
           }),
       );
@@ -375,7 +375,7 @@ describe('getBip32EntropyImplementation', () => {
         async (_selector, operation) =>
           operation({
             keyring: {
-              type: 'HD Key Tree',
+              type: 'hd',
             },
           }),
       );
@@ -405,7 +405,7 @@ describe('getBip32EntropyImplementation', () => {
         async (_selector, operation) =>
           operation({
             keyring: {
-              type: 'HD Key Tree',
+              type: 'hd',
             },
           }),
       );
@@ -439,7 +439,7 @@ describe('getBip32EntropyImplementation', () => {
         async (_selector, operation) =>
           operation({
             keyring: {
-              type: 'HD Key Tree',
+              type: 'hd',
             },
           }),
       );

--- a/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.test.ts
@@ -75,7 +75,7 @@ describe('getBip32EntropyImplementation', () => {
     });
 
     messenger.registerActionHandler(
-      'KeyringController:withKeyringV2',
+      'KeyringController:withKeyringV2Unsafe',
       async (_selector, operation) =>
         operation({
           keyring: {
@@ -247,7 +247,7 @@ describe('getBip32EntropyImplementation', () => {
 
       expect(messenger.call).toHaveBeenCalledTimes(1);
       expect(messenger.call).toHaveBeenCalledWith(
-        'KeyringController:withKeyringV2',
+        'KeyringController:withKeyringV2Unsafe',
         { id: 'source-id' },
         expect.any(Function),
       );
@@ -287,7 +287,7 @@ describe('getBip32EntropyImplementation', () => {
 
       expect(messenger.call).toHaveBeenCalledTimes(1);
       expect(messenger.call).toHaveBeenCalledWith(
-        'KeyringController:withKeyringV2',
+        'KeyringController:withKeyringV2Unsafe',
         { id: 'source-id' },
         expect.any(Function),
       );
@@ -341,7 +341,7 @@ describe('getBip32EntropyImplementation', () => {
       >({ namespace: MOCK_ANY_NAMESPACE });
 
       messenger.registerActionHandler(
-        'KeyringController:withKeyringV2',
+        'KeyringController:withKeyringV2Unsafe',
         async (_selector, operation) =>
           operation({
             keyring: {
@@ -371,7 +371,7 @@ describe('getBip32EntropyImplementation', () => {
       >({ namespace: MOCK_ANY_NAMESPACE });
 
       messenger.registerActionHandler(
-        'KeyringController:withKeyringV2',
+        'KeyringController:withKeyringV2Unsafe',
         async (_selector, operation) =>
           operation({
             keyring: {
@@ -401,7 +401,7 @@ describe('getBip32EntropyImplementation', () => {
       >({ namespace: MOCK_ANY_NAMESPACE });
 
       messenger.registerActionHandler(
-        'KeyringController:withKeyringV2',
+        'KeyringController:withKeyringV2Unsafe',
         async (_selector, operation) =>
           operation({
             keyring: {
@@ -435,7 +435,7 @@ describe('getBip32EntropyImplementation', () => {
       >({ namespace: MOCK_ANY_NAMESPACE });
 
       messenger.registerActionHandler(
-        'KeyringController:withKeyringV2',
+        'KeyringController:withKeyringV2Unsafe',
         async (_selector, operation) =>
           operation({
             keyring: {

--- a/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.test.ts
@@ -75,7 +75,7 @@ describe('getBip32EntropyImplementation', () => {
     });
 
     messenger.registerActionHandler(
-      'KeyringController:withKeyring',
+      'KeyringController:withKeyringV2',
       async (_selector, operation) =>
         operation({
           keyring: {
@@ -247,7 +247,7 @@ describe('getBip32EntropyImplementation', () => {
 
       expect(messenger.call).toHaveBeenCalledTimes(1);
       expect(messenger.call).toHaveBeenCalledWith(
-        'KeyringController:withKeyring',
+        'KeyringController:withKeyringV2',
         { id: 'source-id' },
         expect.any(Function),
       );
@@ -287,7 +287,7 @@ describe('getBip32EntropyImplementation', () => {
 
       expect(messenger.call).toHaveBeenCalledTimes(1);
       expect(messenger.call).toHaveBeenCalledWith(
-        'KeyringController:withKeyring',
+        'KeyringController:withKeyringV2',
         { id: 'source-id' },
         expect.any(Function),
       );
@@ -341,7 +341,7 @@ describe('getBip32EntropyImplementation', () => {
       >({ namespace: MOCK_ANY_NAMESPACE });
 
       messenger.registerActionHandler(
-        'KeyringController:withKeyring',
+        'KeyringController:withKeyringV2',
         async (_selector, operation) =>
           operation({
             keyring: {
@@ -371,7 +371,7 @@ describe('getBip32EntropyImplementation', () => {
       >({ namespace: MOCK_ANY_NAMESPACE });
 
       messenger.registerActionHandler(
-        'KeyringController:withKeyring',
+        'KeyringController:withKeyringV2',
         async (_selector, operation) =>
           operation({
             keyring: {
@@ -401,7 +401,7 @@ describe('getBip32EntropyImplementation', () => {
       >({ namespace: MOCK_ANY_NAMESPACE });
 
       messenger.registerActionHandler(
-        'KeyringController:withKeyring',
+        'KeyringController:withKeyringV2',
         async (_selector, operation) =>
           operation({
             keyring: {
@@ -435,7 +435,7 @@ describe('getBip32EntropyImplementation', () => {
       >({ namespace: MOCK_ANY_NAMESPACE });
 
       messenger.registerActionHandler(
-        'KeyringController:withKeyring',
+        'KeyringController:withKeyringV2',
         async (_selector, operation) =>
           operation({
             keyring: {

--- a/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.ts
@@ -16,7 +16,7 @@ import { SnapCaveatType } from '@metamask/snaps-utils';
 import type { NonEmptyArray } from '@metamask/utils';
 import { assert } from '@metamask/utils';
 
-import type { KeyringControllerWithKeyringV2Action } from '../types';
+import type { KeyringControllerWithKeyringV2UnsafeAction } from '../types';
 import type { MethodHooksObject } from '../utils';
 import {
   getMnemonic,
@@ -47,7 +47,7 @@ export type GetBip32EntropyMethodHooks = {
 };
 
 export type GetBip32EntropyMessengerActions =
-  KeyringControllerWithKeyringV2Action;
+  KeyringControllerWithKeyringV2UnsafeAction;
 
 type GetBip32EntropySpecificationBuilderOptions = {
   methodHooks: GetBip32EntropyMethodHooks;
@@ -166,7 +166,7 @@ export const getBip32EntropyBuilder = Object.freeze({
   targetName,
   specificationBuilder,
   methodHooks,
-  actionNames: ['KeyringController:withKeyringV2'],
+  actionNames: ['KeyringController:withKeyringV2Unsafe'],
 } as const);
 
 /**

--- a/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32Entropy.ts
@@ -16,7 +16,7 @@ import { SnapCaveatType } from '@metamask/snaps-utils';
 import type { NonEmptyArray } from '@metamask/utils';
 import { assert } from '@metamask/utils';
 
-import type { KeyringControllerWithKeyringAction } from '../types';
+import type { KeyringControllerWithKeyringV2Action } from '../types';
 import type { MethodHooksObject } from '../utils';
 import {
   getMnemonic,
@@ -47,7 +47,7 @@ export type GetBip32EntropyMethodHooks = {
 };
 
 export type GetBip32EntropyMessengerActions =
-  KeyringControllerWithKeyringAction;
+  KeyringControllerWithKeyringV2Action;
 
 type GetBip32EntropySpecificationBuilderOptions = {
   methodHooks: GetBip32EntropyMethodHooks;
@@ -166,7 +166,7 @@ export const getBip32EntropyBuilder = Object.freeze({
   targetName,
   specificationBuilder,
   methodHooks,
-  actionNames: ['KeyringController:withKeyring'],
+  actionNames: ['KeyringController:withKeyringV2'],
 } as const);
 
 /**

--- a/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.test.ts
@@ -79,7 +79,7 @@ describe('getBip32PublicKeyImplementation', () => {
       async (_selector, operation) =>
         operation({
           keyring: {
-            type: 'HD Key Tree',
+            type: 'hd',
             mnemonic: TEST_SECRET_RECOVERY_PHRASE_BYTES,
             seed: TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES,
           },

--- a/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.test.ts
@@ -75,7 +75,7 @@ describe('getBip32PublicKeyImplementation', () => {
     });
 
     messenger.registerActionHandler(
-      'KeyringController:withKeyring',
+      'KeyringController:withKeyringV2',
       async (_selector, operation) =>
         operation({
           keyring: {
@@ -223,7 +223,7 @@ describe('getBip32PublicKeyImplementation', () => {
 
       expect(messenger.call).toHaveBeenCalledTimes(1);
       expect(messenger.call).toHaveBeenCalledWith(
-        'KeyringController:withKeyring',
+        'KeyringController:withKeyringV2',
         { id: 'source-id' },
         expect.any(Function),
       );
@@ -253,7 +253,7 @@ describe('getBip32PublicKeyImplementation', () => {
 
       expect(messenger.call).toHaveBeenCalledTimes(1);
       expect(messenger.call).toHaveBeenCalledWith(
-        'KeyringController:withKeyring',
+        'KeyringController:withKeyringV2',
         { id: 'source-id' },
         expect.any(Function),
       );

--- a/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.test.ts
@@ -75,7 +75,7 @@ describe('getBip32PublicKeyImplementation', () => {
     });
 
     messenger.registerActionHandler(
-      'KeyringController:withKeyringV2',
+      'KeyringController:withKeyringV2Unsafe',
       async (_selector, operation) =>
         operation({
           keyring: {
@@ -223,7 +223,7 @@ describe('getBip32PublicKeyImplementation', () => {
 
       expect(messenger.call).toHaveBeenCalledTimes(1);
       expect(messenger.call).toHaveBeenCalledWith(
-        'KeyringController:withKeyringV2',
+        'KeyringController:withKeyringV2Unsafe',
         { id: 'source-id' },
         expect.any(Function),
       );
@@ -253,7 +253,7 @@ describe('getBip32PublicKeyImplementation', () => {
 
       expect(messenger.call).toHaveBeenCalledTimes(1);
       expect(messenger.call).toHaveBeenCalledWith(
-        'KeyringController:withKeyringV2',
+        'KeyringController:withKeyringV2Unsafe',
         { id: 'source-id' },
         expect.any(Function),
       );

--- a/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -22,7 +22,7 @@ import { boolean, object, optional, string } from '@metamask/superstruct';
 import type { NonEmptyArray } from '@metamask/utils';
 import { assertStruct } from '@metamask/utils';
 
-import type { KeyringControllerWithKeyringAction } from '../types';
+import type { KeyringControllerWithKeyringV2Action } from '../types';
 import type { MethodHooksObject } from '../utils';
 import {
   getMnemonic,
@@ -53,7 +53,7 @@ export type GetBip32PublicKeyMethodHooks = {
 };
 
 export type GetBip32PublicKeyMessengerActions =
-  KeyringControllerWithKeyringAction;
+  KeyringControllerWithKeyringV2Action;
 
 type GetBip32PublicKeySpecificationBuilderOptions = {
   methodHooks: GetBip32PublicKeyMethodHooks;
@@ -162,7 +162,7 @@ export const getBip32PublicKeyBuilder = Object.freeze({
   targetName,
   specificationBuilder,
   methodHooks,
-  actionNames: ['KeyringController:withKeyring'],
+  actionNames: ['KeyringController:withKeyringV2'],
 } as const);
 
 /**

--- a/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -22,7 +22,7 @@ import { boolean, object, optional, string } from '@metamask/superstruct';
 import type { NonEmptyArray } from '@metamask/utils';
 import { assertStruct } from '@metamask/utils';
 
-import type { KeyringControllerWithKeyringV2Action } from '../types';
+import type { KeyringControllerWithKeyringV2UnsafeAction } from '../types';
 import type { MethodHooksObject } from '../utils';
 import {
   getMnemonic,
@@ -53,7 +53,7 @@ export type GetBip32PublicKeyMethodHooks = {
 };
 
 export type GetBip32PublicKeyMessengerActions =
-  KeyringControllerWithKeyringV2Action;
+  KeyringControllerWithKeyringV2UnsafeAction;
 
 type GetBip32PublicKeySpecificationBuilderOptions = {
   methodHooks: GetBip32PublicKeyMethodHooks;
@@ -162,7 +162,7 @@ export const getBip32PublicKeyBuilder = Object.freeze({
   targetName,
   specificationBuilder,
   methodHooks,
-  actionNames: ['KeyringController:withKeyringV2'],
+  actionNames: ['KeyringController:withKeyringV2Unsafe'],
 } as const);
 
 /**

--- a/packages/snaps-rpc-methods/src/restricted/getBip44Entropy.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip44Entropy.test.ts
@@ -74,7 +74,7 @@ describe('getBip44EntropyImplementation', () => {
     });
 
     messenger.registerActionHandler(
-      'KeyringController:withKeyring',
+      'KeyringController:withKeyringV2',
       async (_selector, operation) =>
         operation({
           keyring: {
@@ -150,7 +150,7 @@ describe('getBip44EntropyImplementation', () => {
 
       expect(messenger.call).toHaveBeenCalledTimes(1);
       expect(messenger.call).toHaveBeenCalledWith(
-        'KeyringController:withKeyring',
+        'KeyringController:withKeyringV2',
         { id: 'source-id' },
         expect.any(Function),
       );

--- a/packages/snaps-rpc-methods/src/restricted/getBip44Entropy.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip44Entropy.test.ts
@@ -74,7 +74,7 @@ describe('getBip44EntropyImplementation', () => {
     });
 
     messenger.registerActionHandler(
-      'KeyringController:withKeyringV2',
+      'KeyringController:withKeyringV2Unsafe',
       async (_selector, operation) =>
         operation({
           keyring: {
@@ -150,7 +150,7 @@ describe('getBip44EntropyImplementation', () => {
 
       expect(messenger.call).toHaveBeenCalledTimes(1);
       expect(messenger.call).toHaveBeenCalledWith(
-        'KeyringController:withKeyringV2',
+        'KeyringController:withKeyringV2Unsafe',
         { id: 'source-id' },
         expect.any(Function),
       );

--- a/packages/snaps-rpc-methods/src/restricted/getBip44Entropy.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip44Entropy.test.ts
@@ -78,7 +78,7 @@ describe('getBip44EntropyImplementation', () => {
       async (_selector, operation) =>
         operation({
           keyring: {
-            type: 'HD Key Tree',
+            type: 'hd',
             seed: TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES,
           },
         }),

--- a/packages/snaps-rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip44Entropy.ts
@@ -16,7 +16,7 @@ import type {
 import { SnapCaveatType } from '@metamask/snaps-utils';
 import type { NonEmptyArray } from '@metamask/utils';
 
-import type { KeyringControllerWithKeyringAction } from '../types';
+import type { KeyringControllerWithKeyringV2Action } from '../types';
 import type { MethodHooksObject } from '../utils';
 import { getMnemonicSeed, getValueFromEntropySource } from '../utils';
 
@@ -41,7 +41,7 @@ export type GetBip44EntropyMethodHooks = {
 };
 
 export type GetBip44EntropyMessengerActions =
-  KeyringControllerWithKeyringAction;
+  KeyringControllerWithKeyringV2Action;
 
 type GetBip44EntropySpecificationBuilderOptions = {
   methodHooks: GetBip44EntropyMethodHooks;
@@ -159,7 +159,7 @@ export const getBip44EntropyBuilder = Object.freeze({
   targetName,
   specificationBuilder,
   methodHooks,
-  actionNames: ['KeyringController:withKeyring'],
+  actionNames: ['KeyringController:withKeyringV2'],
 } as const);
 
 /**

--- a/packages/snaps-rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getBip44Entropy.ts
@@ -16,7 +16,7 @@ import type {
 import { SnapCaveatType } from '@metamask/snaps-utils';
 import type { NonEmptyArray } from '@metamask/utils';
 
-import type { KeyringControllerWithKeyringV2Action } from '../types';
+import type { KeyringControllerWithKeyringV2UnsafeAction } from '../types';
 import type { MethodHooksObject } from '../utils';
 import { getMnemonicSeed, getValueFromEntropySource } from '../utils';
 
@@ -41,7 +41,7 @@ export type GetBip44EntropyMethodHooks = {
 };
 
 export type GetBip44EntropyMessengerActions =
-  KeyringControllerWithKeyringV2Action;
+  KeyringControllerWithKeyringV2UnsafeAction;
 
 type GetBip44EntropySpecificationBuilderOptions = {
   methodHooks: GetBip44EntropyMethodHooks;
@@ -159,7 +159,7 @@ export const getBip44EntropyBuilder = Object.freeze({
   targetName,
   specificationBuilder,
   methodHooks,
-  actionNames: ['KeyringController:withKeyringV2'],
+  actionNames: ['KeyringController:withKeyringV2Unsafe'],
 } as const);
 
 /**

--- a/packages/snaps-rpc-methods/src/restricted/getEntropy.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getEntropy.test.ts
@@ -20,7 +20,7 @@ describe('getEntropyBuilder', () => {
         getUnlockPromise: true,
         getClientCryptography: true,
       },
-      actionNames: ['KeyringController:withKeyringV2'],
+      actionNames: ['KeyringController:withKeyringV2Unsafe'],
     });
   });
 
@@ -55,7 +55,7 @@ describe('getEntropyImplementation', () => {
     });
 
     messenger.registerActionHandler(
-      'KeyringController:withKeyringV2',
+      'KeyringController:withKeyringV2Unsafe',
       async (_selector, operation) =>
         operation({
           keyring: {
@@ -133,7 +133,7 @@ describe('getEntropyImplementation', () => {
     );
 
     expect(messenger.call).toHaveBeenCalledWith(
-      'KeyringController:withKeyringV2',
+      'KeyringController:withKeyringV2Unsafe',
       { id: 'source-id' },
       expect.any(Function),
     );

--- a/packages/snaps-rpc-methods/src/restricted/getEntropy.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getEntropy.test.ts
@@ -59,7 +59,7 @@ describe('getEntropyImplementation', () => {
       async (_selector, operation) =>
         operation({
           keyring: {
-            type: 'HD Key Tree',
+            type: 'hd',
             seed: TEST_SECRET_RECOVERY_PHRASE_SEED_BYTES,
           },
         }),

--- a/packages/snaps-rpc-methods/src/restricted/getEntropy.test.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getEntropy.test.ts
@@ -20,7 +20,7 @@ describe('getEntropyBuilder', () => {
         getUnlockPromise: true,
         getClientCryptography: true,
       },
-      actionNames: ['KeyringController:withKeyring'],
+      actionNames: ['KeyringController:withKeyringV2'],
     });
   });
 
@@ -55,7 +55,7 @@ describe('getEntropyImplementation', () => {
     });
 
     messenger.registerActionHandler(
-      'KeyringController:withKeyring',
+      'KeyringController:withKeyringV2',
       async (_selector, operation) =>
         operation({
           keyring: {
@@ -133,7 +133,7 @@ describe('getEntropyImplementation', () => {
     );
 
     expect(messenger.call).toHaveBeenCalledWith(
-      'KeyringController:withKeyring',
+      'KeyringController:withKeyringV2',
       { id: 'source-id' },
       expect.any(Function),
     );

--- a/packages/snaps-rpc-methods/src/restricted/getEntropy.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getEntropy.ts
@@ -14,7 +14,7 @@ import { literal, object, optional, string } from '@metamask/superstruct';
 import type { NonEmptyArray } from '@metamask/utils';
 import { assertStruct } from '@metamask/utils';
 
-import type { KeyringControllerWithKeyringV2Action } from '../types';
+import type { KeyringControllerWithKeyringV2UnsafeAction } from '../types';
 import type { MethodHooksObject } from '../utils';
 import {
   deriveEntropyFromSeed,
@@ -24,7 +24,7 @@ import {
 
 const targetName = 'snap_getEntropy';
 
-export type GetEntropyMessengerActions = KeyringControllerWithKeyringV2Action;
+export type GetEntropyMessengerActions = KeyringControllerWithKeyringV2UnsafeAction;
 
 type GetEntropySpecificationBuilderOptions = {
   allowedCaveats?: Readonly<NonEmptyArray<string>> | null;
@@ -115,7 +115,7 @@ export const getEntropyBuilder = Object.freeze({
   targetName,
   specificationBuilder,
   methodHooks,
-  actionNames: ['KeyringController:withKeyringV2'],
+  actionNames: ['KeyringController:withKeyringV2Unsafe'],
 } as const);
 
 export type GetEntropyHooks = {

--- a/packages/snaps-rpc-methods/src/restricted/getEntropy.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getEntropy.ts
@@ -24,7 +24,8 @@ import {
 
 const targetName = 'snap_getEntropy';
 
-export type GetEntropyMessengerActions = KeyringControllerWithKeyringV2UnsafeAction;
+export type GetEntropyMessengerActions =
+  KeyringControllerWithKeyringV2UnsafeAction;
 
 type GetEntropySpecificationBuilderOptions = {
   allowedCaveats?: Readonly<NonEmptyArray<string>> | null;

--- a/packages/snaps-rpc-methods/src/restricted/getEntropy.ts
+++ b/packages/snaps-rpc-methods/src/restricted/getEntropy.ts
@@ -14,7 +14,7 @@ import { literal, object, optional, string } from '@metamask/superstruct';
 import type { NonEmptyArray } from '@metamask/utils';
 import { assertStruct } from '@metamask/utils';
 
-import type { KeyringControllerWithKeyringAction } from '../types';
+import type { KeyringControllerWithKeyringV2Action } from '../types';
 import type { MethodHooksObject } from '../utils';
 import {
   deriveEntropyFromSeed,
@@ -24,7 +24,7 @@ import {
 
 const targetName = 'snap_getEntropy';
 
-export type GetEntropyMessengerActions = KeyringControllerWithKeyringAction;
+export type GetEntropyMessengerActions = KeyringControllerWithKeyringV2Action;
 
 type GetEntropySpecificationBuilderOptions = {
   allowedCaveats?: Readonly<NonEmptyArray<string>> | null;
@@ -115,7 +115,7 @@ export const getEntropyBuilder = Object.freeze({
   targetName,
   specificationBuilder,
   methodHooks,
-  actionNames: ['KeyringController:withKeyring'],
+  actionNames: ['KeyringController:withKeyringV2'],
 } as const);
 
 export type GetEntropyHooks = {

--- a/packages/snaps-rpc-methods/src/types.ts
+++ b/packages/snaps-rpc-methods/src/types.ts
@@ -23,7 +23,7 @@ export type JsonRpcRequestWithOrigin<
 > = JsonRpcRequest<Params> & { origin: string };
 
 export type HdKeyring = {
-  type: 'HD Key Tree';
+  type: 'hd';
   seed?: Uint8Array;
   mnemonic?: Uint8Array;
 };

--- a/packages/snaps-rpc-methods/src/types.ts
+++ b/packages/snaps-rpc-methods/src/types.ts
@@ -28,8 +28,8 @@ export type HdKeyring = {
   mnemonic?: Uint8Array;
 };
 
-export type KeyringControllerWithKeyringV2Action = {
-  type: 'KeyringController:withKeyringV2';
+export type KeyringControllerWithKeyringV2UnsafeAction = {
+  type: 'KeyringController:withKeyringV2Unsafe';
   handler: (
     selector:
       | {

--- a/packages/snaps-rpc-methods/src/types.ts
+++ b/packages/snaps-rpc-methods/src/types.ts
@@ -28,8 +28,8 @@ export type HdKeyring = {
   mnemonic?: Uint8Array;
 };
 
-export type KeyringControllerWithKeyringAction = {
-  type: 'KeyringController:withKeyring';
+export type KeyringControllerWithKeyringV2Action = {
+  type: 'KeyringController:withKeyringV2';
   handler: (
     selector:
       | {

--- a/packages/snaps-rpc-methods/src/utils.ts
+++ b/packages/snaps-rpc-methods/src/utils.ts
@@ -21,7 +21,7 @@ import {
 import { keccak_256 as keccak256 } from '@noble/hashes/sha3';
 
 import { SnapEndowments } from './endowments';
-import type { KeyringControllerWithKeyringV2Action } from './types';
+import type { KeyringControllerWithKeyringV2UnsafeAction } from './types';
 
 const HARDENED_VALUE = 0x80000000;
 
@@ -363,12 +363,12 @@ export const HD_KEYRING = 'HD Key Tree';
  * @returns The mnemonic.
  */
 export async function getMnemonic(
-  messenger: Messenger<string, KeyringControllerWithKeyringV2Action>,
+  messenger: Messenger<string, KeyringControllerWithKeyringV2UnsafeAction>,
   source?: string | undefined,
 ): Promise<Uint8Array> {
   if (!source) {
     const mnemonic = (await messenger.call(
-      'KeyringController:withKeyringV2',
+      'KeyringController:withKeyringV2Unsafe',
       {
         type: HD_KEYRING,
         index: 0,
@@ -385,7 +385,7 @@ export async function getMnemonic(
 
   try {
     const keyringData = await messenger.call(
-      'KeyringController:withKeyringV2',
+      'KeyringController:withKeyringV2Unsafe',
       {
         id: source,
       },
@@ -420,12 +420,12 @@ export async function getMnemonic(
  * @returns The mnemonic seed.
  */
 export async function getMnemonicSeed(
-  messenger: Messenger<string, KeyringControllerWithKeyringV2Action>,
+  messenger: Messenger<string, KeyringControllerWithKeyringV2UnsafeAction>,
   source?: string | undefined,
 ): Promise<Uint8Array> {
   if (!source) {
     const seed = (await messenger.call(
-      'KeyringController:withKeyringV2',
+      'KeyringController:withKeyringV2Unsafe',
       {
         type: HD_KEYRING,
         index: 0,
@@ -442,7 +442,7 @@ export async function getMnemonicSeed(
 
   try {
     const keyringData = await messenger.call(
-      'KeyringController:withKeyringV2',
+      'KeyringController:withKeyringV2Unsafe',
       {
         id: source,
       },

--- a/packages/snaps-rpc-methods/src/utils.ts
+++ b/packages/snaps-rpc-methods/src/utils.ts
@@ -352,7 +352,7 @@ export const UI_PERMISSIONS = [
   SnapEndowments.SignatureInsight,
 ] as const;
 
-export const HD_KEYRING = 'HD Key Tree';
+export const HD_KEYRING = 'hd';
 
 /**
  * Get the mnemonic for a given entropy source. If no source is

--- a/packages/snaps-rpc-methods/src/utils.ts
+++ b/packages/snaps-rpc-methods/src/utils.ts
@@ -21,7 +21,7 @@ import {
 import { keccak_256 as keccak256 } from '@noble/hashes/sha3';
 
 import { SnapEndowments } from './endowments';
-import type { KeyringControllerWithKeyringAction } from './types';
+import type { KeyringControllerWithKeyringV2Action } from './types';
 
 const HARDENED_VALUE = 0x80000000;
 
@@ -363,12 +363,12 @@ export const HD_KEYRING = 'HD Key Tree';
  * @returns The mnemonic.
  */
 export async function getMnemonic(
-  messenger: Messenger<string, KeyringControllerWithKeyringAction>,
+  messenger: Messenger<string, KeyringControllerWithKeyringV2Action>,
   source?: string | undefined,
 ): Promise<Uint8Array> {
   if (!source) {
     const mnemonic = (await messenger.call(
-      'KeyringController:withKeyring',
+      'KeyringController:withKeyringV2',
       {
         type: HD_KEYRING,
         index: 0,
@@ -385,7 +385,7 @@ export async function getMnemonic(
 
   try {
     const keyringData = await messenger.call(
-      'KeyringController:withKeyring',
+      'KeyringController:withKeyringV2',
       {
         id: source,
       },
@@ -420,12 +420,12 @@ export async function getMnemonic(
  * @returns The mnemonic seed.
  */
 export async function getMnemonicSeed(
-  messenger: Messenger<string, KeyringControllerWithKeyringAction>,
+  messenger: Messenger<string, KeyringControllerWithKeyringV2Action>,
   source?: string | undefined,
 ): Promise<Uint8Array> {
   if (!source) {
     const seed = (await messenger.call(
-      'KeyringController:withKeyring',
+      'KeyringController:withKeyringV2',
       {
         type: HD_KEYRING,
         index: 0,
@@ -442,7 +442,7 @@ export async function getMnemonicSeed(
 
   try {
     const keyringData = await messenger.call(
-      'KeyringController:withKeyring',
+      'KeyringController:withKeyringV2',
       {
         id: source,
       },

--- a/packages/snaps-simulation/CHANGELOG.md
+++ b/packages/snaps-simulation/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `withKeyring` to `withKeyringV2Unsafe` ([#4009](https://github.com/MetaMask/snaps/pull/4009))
+- Use `withKeyringV2Unsafe` for accessing entropy ([#4009](https://github.com/MetaMask/snaps/pull/4009))
 
 ## [4.1.4]
 

--- a/packages/snaps-simulation/CHANGELOG.md
+++ b/packages/snaps-simulation/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `withKeyring` to `withKeyringV2` ([#xxx](https://github.com/MetaMask/snaps/pull/xxxx))
+
 ## [4.1.4]
 
 ### Changed

--- a/packages/snaps-simulation/CHANGELOG.md
+++ b/packages/snaps-simulation/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `withKeyring` to `withKeyringV2` ([#4009](https://github.com/MetaMask/snaps/pull/4009))
+- Update `withKeyring` to `withKeyringV2Unsafe` ([#4009](https://github.com/MetaMask/snaps/pull/4009))
 
 ## [4.1.4]
 

--- a/packages/snaps-simulation/CHANGELOG.md
+++ b/packages/snaps-simulation/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `withKeyring` to `withKeyringV2` ([#xxx](https://github.com/MetaMask/snaps/pull/xxxx))
+- Update `withKeyring` to `withKeyringV2` ([#4009](https://github.com/MetaMask/snaps/pull/4009))
 
 ## [4.1.4]
 

--- a/packages/snaps-simulation/src/simulation.test.ts
+++ b/packages/snaps-simulation/src/simulation.test.ts
@@ -522,12 +522,12 @@ describe('registerActions', () => {
     });
   });
 
-  it('registers `KeyringController:withKeyringV2`', async () => {
+  it('registers `KeyringController:withKeyringV2Unsafe`', async () => {
     registerActions(controllerMessenger, runSaga, options, MOCK_SNAP_ID, []);
 
     expect(
       await controllerMessenger.call(
-        'KeyringController:withKeyringV2',
+        'KeyringController:withKeyringV2Unsafe',
         { type: 'HD Key Tree' },
         ({ keyring }) => keyring,
       ),
@@ -539,7 +539,7 @@ describe('registerActions', () => {
 
     expect(
       await controllerMessenger.call(
-        'KeyringController:withKeyringV2',
+        'KeyringController:withKeyringV2Unsafe',
         { id: 'alternative' },
         ({ keyring }) => keyring,
       ),

--- a/packages/snaps-simulation/src/simulation.test.ts
+++ b/packages/snaps-simulation/src/simulation.test.ts
@@ -522,12 +522,12 @@ describe('registerActions', () => {
     });
   });
 
-  it('registers `KeyringController:withKeyring`', async () => {
+  it('registers `KeyringController:withKeyringV2`', async () => {
     registerActions(controllerMessenger, runSaga, options, MOCK_SNAP_ID, []);
 
     expect(
       await controllerMessenger.call(
-        'KeyringController:withKeyring',
+        'KeyringController:withKeyringV2',
         { type: 'HD Key Tree' },
         ({ keyring }) => keyring,
       ),
@@ -539,7 +539,7 @@ describe('registerActions', () => {
 
     expect(
       await controllerMessenger.call(
-        'KeyringController:withKeyring',
+        'KeyringController:withKeyringV2',
         { id: 'alternative' },
         ({ keyring }) => keyring,
       ),

--- a/packages/snaps-simulation/src/simulation.test.ts
+++ b/packages/snaps-simulation/src/simulation.test.ts
@@ -528,11 +528,11 @@ describe('registerActions', () => {
     expect(
       await controllerMessenger.call(
         'KeyringController:withKeyringV2Unsafe',
-        { type: 'HD Key Tree' },
+        { type: 'hd' },
         ({ keyring }) => keyring,
       ),
     ).toStrictEqual({
-      type: 'HD Key Tree',
+      type: 'hd',
       mnemonic: mnemonicPhraseToBytes(DEFAULT_SRP),
       seed: await mnemonicToSeed(DEFAULT_SRP),
     });
@@ -544,7 +544,7 @@ describe('registerActions', () => {
         ({ keyring }) => keyring,
       ),
     ).toStrictEqual({
-      type: 'HD Key Tree',
+      type: 'hd',
       mnemonic: mnemonicPhraseToBytes(DEFAULT_ALTERNATIVE_SRP),
       seed: await mnemonicToSeed(DEFAULT_ALTERNATIVE_SRP),
     });

--- a/packages/snaps-simulation/src/simulation.ts
+++ b/packages/snaps-simulation/src/simulation.ts
@@ -739,7 +739,7 @@ export function registerActions(
 
   controllerMessenger.registerActionHandler(
     // @ts-expect-error - `KeyringController` is not part of the simulation messenger types.
-    'KeyringController:withKeyring',
+    'KeyringController:withKeyringV2',
     async (
       selector: { type: string; index?: number } | { id: string },
       operation: (args: {

--- a/packages/snaps-simulation/src/simulation.ts
+++ b/packages/snaps-simulation/src/simulation.ts
@@ -739,7 +739,7 @@ export function registerActions(
 
   controllerMessenger.registerActionHandler(
     // @ts-expect-error - `KeyringController` is not part of the simulation messenger types.
-    'KeyringController:withKeyringV2',
+    'KeyringController:withKeyringV2Unsafe',
     async (
       selector: { type: string; index?: number } | { id: string },
       operation: (args: {

--- a/packages/snaps-simulation/src/simulation.ts
+++ b/packages/snaps-simulation/src/simulation.ts
@@ -755,7 +755,7 @@ export function registerActions(
 
       return await operation({
         keyring: {
-          type: 'HD Key Tree',
+          type: 'hd',
           mnemonic,
           seed,
         },


### PR DESCRIPTION
This PR updates usage of `withKeyring` to the new `withKeyringV2`. The plan is to convert `withKeyringV2` to be `withKeyring` once usage across the codebase has been converted to v2.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how Snaps read mnemonics/seeds via KeyringController; hosts must expose the new action and correct keyring types or entropy RPCs will fail.
> 
> **Overview**
> **Breaking:** Snap entropy RPCs (`snap_getEntropy`, `snap_getBip32Entropy`, `snap_getBip32PublicKey`, `snap_getBip44Entropy`) and shared helpers now call **`KeyringController:withKeyringV2Unsafe`** instead of **`KeyringController:withKeyring`**. Messenger types, builder `actionNames`, and tests were updated accordingly.
> 
> The expected HD keyring **`type`** string changes from **`HD Key Tree`** to **`hd`** (`HdKeyring`, `HD_KEYRING`, and simulation mocks). **`@metamask/snaps-simulation`** registers the same v2 unsafe handler for tests.
> 
> Changelogs mark this as breaking for **`snaps-rpc-methods`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52d1c9a51e1f189e070e56d4aec1894606236eff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->