### PR TITLE
ci: Add missing permissions to update-pull-request workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: read
 
   lint-build-test:
     name: Build, lint, and test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,9 @@ jobs:
       dependabot: true
       pull-request: ${{ github.event.pull_request.number }}
       pull-request-title: ${{ github.event.pull_request.title }}
+    permissions:
+      contents: read
+      id-token: write
 
   lint-build-test:
     name: Build, lint, and test

--- a/.github/workflows/update-pull-request.yml
+++ b/.github/workflows/update-pull-request.yml
@@ -19,6 +19,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   is-fork-pull-request:
     name: Determine whether this issue comment was on a pull request from a fork
@@ -44,6 +47,8 @@ jobs:
     # Early exit if this is a fork, since later steps are skipped for forks.
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' && inputs.dependabot == false }}
     environment: default-branch
+    permissions:
+      id-token: write
     steps:
       - name: Get access token
         id: get-token
@@ -76,6 +81,9 @@ jobs:
     environment: default-branch
     outputs:
       COMMIT_SHA: ${{ steps.commit-sha.outputs.COMMIT_SHA }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Get access token
         id: get-token
@@ -112,6 +120,9 @@ jobs:
     environment: default-branch
     outputs:
       YARN_LOCK_CHANGED: ${{ steps.check-yarn-lock.outputs.YARN_LOCK_CHANGED }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Get access token
         id: get-token
@@ -157,6 +168,9 @@ jobs:
     needs:
       - prepare
       - dedupe-yarn-lock
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Get access token
         id: get-token
@@ -203,6 +217,9 @@ jobs:
       - prepare
       - dedupe-yarn-lock
       - build
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Get access token
         id: get-token
@@ -257,6 +274,9 @@ jobs:
       - prepare
       - dedupe-yarn-lock
       - build
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Get access token
         id: get-token
@@ -314,6 +334,9 @@ jobs:
       - dedupe-yarn-lock
       - regenerate-lavamoat-policies
       - update-examples
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Get access token
         id: get-token

--- a/.github/workflows/update-pull-request.yml
+++ b/.github/workflows/update-pull-request.yml
@@ -29,6 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
The `update-pull-request` workflow is missing `id-token: write` permission to perform OIDC token exchange.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow permission scoping only; no runtime application or data-path changes.
> 
> **Overview**
> Adds explicit **GitHub Actions `permissions`** so the **update-pull-request** flow can use OIDC with `MetaMask/github-tools/.github/actions/get-token` and run `gh` against PRs without relying on overly broad defaults.
> 
> In **`main.yml`**, the Dependabot **`update-pull-request`** reusable-workflow call now passes **`contents: read`**, **`id-token: write`**, and **`pull-requests: read`** into the child workflow.
> 
> In **`update-pull-request.yml`**, a workflow default of **`contents: read`** is set, **`is-fork-pull-request`** gets **`pull-requests: read`** for `gh pr view`, and every job that calls **`get-token`** (`react-to-comment`, `prepare`, dedupe/build/LavaMoat/examples, and **`commit-result`**) declares **`id-token: write`** (with **`contents: read`** where checkout/token exchange needs it).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b9a10daeaa16cb9e9373b2c019b12c52476d92c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->