### PR TITLE
fix: Correct `KeyringAccountType` values

### DIFF
--- a/packages/snaps-sdk/CHANGELOG.md
+++ b/packages/snaps-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `KeyringAccountType` members ([#4057](https://github.com/MetaMask/snaps/pull/4057))
+  - Removed bad member `entropy:account`.
+  - Added `any:account` and missing `stellar:account`.
+
 ## [11.1.1]
 
 ### Fixed

--- a/packages/snaps-sdk/CHANGELOG.md
+++ b/packages/snaps-sdk/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `KeyringAccountType` members ([#4057](https://github.com/MetaMask/snaps/pull/4057))
-  - Removed bad member `entropy:account`.
-  - Added `any:account` and missing `stellar:account`.
+- Correct `KeyringAccountType` values ([#4057](https://github.com/MetaMask/snaps/pull/4057))
+  - Removed invalid value `entropy:account`.
+  - Added missing values `any:account` and `stellar:account`.
 
 ## [11.1.1]
 

--- a/packages/snaps-sdk/src/types/permissions.ts
+++ b/packages/snaps-sdk/src/types/permissions.ts
@@ -97,7 +97,8 @@ type KeyringAccountType =
   | 'bip122:p2tr'
   | 'solana:data-account'
   | 'tron:eoa'
-  | 'entropy:account';
+  | 'stellar:account'
+  | 'any:account';
 
 /**
  * Capabilities object supported by a keyring Snap.

--- a/packages/snaps-utils/CHANGELOG.md
+++ b/packages/snaps-utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `KeyringAccountType` members ([#4057](https://github.com/MetaMask/snaps/pull/4057))
+  - Removed bad member `entropy:account`.
+  - Added `any:account` and missing `stellar:account`.
+
 ## [12.2.1]
 
 ### Fixed

--- a/packages/snaps-utils/CHANGELOG.md
+++ b/packages/snaps-utils/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `KeyringAccountType` members ([#4057](https://github.com/MetaMask/snaps/pull/4057))
-  - Removed bad member `entropy:account`.
-  - Added `any:account` and missing `stellar:account`.
+- Correct `KeyringAccountType` values in `KeyringCapabilitiesStruct` ([#4057](https://github.com/MetaMask/snaps/pull/4057))
+  - Removed invalid value `entropy:account`.
+  - Added missing values `any:account` and `stellar:account`.
 
 ## [12.2.1]
 

--- a/packages/snaps-utils/src/keyring.ts
+++ b/packages/snaps-utils/src/keyring.ts
@@ -32,7 +32,8 @@ const KeyringAccountTypeStruct = enums([
   'bip122:p2tr',
   'solana:data-account',
   'tron:eoa',
-  'entropy:account',
+  'stellar:account',
+  'any:account',
 ]);
 
 /**


### PR DESCRIPTION
The `entropy:account` does not exist at all on the `accounts` side. I assume this was meant to be `any:account` (which is a generic account type we can use for dev purposes).

Also added `stellar:account` which is new account type we now support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small enum alignment for keyring permissions; removing `entropy:account` could fail validation for any manifest that still declared it, but that value was never valid on the accounts side.
> 
> **Overview**
> Aligns **`KeyringAccountType`** with `@metamask/keyring-api` in **`@metamask/snaps-sdk`** (`permissions.ts`) and **`@metamask/snaps-utils`** (`KeyringAccountTypeStruct` in `keyring.ts`).
> 
> **Removed** the invalid literal **`entropy:account`**. **Added** **`stellar:account`** and **`any:account`** so keyring capability typing and manifest/runtime validation accept the account types the accounts stack actually supports.
> 
> Changelogs for both packages document the fix under **[Unreleased]**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b603c188423dbb220754989d8d79569d7341df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->