### PR TITLE
feat: Add Stellar to the known Snap derivation paths

### DIFF
--- a/packages/snaps-utils/src/derivation-path.test.ts
+++ b/packages/snaps-utils/src/derivation-path.test.ts
@@ -10,6 +10,12 @@ describe('getSnapDerivationPathName', () => {
     );
   });
 
+  it('returns a name for ed25519 paths that only SLIP-44 would miss', () => {
+    expect(getSnapDerivationPathName(['m', `44'`, `148'`], 'ed25519')).toBe(
+      'Stellar',
+    );
+  });
+
   it("returns a name from the hardcoded list starting with `1852'`, `1815'`", () => {
     expect(
       getSnapDerivationPathName(['m', `1852'`, `1815'`], 'ed25519Bip32'),

--- a/packages/snaps-utils/src/derivation-paths.ts
+++ b/packages/snaps-utils/src/derivation-paths.ts
@@ -106,6 +106,11 @@ export const SNAPS_DERIVATION_PATHS: SnapsDerivationPath[] = [
     name: 'Sui',
   },
   {
+    path: ['m', `44'`, `148'`],
+    curve: 'ed25519',
+    name: 'Stellar',
+  },
+  {
     path: ['m', `44'`, `931'`],
     curve: 'secp256k1',
     name: 'THORChain (RUNE)',


### PR DESCRIPTION
Adds Stellar to `SNAPS_DERIVATION_PATHS` in `snaps-utils`, so the permission prompt for Snaps requesting `snap_getBip32Entropy` on the Stellar path shows **"Manage Stellar accounts"** instead of **"Manage Unknown network m/44'/148' (ed25519) accounts"**.

Also, adds a unit test covering the new entry.

<img width="496" height="237" alt="stellar_snap_mm" src="https://github.com/user-attachments/assets/afb08904-be0f-475a-8d87-99e18302fa16" />

 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small metadata and test-only change to derivation path labeling; no crypto or permission logic changes.
> 
> **Overview**
> Registers **Stellar** (`m/44'/148'`, `ed25519`) in `SNAPS_DERIVATION_PATHS`, so Snap permission UI for `snap_getBip32Entropy` on that path shows a friendly **"Manage Stellar accounts"** label instead of an unknown-network message.
> 
> Because `getSnapDerivationPathName` only falls back to SLIP-44 for `secp256k1`, ed25519 coin types like Stellar must live in the hardcoded list. A unit test asserts the new mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 631640698b699a64535790ad5f951170730154b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->