### PR TITLE
ci: Bump `action-npm-publish` to `v6`

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -108,6 +108,7 @@ jobs:
       - npm-publish-dry-run
       - get-release-tag
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Checkout and setup environment

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,7 +20,7 @@ on:
         default: 'MetaMask bot'
     secrets:
       NPM_TOKEN:
-        required: true
+        required: false
       PUBLISH_PAGES_TOKEN:
         required: true
       SLACK_WEBHOOK_URL:
@@ -94,7 +94,7 @@ jobs:
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Dry run publish to NPM
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: ${{ inputs.slack-subteam }}
@@ -107,6 +107,8 @@ jobs:
     needs:
       - npm-publish-dry-run
       - get-release-tag
+    permissions:
+      id-token: write
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
@@ -118,7 +120,7 @@ jobs:
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Publish ${{ needs.get-release-tag.outputs.tag }} to NPM
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
           npm-tag: ${{ needs.get-release-tag.outputs.tag }}


### PR DESCRIPTION
This bumps `action-npm-publish` to `v6` and enables trusted publishing with OIDC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production NPM packages are authenticated and published; misconfigured OIDC or NPM trusted-publisher setup could block releases until secrets/registry settings are aligned.
> 
> **Overview**
> Updates the **Publish Release** reusable workflow to use **`MetaMask/action-npm-publish@v6`** for both the NPM dry-run and real publish jobs, replacing v5.
> 
> **Trusted publishing (OIDC):** The `npm-publish` job now requests `id-token: write` and `contents: read` so the action can authenticate to NPM without relying solely on a long-lived token. The workflow’s `NPM_TOKEN` caller secret is **optional** (`required: false`); the publish step still passes `npm-token` when provided, but OIDC can satisfy auth under v6.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 036c25013ce258b1ea41a9ffa383cb6ba5864c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->