### PR TITLE
fix: Hide preinstalled example Snap

### DIFF
--- a/packages/examples/packages/preinstalled/snap.config.ts
+++ b/packages/examples/packages/preinstalled/snap.config.ts
@@ -10,7 +10,7 @@ const config: SnapConfig = {
   },
   preinstalled: {
     hideSnapBranding: true,
-    hidden: false,
+    hidden: true,
     removable: false,
   },
   stats: {


### PR DESCRIPTION
The previous versions of the preinstalled example Snap had omitted `hidden`, this results in it actually being hidden from the UI, which some E2Es assert against. This PR restores that behaviour and makes it explicit. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single boolean in an example snap config; no production snap controller or security behavior changes.
> 
> **Overview**
> Sets **`preinstalled.hidden`** to **`true`** in the preinstalled example’s `snap.config.ts` so the snap stays out of the normal UI, matching how older builds behaved when the flag was omitted and what E2E tests expect.
> 
> No runtime logic changes—only explicit config for the example package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b87e12883c1a85c9bb1917123c203d43fc3f511e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->