### PR TITLE
feat: block `AccountTreeController` messenger calls

### DIFF
--- a/packages/snaps-rpc-methods/src/permitted/messengerCall.ts
+++ b/packages/snaps-rpc-methods/src/permitted/messengerCall.ts
@@ -43,6 +43,7 @@ export type MessengerCallMethodActions =
   | PermissionControllerGetPermissionAction;
 
 const BLOCKED_MESSENGER_CLIENTS = [
+  'AccountTreeController',
   'ApprovalController',
   'KeyringController',
   'PermissionController',


### PR DESCRIPTION
We'll soon introduce some export/import feature on the `AccountTreeController`, so it's best if we block it from messenger calls for now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line addition to an existing Snap RPC denylist; tightens access rather than widening it.
> 
> **Overview**
> **`AccountTreeController`** is added to the denylist used by **`snap_messengerCall`**, so preinstalled Snaps can no longer dispatch messenger actions whose names start with that client (same pattern as other blocked controllers).
> 
> This is a proactive lockdown ahead of planned account-tree export/import work, reducing the chance Snaps reach that surface before it is intentionally exposed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa86561089001957d3666e65bafd12c46260eef2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->