### PR TITLE
feat: add `requestPeriodicUpdate` method to `SnapRegistryController`

### DIFF
--- a/packages/snaps-controllers/src/snaps/registry/SnapRegistryController-method-action-types.ts
+++ b/packages/snaps-controllers/src/snaps/registry/SnapRegistryController-method-action-types.ts
@@ -6,7 +6,7 @@
 import type { SnapRegistryController } from './SnapRegistryController';
 
 /**
- * Trigger a periodic update of the registry database.
+ * Request a periodic update of the registry database.
  *
  * This useful for updating the database with a longer interval than the
  * recent fetch threshold, which can help to reduce the number of fetches

--- a/packages/snaps-controllers/src/snaps/registry/SnapRegistryController-method-action-types.ts
+++ b/packages/snaps-controllers/src/snaps/registry/SnapRegistryController-method-action-types.ts
@@ -6,6 +6,18 @@
 import type { SnapRegistryController } from './SnapRegistryController';
 
 /**
+ * Trigger a periodic update of the registry database.
+ *
+ * This useful for updating the database with a longer interval than the
+ * recent fetch threshold, which can help to reduce the number of fetches
+ * while still keeping the database reasonably up to date.
+ */
+export type SnapRegistryControllerRequestPeriodicUpdateAction = {
+  type: `SnapRegistryController:requestPeriodicUpdate`;
+  handler: SnapRegistryController['requestPeriodicUpdate'];
+};
+
+/**
  * Triggers an update of the registry database.
  *
  * If an existing update is in progress this function will await that update.
@@ -49,6 +61,7 @@ export type SnapRegistryControllerGetMetadataAction = {
  * Union of all SnapRegistryController action types.
  */
 export type SnapRegistryControllerMethodActions =
+  | SnapRegistryControllerRequestPeriodicUpdateAction
   | SnapRegistryControllerRequestUpdateAction
   | SnapRegistryControllerGetAction
   | SnapRegistryControllerResolveVersionAction

