### PR TITLE
docs: fix broken file links in package READMEs

### DIFF
--- a/packages/examples/packages/cronjobs/README.md
+++ b/packages/examples/packages/cronjobs/README.md
@@ -52,4 +52,4 @@ request:
 ```
 
 For more information, you can refer to
-[the end-to-end tests](./src/index.test.ts).
+[the end-to-end tests](./src/index.test.tsx).

--- a/packages/examples/packages/dialogs/README.md
+++ b/packages/examples/packages/dialogs/README.md
@@ -34,4 +34,4 @@ For the sake of simplicity, the methods do not accept any parameters, and
 return the value returned by `snap_dialog` directly.
 
 For more information, you can refer to
-[the end-to-end tests](./src/index.test.ts).
+[the end-to-end tests](./src/index.test.tsx).

--- a/packages/examples/packages/ethers-js/README.md
+++ b/packages/examples/packages/ethers-js/README.md
@@ -19,4 +19,4 @@ JSON-RPC methods:
   uses it to sign a `message`.
 
 For more information, you can refer to
-[the end-to-end tests](./src/index.test.ts).
+[the end-to-end tests](./src/index.test.tsx).

--- a/packages/examples/packages/images/README.md
+++ b/packages/examples/packages/images/README.md
@@ -31,4 +31,4 @@ JSON-RPC methods:
 - `getCat` - Show an image of a random cat in a dialog.
 
 For more information, you can refer to
-[the end-to-end tests](./src/index.test.ts).
+[the end-to-end tests](./src/index.test.tsx).

--- a/packages/examples/packages/notifications/README.md
+++ b/packages/examples/packages/notifications/README.md
@@ -31,4 +31,4 @@ JSON-RPC methods:
 - `native` - Send a desktop notification to the user.
 
 For more information, you can refer to
-[the end-to-end tests](./src/index.test.ts).
+[the end-to-end tests](./src/index.test.tsx).

--- a/packages/examples/packages/signature-insights/README.md
+++ b/packages/examples/packages/signature-insights/README.md
@@ -48,4 +48,4 @@ The snap decodes the signature data and returns the decoded data as the
 signature insight.
 
 For more information, you can refer to
-[the end-to-end tests](./src/index.test.ts).
+[the end-to-end tests](./src/index.test.tsx).

--- a/packages/examples/packages/transaction-insights/README.md
+++ b/packages/examples/packages/transaction-insights/README.md
@@ -48,4 +48,4 @@ The snap decodes the transaction data and returns the decoded data as the
 transaction insight.
 
 For more information, you can refer to
-[the end-to-end tests](./src/index.test.ts).
+[the end-to-end tests](./src/index.test.tsx).

--- a/packages/snaps-rollup-plugin/README.md
+++ b/packages/snaps-rollup-plugin/README.md
@@ -1,6 +1,6 @@
 # @metamask/snaps-rollup-plugin
 
-A plugin for developing [MetaMask Snaps](https://docs.metamask.io/guide/snaps.html) using [Rollup](https://rollupjs.org/). This can be used as alternative to the `mm-snap` CLI `build` command. It transforms the bundle to fix common issues with SES. For a list of changes the plugin makes, you can refer to [the source code](../utils/src/post-process.ts).
+A plugin for developing [MetaMask Snaps](https://docs.metamask.io/guide/snaps.html) using [Rollup](https://rollupjs.org/). This can be used as alternative to the `mm-snap` CLI `build` command. It transforms the bundle to fix common issues with SES. For a list of changes the plugin makes, you can refer to [the source code](../snaps-utils/src/post-process.ts).
 
 ## Installation
 

--- a/packages/snaps-webpack-plugin/README.md
+++ b/packages/snaps-webpack-plugin/README.md
@@ -1,6 +1,6 @@
 # @metamask/snaps-webpack-plugin
 
-A plugin for developing [MetaMask Snaps](https://docs.metamask.io/guide/snaps.html) using [Webpack](https://webpack.js.org/). This can be used as alternative to the `mm-snap` CLI `build` command. It transforms the bundle to fix common issues with SES. For a list of changes the plugin makes, you can refer to [the source code](../utils/src/post-process.ts).
+A plugin for developing [MetaMask Snaps](https://docs.metamask.io/guide/snaps.html) using [Webpack](https://webpack.js.org/). This can be used as alternative to the `mm-snap` CLI `build` command. It transforms the bundle to fix common issues with SES. For a list of changes the plugin makes, you can refer to [the source code](../snaps-utils/src/post-process.ts).
 
 ## Installation
 


### PR DESCRIPTION
## Description

A mechanical link audit (resolving every relative markdown link against the filesystem) found 9 broken file links in package READMEs:

- `snaps-rollup-plugin` and `snaps-webpack-plugin` READMEs link to `../utils/src/post-process.ts` for the list of SES transforms, but the package directory is `packages/snaps-utils` → `../snaps-utils/src/post-process.ts`
- The `transaction-insights`, `cronjobs`, `signature-insights`, `images`, `ethers-js`, `dialogs`, and `notifications` example READMEs link to `./src/index.test.ts`, but the test files are `.tsx` → `./src/index.test.tsx`

Link targets only; no prose changes. After the change the audit reports zero broken relative links (excluding the intentional `link-to-pr` placeholders in AGENTS.md/CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link path corrections with no runtime or build behavior changes.
> 
> **Overview**
> Fixes **nine broken relative markdown links** in package READMEs so they resolve to real files.
> 
> Seven example snap READMEs (`cronjobs`, `dialogs`, `ethers-js`, `images`, `notifications`, `signature-insights`, `transaction-insights`) now point end-to-end test links at `./src/index.test.tsx` instead of the non-existent `.ts` path.
> 
> The `@metamask/snaps-rollup-plugin` and `@metamask/snaps-webpack-plugin` READMEs now link SES post-process source at `../snaps-utils/src/post-process.ts` instead of `../utils/src/post-process.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f437e93ec8e9ed9d678eb105ef81741e29865320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->