### PR TITLE
docs(snaps-jest): remove `executionEnvironmentUrl` / `simulatorUrl` from the docs

### DIFF
--- a/packages/snaps-jest/README.md
+++ b/packages/snaps-jest/README.md
@@ -540,9 +540,8 @@ bundle during tests.
 - Default: `true`
 
 Whether to enable the built-in HTTP server. By default, it will be enabled. If
-you want to use your own HTTP server, you can disable this option, and use the
-`executionEnvironmentUrl` and `simulatorUrl` options to configure the URLs of
-your own server.
+you want to use your own HTTP server, you can disable this option and serve the
+snap bundle yourself.
 
 ##### Example
 

--- a/packages/snaps-jest/src/options.ts
+++ b/packages/snaps-jest/src/options.ts
@@ -28,7 +28,6 @@ const SnapsEnvironmentOptionsStruct = type({
  * {
  *   "testEnvironment": "@metamask/snaps-jest",
  *   "testEnvironmentOptions": {
- *     "executionEnvironmentUrl": "http://localhost:8080",
  *     "server": {
  *       "port": 8080,
  *       /* ... *\/


### PR DESCRIPTION
## Problem

The snaps-jest docs point people at two options that the package does not accept.

`packages/snaps-jest/src/options.ts:12` is the whole surface:

```ts
const SnapsEnvironmentOptionsStruct = type({
  server: defaulted(
    object({
      enabled: defaulted(boolean(), true),
      port: defaulted(number(), 0),
      root: defaulted(string(), process.cwd()),
    }),
    {},
  ),
});
```

There is no `executionEnvironmentUrl` and no `simulatorUrl`. Yet:

- the `@example` block at `src/options.ts:31` shows `"executionEnvironmentUrl": "http://localhost:8080"` as a `testEnvironmentOptions` key;
- `README.md:544` tells the reader that after disabling the built-in server they can *"use the `executionEnvironmentUrl` and `simulatorUrl` options to configure the URLs of your own server"*.

Both are dead ends. Setting either key is silently ignored, so someone who disables the built-in server on that advice has no documented way to point the environment anywhere, and the tests quietly carry on against the default.

## Fix

- drop the phantom key from the JSDoc example;
- reword the README sentence so it no longer promises options that do not exist.

Four lines across two files; no behaviour change.

## Note

Issue #2181 reported this in February 2024 and is still open with no linked PR, so this should close it. I have kept the change to removing the incorrect claims rather than implementing the options, since whether those URLs *should* be configurable is a design question for you.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README and JSDoc edits only; no runtime or configuration behavior changes.
> 
> **Overview**
> **Documentation-only fix** so `@metamask/snaps-jest` docs match the real `testEnvironmentOptions` surface (`server.enabled`, `server.port`, `server.root` only).
> 
> The JSDoc `@example` in `options.ts` no longer shows a non-existent `executionEnvironmentUrl` key. The README for `server.enabled` no longer tells readers to configure `executionEnvironmentUrl` and `simulatorUrl` when disabling the built-in server; it now says to disable the server and serve the snap bundle yourself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a67bc38579a85764427bda1e1164c3a24d967e1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->