### PR TITLE
chore: restrict Dependabot GitHub Actions updates to major versions only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,5 +25,10 @@ updates:
     allow:
       - dependency-name: 'MetaMask/*'
       - dependency-name: 'actions/*'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
     target-branch: 'main'
     open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot was opening PRs for minor and patch updates to GitHub Actions (e.g., `MetaMask/action-is-release@v2.2.0`). Since we use floating major tags (e.g., `MetaMask/action-is-release@v2`), minor and patch bumps are automatically picked up and don't need separate PRs. This adds an `ignore` block to skip `semver-minor` and `semver-patch` updates, so Dependabot will only open PRs for major version bumps (e.g., `v2` → `v3`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI automation config only; no runtime or application code changes.
> 
> **Overview**
> **Dependabot** for the `github-actions` ecosystem now **ignores** minor and patch version updates for all allowed action dependencies.
> 
> Only **major** version bumps (e.g. `v2` → `v3`) will open PRs. This matches workflows that pin **floating major tags** (`@v3`, `@v7`), so routine minor/patch releases no longer generate redundant update PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3808152f54ff23aa8e4febadfe92da165812e811. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->