### PR TITLE
test: fix misspelled test identifiers

### DIFF
--- a/packages/snaps-sandbox/src/state.test.ts
+++ b/packages/snaps-sandbox/src/state.test.ts
@@ -105,17 +105,17 @@ describe('historyAtom', () => {
         timestamp: Date.now(),
       };
 
-      const secondRequst = {
+      const secondRequest = {
         id: '2',
         title: 'Test 2',
         request: JSON.stringify({ method: 'test' }),
         timestamp: Date.now(),
       };
 
-      store.set(persistedHistoryAtom, [firstRequest, secondRequst]);
+      store.set(persistedHistoryAtom, [firstRequest, secondRequest]);
 
       const updatedRequest = {
-        ...secondRequst,
+        ...secondRequest,
         title: 'Updated Test',
       };
 

--- a/packages/snaps-utils/src/checksum.test.ts
+++ b/packages/snaps-utils/src/checksum.test.ts
@@ -37,7 +37,7 @@ describe('checksum', () => {
   });
 });
 
-describe('checkumFiles', () => {
+describe('checksumFiles', () => {
   it('throws on duplicated paths', async () => {
     const files = [
       new VirtualFile({ value: 'foo', path: '/foo' }),


### PR DESCRIPTION
Fix two spelling errors in test-only identifiers and descriptions:

- `checkumFiles` → `checksumFiles` in the checksum test suite description;
- `secondRequst` → `secondRequest` in the sandbox state test.

Assertions, fixtures, snapshots, and production behavior are unchanged. Deprecated compatibility identifiers with historical spelling are intentionally left intact.

Validation:

    `npx prettier --check packages/snaps-utils/src/checksum.test.ts packages/snaps-sandbox/src/state.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only identifier and describe-block renames with no production or behavioral impact.
> 
> **Overview**
> This PR **only renames misspelled test-only symbols** so names match the real APIs and intent. No assertions, fixtures, or runtime behavior change.
> 
> In **`packages/snaps-sandbox/src/state.test.ts`**, the history **update** test renames `secondRequst` to **`secondRequest`** everywhere it is declared, stored in `persistedHistoryAtom`, and spread into `updatedRequest`.
> 
> In **`packages/snaps-utils/src/checksum.test.ts`**, the outer **`describe`** label is corrected from `checkumFiles` to **`checksumFiles`**, aligning the suite title with the imported function under test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae524a70a7aa1f8933dc0504c4d5b3c5367de08d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->