### PR TITLE
ci: Correct permissions for GitHub Pages publishing

### DIFF
--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -19,7 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: github-pages
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     steps:
       - name: Ensure `build_script` is not empty
         if: ${{ inputs.destination_dir == '' }}

--- a/.github/workflows/publish-main-docs.yml
+++ b/.github/workflows/publish-main-docs.yml
@@ -9,7 +9,8 @@ jobs:
   publish-to-gh-pages:
     name: Publish docs to `staging` directory of `gh-pages` branch
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-github-pages.yml
     with:
       build_script: yarn workspace @metamask/snaps-sdk build:docs
@@ -21,7 +22,8 @@ jobs:
     needs:
       - publish-to-gh-pages
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-github-pages.yml
     with:
       build_script: yarn workspace @metamask/snaps-rpc-methods build:schema

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,7 +26,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   get-release-tag:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,6 +26,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   get-release-tag:
@@ -131,7 +132,8 @@ jobs:
     name: Publish schema to `schema/latest` directory of `gh-pages` branch
     needs: publish-release
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-github-pages.yml
     with:
       build_script: yarn workspace @metamask/snaps-rpc-methods build:schema
@@ -170,7 +172,8 @@ jobs:
     needs: is-sdk-release
     if: ${{ needs.is-sdk-release.outputs.IS_SDK_RELEASE == 'true' }}
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-github-pages.yml
     with:
       build_script: yarn workspace @metamask/snaps-sdk build:docs
@@ -181,7 +184,8 @@ jobs:
     name: Publish docs to `docs/latest` directory of `gh-pages` branch
     needs: publish-docs-to-gh-pages
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-github-pages.yml
     with:
       build_script: yarn workspace @metamask/snaps-sdk build:docs
@@ -306,7 +310,8 @@ jobs:
     needs: is-test-snaps-release
     if: ${{ needs.is-test-snaps-release.outputs.IS_TEST_SNAPS_RELEASE == 'true' }}
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-github-pages.yml
     with:
       build_script: yarn workspace @metamask/test-snaps build
@@ -320,7 +325,8 @@ jobs:
       - publish-test-snaps
     if: ${{ needs.is-test-snaps-release.outputs.IS_TEST_SNAPS_RELEASE == 'true' }}
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-github-pages.yml
     with:
       build_script: yarn workspace @metamask/test-snaps build


### PR DESCRIPTION
Add `id-token: write` to CI workflows that try to use token exchange service for publishing to GitHub Pages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission tightening aligned with existing token-exchange deploy; no application or runtime behavior changes.
> 
> **Overview**
> Updates GitHub Actions **permissions** on every job that calls the reusable `publish-github-pages` workflow so publishing can use the MetaMask **token exchange** path instead of relying on `contents: write` on `GITHUB_TOKEN`.
> 
> Each affected job now sets **`contents: read`** and **`id-token: write`** (replacing **`contents: write`**). The same change is applied in the reusable workflow’s `publish-environment` job. Call sites include main-branch doc/schema publishing, release-time docs/schema/test-snaps Pages deploys, and the shared workflow definition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfd4480921172e852bdd2ab9fcdf08e0d4b9e165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->