### PR TITLE
chore: Add `sha256` hash to `packageManager` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "vite": "^6.4.1",
     "yargs": "^17.7.1"
   },
-  "packageManager": "yarn@4.16.0",
+  "packageManager": "yarn@4.16.0+sha256.ba05224324578801b9cc98170d64aa50b9a36733b440fb0942306da3fbbdc7d1",
   "engines": {
     "node": "^20 || >=22"
   },

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -241,7 +241,7 @@ module.exports = defineConfig({
       if (isChildWorkspace) {
         workspace.unset('packageManager');
       } else {
-        expectWorkspaceField(workspace, 'packageManager', 'yarn@4.16.0');
+        expectYarnPackageManager(workspace);
       }
 
       // All packages must specify a minimum Node.js version of 18.18.
@@ -765,5 +765,28 @@ function expectConsistentDependenciesAndDevDependencies(Yarn) {
         }
       }
     }
+  }
+}
+
+/**
+ * Expect that the workspace has a package manager set, and that it is Yarn with
+ * a sha256 hash.
+ *
+ * @param {Workspace} workspace - The workspace to check.
+ */
+function expectYarnPackageManager(workspace) {
+  expectWorkspaceField(workspace, 'packageManager');
+
+  const { packageManager } = workspace.manifest;
+  if (!packageManager.startsWith('yarn@')) {
+    workspace.error(
+      `Expected packageManager to start with "yarn@<version>", but got "${packageManager}".`,
+    );
+  }
+
+  if (!packageManager.includes('sha256')) {
+    workspace.error(
+      `Expected packageManager to include a sha256 hash, but got "${packageManager}".`,
+    );
   }
 }


### PR DESCRIPTION
## Explanation

The root `package.json` previously set `packageManager` to `yarn@4.16.0` with no integrity hash. Corepack supports an optional `+sha256.<hash>` suffix that pins the Yarn binary to a known checksum, ensuring that anyone running `corepack` against this repo gets the exact same Yarn binary that was vetted.

This PR adds the sha256 hash to the `packageManager` field. To accommodate it, the Yarn constraint in `yarn.config.cjs` is relaxed from an exact-string match (`yarn@4.16.0`) to a structural check via a new `expectYarnPackageManager` helper that asserts the field starts with `yarn@` and includes a sha256 hash. This lets the hash evolve when Yarn is bumped without requiring a constraint change at the same time.

## References

Mirrors [`MetaMask/core#9122`](https://github.com/MetaMask/core/pull/9122).