### PR TITLE
feat: Add `originMetadata` to requests

### DIFF
--- a/packages/snaps-controllers/src/multichain/MultichainRoutingService-method-action-types.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRoutingService-method-action-types.ts
@@ -16,6 +16,7 @@ import type { MultichainRoutingService } from './MultichainRoutingService';
  * @param options.connectedAddresses - Addresses currently connected to the
  * origin for the requested scope.
  * @param options.origin - The origin of the RPC request.
+ * @param options.originMetadata - Optional additional origin metadata.
  * @param options.request - The JSON-RPC request.
  * @param options.scope - The CAIP-2 scope for the request.
  * @returns The response from the chosen Snap.

--- a/packages/snaps-controllers/src/multichain/MultichainRoutingService.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRoutingService.ts
@@ -36,7 +36,7 @@ import type {
 type SnapKeyring = {
   submitRequest: (request: {
     origin: string;
-    originMetadata?: OriginMetadata;
+    originMetadata?: OriginMetadata | null;
     account: string;
     method: string;
     params?: Json[] | Record<string, Json>;
@@ -279,7 +279,7 @@ export class MultichainRoutingService {
   }: {
     connectedAddresses: CaipAccountId[];
     origin: string;
-    originMetadata?: OriginMetadata;
+    originMetadata?: OriginMetadata | null;
     scope: CaipChainId;
     request: JsonRpcRequest;
   }): Promise<Json> {

--- a/packages/snaps-controllers/src/multichain/MultichainRoutingService.ts
+++ b/packages/snaps-controllers/src/multichain/MultichainRoutingService.ts
@@ -5,7 +5,12 @@ import {
   getProtocolCaveatScopes,
   SnapEndowments,
 } from '@metamask/snaps-rpc-methods';
-import type { Json, JsonRpcRequest, SnapId } from '@metamask/snaps-sdk';
+import type {
+  Json,
+  JsonRpcRequest,
+  SnapId,
+  OriginMetadata,
+} from '@metamask/snaps-sdk';
 import type { InternalAccount } from '@metamask/snaps-utils';
 import { HandlerType } from '@metamask/snaps-utils';
 import type {
@@ -31,6 +36,7 @@ import type {
 type SnapKeyring = {
   submitRequest: (request: {
     origin: string;
+    originMetadata?: OriginMetadata;
     account: string;
     method: string;
     params?: Json[] | Record<string, Json>;
@@ -258,6 +264,7 @@ export class MultichainRoutingService {
    * @param options.connectedAddresses - Addresses currently connected to the
    * origin for the requested scope.
    * @param options.origin - The origin of the RPC request.
+   * @param options.originMetadata - Optional additional origin metadata.
    * @param options.request - The JSON-RPC request.
    * @param options.scope - The CAIP-2 scope for the request.
    * @returns The response from the chosen Snap.
@@ -266,11 +273,13 @@ export class MultichainRoutingService {
   async handleRequest({
     connectedAddresses,
     origin,
+    originMetadata,
     scope,
     request: rawRequest,
   }: {
     connectedAddresses: CaipAccountId[];
     origin: string;
+    originMetadata?: OriginMetadata;
     scope: CaipChainId;
     request: JsonRpcRequest;
   }): Promise<Json> {
@@ -301,6 +310,7 @@ export class MultichainRoutingService {
       return this.#withSnapKeyring(async ({ keyring }) =>
         keyring.submitRequest({
           origin,
+          originMetadata,
           account: accountId,
           scope,
           method,
@@ -320,6 +330,7 @@ export class MultichainRoutingService {
       return this.#messenger.call('SnapController:handleRequest', {
         snapId: protocolSnap.snapId,
         origin,
+        originMetadata,
         request: {
           method: '',
           params: {

--- a/packages/snaps-controllers/src/services/ExecutionService.ts
+++ b/packages/snaps-controllers/src/services/ExecutionService.ts
@@ -514,7 +514,7 @@ export abstract class ExecutionService<WorkerType = unknown> {
       params: {
         snapId,
         origin,
-        ...(originMetadata ? { originMetadata } : {}),
+        ...(originMetadata && { originMetadata }),
         handler,
         request: request as JsonRpcRequest,
       },

--- a/packages/snaps-controllers/src/services/ExecutionService.ts
+++ b/packages/snaps-controllers/src/services/ExecutionService.ts
@@ -505,7 +505,7 @@ export abstract class ExecutionService<WorkerType = unknown> {
     snapId: string,
     options: SnapRpcHookArgs,
   ): Promise<unknown> {
-    const { handler, request, origin } = options;
+    const { handler, request, origin, originMetadata } = options;
 
     return await this.#command(snapId, {
       id: nanoid(),
@@ -514,6 +514,7 @@ export abstract class ExecutionService<WorkerType = unknown> {
       params: {
         snapId,
         origin,
+        originMetadata,
         handler,
         request: request as JsonRpcRequest,
       },

--- a/packages/snaps-controllers/src/services/ExecutionService.ts
+++ b/packages/snaps-controllers/src/services/ExecutionService.ts
@@ -505,7 +505,7 @@ export abstract class ExecutionService<WorkerType = unknown> {
     snapId: string,
     options: SnapRpcHookArgs,
   ): Promise<unknown> {
-    const { handler, request, origin, originMetadata = null } = options;
+    const { handler, request, origin, originMetadata } = options;
 
     return await this.#command(snapId, {
       id: nanoid(),
@@ -514,7 +514,7 @@ export abstract class ExecutionService<WorkerType = unknown> {
       params: {
         snapId,
         origin,
-        originMetadata,
+        ...(originMetadata ? { originMetadata } : {}),
         handler,
         request: request as JsonRpcRequest,
       },

--- a/packages/snaps-controllers/src/services/ExecutionService.ts
+++ b/packages/snaps-controllers/src/services/ExecutionService.ts
@@ -505,7 +505,7 @@ export abstract class ExecutionService<WorkerType = unknown> {
     snapId: string,
     options: SnapRpcHookArgs,
   ): Promise<unknown> {
-    const { handler, request, origin, originMetadata } = options;
+    const { handler, request, origin, originMetadata = null } = options;
 
     return await this.#command(snapId, {
       id: nanoid(),

--- a/packages/snaps-controllers/src/snaps/SnapController-method-action-types.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController-method-action-types.ts
@@ -284,6 +284,7 @@ export type SnapControllerInstallSnapsAction = {
  * @param options - A bag of options.
  * @param options.snapId - The ID of the recipient snap.
  * @param options.origin - The origin of the RPC request.
+ * @param options.originMetadata - Optional additional origin metadata for the RPC request.
  * @param options.handler - The handler to trigger on the snap for the request.
  * @param options.request - The JSON-RPC request object.
  * @returns The result of the JSON-RPC request.

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -3708,6 +3708,7 @@ export class SnapController extends BaseController<
    * @param options - A bag of options.
    * @param options.snapId - The ID of the recipient snap.
    * @param options.origin - The origin of the RPC request.
+   * @param options.originMetadata - Optional additional origin metadata for the RPC request.
    * @param options.handler - The handler to trigger on the snap for the request.
    * @param options.request - The JSON-RPC request object.
    * @returns The result of the JSON-RPC request.
@@ -3715,6 +3716,7 @@ export class SnapController extends BaseController<
   async handleRequest({
     snapId,
     origin,
+    originMetadata,
     handler: handlerType,
     request: rawRequest,
   }: SnapRpcHookArgs & { snapId: SnapId }): Promise<unknown> {
@@ -3847,7 +3849,12 @@ export class SnapController extends BaseController<
     const handleRpcRequestPromise = this.messenger.call(
       'ExecutionService:handleRpcRequest',
       snapId,
-      { origin, handler: handlerType, request: transformedRequest },
+      {
+        origin,
+        originMetadata,
+        handler: handlerType,
+        request: transformedRequest,
+      },
     );
 
     // This will either get the result or reject due to the timeout.

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -33,6 +33,8 @@ describe('BaseSnapExecutor', () => {
     'console',
   ];
 
+  const MOCK_WALLETCONNECT_SESSION_ID = 'f7a0a2e3-9a4b-4c1d-8e5f-6b7c8d9e0f1a';
+
   describe('timers', () => {
     it("doesn't leak execution outside of expected timeshare during initial eval", async () => {
       const CODE = `
@@ -1501,6 +1503,78 @@ describe('BaseSnapExecutor', () => {
     });
   });
 
+  it('passes `originMetadata` to `onRpcRequest`', async () => {
+    const CODE = `
+      module.exports.onRpcRequest = ({ originMetadata }) => originMetadata;
+    `;
+
+    const executor = new TestSnapExecutor();
+    await executor.executeSnap(1, MOCK_SNAP_ID, CODE, []);
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'OK',
+    });
+
+    const originMetadata = {
+      transport: 'WalletConnect',
+      selfReportedOrigin: MOCK_ORIGIN,
+    };
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'snapRpc',
+      params: {
+        snapId: MOCK_SNAP_ID,
+        handler: HandlerType.OnRpcRequest,
+        origin: MOCK_WALLETCONNECT_SESSION_ID,
+        originMetadata,
+        request: { jsonrpc: '2.0', method: '' },
+      },
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      id: 2,
+      jsonrpc: '2.0',
+      result: originMetadata,
+    });
+  });
+
+  it('defaults `originMetadata` to `null` in `onRpcRequest` when not provided', async () => {
+    const CODE = `
+      module.exports.onRpcRequest = ({ originMetadata }) => originMetadata;
+    `;
+
+    const executor = new TestSnapExecutor();
+    await executor.executeSnap(1, MOCK_SNAP_ID, CODE, []);
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'OK',
+    });
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'snapRpc',
+      params: {
+        snapId: MOCK_SNAP_ID,
+        handler: HandlerType.OnRpcRequest,
+        origin: MOCK_ORIGIN,
+        request: { jsonrpc: '2.0', method: '' },
+      },
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      id: 2,
+      jsonrpc: '2.0',
+      result: null,
+    });
+  });
+
   it('supports onKeyringRequest export', async () => {
     const CODE = `
       module.exports.onKeyringRequest = ({ request }) => request.params[0];
@@ -1531,6 +1605,45 @@ describe('BaseSnapExecutor', () => {
       id: 2,
       jsonrpc: '2.0',
       result: 'bar',
+    });
+  });
+
+  it('passes `originMetadata` to `onKeyringRequest`', async () => {
+    const CODE = `
+      module.exports.onKeyringRequest = ({ originMetadata }) => originMetadata;
+    `;
+
+    const executor = new TestSnapExecutor();
+    await executor.executeSnap(1, MOCK_SNAP_ID, CODE, []);
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'OK',
+    });
+
+    const originMetadata = {
+      transport: 'WalletConnect',
+      selfReportedOrigin: MOCK_ORIGIN,
+    };
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'snapRpc',
+      params: {
+        snapId: MOCK_SNAP_ID,
+        handler: HandlerType.OnKeyringRequest,
+        origin: MOCK_WALLETCONNECT_SESSION_ID,
+        originMetadata,
+        request: { jsonrpc: '2.0', method: 'foo', params: ['bar'] },
+      },
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      id: 2,
+      jsonrpc: '2.0',
+      result: originMetadata,
     });
   });
 
@@ -1949,6 +2062,54 @@ describe('BaseSnapExecutor', () => {
     });
   });
 
+  it('passes `originMetadata` to `onProtocolRequest`', async () => {
+    const CODE = `
+      module.exports.onProtocolRequest = ({ originMetadata }) => originMetadata;
+    `;
+
+    const executor = new TestSnapExecutor();
+    await executor.executeSnap(1, MOCK_SNAP_ID, CODE, []);
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'OK',
+    });
+
+    const originMetadata = {
+      transport: 'WalletConnect',
+      selfReportedOrigin: MOCK_ORIGIN,
+    };
+
+    const params = {
+      scope: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+      request: {
+        jsonrpc: '2.0',
+        id: 'foo',
+        method: 'getVersion',
+      },
+    };
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'snapRpc',
+      params: {
+        snapId: MOCK_SNAP_ID,
+        handler: HandlerType.OnProtocolRequest,
+        origin: MOCK_WALLETCONNECT_SESSION_ID,
+        originMetadata,
+        request: { jsonrpc: '2.0', method: '', params },
+      },
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      id: 2,
+      jsonrpc: '2.0',
+      result: originMetadata,
+    });
+  });
+
   it('supports onClientRequest export', async () => {
     const CODE = `
       module.exports.onClientRequest = ({ request }) => ({ request });
@@ -2096,6 +2257,45 @@ describe('BaseSnapExecutor', () => {
           id: 2,
           jsonrpc: '2.0',
           result: null,
+        });
+      });
+
+      it(`passes \`originMetadata\` to \`${handler}\``, async () => {
+        const CODE = `
+          module.exports.${handler} = ({ originMetadata }) => originMetadata;
+        `;
+
+        const executor = new TestSnapExecutor();
+        await executor.executeSnap(1, MOCK_SNAP_ID, CODE, []);
+
+        expect(await executor.readCommand()).toStrictEqual({
+          jsonrpc: '2.0',
+          id: 1,
+          result: 'OK',
+        });
+
+        const originMetadata = {
+          transport: 'WalletConnect',
+          selfReportedOrigin: MOCK_ORIGIN,
+        };
+
+        await executor.writeCommand({
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'snapRpc',
+          params: {
+            snapId: MOCK_SNAP_ID,
+            handler,
+            origin: MOCK_WALLETCONNECT_SESSION_ID,
+            originMetadata,
+            request: { jsonrpc: '2.0', method: handler },
+          },
+        });
+
+        expect(await executor.readCommand()).toStrictEqual({
+          id: 2,
+          jsonrpc: '2.0',
+          result: originMetadata,
         });
       });
     }

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -224,6 +224,7 @@ export class BaseSnapExecutor {
    * @param options.snapId - The Snap ID.
    * @param options.handler - The handler to invoke.
    * @param options.origin - The origin invoking the handler.
+   * @param options.originMetadata - The optional metadata for the origin invoking the handler.
    * @param options.request - The JSON-RPC request to invoke the handler with.
    * @returns The result of invoking the handler on the Snap.
    */
@@ -231,9 +232,15 @@ export class BaseSnapExecutor {
     snapId,
     handler: handlerType,
     origin,
+    originMetadata,
     request,
   }: SnapRpcRequestArguments) {
-    const args = getHandlerArguments(origin, handlerType, request);
+    const args = getHandlerArguments(
+      origin,
+      originMetadata,
+      handlerType,
+      request,
+    );
 
     const data = this.#snapData.get(snapId);
     // We're capturing the handler in case someone modifies the data object

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -237,9 +237,9 @@ export class BaseSnapExecutor {
   }: SnapRpcRequestArguments) {
     const args = getHandlerArguments(
       origin,
-      originMetadata,
       handlerType,
       request,
+      originMetadata,
     );
 
     const data = this.#snapData.get(snapId);

--- a/packages/snaps-execution-environments/src/common/commands.test.ts
+++ b/packages/snaps-execution-environments/src/common/commands.test.ts
@@ -6,7 +6,7 @@ import { getHandlerArguments } from './commands';
 describe('getHandlerArguments', () => {
   it('validates the request params for the OnTransaction handler', () => {
     expect(() =>
-      getHandlerArguments(MOCK_ORIGIN, HandlerType.OnTransaction, {
+      getHandlerArguments(MOCK_ORIGIN, null, HandlerType.OnTransaction, {
         id: 1,
         jsonrpc: '2.0',
         method: 'foo',
@@ -17,7 +17,7 @@ describe('getHandlerArguments', () => {
 
   it('validates the request params for the OnSignature handler', () => {
     expect(() =>
-      getHandlerArguments(MOCK_ORIGIN, HandlerType.OnSignature, {
+      getHandlerArguments(MOCK_ORIGIN, null, HandlerType.OnSignature, {
         id: 1,
         jsonrpc: '2.0',
         method: 'foo',
@@ -28,7 +28,7 @@ describe('getHandlerArguments', () => {
 
   it('validates the request params for the OnUserInput handler', () => {
     expect(() =>
-      getHandlerArguments(MOCK_ORIGIN, HandlerType.OnUserInput, {
+      getHandlerArguments(MOCK_ORIGIN, null, HandlerType.OnUserInput, {
         id: 1,
         jsonrpc: '2.0',
         method: 'foo',
@@ -39,7 +39,7 @@ describe('getHandlerArguments', () => {
 
   it('validates the request params for the OnAssetsConversion handler', () => {
     expect(() =>
-      getHandlerArguments(MOCK_ORIGIN, HandlerType.OnAssetsConversion, {
+      getHandlerArguments(MOCK_ORIGIN, null, HandlerType.OnAssetsConversion, {
         id: 1,
         jsonrpc: '2.0',
         method: 'foo',
@@ -50,7 +50,7 @@ describe('getHandlerArguments', () => {
 
   it('validates the request params for the OnAssetsLookup handler', () => {
     expect(() =>
-      getHandlerArguments(MOCK_ORIGIN, HandlerType.OnAssetsLookup, {
+      getHandlerArguments(MOCK_ORIGIN, null, HandlerType.OnAssetsLookup, {
         id: 1,
         jsonrpc: '2.0',
         method: 'foo',
@@ -61,18 +61,23 @@ describe('getHandlerArguments', () => {
 
   it('validates the request params for the OnAssetHistoricalPrice handler', () => {
     expect(() =>
-      getHandlerArguments(MOCK_ORIGIN, HandlerType.OnAssetHistoricalPrice, {
-        id: 1,
-        jsonrpc: '2.0',
-        method: 'foo',
-        params: {},
-      }),
+      getHandlerArguments(
+        MOCK_ORIGIN,
+        null,
+        HandlerType.OnAssetHistoricalPrice,
+        {
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'foo',
+          params: {},
+        },
+      ),
     ).toThrow('Invalid request params');
   });
 
   it('validates the request params for the OnWebSocketEvent handler', () => {
     expect(() =>
-      getHandlerArguments(MOCK_ORIGIN, HandlerType.OnWebSocketEvent, {
+      getHandlerArguments(MOCK_ORIGIN, null, HandlerType.OnWebSocketEvent, {
         id: 1,
         jsonrpc: '2.0',
         method: 'foo',
@@ -84,7 +89,7 @@ describe('getHandlerArguments', () => {
   it('throws for invalid handler types', () => {
     expect(() =>
       // @ts-expect-error Invalid handler type.
-      getHandlerArguments(MOCK_ORIGIN, 'foo', {
+      getHandlerArguments(MOCK_ORIGIN, null, 'foo', {
         id: 1,
         jsonrpc: '2.0',
         method: 'foo',

--- a/packages/snaps-execution-environments/src/common/commands.test.ts
+++ b/packages/snaps-execution-environments/src/common/commands.test.ts
@@ -6,7 +6,7 @@ import { getHandlerArguments } from './commands';
 describe('getHandlerArguments', () => {
   it('validates the request params for the OnTransaction handler', () => {
     expect(() =>
-      getHandlerArguments(MOCK_ORIGIN, null, HandlerType.OnTransaction, {
+      getHandlerArguments(MOCK_ORIGIN, HandlerType.OnTransaction, {
         id: 1,
         jsonrpc: '2.0',
         method: 'foo',
@@ -17,7 +17,7 @@ describe('getHandlerArguments', () => {
 
   it('validates the request params for the OnSignature handler', () => {
     expect(() =>
-      getHandlerArguments(MOCK_ORIGIN, null, HandlerType.OnSignature, {
+      getHandlerArguments(MOCK_ORIGIN, HandlerType.OnSignature, {
         id: 1,
         jsonrpc: '2.0',
         method: 'foo',
@@ -28,7 +28,7 @@ describe('getHandlerArguments', () => {
 
   it('validates the request params for the OnUserInput handler', () => {
     expect(() =>
-      getHandlerArguments(MOCK_ORIGIN, null, HandlerType.OnUserInput, {
+      getHandlerArguments(MOCK_ORIGIN, HandlerType.OnUserInput, {
         id: 1,
         jsonrpc: '2.0',
         method: 'foo',
@@ -39,7 +39,7 @@ describe('getHandlerArguments', () => {
 
   it('validates the request params for the OnAssetsConversion handler', () => {
     expect(() =>
-      getHandlerArguments(MOCK_ORIGIN, null, HandlerType.OnAssetsConversion, {
+      getHandlerArguments(MOCK_ORIGIN, HandlerType.OnAssetsConversion, {
         id: 1,
         jsonrpc: '2.0',
         method: 'foo',
@@ -50,7 +50,7 @@ describe('getHandlerArguments', () => {
 
   it('validates the request params for the OnAssetsLookup handler', () => {
     expect(() =>
-      getHandlerArguments(MOCK_ORIGIN, null, HandlerType.OnAssetsLookup, {
+      getHandlerArguments(MOCK_ORIGIN, HandlerType.OnAssetsLookup, {
         id: 1,
         jsonrpc: '2.0',
         method: 'foo',
@@ -61,23 +61,18 @@ describe('getHandlerArguments', () => {
 
   it('validates the request params for the OnAssetHistoricalPrice handler', () => {
     expect(() =>
-      getHandlerArguments(
-        MOCK_ORIGIN,
-        null,
-        HandlerType.OnAssetHistoricalPrice,
-        {
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'foo',
-          params: {},
-        },
-      ),
+      getHandlerArguments(MOCK_ORIGIN, HandlerType.OnAssetHistoricalPrice, {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'foo',
+        params: {},
+      }),
     ).toThrow('Invalid request params');
   });
 
   it('validates the request params for the OnWebSocketEvent handler', () => {
     expect(() =>
-      getHandlerArguments(MOCK_ORIGIN, null, HandlerType.OnWebSocketEvent, {
+      getHandlerArguments(MOCK_ORIGIN, HandlerType.OnWebSocketEvent, {
         id: 1,
         jsonrpc: '2.0',
         method: 'foo',
@@ -89,7 +84,7 @@ describe('getHandlerArguments', () => {
   it('throws for invalid handler types', () => {
     expect(() =>
       // @ts-expect-error Invalid handler type.
-      getHandlerArguments(MOCK_ORIGIN, null, 'foo', {
+      getHandlerArguments(MOCK_ORIGIN, 'foo', {
         id: 1,
         jsonrpc: '2.0',
         method: 'foo',

--- a/packages/snaps-execution-environments/src/common/commands.ts
+++ b/packages/snaps-execution-environments/src/common/commands.ts
@@ -51,16 +51,16 @@ export function assertCommandParams<Type extends Json | undefined, Schema>(
  * Formats the arguments for the given handler.
  *
  * @param origin - The origin of the request.
- * @param originMetadata - The optional metadata for the origin of the request.
  * @param handler - The handler to pass the request to.
  * @param request - The request object.
+ * @param originMetadata - The optional metadata for the origin of the request.
  * @returns The formatted arguments.
  */
 export function getHandlerArguments(
   origin: string,
-  originMetadata: OriginMetadata | undefined | null,
   handler: HandlerType,
   request: JsonRpcRequestWithoutId,
+  originMetadata: OriginMetadata | undefined | null = null,
 ): InvokeSnapArgs {
   // `request` is already validated by the time this function is called.
 

--- a/packages/snaps-execution-environments/src/common/commands.ts
+++ b/packages/snaps-execution-environments/src/common/commands.ts
@@ -1,4 +1,5 @@
 import { rpcErrors } from '@metamask/rpc-errors';
+import type { OriginMetadata } from '@metamask/snaps-sdk';
 import { HandlerType } from '@metamask/snaps-utils';
 import type { Struct } from '@metamask/superstruct';
 import { validate } from '@metamask/superstruct';
@@ -50,12 +51,14 @@ export function assertCommandParams<Type extends Json | undefined, Schema>(
  * Formats the arguments for the given handler.
  *
  * @param origin - The origin of the request.
+ * @param originMetadata - The optional metadata for the origin of the request.
  * @param handler - The handler to pass the request to.
  * @param request - The request object.
  * @returns The formatted arguments.
  */
 export function getHandlerArguments(
   origin: string,
+  originMetadata: OriginMetadata | undefined | null,
   handler: HandlerType,
   request: JsonRpcRequestWithoutId,
 ): InvokeSnapArgs {
@@ -125,7 +128,7 @@ export function getHandlerArguments(
       assertIsOnProtocolRequestArguments(request.params);
 
       const { request: nestedRequest, scope } = request.params;
-      return { origin, request: nestedRequest, scope };
+      return { origin, originMetadata, request: nestedRequest, scope };
     }
 
     case HandlerType.OnWebSocketEvent: {
@@ -136,7 +139,7 @@ export function getHandlerArguments(
 
     case HandlerType.OnRpcRequest:
     case HandlerType.OnKeyringRequest:
-      return { origin, request };
+      return { origin, originMetadata, request };
 
     case HandlerType.OnClientRequest:
     case HandlerType.OnCronjob:
@@ -147,7 +150,7 @@ export function getHandlerArguments(
     case HandlerType.OnStart:
     case HandlerType.OnActive:
     case HandlerType.OnInactive:
-      return { origin };
+      return { origin, originMetadata };
 
     case HandlerType.OnHomePage:
     case HandlerType.OnSettingsPage:

--- a/packages/snaps-execution-environments/src/common/validation.ts
+++ b/packages/snaps-execution-environments/src/common/validation.ts
@@ -4,6 +4,7 @@ import {
   literal as customLiteral,
   typedUnion,
   UserInputEventStruct,
+  OriginMetadataStruct,
 } from '@metamask/snaps-sdk';
 import { HandlerType } from '@metamask/snaps-utils';
 import type { Infer, Struct } from '@metamask/superstruct';
@@ -79,11 +80,6 @@ export const ExecuteSnapRequestArgumentsStruct = object({
   snapId: string(),
   sourceCode: string(),
   endowments: array(EndowmentStruct),
-});
-
-const OriginMetadataStruct = object({
-  transport: string(),
-  selfReportedOrigin: string(),
 });
 
 export const SnapRpcRequestArgumentsStruct = object({

--- a/packages/snaps-execution-environments/src/common/validation.ts
+++ b/packages/snaps-execution-environments/src/common/validation.ts
@@ -86,7 +86,7 @@ export const SnapRpcRequestArgumentsStruct = object({
   snapId: string(),
   handler: enums(Object.values(HandlerType)),
   origin: string(),
-  originMetadata: optional(OriginMetadataStruct),
+  originMetadata: optional(nullable(OriginMetadataStruct)),
   request: assign(
     JsonRpcRequestWithoutIdStruct,
     object({

--- a/packages/snaps-execution-environments/src/common/validation.ts
+++ b/packages/snaps-execution-environments/src/common/validation.ts
@@ -81,10 +81,16 @@ export const ExecuteSnapRequestArgumentsStruct = object({
   endowments: array(EndowmentStruct),
 });
 
+const OriginMetadataStruct = object({
+  transport: string(),
+  selfReportedOrigin: string(),
+});
+
 export const SnapRpcRequestArgumentsStruct = object({
   snapId: string(),
   handler: enums(Object.values(HandlerType)),
   origin: string(),
+  originMetadata: optional(OriginMetadataStruct),
   request: assign(
     JsonRpcRequestWithoutIdStruct,
     object({

--- a/packages/snaps-jest/src/helpers.test.tsx
+++ b/packages/snaps-jest/src/helpers.test.tsx
@@ -319,6 +319,7 @@ describe('installSnap', () => {
             result: {
               request: {
                 origin: 'https://metamask.io',
+                originMetadata: null,
                 request: {
                   id: 1,
                   jsonrpc: '2.0',

--- a/packages/snaps-sdk/src/types/handlers/keyring.ts
+++ b/packages/snaps-sdk/src/types/handlers/keyring.ts
@@ -1,5 +1,7 @@
 import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
 
+import type { OriginMetadata } from '../origin';
+
 /**
  * The `onKeyringRequest` handler, which is called when a Snap receives a
  * keyring request.
@@ -9,6 +11,9 @@ import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
  * @param args - The request arguments.
  * @param args.origin - The origin of the request. This can be the ID of another
  * Snap, or the URL of a website.
+ * @param args.originMetadata - Optional metadata about the origin. This is only
+ * present if the origin is not directly verifiable, e.g., when the request
+ * comes from a transport that cannot verify the origin.
  * @param args.request - The keyring request sent to the Snap. This includes
  * the method name and parameters.
  * @returns The response to the keyring request. This must be a
@@ -19,5 +24,6 @@ export type OnKeyringRequestHandler<
   Params extends JsonRpcParams = JsonRpcParams,
 > = (args: {
   origin: string;
+  originMetadata: OriginMetadata | null;
   request: JsonRpcRequest<Params>;
 }) => Promise<Json>;

--- a/packages/snaps-sdk/src/types/handlers/lifecycle.ts
+++ b/packages/snaps-sdk/src/types/handlers/lifecycle.ts
@@ -1,3 +1,5 @@
+import type { OriginMetadata } from '../origin';
+
 /**
  * A lifecycle event handler. This is called whenever a lifecycle event occurs,
  * such as the Snap being installed or updated.
@@ -7,9 +9,13 @@
  *
  * @param args - The request arguments.
  * @param args.origin - The origin that triggered the lifecycle event hook.
+ * @param args.originMetadata - Optional metadata about the origin. This is only
+ * present if the origin is not directly verifiable, e.g., when the request
+ * comes from a transport that cannot verify the origin.
  */
 export type LifecycleEventHandler = (args: {
   origin: string;
+  originMetadata: OriginMetadata | null;
 }) => Promise<unknown>;
 
 /**

--- a/packages/snaps-sdk/src/types/handlers/protocol.ts
+++ b/packages/snaps-sdk/src/types/handlers/protocol.ts
@@ -5,6 +5,8 @@ import type {
   JsonRpcRequest,
 } from '@metamask/utils';
 
+import type { OriginMetadata } from '../origin';
+
 /**
  * The `onProtocolRequest` handler, which is called when a Snap receives a
  * protocol request.
@@ -14,6 +16,9 @@ import type {
  * @param args - The request arguments.
  * @param args.origin - The origin of the request. This can be the ID of another
  * Snap, or the URL of a website.
+ * @param args.originMetadata - Optional metadata about the origin. This is only
+ * present if the origin is not directly verifiable, e.g., when the request
+ * comes from a transport that cannot verify the origin.
  * @param args.scope - The scope of the request.
  * @param args.request - The protocol request sent to the Snap. This includes
  * the method name and parameters.
@@ -25,6 +30,7 @@ export type OnProtocolRequestHandler<
   Params extends JsonRpcParams = JsonRpcParams,
 > = (args: {
   origin: string;
+  originMetadata: OriginMetadata | null;
   scope: CaipChainId;
   request: JsonRpcRequest<Params>;
 }) => Promise<Json>;

--- a/packages/snaps-sdk/src/types/handlers/rpc-request.ts
+++ b/packages/snaps-sdk/src/types/handlers/rpc-request.ts
@@ -1,5 +1,7 @@
 import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
 
+import type { OriginMetadata } from '../origin';
+
 /**
  * The `onRpcRequest` handler, which is called when a Snap receives a JSON-RPC
  * request. This can be called from another Snap, or from a website, depending
@@ -10,6 +12,9 @@ import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
  * @param args - The request arguments.
  * @param args.origin - The origin of the request. This can be the ID of another
  * Snap, or the URL of a website.
+ * @param args.originMetadata - Optional metadata about the origin. This is only
+ * present if the origin is not directly verifiable, e.g., when the request
+ * comes from a transport that cannot verify the origin.
  * @param args.request - The JSON-RPC request sent to the snap. This includes
  * the method name and parameters.
  * @returns The response to the JSON-RPC request. This must be a
@@ -17,4 +22,8 @@ import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
  * instead.
  */
 export type OnRpcRequestHandler<Params extends JsonRpcParams = JsonRpcParams> =
-  (args: { origin: string; request: JsonRpcRequest<Params> }) => Promise<Json>;
+  (args: {
+    origin: string;
+    originMetadata: OriginMetadata | null;
+    request: JsonRpcRequest<Params>;
+  }) => Promise<Json>;

--- a/packages/snaps-sdk/src/types/index.ts
+++ b/packages/snaps-sdk/src/types/index.ts
@@ -7,6 +7,7 @@ import './images';
 export * from './caip';
 export * from './handlers';
 export * from './methods';
+export type * from './origin';
 export type * from './permissions';
 export type * from './provider';
 export type * from './snap';

--- a/packages/snaps-sdk/src/types/index.ts
+++ b/packages/snaps-sdk/src/types/index.ts
@@ -7,7 +7,7 @@ import './images';
 export * from './caip';
 export * from './handlers';
 export * from './methods';
-export type * from './origin';
+export * from './origin';
 export type * from './permissions';
 export type * from './provider';
 export type * from './snap';

--- a/packages/snaps-sdk/src/types/origin.ts
+++ b/packages/snaps-sdk/src/types/origin.ts
@@ -1,9 +1,7 @@
+import type { Infer } from '@metamask/superstruct';
 import { object, string } from '@metamask/superstruct';
 
-export type OriginMetadata = {
-  transport: string;
-  selfReportedOrigin: string;
-};
+export type OriginMetadata = Infer<typeof OriginMetadataStruct>;
 
 export const OriginMetadataStruct = object({
   transport: string(),

--- a/packages/snaps-sdk/src/types/origin.ts
+++ b/packages/snaps-sdk/src/types/origin.ts
@@ -1,0 +1,4 @@
+export type OriginMetadata = {
+  transport: string;
+  selfReportedOrigin: string;
+};

--- a/packages/snaps-sdk/src/types/origin.ts
+++ b/packages/snaps-sdk/src/types/origin.ts
@@ -1,4 +1,11 @@
+import { object, string } from '@metamask/superstruct';
+
 export type OriginMetadata = {
   transport: string;
   selfReportedOrigin: string;
 };
+
+export const OriginMetadataStruct = object({
+  transport: string(),
+  selfReportedOrigin: string(),
+});

--- a/packages/snaps-simulation/src/helpers.test.tsx
+++ b/packages/snaps-simulation/src/helpers.test.tsx
@@ -48,6 +48,7 @@ describe('helpers', () => {
             result: {
               request: {
                 origin: 'https://metamask.io',
+                originMetadata: null,
                 request: {
                   id: 1,
                   jsonrpc: '2.0',

--- a/packages/snaps-utils/src/handlers/types.ts
+++ b/packages/snaps-utils/src/handlers/types.ts
@@ -4,7 +4,7 @@ import type { SNAP_EXPORTS } from './exports';
 
 export type SnapRpcHookArgs = {
   origin: string;
-  originMetadata?: OriginMetadata;
+  originMetadata?: OriginMetadata | null;
   handler: HandlerType;
   request: Record<string, unknown>;
 };

--- a/packages/snaps-utils/src/handlers/types.ts
+++ b/packages/snaps-utils/src/handlers/types.ts
@@ -1,7 +1,10 @@
+import type { OriginMetadata } from '@metamask/snaps-sdk';
+
 import type { SNAP_EXPORTS } from './exports';
 
 export type SnapRpcHookArgs = {
   origin: string;
+  originMetadata?: OriginMetadata;
   handler: HandlerType;
   request: Record<string, unknown>;
 };


### PR DESCRIPTION
Add an `originMetadata` field to handlers arguments that also contain `origin`. This should only be used when the origin is using a non-verifiable transport.

https://consensyssoftware.atlassian.net/browse/WPC-1195

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the full inbound RPC path to Snaps and expands handler APIs; behavior is backward-compatible (optional field, null default) but Snaps may start relying on self-reported origin data for UX or policy.
> 
> **Overview**
> Introduces **`OriginMetadata`** in `snaps-sdk` (`transport`, `selfReportedOrigin`) and threads optional **`originMetadata`** from multichain routing and `SnapController` through `ExecutionService` into the snap executor.
> 
> Snap handlers that already receive **`origin`** now also get **`originMetadata: OriginMetadata | null`** (defaults to **`null`** when omitted): `onRpcRequest`, `onKeyringRequest`, `onProtocolRequest`, and lifecycle hooks (`onInstall`, `onUpdate`, `onStart`, `onActive`, `onInactive`). JSDoc states this is for transports that cannot verify the origin.
> 
> **`SnapRpcHookArgs`**, **`snapRpc`** validation, and **`getHandlerArguments`** are updated accordingly; simulation/jest expectations include **`originMetadata: null`** when not provided. Browser tests cover passing metadata through multiple handler types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff3d47cf213d7b245751e3b1df6d54119a634932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->