### PR TITLE
fix: Rename duplicate identifiers

### DIFF
--- a/packages/test-snaps/src/features/snaps/jsx/Jsx.tsx
+++ b/packages/test-snaps/src/features/snaps/jsx/Jsx.tsx
@@ -35,7 +35,7 @@ export const Jsx: FunctionComponent = () => {
         Show JSX dialog
       </Button>
       <Result>
-        <span id="rpcResult">
+        <span id="jsxResult">
           {JSON.stringify(data, null, 2)}
           {JSON.stringify(error, null, 2)}
         </span>

--- a/packages/test-snaps/src/features/snaps/preinstalled/Preinstalled.tsx
+++ b/packages/test-snaps/src/features/snaps/preinstalled/Preinstalled.tsx
@@ -126,7 +126,7 @@ export const Preinstalled: FunctionComponent = () => {
         </Button>
       </ButtonGroup>
       <Result>
-        <span id="rpcResult">
+        <span id="preinstalledResult">
           {JSON.stringify(data, null, 2)}
           {JSON.stringify(error, null, 2)}
         </span>


### PR DESCRIPTION
Rename duplicate identifiers in test-snaps to prevent collisions during E2E.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness DOM id changes only; no production or snap runtime behavior is affected.
> 
> **Overview**
> Renames shared **`rpcResult`** DOM ids on the JSX and Preinstalled snap demo pages so each feature exposes a **unique** result span for tests.
> 
> **`Jsx.tsx`** now uses **`jsxResult`**; **`Preinstalled.tsx`** uses **`preinstalledResult`**. The JSON-RPC snap page keeps **`rpcResult`**, so E2E selectors no longer collide when multiple snap panels render on one page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf73b1b1d1470da26dd95e2cc56bb52c9edea8a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->