### PR TITLE
ci: Add missing top-level `permissions` to publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,6 +26,9 @@ on:
       SLACK_WEBHOOK_URL:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   get-release-tag:
     name: Get release tag


### PR DESCRIPTION
## Summary

- Adds top-level `permissions: contents: read` to the publish-release workflow, following the principle of least privilege.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that narrows default GitHub Actions token permissions; jobs with explicit write/id-token permissions are unchanged.
> 
> **Overview**
> Adds **workflow-level** `permissions: contents: read` to the reusable `publish-release` workflow so the default `GITHUB_TOKEN` scope is read-only instead of inheriting broader defaults.
> 
> Jobs that need more access (e.g. `contents: write` for releases/GitHub Pages, `id-token: write` for NPM OIDC) already declare their own `permissions`, so this tightens the baseline without changing those elevated steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5ce360f5165eca8c0b088899c54c8bbbf2aae3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->