### PR TITLE
ci: Use token-exchange action for workflow tokens

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,6 @@ jobs:
       slack-subteam: S05RL9W7H54 # @metamask-snaps-publishers
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      PUBLISH_PAGES_TOKEN: ${{ secrets.PUBLISH_PAGES_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   all-jobs-complete:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,8 +88,6 @@ jobs:
       dependabot: true
       pull-request: ${{ github.event.pull_request.number }}
       pull-request-title: ${{ github.event.pull_request.title }}
-    secrets:
-      PULL_REQUEST_UPDATE_TOKEN: ${{ secrets.PULL_REQUEST_UPDATE_TOKEN }}
 
   lint-build-test:
     name: Build, lint, and test

--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -12,9 +12,6 @@ on:
       publish_dir:
         required: true
         type: string
-    secrets:
-      PUBLISH_PAGES_TOKEN:
-        required: true
 
 jobs:
   publish-environment:
@@ -33,6 +30,13 @@ jobs:
       - name: Ensure `publish_dir` is not empty
         if: ${{ inputs.publish_dir == '' }}
         run: exit 1
+      - name: Get access token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            contents: write
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
@@ -42,6 +46,6 @@ jobs:
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
         uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
         with:
-          personal_token: ${{ secrets.PUBLISH_PAGES_TOKEN }}
+          personal_token: ${{ steps.get-token.outputs.token }}
           publish_dir: ${{ inputs.publish_dir }}
           destination_dir: ${{ inputs.destination_dir }}

--- a/.github/workflows/publish-main-docs.yml
+++ b/.github/workflows/publish-main-docs.yml
@@ -15,8 +15,6 @@ jobs:
       build_script: yarn workspace @metamask/snaps-sdk build:docs
       destination_dir: docs/staging
       publish_dir: ./packages/snaps-sdk/docs
-    secrets:
-      PUBLISH_PAGES_TOKEN: ${{ secrets.PUBLISH_PAGES_TOKEN }}
 
   publish-schema-to-gh-pages:
     name: Publish schema to `schema/staging` directory of `gh-pages` branch
@@ -29,5 +27,3 @@ jobs:
       build_script: yarn workspace @metamask/snaps-rpc-methods build:schema
       destination_dir: schema/staging
       publish_dir: ./packages/snaps-rpc-methods/schema
-    secrets:
-      PUBLISH_PAGES_TOKEN: ${{ secrets.PUBLISH_PAGES_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,8 +21,6 @@ on:
     secrets:
       NPM_TOKEN:
         required: false
-      PUBLISH_PAGES_TOKEN:
-        required: true
       SLACK_WEBHOOK_URL:
         required: false
 
@@ -139,8 +137,6 @@ jobs:
       build_script: yarn workspace @metamask/snaps-rpc-methods build:schema
       destination_dir: schema/latest
       publish_dir: ./packages/snaps-rpc-methods/schema
-    secrets:
-      PUBLISH_PAGES_TOKEN: ${{ secrets.PUBLISH_PAGES_TOKEN }}
 
   is-sdk-release:
     name: Determine whether this release updates Snaps SDK
@@ -180,8 +176,6 @@ jobs:
       build_script: yarn workspace @metamask/snaps-sdk build:docs
       destination_dir: docs/${{ needs.is-sdk-release.outputs.SDK_VERSION }}
       publish_dir: ./packages/snaps-sdk/docs
-    secrets:
-      PUBLISH_PAGES_TOKEN: ${{ secrets.PUBLISH_PAGES_TOKEN }}
 
   publish-docs-to-latest-gh-pages:
     name: Publish docs to `docs/latest` directory of `gh-pages` branch
@@ -193,8 +187,6 @@ jobs:
       build_script: yarn workspace @metamask/snaps-sdk build:docs
       destination_dir: docs/latest
       publish_dir: ./packages/snaps-sdk/docs
-    secrets:
-      PUBLISH_PAGES_TOKEN: ${{ secrets.PUBLISH_PAGES_TOKEN }}
 
   is-environment-release:
     name: Determine whether this release updates the iframe execution environment
@@ -320,8 +312,6 @@ jobs:
       build_script: yarn workspace @metamask/test-snaps build
       destination_dir: test-snaps/${{ needs.is-test-snaps-release.outputs.TEST_SNAPS_VERSION }}
       publish_dir: ./packages/test-snaps/dist
-    secrets:
-      PUBLISH_PAGES_TOKEN: ${{ secrets.PUBLISH_PAGES_TOKEN }}
 
   publish-test-snaps-latest:
     name: Publish test snaps to `latest` folder
@@ -336,5 +326,3 @@ jobs:
       build_script: yarn workspace @metamask/test-snaps build
       destination_dir: test-snaps/latest
       publish_dir: ./packages/test-snaps/dist
-    secrets:
-      PUBLISH_PAGES_TOKEN: ${{ secrets.PUBLISH_PAGES_TOKEN }}

--- a/.github/workflows/update-pull-request.yml
+++ b/.github/workflows/update-pull-request.yml
@@ -5,9 +5,6 @@ on:
     types:
       - created
   workflow_call:
-    secrets:
-      PULL_REQUEST_UPDATE_TOKEN:
-        required: true
     inputs:
       dependabot:
         type: boolean
@@ -48,8 +45,14 @@ jobs:
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' && inputs.dependabot == false }}
     environment: default-branch
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - name: Get access token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            pull_requests: write
+
       - name: React to the comment
         run: |
           gh api \
@@ -60,7 +63,7 @@ jobs:
             -f content='+1'
         env:
           COMMENT_ID: ${{ github.event.comment.id }}
-          GITHUB_TOKEN: ${{ secrets.PULL_REQUEST_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
           REPO: ${{ github.repository }}
 
   prepare:
@@ -74,18 +77,30 @@ jobs:
     outputs:
       COMMIT_SHA: ${{ steps.commit-sha.outputs.COMMIT_SHA }}
     steps:
+      - name: Get access token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            contents: read
+            pull_requests: read
+
       - name: Checkout repository
         uses: actions/checkout@v6
+
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
-          GITHUB_TOKEN: ${{ secrets.PULL_REQUEST_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
           PR_NUMBER: ${{ inputs.pull-request != 0 && inputs.pull-request || github.event.issue.number }}
+
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           cache-node-modules: true
+
       - name: Get commit SHA
         id: commit-sha
         run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
@@ -98,23 +113,37 @@ jobs:
     outputs:
       YARN_LOCK_CHANGED: ${{ steps.check-yarn-lock.outputs.YARN_LOCK_CHANGED }}
     steps:
+      - name: Get access token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            contents: read
+            pull_requests: read
+
       - name: Checkout repository
         uses: actions/checkout@v6
+
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
-          GITHUB_TOKEN: ${{ secrets.PULL_REQUEST_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
           PR_NUMBER: ${{ inputs.pull-request != 0 && inputs.pull-request || github.event.issue.number }}
+
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
+
       - name: Deduplicate yarn.lock
         run: yarn dedupe
+
       - name: Check if yarn.lock changed
         id: check-yarn-lock
         run: |
           git diff --exit-code yarn.lock || echo "YARN_LOCK_CHANGED=true" >> "$GITHUB_OUTPUT"
+
       - name: Save yarn.lock
         uses: actions/upload-artifact@v7
         with:
@@ -129,13 +158,24 @@ jobs:
       - prepare
       - dedupe-yarn-lock
     steps:
+      - name: Get access token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            contents: read
+            pull_requests: read
+
       - name: Checkout repository
         uses: actions/checkout@v6
+
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
-          GITHUB_TOKEN: ${{ secrets.PULL_REQUEST_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
           PR_NUMBER: ${{ inputs.pull-request != 0 && inputs.pull-request || github.event.issue.number }}
+
       - name: Restore yarn.lock
         uses: actions/download-artifact@v8
         with:
@@ -164,28 +204,43 @@ jobs:
       - dedupe-yarn-lock
       - build
     steps:
+      - name: Get access token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            contents: read
+            pull_requests: read
+
       - name: Checkout repository
         uses: actions/checkout@v6
+
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
-          GITHUB_TOKEN: ${{ secrets.PULL_REQUEST_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
           PR_NUMBER: ${{ inputs.pull-request != 0 && inputs.pull-request || github.event.issue.number }}
+
       - name: Restore yarn.lock
         uses: actions/download-artifact@v8
         with:
           name: yarn-lock-${{ needs.prepare.outputs.COMMIT_SHA }}
+
       - name: Restore packages
         uses: actions/download-artifact@v8
         with:
           name: packages-${{ needs.prepare.outputs.COMMIT_SHA }}
+
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           # If the Yarn lock changed we need to reinstall the dependencies.
           is-high-risk-environment: ${{ needs.dedupe-yarn-lock.outputs.YARN_LOCK_CHANGED == 'true' }}
+
       - name: Regenerate LavaMoat policies
         run: yarn build:lavamoat:policy
+
       - name: Save LavaMoat policies
         uses: actions/upload-artifact@v7
         with:
@@ -203,28 +258,43 @@ jobs:
       - dedupe-yarn-lock
       - build
     steps:
+      - name: Get access token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            contents: read
+            pull_requests: read
+
       - name: Checkout repository
         uses: actions/checkout@v6
+
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
-          GITHUB_TOKEN: ${{ secrets.PULL_REQUEST_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
           PR_NUMBER: ${{ inputs.pull-request != 0 && inputs.pull-request || github.event.issue.number }}
+
       - name: Restore yarn.lock
         uses: actions/download-artifact@v8
         with:
           name: yarn-lock-${{ needs.prepare.outputs.COMMIT_SHA }}
+
       - name: Restore packages
         uses: actions/download-artifact@v8
         with:
           name: packages-${{ needs.prepare.outputs.COMMIT_SHA }}
+
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           # If the Yarn lock changed we need to reinstall the dependencies.
           is-high-risk-environment: ${{ needs.dedupe-yarn-lock.outputs.YARN_LOCK_CHANGED == 'true' }}
+
       - name: Update examples
         run: yarn build:examples
+
       - name: Save examples
         uses: actions/upload-artifact@v7
         with:
@@ -245,50 +315,70 @@ jobs:
       - regenerate-lavamoat-policies
       - update-examples
     steps:
+      - name: Get access token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            contents: write
+            pull_requests: read
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           # Use PAT to ensure that the commit later can trigger status check
           # workflows.
-          token: ${{ secrets.PULL_REQUEST_UPDATE_TOKEN }}
+          token: ${{ steps.get-token.outputs.token }}
+
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
-          GITHUB_TOKEN: ${{ secrets.PULL_REQUEST_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
           PR_NUMBER: ${{ inputs.pull-request != 0 && inputs.pull-request || github.event.issue.number }}
+
       - name: Configure Git
         run: |
           git config --global user.name 'MetaMask Bot'
           git config --global user.email 'metamaskbot@users.noreply.github.com'
+
       - name: Get commit SHA
         id: commit-sha
         run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Restore yarn.lock
         uses: actions/download-artifact@v8
         with:
           name: yarn-lock-${{ needs.prepare.outputs.COMMIT_SHA }}
+
       - name: Set commit prefix
         if: ${{ inputs.dependabot == true }}
         run: echo "COMMIT_PREFIX=[dependabot skip] " >> "$GITHUB_ENV"
+
       - name: Commit yarn.lock
         run: |
           git add yarn.lock
           git commit -m "${COMMIT_PREFIX}Deduplicate yarn.lock" || true
+
       - name: Restore LavaMoat policies
         uses: actions/download-artifact@v8
         with:
           name: lavamoat-policies-${{ needs.prepare.outputs.COMMIT_SHA }}
+
       - name: Commit LavaMoat policies
         run: |
           git add packages/snaps-execution-environments/lavamoat
           git commit -m "${COMMIT_PREFIX}Update LavaMoat policies" || true
+
       - name: Restore examples
         uses: actions/download-artifact@v8
         with:
           name: examples-${{ needs.prepare.outputs.COMMIT_SHA }}
+
       - name: Commit examples
         run: |
           git add packages/examples/packages
           git commit -m "${COMMIT_PREFIX}Update example snaps" || true
+
       - name: Push changes
         run: git push


### PR DESCRIPTION
## Summary

Replace the Patroll-based `PULL_REQUEST_UPDATE_TOKEN` and `PUBLISH_PAGES_TOKEN` secrets with tokens fetched via the [`MetaMask/github-tools/get-token`](https://github.com/MetaMask/github-tools) action. Patroll has proven unreliable, so this moves these workflows over to the token-exchange service instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how write-capable tokens are issued for gh-pages deploys and bot commits to PR branches; failures depend on TOKEN_EXCHANGE_URL and environment protection being configured correctly.
> 
> **Overview**
> Replaces Patroll-backed repo secrets **`PULL_REQUEST_UPDATE_TOKEN`** and **`PUBLISH_PAGES_TOKEN`** with short-lived tokens from **`MetaMask/github-tools/.github/actions/get-token@v1`**, using **`vars.TOKEN_EXCHANGE_URL`** and scoped GitHub permissions.
> 
> **GitHub Pages** (`publish-github-pages.yml`): removes the reusable workflow’s `PUBLISH_PAGES_TOKEN` secret input; the publish job fetches a token with `contents: write` and passes it to `peaceiris/actions-gh-pages`. Callers in `main.yml`, `publish-main-docs.yml`, and `publish-release.yml` no longer forward that secret.
> 
> **PR automation** (`update-pull-request.yml`): drops the `PULL_REQUEST_UPDATE_TOKEN` workflow_call secret; each job that needs API/git access runs `get-token` first (read vs write scopes per job) and uses `steps.get-token.outputs.token` for `gh`, checkout, and push. `main.yml` stops passing `PULL_REQUEST_UPDATE_TOKEN` into the Dependabot update job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdf6d3d1964ef83b01b5e101a042c7252a4d1881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->