### PR TITLE
fix: Simplify endowment handling

### DIFF
--- a/packages/snaps-controllers/src/services/iframe/IframeExecutionService.test.browser.ts
+++ b/packages/snaps-controllers/src/services/iframe/IframeExecutionService.test.browser.ts
@@ -180,27 +180,27 @@ describe('IframeExecutionService', () => {
       snapId: MOCK_SNAP_ID,
       sourceCode: `
         module.exports.onRpcRequest = async ({ request }) => {
-            let result;
-            const promise = new Promise((resolve) => {
-                const xhr = new XMLHttpRequest();
-                xhr.open('GET', 'https://metamask.io/');
-                xhr.send();
-                xhr.onreadystatechange = (ev) => {
-                  result = ev;
-                  resolve();
-                };
+          const controller = new AbortController();
+          let result;
+          const promise = new Promise((resolve) => {
+            controller.signal.addEventListener('abort', (ev) => {
+              result = ev;
+              resolve();
             });
-            await promise;
+          });
 
-            return {
-              targetIsUndefined: result.target === undefined,
-              currentTargetIsUndefined: result.target === undefined,
-              srcElementIsUndefined: result.target === undefined,
-              composedPathIsUndefined: result.target === undefined
-            };
+          controller.abort();
+          await promise;
+
+          return {
+            targetIsUndefined: result.target === undefined,
+            currentTargetIsUndefined: result.currentTarget === undefined,
+            srcElementIsUndefined: result.srcElement === undefined,
+            composedPathIsUndefined: result.composedPath === undefined,
+          };
         };
       `,
-      endowments: ['console', 'XMLHttpRequest'],
+      endowments: ['console', 'AbortController'],
     });
 
     const result = await service.handleRpcRequest(MOCK_SNAP_ID, {

--- a/packages/snaps-execution-environments/src/common/endowments/index.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.test.ts
@@ -38,16 +38,6 @@ describe('Endowment utils', () => {
       expect(result.endowments.snap).toBe(mockSnapAPI);
     });
 
-    it('handles special cases where endowment is not available as part of a factory', () => {
-      const mockEndowment = {};
-      Object.assign(globalThis, { mockEndowment });
-      const { endowments } = createEndowments({
-        ...mockOptions,
-        endowments: ['mockEndowment'],
-      });
-      expect(endowments.mockEndowment).toBeDefined();
-    });
-
     it('handles special case for ethereum endowment', () => {
       Object.assign(globalThis, { ethereum: {} });
       const { endowments } = createEndowments({

--- a/packages/snaps-execution-environments/src/common/endowments/index.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.ts
@@ -1,6 +1,5 @@
 import { rpcErrors } from '@metamask/rpc-errors';
 import type { SnapsEthereumProvider, SnapsProvider } from '@metamask/snaps-sdk';
-import { logWarning } from '@metamask/snaps-utils';
 import { hasProperty } from '@metamask/utils';
 
 import type {
@@ -9,7 +8,6 @@ import type {
   NotifyFunction,
 } from './commonEndowmentFactory';
 import buildCommonEndowments from './commonEndowmentFactory';
-import { rootRealmGlobal } from '../globalObject';
 
 /**
  * Retrieve consolidated endowment factories for common endowments.
@@ -89,14 +87,6 @@ export function createEndowments({
       } else if (endowmentName === 'ethereum') {
         // Special case for adding the EIP-1193 provider.
         allEndowments[endowmentName] = ethereum;
-      } else if (endowmentName in rootRealmGlobal) {
-        logWarning(`Access to unhardened global ${endowmentName}.`);
-        // If the endowment doesn't have a factory, just use whatever is on the
-        // global object.
-        const globalValue = (rootRealmGlobal as Record<string, unknown>)[
-          endowmentName
-        ];
-        allEndowments[endowmentName] = globalValue;
       } else {
         // If we get to this point, we've been passed an endowment that doesn't
         // exist in our current environment.


### PR DESCRIPTION
This removes some dead code.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Removing unhardened global passthrough is a breaking sandbox/API change for any snap that relied on undeclared globals; misconfigured endowment lists will fail at runtime instead of receiving raw host objects.
> 
> **Overview**
> Tightens how Snap execution environments resolve endowments by **removing the fallback that exposed raw `rootRealmGlobal` values** for names without a registered factory. Endowments must now come from the common factory registry (or the existing `ethereum` special case); anything else throws **Unknown endowment** instead of silently wiring unhardened globals (and the warning path is dropped).
> 
> Tests follow that model: the unit case that asserted passthrough for arbitrary globals is removed. The iframe browser test for secured events now drives an **`abort` listener via `AbortController`** (with `AbortController` in the snap endowment list) instead of `XMLHttpRequest`, and expectations are corrected for **`currentTarget`** and **`composedPath`** on the event object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee3b6e921e7299916cea5a4d26c31e635dd53342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->