### PR TITLE
feat: Add `Blob` as a default endowment

### DIFF
--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -1113,6 +1113,69 @@ describe('BaseSnapExecutor', () => {
     });
   });
 
+  it('exposes a Blob global works with instanceof', async () => {
+    const CODE = `
+      module.exports.onRpcRequest = () => fetch('https://metamask.io').then(res => res.blob()).then(blob => blob instanceof Blob);
+    `;
+
+    const fetchSpy = spy(globalThis, 'fetch');
+
+    fetchSpy.mockImplementation(async () => {
+      return new Response('foo');
+    });
+
+    const executor = new TestSnapExecutor();
+    await executor.executeSnap(1, MOCK_SNAP_ID, CODE, ['fetch', 'Blob']);
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'OK',
+    });
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'snapRpc',
+      params: {
+        snapId: MOCK_SNAP_ID,
+        handler: HandlerType.OnRpcRequest,
+        origin: MOCK_ORIGIN,
+        request: { jsonrpc: '2.0', method: '' },
+      },
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      method: 'OutboundRequest',
+      params: { source: 'fetch' },
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      method: 'OutboundResponse',
+      params: { source: 'fetch' },
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      method: 'OutboundRequest',
+      params: { source: 'fetch' },
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      method: 'OutboundResponse',
+      params: { source: 'fetch' },
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      id: 2,
+      jsonrpc: '2.0',
+      result: true,
+    });
+  });
+
   it('notifies execution service of out of band errors via unhandledrejection', async () => {
     const CODE = `
       module.exports.onRpcRequest = async () => 'foo';

--- a/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
@@ -82,6 +82,7 @@ const commonEndowments: CommonEndowmentSpecification[] = [
   { endowment: BigInt, name: 'BigInt' },
   { endowment: BigInt64Array, name: 'BigInt64Array' },
   { endowment: BigUint64Array, name: 'BigUint64Array' },
+  { endowment: Blob, name: 'Blob' },
   { endowment: btoa, name: 'btoa', bind: true },
   { endowment: DataView, name: 'DataView' },
   { endowment: Float32Array, name: 'Float32Array' },

--- a/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
@@ -166,6 +166,10 @@ describe('endowments', () => {
         endowments: { DateAttenuated },
         factory: () => new DateAttenuated(),
       },
+      Blob: {
+        endowments: { Blob },
+        factory: () => new Blob([new ArrayBuffer(64)]),
+      },
 
       // Objects.
       consoleAttenuated: {
@@ -347,6 +351,10 @@ describe('endowments', () => {
         {
           factory: expect.any(Function),
           names: ['BigUint64Array'],
+        },
+        {
+          factory: expect.any(Function),
+          names: ['Blob'],
         },
         {
           factory: expect.any(Function),

--- a/packages/snaps-simulation/src/methods/specifications.test.ts
+++ b/packages/snaps-simulation/src/methods/specifications.test.ts
@@ -415,6 +415,7 @@ describe('getEndowments', () => {
         "ArrayBuffer",
         "AbortController",
         "AbortSignal",
+        "Blob",
         "fetch",
         "Request",
         "Headers",

--- a/packages/snaps-utils/src/default-endowments.ts
+++ b/packages/snaps-utils/src/default-endowments.ts
@@ -38,4 +38,5 @@ export const DEFAULT_ENDOWMENTS: readonly string[] = Object.freeze([
   // https://github.com/MetaMask/snaps-monorepo/discussions/678
   'AbortController',
   'AbortSignal',
+  'Blob',
 ]);


### PR DESCRIPTION
Add `Blob` as a default endowment for `instanceof` checks when using `fetch`.

https://consensyssoftware.atlassian.net/browse/WPC-1126

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small expansion of the default sandbox API using the same hardened global pattern as other Web platform types; no auth or network policy changes.
> 
> **Overview**
> Snaps now receive a hardened global **`Blob`** by default, alongside existing fetch-related globals like **`Response`**.
> 
> **`Blob`** is registered in the common endowment factory, included in **`DEFAULT_ENDOWMENTS`**, and covered by hardening and executor tests (including **`fetch` → `res.blob()` → `instanceof Blob`**). Simulation endowment snapshots are updated to list **`Blob`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00347d2173826058c055f13b8188fb375f24cef5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->