### PR TITLE
chore: Bump minimum browsers

### DIFF
--- a/packages/snaps-cli/.browserslistrc
+++ b/packages/snaps-cli/.browserslistrc
@@ -1,3 +1,3 @@
 # The minimum browser versions supported by MetaMask.
-chrome >= 113
-firefox >= 115
+chrome >= 123
+firefox >= 128

--- a/packages/snaps-cli/src/webpack/utils.test.ts
+++ b/packages/snaps-cli/src/webpack/utils.test.ts
@@ -69,8 +69,8 @@ describe('getBrowserslistTargets', () => {
     const targets = await getBrowserslistTargets();
     expect(targets).toMatchInlineSnapshot(`
       [
-        "chrome >= 113",
-        "firefox >= 115",
+        "chrome >= 123",
+        "firefox >= 128",
       ]
     `);
   });

--- a/packages/snaps-execution-environments/.browserslistrc
+++ b/packages/snaps-execution-environments/.browserslistrc
@@ -1,3 +1,3 @@
 # The minimum browser versions supported by MetaMask.
-chrome >= 113
-firefox >= 115
+chrome >= 123
+firefox >= 128


### PR DESCRIPTION
Bump minimum support browsers for Snaps to match latest values from the MetaMask extension.