### PR TITLE
fix: Sync `PrivateKeyEncoding` type and struct

### DIFF
--- a/packages/snaps-sdk/src/types/permissions.ts
+++ b/packages/snaps-sdk/src/types/permissions.ts
@@ -80,7 +80,7 @@ export type RequestedSnap = {
  * Mirrors `PrivateKeyEncoding` from `@metamask/keyring-api`.
  * Keep in sync with `PrivateKeyEncoding` in `@metamask/keyring-api`.
  */
-type PrivateKeyEncoding = 'hexadecimal' | 'base58';
+type PrivateKeyEncoding = 'hexadecimal' | 'base58' | 'base32';
 
 /**
  * Supported account types for keyring accounts.

--- a/packages/snaps-utils/src/keyring.ts
+++ b/packages/snaps-utils/src/keyring.ts
@@ -16,7 +16,7 @@ import { assertStruct, CaipChainIdStruct } from '@metamask/utils';
  * Mirrors `PrivateKeyEncoding` from `@metamask/keyring-api` to avoid pulling
  * in that package's Node.js-only transitive dependencies into browser bundles.
  */
-const PrivateKeyEncodingStruct = enums(['hexadecimal', 'base58']);
+const PrivateKeyEncodingStruct = enums(['hexadecimal', 'base58', 'base32']);
 
 /**
  * Supported account types for keyring accounts.


### PR DESCRIPTION
Sync `PrivateKeyEncoding` type and struct with `keyring-api`. It was out of sync causing issues for certain Snaps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow type and validation allowlist expansion aligned with keyring-api; no auth or data-path changes.
> 
> **Overview**
> Adds **`base32`** as a supported private-key encoding in the Snaps SDK and utils so they match `@metamask/keyring-api`.
> 
> The **`PrivateKeyEncoding`** union in `permissions.ts` and the **`PrivateKeyEncodingStruct`** enum used by **`endowment:keyring`** capabilities validation in `keyring.ts` previously only allowed `hexadecimal` and `base58`. Snaps that declare `base32` in import/export format capabilities were failing type or runtime checks until this sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05c94ace097a9fe9360cca4a0985dfe44d37f07d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->