### PR TITLE
chore: fix typo in SnapController comment

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -616,7 +616,7 @@ export type SnapControllerArgs = {
   excludedPermissions?: Record<string, string>;
 
   /**
-   * The function that will be used by the controller fo make network requests.
+   * The function that will be used by the controller to make network requests.
    * Should be compatible with {@link fetch}.
    */
   fetchFunction?: typeof fetch;


### PR DESCRIPTION
## Description

Fix a typo in the `fetchFunction` documentation in `SnapControllerArgs`, changing “fo make network requests” to “to make network requests”.

This is a documentation-only change with no runtime or type behavior changes.

## Testing

- Prettier check passes
- ESLint passes
- Targeted spelling check passes
- `git diff --check` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no effect on execution or types.
> 
> **Overview**
> Fixes a typo in the `SnapControllerArgs` JSDoc for **`fetchFunction`**: “fo make network requests” → “**to make network requests**”.
> 
> Documentation-only; no runtime, types, or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79a2089e5d996d2528446c53adbdfa85b31f28db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->