### PR TITLE
docs(snaps-cli): `sourceMap` is documented as defaulting to `true`, but it is `false`

### DIFF
--- a/packages/snaps-cli/README.md
+++ b/packages/snaps-cli/README.md
@@ -232,7 +232,7 @@ the bundle, mangle variable names, and perform other optimizations.
 #### `sourceMap`
 
 - Type: `boolean | "inline"`
-- Default: `true`
+- Default: `false`
 
 Whether to generate a source map. If `"inline"`, the source map will be
 inlined in the bundle. Otherwise, it will be written to a separate file.

--- a/packages/snaps-cli/src/config.ts
+++ b/packages/snaps-cli/src/config.ts
@@ -50,7 +50,7 @@ export type SnapConfig = {
    * be generated as separate files. If `'inline'`, source maps will be
    * inlined in the generated JavaScript bundle.
    *
-   * @default true
+   * @default false
    */
   sourceMap?: boolean | 'inline';
 


### PR DESCRIPTION
## Problem

Two places tell snap authors that source maps are on by default:

- `packages/snaps-cli/src/config.ts:53` — `@default true`
- `packages/snaps-cli/README.md:235` — `- Default: \`true\``

The struct says otherwise, `packages/snaps-cli/src/config.ts:385`:

```ts
sourceMap: defaulted(union([boolean(), literal('inline')]), false),
```

The behaviour changed when source maps were disabled by default; the type annotation and the README entry were not updated with it, so they have been describing the old behaviour ever since.

The effect is quiet: an author reads the docs, expects a `.map` file next to the bundle, does not get one, and has no reason to suspect the documentation rather than their setup.

## Fix

Change both annotations to `false`. Two lines; the struct — the thing that actually decides — is untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only README and JSDoc defaults are updated; build behavior and config parsing are untouched.
> 
> **Overview**
> **Documentation-only fix** for `sourceMap` in `@metamask/snaps-cli`: the README and `SnapConfig` JSDoc previously said the default was `true`, while `SnapsConfigStruct` has always defaulted to `false`.
> 
> Updates the README `sourceMap` section and the `@default` on `sourceMap` in `config.ts` to **`false`**. Runtime behavior and the struct default are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82ebd634fd9b9754834d1b8f770d1b4c2d9146ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->