--- a/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.test.ts
+++ b/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.test.ts
@@ -624,7 +624,7 @@ describe('SnapRegistryController', () => {
     });
 
     it('skips the update if the registry was fetched within the periodic threshold', async () => {
-      const { registry } = getRegistry({
+      const { registry, messenger } = getRegistry({
         state: {
           lastUpdated: Date.now(),
           database: MOCK_DATABASE,
@@ -632,9 +632,14 @@ describe('SnapRegistryController', () => {
           databaseUnavailable: false,
         },
       });
+
+      const listener = jest.fn();
+      messenger.subscribe('SnapRegistryController:registryUpdated', listener);
+
       await registry.requestPeriodicUpdate();
 
       expect(fetchMock).not.toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledWith(false);
     });
 
     it('fetches the registry if the last update was older than the periodic threshold', async () => {

--- a/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.test.ts
+++ b/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.test.ts
@@ -617,14 +617,14 @@ describe('SnapRegistryController', () => {
         .mockResponseOnce(JSON.stringify(MOCK_DATABASE))
         .mockResponseOnce(JSON.stringify(MOCK_SIGNATURE_FILE));
 
-      const { registry } = getRegistry();
-      await registry.requestPeriodicUpdate();
+      const { messenger } = getRegistry();
+      await messenger.call('SnapRegistryController:requestPeriodicUpdate');
 
       expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
     it('skips the update if the registry was fetched within the periodic threshold', async () => {
-      const { registry, messenger } = getRegistry({
+      const { messenger } = getRegistry({
         state: {
           lastUpdated: Date.now(),
           database: MOCK_DATABASE,
@@ -636,7 +636,7 @@ describe('SnapRegistryController', () => {
       const listener = jest.fn();
       messenger.subscribe('SnapRegistryController:registryUpdated', listener);
 
-      await registry.requestPeriodicUpdate();
+      await messenger.call('SnapRegistryController:requestPeriodicUpdate');
 
       expect(fetchMock).not.toHaveBeenCalled();
       expect(listener).toHaveBeenCalledWith(false);
@@ -647,7 +647,7 @@ describe('SnapRegistryController', () => {
         .mockResponseOnce(JSON.stringify(MOCK_DATABASE))
         .mockResponseOnce(JSON.stringify(MOCK_SIGNATURE_FILE));
 
-      const { registry } = getRegistry({
+      const { messenger } = getRegistry({
         state: {
           lastUpdated: 0,
           database: MOCK_DATABASE,
@@ -655,7 +655,7 @@ describe('SnapRegistryController', () => {
           databaseUnavailable: false,
         },
       });
-      await registry.requestPeriodicUpdate();
+      await messenger.call('SnapRegistryController:requestPeriodicUpdate');
 
       expect(fetchMock).toHaveBeenCalledTimes(2);
     });

--- a/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.test.ts
+++ b/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.test.ts
@@ -611,6 +611,51 @@ describe('SnapRegistryController', () => {
     });
   });
 
+  describe('requestPeriodicUpdate', () => {
+    it('fetches the registry if it has never been fetched', async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(MOCK_DATABASE))
+        .mockResponseOnce(JSON.stringify(MOCK_SIGNATURE_FILE));
+
+      const { registry } = getRegistry();
+      await registry.requestPeriodicUpdate();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips the update if the registry was fetched within the periodic threshold', async () => {
+      const { registry } = getRegistry({
+        state: {
+          lastUpdated: Date.now(),
+          database: MOCK_DATABASE,
+          signature: MOCK_SIGNATURE,
+          databaseUnavailable: false,
+        },
+      });
+      await registry.requestPeriodicUpdate();
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('fetches the registry if the last update was older than the periodic threshold', async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(MOCK_DATABASE))
+        .mockResponseOnce(JSON.stringify(MOCK_SIGNATURE_FILE));
+
+      const { registry } = getRegistry({
+        state: {
+          lastUpdated: 0,
+          database: MOCK_DATABASE,
+          signature: MOCK_SIGNATURE,
+          databaseUnavailable: false,
+        },
+      });
+      await registry.requestPeriodicUpdate();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('update', () => {
     it('updates the database', async () => {
       fetchMock

--- a/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.ts
+++ b/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.ts
@@ -103,6 +103,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'getMetadata',
   'resolveVersion',
   'requestUpdate',
+  'requestPeriodicUpdate',
 ] as const;
 
 const defaultState = {

--- a/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.ts
+++ b/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.ts
@@ -211,7 +211,7 @@ export class SnapRegistryController extends BaseController<
   }
 
   /**
-   * Trigger a periodic update of the registry database.
+   * Request a periodic update of the registry database.
    *
    * This useful for updating the database with a longer interval than the
    * recent fetch threshold, which can help to reduce the number of fetches

--- a/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.ts
+++ b/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.ts
@@ -218,6 +218,7 @@ export class SnapRegistryController extends BaseController<
    */
   async requestPeriodicUpdate() {
     if (this.#wasRecentlyFetched(this.#periodicFetchThreshold)) {
+      this.messenger.publish('SnapRegistryController:registryUpdated', false);
       return;
     }
 

--- a/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.ts
+++ b/packages/snaps-controllers/src/snaps/registry/SnapRegistryController.ts
@@ -54,6 +54,7 @@ export type SnapRegistryControllerArgs = {
   fetchFunction?: typeof fetch;
   url?: JsonSnapsRegistryUrl;
   recentFetchThreshold?: number;
+  periodicFetchThreshold?: number;
   refetchOnAllowlistMiss?: boolean;
   publicKey?: Hex;
   clientConfig: ClientConfig;
@@ -128,6 +129,8 @@ export class SnapRegistryController extends BaseController<
 
   readonly #refetchOnAllowlistMiss: boolean;
 
+  readonly #periodicFetchThreshold: number;
+
   #currentUpdate: Promise<void> | null;
 
   constructor({
@@ -141,6 +144,7 @@ export class SnapRegistryController extends BaseController<
     clientConfig,
     fetchFunction = globalThis.fetch.bind(undefined),
     recentFetchThreshold = inMilliseconds(5, Duration.Minute),
+    periodicFetchThreshold = inMilliseconds(4, Duration.Hour),
     refetchOnAllowlistMiss = true,
   }: SnapRegistryControllerArgs) {
     super({
@@ -182,6 +186,7 @@ export class SnapRegistryController extends BaseController<
     this.#clientConfig = clientConfig;
     this.#fetchFunction = fetchFunction;
     this.#recentFetchThreshold = recentFetchThreshold;
+    this.#periodicFetchThreshold = periodicFetchThreshold;
     this.#refetchOnAllowlistMiss = refetchOnAllowlistMiss;
     this.#currentUpdate = null;
 
@@ -191,11 +196,32 @@ export class SnapRegistryController extends BaseController<
     );
   }
 
-  #wasRecentlyFetched() {
+  /**
+   * Get whether the registry was recently fetched.
+   *
+   * @param threshold - The threshold in milliseconds to consider the registry
+   * as recently fetched.
+   * @returns Whether the registry was recently fetched.
+   */
+  #wasRecentlyFetched(threshold = this.#recentFetchThreshold) {
     return (
-      this.state.lastUpdated &&
-      Date.now() - this.state.lastUpdated < this.#recentFetchThreshold
+      this.state.lastUpdated && Date.now() - this.state.lastUpdated < threshold
     );
+  }
+
+  /**
+   * Trigger a periodic update of the registry database.
+   *
+   * This useful for updating the database with a longer interval than the
+   * recent fetch threshold, which can help to reduce the number of fetches
+   * while still keeping the database reasonably up to date.
+   */
+  async requestPeriodicUpdate() {
+    if (this.#wasRecentlyFetched(this.#periodicFetchThreshold)) {
+      return;
+    }
+
+    await this.requestUpdate();
   }
 
   /**
@@ -220,7 +246,7 @@ export class SnapRegistryController extends BaseController<
   /**
    * Updates the registry database if the registry hasn't been updated recently.
    *
-   * NOTE: SHOULD NOT be called directly, instead `triggerUpdate` should be used.
+   * NOTE: SHOULD NOT be called directly, instead `requestUpdate` should be used.
    */
   async #update() {
     // No-op if we recently fetched the registry.


### PR DESCRIPTION
## Summary

Adds a `periodicFetchThreshold` option (default: 4 hours) and a public `requestPeriodicUpdate` method to `SnapRegistryController`.

The new method is similar to `requestUpdate`, but skips the update if the registry was fetched within the periodic threshold. This is useful for callers that want to keep the registry reasonably up to date on a longer interval (e.g., on wallet unlock) without triggering a fetch on every call.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and config with tests; existing `requestUpdate` behavior is unchanged.
> 
> **Overview**
> Adds **`requestPeriodicUpdate`** on `SnapRegistryController` so callers can refresh the snap allowlist registry on a **longer cadence** (default **4 hours**) without hitting the existing **5-minute** “recent fetch” guard used by `requestUpdate`.
> 
> The controller gains a configurable **`periodicFetchThreshold`** and refactors **`#wasRecentlyFetched`** to accept an optional threshold. When the last fetch is still inside that window, **`requestPeriodicUpdate`** no-ops and publishes **`registryUpdated`** with `false`; otherwise it delegates to **`requestUpdate`**. Messenger action types and unit tests cover first fetch, skip-within-threshold, and fetch-after-threshold behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9343e1f9535196df2112d97e88e52a7640bbe76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->