### PR TITLE
ci: Add zizmor config

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,16 @@
+# Please see the documentation for all configuration options:
+# https://docs.zizmor.sh/configuration/
+
+rules:
+  dependabot-cooldown:
+    config:
+      # Change the minimum allowed cooldown period for Dependabot to 3 days.
+      days: 3
+
+  unpinned-uses:
+    config:
+      policies:
+        # Allow `actions/*` and `MetaMask/*` to be pinned to a version instead
+        # of only to a commit hash.
+        actions/*: ref-pin
+        MetaMask/*: ref-pin


### PR DESCRIPTION
This adds a config for zizmor, which now runs by default as part of `action-security-code-scanner`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only security linter configuration with no runtime or application code changes.
> 
> **Overview**
> Adds **`.github/zizmor.yml`** so the zizmor checks run via `MetaMask/action-security-code-scanner` use repo-specific rule settings.
> 
> **`dependabot-cooldown`** is set to a **3-day** minimum cooldown for Dependabot updates. **`unpinned-uses`** allows `actions/*` and `MetaMask/*` workflow references to satisfy pinning via **version refs** (`ref-pin`) instead of requiring full commit SHAs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92dd755ab40525bb7ae5049ad68356aeceacc2b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->